### PR TITLE
fix(habits): correct over-counted 'X/Y habits done today' denominator

### DIFF
--- a/backoffice/src/app/gc-fitness/clients/[id]/_components/HabitTrendsWidget.tsx
+++ b/backoffice/src/app/gc-fitness/clients/[id]/_components/HabitTrendsWidget.tsx
@@ -21,6 +21,7 @@ import { getTranslations } from "next-intl/server";
 import { gcFitnessFirestore } from "@/lib/firebase/gc-fitness-admin";
 import { FirestoreCollections } from "@/lib/gc-fitness/collections";
 import { civilDateFormat } from "@/lib/gc-fitness/civil-date";
+import { isHabitScheduledOn } from "@/lib/gc-fitness/habit-schedule";
 import type { HabitType } from "@/lib/gc-fitness/habit-schema";
 import { TREND_RANGES, type TrendRangeKey, addCivilDays } from "./trend-range";
 import { HabitTrendsClient, type HabitTrendRow } from "./HabitTrendsClient";
@@ -36,49 +37,9 @@ function isHabitScheduledOnDate(
   habit: Record<string, unknown>,
   civilDate: string,
 ): boolean {
-  const startsOn =
-    typeof habit.startsOn === "string" && habit.startsOn.length > 0
-      ? habit.startsOn
-      : null;
-  const endsOn =
-    typeof habit.endsOn === "string" && habit.endsOn.length > 0
-      ? habit.endsOn
-      : null;
-
-  if (startsOn && civilDate < startsOn) return false;
-  if (endsOn && civilDate > endsOn) return false;
-
-  const scheduleType = habit.scheduleType === "one-time" ? "one-time" : "recurring";
-  if (scheduleType === "one-time") {
-    return startsOn ? civilDate === startsOn : true;
-  }
-
-  const cadence =
-    habit.scheduleCadence === "weekly" || habit.scheduleCadence === "monthly"
-      ? habit.scheduleCadence
-      : "daily";
-
-  if (cadence === "daily") return true;
-
-  const date = new Date(`${civilDate}T12:00:00Z`);
-  if (Number.isNaN(date.getTime())) return false;
-
-  if (cadence === "weekly") {
-    const weekdays = Array.isArray(habit.scheduleWeekdays)
-      ? (habit.scheduleWeekdays as number[])
-      : [];
-    const weekday = date.getUTCDay() === 0 ? 7 : date.getUTCDay();
-    const legacyWeekday = weekday === 7 ? 1 : weekday + 1;
-    return weekdays.includes(weekday) || weekdays.includes(legacyWeekday);
-  }
-
-  const monthDays = Array.isArray(habit.scheduleMonthDays)
-    ? (habit.scheduleMonthDays as number[])
-    : typeof habit.scheduleDayOfMonth === "number"
-      ? [habit.scheduleDayOfMonth]
-      : [1];
-
-  return monthDays.includes(date.getUTCDate());
+  // Delegates to the shared iOS-parity predicate (incl. skippedDates +
+  // disambiguated legacy weekday). See lib/gc-fitness/habit-schedule.ts.
+  return isHabitScheduledOn(habit, civilDate);
 }
 
 export async function HabitTrendsWidget({ clientId, timezone }: HabitTrendsWidgetProps) {

--- a/backoffice/src/lib/gc-fitness/__tests__/habit-schedule.test.ts
+++ b/backoffice/src/lib/gc-fitness/__tests__/habit-schedule.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, it } from "@jest/globals";
+
+import { isHabitScheduledOn } from "../habit-schedule";
+
+/**
+ * `isHabitScheduledOn` is the single source of truth for the trainer-facing
+ * "X/Y habits done today" denominator (recent-logs feed, client daily timeline,
+ * coach pulse, habit trends). It must agree with the iOS client
+ * (`HabitSchedule.isActive`); divergences here are exactly the
+ * "2/5 habits done today, but the client only has 4 habits today" report.
+ *
+ * Civil-date weekday reference (verified):
+ *   2026-05-29 = Friday   (ISO 5)
+ *   2026-05-30 = Saturday (ISO 6)
+ *   2026-05-31 = Sunday   (ISO 7)
+ *   2026-06-01 = Monday   (ISO 1)
+ */
+function weekly(weekdays: number[], extra: Record<string, unknown> = {}) {
+  return {
+    scheduleType: "recurring",
+    scheduleCadence: "weekly",
+    scheduleWeekdays: weekdays,
+    ...extra,
+  };
+}
+
+describe("isHabitScheduledOn — weekly cadence (canonical ISO, no over-count)", () => {
+  it("matches on the canonical ISO weekday (Friday=5)", () => {
+    expect(isHabitScheduledOn(weekly([5]), "2026-05-29")).toBe(true);
+  });
+
+  it("does NOT match an adjacent weekday — the over-count bug (Saturday=6 must not count on Friday)", () => {
+    // Old code OR-ed in a legacy Sun=1..Sat=7 alias (Friday→6), so a Saturday
+    // habit wrongly counted on Friday. That is the inflated denominator.
+    expect(isHabitScheduledOn(weekly([6]), "2026-05-29")).toBe(false);
+  });
+
+  it("still matches the same habit on its real day (Saturday)", () => {
+    expect(isHabitScheduledOn(weekly([6]), "2026-05-30")).toBe(true);
+  });
+
+  it("Monday alias must not count on Sunday (Monday=1 must not fire on 2026-05-31)", () => {
+    expect(isHabitScheduledOn(weekly([1]), "2026-05-31")).toBe(false);
+    expect(isHabitScheduledOn(weekly([7]), "2026-05-31")).toBe(true);
+  });
+
+  it("empty weekdays never matches", () => {
+    expect(isHabitScheduledOn(weekly([]), "2026-05-29")).toBe(false);
+  });
+});
+
+describe("isHabitScheduledOn — disambiguated legacy Sun=1..Sat=7 (iOS parity)", () => {
+  // A habit authored under the OLD Sun=1..Sat=7 convention, with weekdays=[1]
+  // meaning Sunday, and a startsOn that is itself a Sunday. iOS opts into the
+  // legacy reading because startsOn disambiguates it.
+  const legacySundayHabit = weekly([1], { startsOn: "2026-05-31" });
+
+  it("fires on Sunday for a legacy-stored Sunday habit", () => {
+    expect(isHabitScheduledOn(legacySundayHabit, "2026-05-31")).toBe(true);
+  });
+
+  it("does not fire on Monday for that legacy Sunday habit", () => {
+    expect(isHabitScheduledOn(legacySundayHabit, "2026-06-01")).toBe(false);
+  });
+
+  it("zero-based Sunday stray docs (weekday 0) still resolve on Sunday", () => {
+    expect(isHabitScheduledOn(weekly([0]), "2026-05-31")).toBe(true);
+  });
+});
+
+describe("isHabitScheduledOn — skippedDates (trainer removed this day)", () => {
+  it("a daily habit skipped for the day does not count", () => {
+    const habit = { scheduleCadence: "daily", skippedDates: ["2026-05-30"] };
+    expect(isHabitScheduledOn(habit, "2026-05-30")).toBe(false);
+    expect(isHabitScheduledOn(habit, "2026-05-29")).toBe(true);
+  });
+
+  it("a weekly habit skipped on a matching day does not count", () => {
+    const habit = weekly([5], { skippedDates: ["2026-05-29"] });
+    expect(isHabitScheduledOn(habit, "2026-05-29")).toBe(false);
+  });
+});
+
+describe("isHabitScheduledOn — daily / one-time / window / monthly", () => {
+  it("daily is always scheduled", () => {
+    expect(isHabitScheduledOn({ scheduleCadence: "daily" }, "2026-05-29")).toBe(true);
+    expect(isHabitScheduledOn({}, "2026-05-29")).toBe(true); // default cadence
+  });
+
+  it("one-time fires only on startsOn", () => {
+    const habit = { scheduleType: "one-time", startsOn: "2026-05-30" };
+    expect(isHabitScheduledOn(habit, "2026-05-30")).toBe(true);
+    expect(isHabitScheduledOn(habit, "2026-05-29")).toBe(false);
+  });
+
+  it("respects the startsOn / endsOn civil-date window", () => {
+    expect(
+      isHabitScheduledOn({ scheduleCadence: "daily", startsOn: "2026-05-30" }, "2026-05-29"),
+    ).toBe(false);
+    expect(
+      isHabitScheduledOn({ scheduleCadence: "daily", endsOn: "2026-05-29" }, "2026-05-30"),
+    ).toBe(false);
+  });
+
+  it("monthly fires on its month day(s)", () => {
+    expect(
+      isHabitScheduledOn({ scheduleCadence: "monthly", scheduleMonthDays: [30] }, "2026-05-30"),
+    ).toBe(true);
+    expect(
+      isHabitScheduledOn({ scheduleCadence: "monthly", scheduleMonthDays: [30] }, "2026-05-29"),
+    ).toBe(false);
+    expect(
+      isHabitScheduledOn({ scheduleCadence: "monthly", scheduleDayOfMonth: 29 }, "2026-05-29"),
+    ).toBe(true);
+  });
+});

