### PR TITLE
feat(recent-logs): per-client recent activity + admin god-mode client view

### DIFF
--- a/backoffice/messages/en.json
+++ b/backoffice/messages/en.json
@@ -153,7 +153,8 @@
         "workoutTrends": "Workouts",
         "habitTrends": "Habits",
         "recentMessages": "Recent messages",
-        "bodyWeight": "Body weight (30 days)"
+        "bodyWeight": "Body weight (30 days)",
+        "recentLogs": "Recent activity"
       },
       "timeline": {
         "title": "Daily client view",
@@ -309,6 +310,13 @@
         "showPastWorkouts": "Show past workouts ({count})",
         "workoutStreakLabel": "{count} in a row",
         "workoutStreakTooltip": "{count} workouts completed in a row, no miss."
+      },
+      "recentLogs": {
+        "title": "Recent activity",
+        "empty": "No recent activity.",
+        "pageOf": "Page {current} of {total}",
+        "previous": "Previous",
+        "next": "Next"
       }
     }
   },

--- a/backoffice/messages/es.json
+++ b/backoffice/messages/es.json
@@ -153,7 +153,8 @@
         "workoutTrends": "Workouts",
         "habitTrends": "Hábitos",
         "recentMessages": "Mensajes recientes",
-        "bodyWeight": "Peso corporal (30 días)"
+        "bodyWeight": "Peso corporal (30 días)",
+        "recentLogs": "Actividad reciente"
       },
       "timeline": {
         "title": "Vista diaria del cliente",
@@ -309,6 +310,13 @@
         "showPastWorkouts": "Ver workouts pasados ({count})",
         "workoutStreakLabel": "{count} seguidos",
         "workoutStreakTooltip": "{count} entrenamientos completados sin faltar."
+      },
+      "recentLogs": {
+        "title": "Actividad reciente",
+        "empty": "Sin actividad reciente.",
+        "pageOf": "Página {current} de {total}",
+        "previous": "Anterior",
+        "next": "Siguiente"
       }
     }
   },

--- a/backoffice/src/app/gc-fitness/admin/coaches/[uid]/clients/[clientId]/page.tsx
+++ b/backoffice/src/app/gc-fitness/admin/coaches/[uid]/clients/[clientId]/page.tsx
@@ -1,0 +1,109 @@
+// /gc-fitness/admin/coaches/[uid]/clients/[clientId]/page.tsx
+//
+// Admin god-mode (READ-ONLY) drill-down into a specific client of a specific
+// coach. Surfaces the client's recent activity (paginated, 10/page) and
+// progress photos so an admin can see "everything that's happening" without
+// owning the client.
+//
+// Authorization: admin-gated at the page AND inside each action
+// (listRecentLogsForClientAsAdmin / listProgressPhotosForClientAsAdmin), which
+// also verify the client actually belongs to {uid} so the URL can't be edited
+// to read across coaches.
+
+import Link from "next/link";
+import { notFound, redirect } from "next/navigation";
+
+import { getCurrentAdmin } from "@/lib/gc-fitness/auth-helpers";
+import { listRecentLogsForClientAsAdmin } from "@/lib/gc-fitness/recent-logs-actions";
+import { listProgressPhotosForClientAsAdmin } from "@/lib/gc-fitness/progress-photo-actions";
+import { Badge } from "@/components/ui/badge";
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+
+import { ClientRecentLogsFeed } from "@/app/gc-fitness/clients/[id]/_components/ClientRecentLogsFeed";
+import { ProgressPhotosGridClient } from "@/app/gc-fitness/clients/[id]/_components/ProgressPhotosGridClient";
+
+export const dynamic = "force-dynamic";
+
+export default async function AdminCoachClientPage({
+  params,
+}: {
+  params: Promise<{ uid: string; clientId: string }>;
+}) {
+  const { uid, clientId } = await params;
+
+  try {
+    await getCurrentAdmin();
+  } catch (err) {
+    const message = err instanceof Error ? err.message : "Forbidden";
+    if (message === "Forbidden") {
+      redirect("/gc-fitness/forbidden");
+    }
+    throw err;
+  }
+
+  let logs: Awaited<ReturnType<typeof listRecentLogsForClientAsAdmin>>;
+  let photos: Awaited<ReturnType<typeof listProgressPhotosForClientAsAdmin>>;
+  try {
+    [logs, photos] = await Promise.all([
+      listRecentLogsForClientAsAdmin(uid, clientId),
+      listProgressPhotosForClientAsAdmin(uid, clientId),
+    ]);
+  } catch {
+    // Client doesn't exist or doesn't belong to this coach.
+    notFound();
+  }
+
+  const clientName = logs.clients[0]?.name ?? clientId;
+
+  return (
+    <div className="mx-auto flex w-full max-w-5xl flex-col gap-6 px-4 py-8">
+      <div>
+        <Link
+          href={`/gc-fitness/admin/coaches/${uid}`}
+          className="text-sm text-muted-foreground hover:underline"
+        >
+          ← Back to coach
+        </Link>
+      </div>
+
+      <header className="flex flex-col gap-1">
+        <div className="flex items-center gap-2">
+          <h1 className="text-2xl font-semibold">{clientName}</h1>
+          <Badge variant="secondary">Read-only</Badge>
+        </div>
+        <p className="text-xs text-muted-foreground">Client UID: {clientId}</p>
+      </header>
+
+      <Card>
+        <CardHeader className="pb-3">
+          <CardTitle className="text-lg">Recent activity</CardTitle>
+        </CardHeader>
+        <CardContent>
+          {/* showActions=false — admin is read-only and the chat / workout-detail
+              targets are trainer-scoped (would 403 for an admin). */}
+          <ClientRecentLogsFeed logs={logs.logs} showActions={false} />
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader className="pb-3">
+          <CardTitle className="text-lg">Progress photos</CardTitle>
+        </CardHeader>
+        <CardContent>
+          {photos.length > 0 ? (
+            <ProgressPhotosGridClient photos={photos} />
+          ) : (
+            <p className="text-sm text-muted-foreground">
+              No progress photos yet.
+            </p>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/backoffice/src/app/gc-fitness/admin/coaches/[uid]/page.tsx
+++ b/backoffice/src/app/gc-fitness/admin/coaches/[uid]/page.tsx
@@ -148,7 +148,14 @@ export default async function CoachAdminDetailPage({
                   detail.linkedClients.map((client) => (
                     <TableRow key={client.uid}>
                       <TableCell>
-                        <div className="font-medium">{client.displayName || "—"}</div>
+                        <div className="font-medium">
+                          <Link
+                            href={`/gc-fitness/admin/coaches/${detail.coach.uid}/clients/${client.uid}`}
+                            className="text-primary hover:underline"
+                          >
+                            {client.displayName || "—"}
+                          </Link>
+                        </div>
                         <div className="text-xs text-muted-foreground">{client.email}</div>
                       </TableCell>
                       <TableCell className="font-mono text-xs">{client.uid}</TableCell>

--- a/backoffice/src/app/gc-fitness/clients/[id]/_components/ClientRecentLogsFeed.tsx
+++ b/backoffice/src/app/gc-fitness/clients/[id]/_components/ClientRecentLogsFeed.tsx
@@ -1,0 +1,237 @@
+"use client";
+
+import type { ComponentType } from "react";
+import Link from "next/link";
+import { useMemo, useState } from "react";
+import {
+  ArrowRightLeft,
+  CalendarClock,
+  Camera,
+  Dumbbell,
+  Eye,
+  Gauge,
+  ListChecks,
+  MessageCircle,
+  Scale,
+  StickyNote,
+  User,
+} from "lucide-react";
+import { useTranslations } from "next-intl";
+
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import type { RecentLogRow } from "@/lib/gc-fitness/recent-logs-actions";
+
+const PAGE_SIZE = 10;
+
+const CATEGORY_ICON: Record<
+  RecentLogRow["category"],
+  ComponentType<{ className?: string }>
+> = {
+  habit: ListChecks,
+  workout: Dumbbell,
+  reschedule: ArrowRightLeft,
+  photo: Camera,
+  weight: Scale,
+  signup: User,
+};
+
+const CATEGORY_LABEL_KEY: Record<RecentLogRow["category"], string> = {
+  habit: "badgeHabit",
+  workout: "badgeWorkout",
+  reschedule: "badgeReschedule",
+  photo: "badgePhoto",
+  weight: "badgeWeight",
+  signup: "badgeSignup",
+};
+
+const CATEGORY_TONE: Record<RecentLogRow["category"], string> = {
+  workout:
+    "border-violet-200 bg-violet-50 text-violet-700 dark:border-violet-900 dark:bg-violet-950/40 dark:text-violet-300",
+  habit:
+    "border-emerald-200 bg-emerald-50 text-emerald-700 dark:border-emerald-900 dark:bg-emerald-950/40 dark:text-emerald-300",
+  reschedule:
+    "border-amber-200 bg-amber-50 text-amber-700 dark:border-amber-900 dark:bg-amber-950/40 dark:text-amber-300",
+  photo:
+    "border-pink-200 bg-pink-50 text-pink-700 dark:border-pink-900 dark:bg-pink-950/40 dark:text-pink-300",
+  weight:
+    "border-orange-200 bg-orange-50 text-orange-700 dark:border-orange-900 dark:bg-orange-950/40 dark:text-orange-300",
+  signup:
+    "border-sky-200 bg-sky-50 text-sky-700 dark:border-sky-900 dark:bg-sky-950/40 dark:text-sky-300",
+};
+
+interface Props {
+  logs: RecentLogRow[];
+  /**
+   * When true, render the per-row chat + view-workout action buttons. The admin
+   * god-mode surface is read-only and those targets are trainer-scoped (would
+   * 403 for an admin), so admin passes `false`.
+   */
+  showActions?: boolean;
+}
+
+/**
+ * Paginated (10 per page) recent-activity list for a SINGLE client. Shared by
+ * the trainer client-profile section and the admin god-mode client view. The
+ * incoming `logs` are already sorted newest-first by the server action.
+ */
+export function ClientRecentLogsFeed({ logs, showActions = true }: Props) {
+  const t = useTranslations("clients.detail.recentLogs");
+  const tf = useTranslations("recentLogs.feed");
+  const [page, setPage] = useState(0);
+
+  const pageCount = Math.max(1, Math.ceil(logs.length / PAGE_SIZE));
+  const safePage = Math.min(page, pageCount - 1);
+  const pageRows = useMemo(
+    () => logs.slice(safePage * PAGE_SIZE, safePage * PAGE_SIZE + PAGE_SIZE),
+    [logs, safePage],
+  );
+
+  if (logs.length === 0) {
+    return (
+      <p className="py-6 text-center text-sm text-muted-foreground">
+        {t("empty")}
+      </p>
+    );
+  }
+
+  return (
+    <div className="flex flex-col gap-3">
+      <div className="flex flex-col gap-2">
+        {pageRows.map((row) => {
+          const CatIcon = CATEGORY_ICON[row.category];
+          return (
+            <div
+              key={row.id}
+              className="flex items-center gap-3 rounded-lg border bg-card px-3 py-2.5"
+            >
+              <div className="min-w-0 flex-1">
+                <div className="flex flex-wrap items-center gap-2">
+                  <Badge
+                    variant="outline"
+                    className={`gap-1 px-1.5 py-0 text-[11px] font-normal [&>svg]:size-3 ${CATEGORY_TONE[row.category]}`}
+                  >
+                    {CatIcon ? <CatIcon /> : null}
+                    {tf(CATEGORY_LABEL_KEY[row.category])}
+                  </Badge>
+                  <span className="truncate text-sm font-medium">
+                    {row.title}
+                  </span>
+                  {row.forCivilDate ? (
+                    <Badge
+                      variant="outline"
+                      className="gap-1 border-amber-200 bg-amber-50 px-1.5 py-0 text-[10px] font-normal text-amber-700 [&>svg]:size-3 dark:border-amber-900 dark:bg-amber-950/40 dark:text-amber-300"
+                    >
+                      <CalendarClock />
+                      {tf("forDay", { date: formatCivilDate(row.forCivilDate) })}
+                    </Badge>
+                  ) : null}
+                  {row.workout?.rpe != null ? (
+                    <Badge
+                      variant="outline"
+                      className="gap-1 px-1.5 py-0 text-[10px] font-normal text-muted-foreground [&>svg]:size-3 [&>svg]:opacity-70"
+                    >
+                      <Gauge />
+                      RPE {row.workout.rpe}
+                    </Badge>
+                  ) : null}
+                  {row.workout?.hasNotes ? (
+                    <Badge
+                      variant="outline"
+                      className="gap-1 px-1.5 py-0 text-[10px] font-normal text-muted-foreground [&>svg]:size-3 [&>svg]:opacity-70"
+                    >
+                      <StickyNote />
+                      {tf("notesBadge")}
+                    </Badge>
+                  ) : null}
+                </div>
+                <p className="mt-0.5 truncate text-xs text-muted-foreground">
+                  {formatDateTime(row.eventAt)}
+                  {row.detail ? ` · ${row.detail}` : ""}
+                </p>
+              </div>
+              {showActions ? (
+                <div className="flex shrink-0 items-center gap-1">
+                  <Button
+                    asChild
+                    variant="ghost"
+                    size="icon"
+                    className="h-8 w-8 text-muted-foreground"
+                    title={tf("openChat")}
+                  >
+                    <Link href={`/gc-fitness/chat?chatId=${row.clientId}`}>
+                      <MessageCircle className="h-4 w-4" />
+                      <span className="sr-only">{tf("openChat")}</span>
+                    </Link>
+                  </Button>
+                  {row.workoutLogId ? (
+                    <Button
+                      asChild
+                      variant="outline"
+                      size="sm"
+                      className="h-8 gap-1.5 px-2.5"
+                    >
+                      <Link
+                        href={`/gc-fitness/recent-logs/workouts/${row.workoutLogId}`}
+                      >
+                        <Eye className="h-4 w-4" />
+                        {tf("viewWorkout")}
+                      </Link>
+                    </Button>
+                  ) : null}
+                </div>
+              ) : null}
+            </div>
+          );
+        })}
+      </div>
+
+      {pageCount > 1 ? (
+        <div className="flex items-center justify-between">
+          <p className="text-xs text-muted-foreground">
+            {t("pageOf", { current: safePage + 1, total: pageCount })}
+          </p>
+          <div className="flex gap-2">
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => setPage((p) => Math.max(0, p - 1))}
+              disabled={safePage === 0}
+            >
+              {t("previous")}
+            </Button>
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => setPage((p) => Math.min(pageCount - 1, p + 1))}
+              disabled={safePage >= pageCount - 1}
+            >
+              {t("next")}
+            </Button>
+          </div>
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+function formatDateTime(iso: string): string {
+  const date = new Date(iso);
+  if (Number.isNaN(date.getTime())) return iso;
+  return date.toLocaleString(undefined, {
+    month: "short",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+}
+
+// Render a "YYYY-MM-DD" civil date as a short day label. Construct from parts
+// (NOT `new Date(iso)`) so a negative-offset host doesn't shift the day back.
+function formatCivilDate(civil: string): string {
+  const [y, m, d] = civil.split("-").map((n) => Number.parseInt(n, 10));
+  if (!y || !m || !d) return civil;
+  const date = new Date(y, m - 1, d);
+  if (Number.isNaN(date.getTime())) return civil;
+  return date.toLocaleDateString(undefined, { month: "short", day: "numeric" });
+}

--- a/backoffice/src/app/gc-fitness/clients/[id]/_components/ClientRecentLogsWidget.tsx
+++ b/backoffice/src/app/gc-fitness/clients/[id]/_components/ClientRecentLogsWidget.tsx
@@ -1,0 +1,36 @@
+import { getTranslations } from "next-intl/server";
+
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { listRecentLogsForClient } from "@/lib/gc-fitness/recent-logs-actions";
+
+import { ClientRecentLogsFeed } from "./ClientRecentLogsFeed";
+
+/**
+ * Trainer-facing "Recent activity" section on the client profile. Async server
+ * component (own Suspense boundary on the page) — fetches the client-scoped feed
+ * and hands it to the paginated client component. Trainer ownership is enforced
+ * inside `listRecentLogsForClient`.
+ */
+export async function ClientRecentLogsWidget({
+  clientId,
+}: {
+  clientId: string;
+}) {
+  const t = await getTranslations("clients.detail.recentLogs");
+  const { logs } = await listRecentLogsForClient(clientId);
+  return (
+    <Card className="xl:col-span-2">
+      <CardHeader className="pb-3">
+        <CardTitle className="text-lg">{t("title")}</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <ClientRecentLogsFeed logs={logs} showActions />
+      </CardContent>
+    </Card>
+  );
+}

--- a/backoffice/src/lib/gc-fitness/progress-photo-actions.ts
+++ b/backoffice/src/lib/gc-fitness/progress-photo-actions.ts
@@ -2,7 +2,7 @@
 
 import { gcFitnessFirestore, gcFitnessStorage } from "@/lib/firebase/gc-fitness-admin";
 
-import { getCurrentTrainer } from "./auth-helpers";
+import { getCurrentAdmin, getCurrentTrainer } from "./auth-helpers";
 import { FirestoreCollections } from "./collections";
 
 export interface ProgressPhotoRow {
@@ -92,7 +92,30 @@ export async function listProgressPhotosForClient(
 ): Promise<ProgressPhotoRow[]> {
   const trainer = await getCurrentTrainer();
   await assertOwnsClient(trainer.uid, clientId);
+  return loadProgressPhotos(clientId);
+}
 
+/**
+ * Admin god-mode (read-only): a client's progress photos, verifying the client
+ * belongs to `coachId` (reusing `assertOwnsClient`, which checks
+ * `client.coachId === coachId`) so the route can't read across coaches.
+ */
+export async function listProgressPhotosForClientAsAdmin(
+  coachId: string,
+  clientId: string,
+): Promise<ProgressPhotoRow[]> {
+  await getCurrentAdmin();
+  await assertOwnsClient(coachId, clientId);
+  return loadProgressPhotos(clientId);
+}
+
+/**
+ * Core photo loader — query + signed-URL map + check-in-date sort, WITHOUT any
+ * authorization. Callers MUST gate first (trainer ownership or admin).
+ */
+async function loadProgressPhotos(
+  clientId: string,
+): Promise<ProgressPhotoRow[]> {
   // Sort dimension lives client-side, not server-side: we want photos
   // ordered by the client-picked check-in date, not by upload time. A
   // server-side `orderBy("checkInDate")` would silently drop legacy docs

--- a/backoffice/src/lib/gc-fitness/recent-logs-actions.ts
+++ b/backoffice/src/lib/gc-fitness/recent-logs-actions.ts
@@ -2,10 +2,10 @@
 
 import { gcFitnessFirestore } from "@/lib/firebase/gc-fitness-admin";
 
-import { getCurrentTrainer } from "./auth-helpers";
+import { getCurrentAdmin, getCurrentTrainer } from "./auth-helpers";
 import { civilDateFormat, civilDateToday } from "./civil-date";
 import { FirestoreCollections } from "./collections";
-import { listClients } from "./client-roster";
+import { listClients, type ClientRosterEntry } from "./client-roster";
 import { isHabitScheduledOn } from "./habit-schedule";
 import { getTrainerTimezone } from "./trainer-timezone";
 
@@ -261,20 +261,37 @@ function habitLogCountsAsCompleted(
   }
 }
 
-export async function listRecentLogsForTrainer(): Promise<{
+/**
+ * Shared core for the recent-activity feed. Builds the row set for a given
+ * trainer id and an EXPLICIT client roster subset — both passed in (not
+ * resolved from the session) so the same logic serves three callers:
+ *   - listRecentLogsForTrainer()       → full roster, trainer session
+ *   - listRecentLogsForClient(id)      → single client, trainer session
+ *   - listRecentLogsForClientAsAdmin() → single client, admin god-mode
+ *
+ * Scoping to a single client needs NO query change: every row builder below
+ * filters by `nameByClientId.has(clientId)`, and the per-client fan-outs
+ * iterate `params.clients` — so a one-element roster yields exactly that
+ * client's activity. `trainerId` scopes the trainer-wide workout-log /
+ * assignment / signup queries (for god-mode it is the coach's uid).
+ */
+async function buildRecentLogs(params: {
+  trainerId: string;
+  clients: ClientRosterEntry[];
+  timezone: string;
+}): Promise<{
   logs: RecentLogRow[];
   clients: Array<{ id: string; name: string }>;
 }> {
-  const trainer = await getCurrentTrainer();
   const db = gcFitnessFirestore();
 
-  const clients = await listClients();
+  const clients = params.clients;
   const nameByClientId = new Map(clients.map((c) => [c.uid, c.displayName]));
   const clientList = clients.map((c) => ({ id: c.uid, name: c.displayName }));
 
   const workoutLogsPromise = db
     .collection(FirestoreCollections.workoutLogs)
-    .where("trainerId", "==", trainer.uid)
+    .where("trainerId", "==", params.trainerId)
     .limit(600)
     .get();
   // Trainer-scoped assignments — used to surface the "client moved
@@ -283,12 +300,12 @@ export async function listRecentLogsForTrainer(): Promise<{
   // the docs that carry originallyScheduledFor (always a small subset).
   const trainerAssignmentsPromise = db
     .collection(FirestoreCollections.workoutAssignments)
-    .where("trainerId", "==", trainer.uid)
+    .where("trainerId", "==", params.trainerId)
     .limit(600)
     .get();
   const usersSnapPromise = db
     .collection(FirestoreCollections.users)
-    .where("coachId", "==", trainer.uid)
+    .where("coachId", "==", params.trainerId)
     .where("role", "==", "client")
     .limit(400)
     .get();
@@ -307,7 +324,7 @@ export async function listRecentLogsForTrainer(): Promise<{
   // `habit_logs (clientId, civilDate)` index. `limit(200)` stays as a
   // backstop so behaviour never exceeds the prior worst case.
   const recentHabitWindowStartCivil = civilDateToday(
-    await getTrainerTimezone(),
+    params.timezone,
     new Date(Date.now() - 60 * 24 * 60 * 60 * 1000),
   );
   const habitLogPromises = clients.map((client) =>
@@ -455,7 +472,7 @@ export async function listRecentLogsForTrainer(): Promise<{
   // un-mark — because the un-mark only flipped one of the docs. Picking
   // the latest write (`updatedAt` if present, else `createdAt`) is the
   // canonical "what the user last said about this habit on this day".
-  const trainerTz = await getTrainerTimezone();
+  const trainerTz = params.timezone;
   const todayCivil = civilDateToday(trainerTz);
 
   function logTimestampMs(doc: FirebaseFirestore.QueryDocumentSnapshot): number {
@@ -804,7 +821,7 @@ export async function listRecentLogsForTrainer(): Promise<{
   const photoBuckets = new Map<string, PhotoBucket>();
   // Resolved once before the (sync) forEach — getTrainerTimezone() is async
   // and cannot be awaited inside the callback.
-  const photoTrainerTz = await getTrainerTimezone();
+  const photoTrainerTz = params.timezone;
   photoSnaps.forEach((snap, idx) => {
     if (!snap) return;
     const client = clients[idx];
@@ -918,6 +935,95 @@ export async function listRecentLogsForTrainer(): Promise<{
     logs: visibleRows,
     clients: clientList,
   };
+}
+
+/**
+ * Build a single-client roster entry from the canonical /users doc. Returns
+ * null when the doc is missing. `coachId` is returned alongside so callers can
+ * authorize (trainer ownership / admin coach-match) without a second read.
+ */
+async function loadClientRosterEntry(
+  clientId: string,
+): Promise<{ entry: ClientRosterEntry; coachId: string | null } | null> {
+  const snap = await gcFitnessFirestore()
+    .collection(FirestoreCollections.users)
+    .doc(clientId)
+    .get();
+  if (!snap.exists) return null;
+  const data = snap.data() ?? {};
+  const coachId = typeof data.coachId === "string" ? data.coachId : null;
+  const email = typeof data.email === "string" ? data.email : "";
+  const displayName =
+    typeof data.displayName === "string" && data.displayName.trim().length > 0
+      ? data.displayName
+      : email || clientId;
+  return {
+    entry: {
+      uid: clientId,
+      email,
+      displayName,
+      timezone: typeof data.timezone === "string" ? data.timezone : null,
+      photoURL: typeof data.photoURL === "string" ? data.photoURL : null,
+      pendingProvisioning: false,
+    },
+    coachId,
+  };
+}
+
+/** Full-roster recent activity feed for the calling trainer (dashboard + feed). */
+export async function listRecentLogsForTrainer(): Promise<{
+  logs: RecentLogRow[];
+  clients: Array<{ id: string; name: string }>;
+}> {
+  const trainer = await getCurrentTrainer();
+  const [clients, timezone] = await Promise.all([
+    listClients(),
+    getTrainerTimezone(),
+  ]);
+  return buildRecentLogs({ trainerId: trainer.uid, clients, timezone });
+}
+
+/** Recent activity for ONE client, scoped to the calling trainer (ownership-gated). */
+export async function listRecentLogsForClient(clientId: string): Promise<{
+  logs: RecentLogRow[];
+  clients: Array<{ id: string; name: string }>;
+}> {
+  const trainer = await getCurrentTrainer();
+  const loaded = await loadClientRosterEntry(clientId);
+  if (!loaded || loaded.coachId !== trainer.uid) {
+    throw new Error("Forbidden");
+  }
+  const timezone = await getTrainerTimezone();
+  return buildRecentLogs({
+    trainerId: trainer.uid,
+    clients: [loaded.entry],
+    timezone,
+  });
+}
+
+/**
+ * Admin god-mode (read-only): recent activity for ONE client of a SPECIFIC
+ * coach. Verifies the client really belongs to `coachId` so the URL can't be
+ * edited to read a client outside the coach being inspected.
+ */
+export async function listRecentLogsForClientAsAdmin(
+  coachId: string,
+  clientId: string,
+): Promise<{
+  logs: RecentLogRow[];
+  clients: Array<{ id: string; name: string }>;
+}> {
+  await getCurrentAdmin();
+  const loaded = await loadClientRosterEntry(clientId);
+  if (!loaded || loaded.coachId !== coachId) {
+    throw new Error("Not found");
+  }
+  const timezone = await getTrainerTimezone();
+  return buildRecentLogs({
+    trainerId: coachId,
+    clients: [loaded.entry],
+    timezone,
+  });
 }
 
 export async function getWorkoutLogDetail(


### PR DESCRIPTION
Adds a paginated (10/page, Prev/Next) Recent activity section to the client profile, and a read-only admin god-mode route /gc-fitness/admin/coaches/[uid]/clients/[clientId] showing a coach's client recent activity + progress photos (linked from each linked-client row on the coach detail page). Refactors listRecentLogsForTrainer into a param-based buildRecentLogs core + wrappers; adds listRecentLogsForClient, listRecentLogsForClientAsAdmin, listProgressPhotosForClientAsAdmin. Gates green: tsc, next build, jest. No firestore.rules change. Not self-merging per team policy.