--- a/backoffice/src/lib/gc-fitness/client-daily-timeline-actions.ts
+++ b/backoffice/src/lib/gc-fitness/client-daily-timeline-actions.ts
@@ -5,6 +5,7 @@ import { gcFitnessFirestore, gcFitnessStorage } from "@/lib/firebase/gc-fitness-
 import { getCurrentTrainer } from "./auth-helpers";
 import { FirestoreCollections } from "./collections";
 import { civilDateFormat } from "./civil-date";
+import { isHabitScheduledOn } from "./habit-schedule";
 import { getTrainerTimezone } from "./trainer-timezone";
 import { buildClientDailyTimelineDates } from "./client-daily-timeline-utils";
 import type { ProgressPhotoRow } from "./progress-photo-actions";
@@ -142,56 +143,10 @@ function isHabitActiveOnDate(
   habit: Record<string, unknown>,
   civilDate: string,
 ): boolean {
-  const startsOn =
-    typeof habit.startsOn === "string" && habit.startsOn.length > 0
-      ? habit.startsOn
-      : null;
-  const endsOn =
-    typeof habit.endsOn === "string" && habit.endsOn.length > 0
-      ? habit.endsOn
-      : null;
-
-  if (startsOn && civilDate < startsOn) {
-    return false;
-  }
-  if (endsOn && civilDate > endsOn) {
-    return false;
-  }
-
-  const scheduleType =
-    habit.scheduleType === "one-time" ? "one-time" : "recurring";
-  if (scheduleType === "one-time") {
-    return startsOn ? civilDate === startsOn : true;
-  }
-
-  const cadence =
-    habit.scheduleCadence === "weekly" ||
-    habit.scheduleCadence === "monthly"
-      ? habit.scheduleCadence
-      : "daily";
-  if (cadence === "daily") {
-    return true;
-  }
-  const date = new Date(`${civilDate}T12:00:00Z`);
-  if (Number.isNaN(date.getTime())) return false;
-  if (cadence === "weekly") {
-    const weekdays = Array.isArray(habit.scheduleWeekdays)
-      ? (habit.scheduleWeekdays as number[])
-      : [];
-    const weekday = date.getUTCDay() === 0 ? 7 : date.getUTCDay();
-    // Backward compatibility: older backoffice builds stored weekdays as
-    // Sun=1..Sat=7. Current canonical mapping is Mon=1..Sun=7.
-    // Accept both so pre-fix habits render on the correct days without
-    // forcing an immediate data migration.
-    const legacyWeekday = weekday === 7 ? 1 : weekday + 1;
-    return weekdays.includes(weekday) || weekdays.includes(legacyWeekday);
-  }
-  const monthDays = Array.isArray(habit.scheduleMonthDays)
-    ? (habit.scheduleMonthDays as number[])
-    : typeof habit.scheduleDayOfMonth === "number"
-      ? [habit.scheduleDayOfMonth]
-      : [1];
-  return monthDays.includes(date.getUTCDate());
+  // Soft-delete is handled by the `deleted == false` query filter in this
+  // module's habit loads, so this predicate (like iOS `isActive`) only answers
+  // "scheduled on this day?".
+  return isHabitScheduledOn(habit, civilDate);
 }
 
 function createEmptyDay(date: string): ClientDailyTimelineDay {

--- a/backoffice/src/lib/gc-fitness/coach-pulse-actions.ts
+++ b/backoffice/src/lib/gc-fitness/coach-pulse-actions.ts
@@ -6,6 +6,7 @@ import { getCurrentTrainer } from "./auth-helpers";
 import { civilDateFormat, civilDateToday } from "./civil-date";
 import { FirestoreCollections } from "./collections";
 import { listClients, type ClientRosterEntry } from "./client-roster";
+import { isHabitScheduledOn } from "./habit-schedule";
 import { getTrainerTimezone } from "./trainer-timezone";
 
 export interface DailyMetric {
@@ -62,49 +63,7 @@ function habitScheduledOn(
   civilDate: string,
 ): boolean {
   if (habit.deleted === true) return false;
-  if (
-    Array.isArray(habit.skippedDates) &&
-    (habit.skippedDates as unknown[]).includes(civilDate)
-  ) {
-    return false;
-  }
-  const startsOn =
-    typeof habit.startsOn === "string" && habit.startsOn.length > 0
-      ? habit.startsOn
-      : null;
-  const endsOn =
-    typeof habit.endsOn === "string" && habit.endsOn.length > 0
-      ? habit.endsOn
-      : null;
-  if (startsOn && civilDate < startsOn) return false;
-  if (endsOn && civilDate > endsOn) return false;
-
-  const scheduleType =
-    habit.scheduleType === "one-time" ? "one-time" : "recurring";
-  if (scheduleType === "one-time") {
-    return startsOn ? civilDate === startsOn : true;
-  }
-  const cadence =
-    habit.scheduleCadence === "weekly" || habit.scheduleCadence === "monthly"
-      ? habit.scheduleCadence
-      : "daily";
-  if (cadence === "daily") return true;
-  const date = new Date(`${civilDate}T12:00:00Z`);
-  if (Number.isNaN(date.getTime())) return false;
-  if (cadence === "weekly") {
-    const weekdays = Array.isArray(habit.scheduleWeekdays)
-      ? (habit.scheduleWeekdays as number[])
-      : [];
-    const weekday = date.getUTCDay() === 0 ? 7 : date.getUTCDay();
-    const legacyWeekday = weekday === 7 ? 1 : weekday + 1;
-    return weekdays.includes(weekday) || weekdays.includes(legacyWeekday);
-  }
-  const monthDays = Array.isArray(habit.scheduleMonthDays)
-    ? (habit.scheduleMonthDays as number[])
-    : typeof habit.scheduleDayOfMonth === "number"
-      ? [habit.scheduleDayOfMonth]
-      : [1];
-  return monthDays.includes(date.getUTCDate());
+  return isHabitScheduledOn(habit, civilDate);
 }
 
 function habitLogCountsAsCompleted(

--- a/backoffice/src/lib/gc-fitness/habit-schedule.ts
+++ b/backoffice/src/lib/gc-fitness/habit-schedule.ts
@@ -1,0 +1,139 @@
+/**
+ * Single source of truth (backoffice side) for "is this habit scheduled on
+ * this civil date?". Faithful TypeScript parity of the iOS
+ * `HabitSchedule.isActive(_:on:)` in
+ * `gc-fitness/iOS/Packages/GCFitnessCore/Sources/GCFitnessCore/HabitSchedule.swift`.
+ *
+ * Why this file exists
+ * --------------------
+ * The same scheduling predicate had drifted into FOUR hand-rolled copies
+ * (recent-logs, client-daily-timeline, coach-pulse, HabitTrendsWidget). Two of
+ * them disagreed with iOS and inflated the trainer-facing "X/Y habits done
+ * today" denominator vs. what the client sees in the app:
+ *
+ *   1. MISSING `skippedDates`. When a trainer removes a habit from a single day
+ *      ("quitar de este día"), iOS hides it for that day. recent-logs /
+ *      client-daily-timeline never checked `skippedDates`, so a skipped habit
+ *      still counted toward the denominator (client sees 4, trainer feed shows
+ *      "/5").
+ *   2. OVER-BROAD legacy weekday alias. The copies accepted BOTH the canonical
+ *      ISO weekday (Mon=1…Sun=7) AND an unconditional Sun=1…Sat=7 alias, which
+ *      matched a weekly habit on TWO adjacent real-world days. iOS only opts
+ *      into the legacy mapping when it can DISAMBIGUATE from `startsOn`.
+ *
+ * Both bugs are the "2/5 habits done today, but the client has 4 habits today"
+ * report. Centralizing here keeps the four call sites byte-identical to iOS.
+ *
+ * NOTE on `deleted`: iOS `isActive` does NOT consider soft-delete (that lives in
+ * `isVisibleForClientTimeline`). This helper matches `isActive` and likewise
+ * ignores `deleted`; callers keep their own soft-delete handling (some filter
+ * `deleted == false` in the Firestore query, some guard inline).
+ *
+ * Field semantics (mirror `.planning/schemas/habits.md`):
+ *   - `startsOn` / `endsOn`: inclusive civil-date window bounds ("YYYY-MM-DD").
+ *   - `skippedDates`: civil dates explicitly removed from the recurrence.
+ *   - `scheduleType`: "one-time" → only `startsOn`; otherwise "recurring".
+ *   - `scheduleCadence`: "daily" | "weekly" | "monthly".
+ *   - `scheduleWeekdays`: canonical ISO Mon=1 … Sun=7.
+ *   - `scheduleMonthDays` (preferred, multi-day) or legacy `scheduleDayOfMonth`.
+ */
+
+type HabitLike = Record<string, unknown>;
+
+function civilString(value: unknown): string | null {
+  return typeof value === "string" && value.length > 0 ? value : null;
+}
+
+/**
+ * Apple-style weekday (Sun=1 … Sat=7) for a civil date string, computed at noon
+ * UTC. A civil date maps to exactly one weekday regardless of timezone, so this
+ * matches iOS's tz-aware calendar component for the same "YYYY-MM-DD".
+ * Returns null when the civil date can't be parsed.
+ */
+function appleWeekday(civilDate: string): number | null {
+  const date = new Date(`${civilDate}T12:00:00Z`);
+  if (Number.isNaN(date.getTime())) return null;
+  return date.getUTCDay() + 1; // getUTCDay: Sun=0..Sat=6 → Sun=1..Sat=7
+}
+
+export function isHabitScheduledOn(
+  habit: HabitLike,
+  civilDate: string,
+): boolean {
+  const startsOn = civilString(habit.startsOn);
+  const endsOn = civilString(habit.endsOn);
+
+  if (startsOn && civilDate < startsOn) return false;
+  if (endsOn && civilDate > endsOn) return false;
+
+  // Trainer removed this specific day from the recurrence ("quitar de este
+  // día"). Takes precedence over the cadence below — mirrors iOS.
+  if (
+    Array.isArray(habit.skippedDates) &&
+    (habit.skippedDates as unknown[]).includes(civilDate)
+  ) {
+    return false;
+  }
+
+  const scheduleType =
+    habit.scheduleType === "one-time" ? "one-time" : "recurring";
+  if (scheduleType === "one-time") {
+    return startsOn ? civilDate === startsOn : true;
+  }
+
+  const cadence =
+    habit.scheduleCadence === "weekly" || habit.scheduleCadence === "monthly"
+      ? habit.scheduleCadence
+      : "daily";
+  if (cadence === "daily") return true;
+
+  const apple = appleWeekday(civilDate);
+  if (apple === null) return false;
+
+  if (cadence === "weekly") {
+    const weekdays = Array.isArray(habit.scheduleWeekdays)
+      ? (habit.scheduleWeekdays as number[])
+      : [];
+    if (weekdays.length === 0) return false;
+
+    const isoWeekday = apple === 1 ? 7 : apple - 1; // Mon=1..Sun=7
+    const legacySundayFirstWeekday = apple; // Sun=1..Sat=7
+    const zeroBasedSunday = apple - 1; // Sun=0..Sat=6
+
+    const isoMatch = weekdays.includes(isoWeekday);
+
+    // Legacy Sun=1..Sat=7 support: only opt in when `startsOn` lets us
+    // DISAMBIGUATE the stored convention (iOS parity). Without that guard the
+    // old code matched two adjacent weekdays and over-counted.
+    const shouldUseLegacySundayFirst = (() => {
+      if (!startsOn) return false;
+      const startsApple = appleWeekday(startsOn);
+      if (startsApple === null) return false;
+      const startsIso = startsApple === 1 ? 7 : startsApple - 1;
+      const matchesIso = weekdays.includes(startsIso);
+      const matchesLegacy = weekdays.includes(startsApple);
+      // Ambiguous (or both false): keep canonical ISO.
+      if (matchesIso === matchesLegacy) return false;
+      return matchesLegacy;
+    })();
+
+    if (shouldUseLegacySundayFirst) {
+      return weekdays.includes(legacySundayFirstWeekday);
+    }
+
+    // Zero-based Sunday fallback for stray docs (iOS parity).
+    if (!isoMatch && weekdays.includes(zeroBasedSunday)) {
+      return true;
+    }
+    return isoMatch;
+  }
+
+  // monthly
+  const monthDays = Array.isArray(habit.scheduleMonthDays)
+    ? (habit.scheduleMonthDays as number[])
+    : typeof habit.scheduleDayOfMonth === "number"
+      ? [habit.scheduleDayOfMonth]
+      : [1];
+  const dayOfMonth = new Date(`${civilDate}T12:00:00Z`).getUTCDate();
+  return monthDays.includes(dayOfMonth);
+}

--- a/backoffice/src/lib/gc-fitness/recent-logs-actions.ts
+++ b/backoffice/src/lib/gc-fitness/recent-logs-actions.ts
@@ -6,6 +6,7 @@ import { getCurrentTrainer } from "./auth-helpers";
 import { civilDateFormat, civilDateToday } from "./civil-date";
 import { FirestoreCollections } from "./collections";
 import { listClients } from "./client-roster";
+import { isHabitScheduledOn } from "./habit-schedule";
 import { getTrainerTimezone } from "./trainer-timezone";
 
 export type RecentLogCategory =
@@ -223,43 +224,7 @@ function habitScheduledOn(
   civilDate: string,
 ): boolean {
   if (habit.deleted === true) return false;
-  const startsOn =
-    typeof habit.startsOn === "string" && habit.startsOn.length > 0
-      ? habit.startsOn
-      : null;
-  const endsOn =
-    typeof habit.endsOn === "string" && habit.endsOn.length > 0
-      ? habit.endsOn
-      : null;
-  if (startsOn && civilDate < startsOn) return false;
-  if (endsOn && civilDate > endsOn) return false;
-
-  const scheduleType =
-    habit.scheduleType === "one-time" ? "one-time" : "recurring";
-  if (scheduleType === "one-time") {
-    return startsOn ? civilDate === startsOn : true;
-  }
-  const cadence =
-    habit.scheduleCadence === "weekly" || habit.scheduleCadence === "monthly"
-      ? habit.scheduleCadence
-      : "daily";
-  if (cadence === "daily") return true;
-  const date = new Date(`${civilDate}T12:00:00Z`);
-  if (Number.isNaN(date.getTime())) return false;
-  if (cadence === "weekly") {
-    const weekdays = Array.isArray(habit.scheduleWeekdays)
-      ? (habit.scheduleWeekdays as number[])
-      : [];
-    const weekday = date.getUTCDay() === 0 ? 7 : date.getUTCDay();
-    const legacyWeekday = weekday === 7 ? 1 : weekday + 1;
-    return weekdays.includes(weekday) || weekdays.includes(legacyWeekday);
-  }
-  const monthDays = Array.isArray(habit.scheduleMonthDays)
-    ? (habit.scheduleMonthDays as number[])
-    : typeof habit.scheduleDayOfMonth === "number"
-      ? [habit.scheduleDayOfMonth]
-      : [1];
-  return monthDays.includes(date.getUTCDate());
+  return isHabitScheduledOn(habit, civilDate);
 }
 
 /**


### PR DESCRIPTION
## Problem
The trainer activity feed showed e.g. **"2/5 habits done today"** for a client who only has **4 habits scheduled today** (screenshot report).

## Root cause
The "habits scheduled today" denominator had drifted into **four** hand-rolled copies of the iOS schedule predicate (`recent-logs-actions`, `client-daily-timeline-actions`, `coach-pulse-actions`, `HabitTrendsWidget`). Two disagreed with the iOS source of truth `GCFitnessCore/HabitSchedule.isActive` and over-counted:

1. **Missing `skippedDates`.** When a trainer removes a habit from a single day ("quitar de este día"), iOS hides it — but `recent-logs` / `client-daily-timeline` still counted it.
2. **Over-broad legacy weekday alias.** They accepted the canonical ISO weekday (Mon=1…Sun=7) **OR** an unconditional Sun=1…Sat=7 alias, matching a weekly habit on two adjacent real-world days. iOS only opts into the legacy mapping when `startsOn` disambiguates it.

## Fix
Extract one faithful TS port → `lib/gc-fitness/habit-schedule.ts` (`isHabitScheduledOn`) incl. `skippedDates`, the **disambiguated** legacy weekday, and the zero-based-Sunday fallback. All four call sites delegate to it, each keeping its own soft-delete handling.

## Tests / gates
- New `habit-schedule.test.ts`: over-count cases (Saturday-habit-not-on-Friday, Monday-alias-not-on-Sunday), guarded legacy path, `skippedDates`, daily/one-time/window/monthly.
- Backoffice gates green: **jest 29 suites / 291 tests**, `tsc --noEmit`, `next lint`.

## Notes
- Client-side display logic only — no `firestore.rules` change.
- Per the new team branch/PR policy: **not self-merging**; needs a teammate review.