### PR TITLE
fix(clients): render recent-activity widget on the client profile

### DIFF
--- a/backoffice/messages/en.json
+++ b/backoffice/messages/en.json
@@ -224,7 +224,13 @@
         "notesForDate": "Notes for {date}",
         "noNotesForDay": "No notes for this day.",
         "previousNotes": "Previous notes",
-        "noPreviousNotes": "No previous notes."
+        "noPreviousNotes": "No previous notes.",
+        "edit": "Edit",
+        "delete": "Delete",
+        "save": "Save",
+        "cancel": "Cancel",
+        "deleting": "Deleting...",
+        "deleteConfirm": "Delete this note?"
       },
       "workoutTrends": {
         "title": "Workouts",

--- a/backoffice/messages/es.json
+++ b/backoffice/messages/es.json
@@ -224,7 +224,13 @@
         "notesForDate": "Notas para {date}",
         "noNotesForDay": "Sin notas para este día.",
         "previousNotes": "Notas previas",
-        "noPreviousNotes": "Sin notas previas."
+        "noPreviousNotes": "Sin notas previas.",
+        "edit": "Editar",
+        "delete": "Eliminar",
+        "save": "Guardar",
+        "cancel": "Cancelar",
+        "deleting": "Eliminando...",
+        "deleteConfirm": "¿Eliminar esta nota?"
       },
       "workoutTrends": {
         "title": "Workouts",

--- a/backoffice/src/app/gc-fitness/admin/coaches/[uid]/clients/[clientId]/page.tsx
+++ b/backoffice/src/app/gc-fitness/admin/coaches/[uid]/clients/[clientId]/page.tsx
@@ -85,8 +85,15 @@ export default async function AdminCoachClientPage({
         </CardHeader>
         <CardContent>
           {/* showActions=false — admin is read-only and the chat / workout-detail
-              targets are trainer-scoped (would 403 for an admin). */}
-          <ClientRecentLogsFeed logs={logs.logs} showActions={false} />
+              BUTTON targets are trainer-scoped (would 403 for an admin). Rows are
+              still clickable via linkMode="admin", which routes workout + photo to
+              the admin-gated nested detail routes. */}
+          <ClientRecentLogsFeed
+            logs={logs.logs}
+            showActions={false}
+            linkMode="admin"
+            coachUid={uid}
+          />
         </CardContent>
       </Card>
 

--- a/backoffice/src/app/gc-fitness/admin/coaches/[uid]/clients/[clientId]/photos/page.tsx
+++ b/backoffice/src/app/gc-fitness/admin/coaches/[uid]/clients/[clientId]/photos/page.tsx
@@ -1,0 +1,61 @@
+// Admin god-mode (READ-ONLY) progress-photo comparator for a coach's client.
+// Reuses the trainer ProgressPhotoCompareEditor. Admin-gated at the page AND
+// inside listProgressPhotosForClientAsAdmin, which verifies the client belongs
+// to {uid}.
+
+import Link from "next/link";
+import { notFound, redirect } from "next/navigation";
+import { ChevronLeft } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import { getCurrentAdmin } from "@/lib/gc-fitness/auth-helpers";
+import { listProgressPhotosForClientAsAdmin } from "@/lib/gc-fitness/progress-photo-actions";
+import { ProgressPhotoCompareEditor } from "@/app/gc-fitness/clients/[id]/compare-photos/photo-compare-editor";
+
+export const dynamic = "force-dynamic";
+
+export default async function AdminClientPhotosPage({
+  params,
+}: {
+  params: Promise<{ uid: string; clientId: string }>;
+}) {
+  const { uid, clientId } = await params;
+
+  try {
+    await getCurrentAdmin();
+  } catch (err) {
+    const message = err instanceof Error ? err.message : "Forbidden";
+    if (message === "Forbidden") redirect("/gc-fitness/forbidden");
+    throw err;
+  }
+
+  let photos: Awaited<ReturnType<typeof listProgressPhotosForClientAsAdmin>>;
+  try {
+    photos = await listProgressPhotosForClientAsAdmin(uid, clientId);
+  } catch {
+    notFound();
+  }
+
+  return (
+    <div className="mx-auto flex w-full max-w-[1800px] flex-col gap-4 px-4 py-6 sm:px-6">
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-2">
+          <h1 className="text-2xl font-semibold">Progress photos</h1>
+          <Badge variant="secondary">Read-only</Badge>
+        </div>
+        <Button asChild variant="outline" size="sm" className="gap-1">
+          <Link href={`/gc-fitness/admin/coaches/${uid}/clients/${clientId}`}>
+            <ChevronLeft className="h-4 w-4" />
+            Back to client
+          </Link>
+        </Button>
+      </div>
+      {photos.length > 0 ? (
+        <ProgressPhotoCompareEditor photos={photos} />
+      ) : (
+        <p className="text-sm text-muted-foreground">No progress photos yet.</p>
+      )}
+    </div>
+  );
+}

--- a/backoffice/src/app/gc-fitness/admin/coaches/[uid]/clients/[clientId]/workouts/[logId]/page.tsx
+++ b/backoffice/src/app/gc-fitness/admin/coaches/[uid]/clients/[clientId]/workouts/[logId]/page.tsx
@@ -1,0 +1,56 @@
+// Admin god-mode (READ-ONLY) workout-log detail for a coach's client.
+// Reuses the shared WorkoutLogDetailView. Admin-gated at the page AND inside
+// getWorkoutLogDetailAsAdmin, which verifies the log belongs to {uid}.
+
+import Link from "next/link";
+import { notFound, redirect } from "next/navigation";
+import { ChevronLeft } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import { getCurrentAdmin } from "@/lib/gc-fitness/auth-helpers";
+import { getWorkoutLogDetailAsAdmin } from "@/lib/gc-fitness/recent-logs-actions";
+import { WorkoutLogDetailView } from "@/components/gc-fitness/workout-log-detail-view";
+
+export const dynamic = "force-dynamic";
+
+export default async function AdminWorkoutLogDetailPage({
+  params,
+}: {
+  params: Promise<{ uid: string; clientId: string; logId: string }>;
+}) {
+  const { uid, clientId, logId } = await params;
+
+  try {
+    await getCurrentAdmin();
+  } catch (err) {
+    const message = err instanceof Error ? err.message : "Forbidden";
+    if (message === "Forbidden") redirect("/gc-fitness/forbidden");
+    throw err;
+  }
+
+  try {
+    const detail = await getWorkoutLogDetailAsAdmin(uid, logId);
+    return (
+      <div className="mx-auto flex w-full max-w-6xl flex-col gap-6 px-6 py-8">
+        <div className="flex flex-wrap items-center justify-between gap-3">
+          <Button asChild variant="outline" size="sm" className="gap-1">
+            <Link href={`/gc-fitness/admin/coaches/${uid}/clients/${clientId}`}>
+              <ChevronLeft className="h-4 w-4" />
+              Back to client
+            </Link>
+          </Button>
+          <Badge variant="secondary">Read-only</Badge>
+        </div>
+
+        <WorkoutLogDetailView detail={detail} />
+      </div>
+    );
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Unknown";
+    if (message === "Workout log not found." || message === "Forbidden") {
+      notFound();
+    }
+    throw error;
+  }
+}

--- a/backoffice/src/app/gc-fitness/clients/[id]/_components/ClientNotesCard.tsx
+++ b/backoffice/src/app/gc-fitness/clients/[id]/_components/ClientNotesCard.tsx
@@ -1,31 +1,39 @@
 "use client";
 
 import { useState, useTransition } from "react";
-import { StickyNote, CalendarDays, Plus } from "lucide-react";
 import { useTranslations } from "next-intl";
+import { Pencil, Trash2 } from "lucide-react";
 
 import { Button } from "@/components/ui/button";
 import { Textarea } from "@/components/ui/textarea";
-import { updateClientNotes } from "@/lib/gc-fitness/client-notes-actions";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+
+import {
+  deleteClientNote,
+  editClientNote,
+  updateClientNotes,
+} from "@/lib/gc-fitness/client-notes-actions";
+
+interface ClientNoteEntryView {
+  date: string;
+  notes: string;
+  createdAt: string | null;
+}
+
+interface Props {
+  clientId: string;
+  initialNotes: string;
+  initialUpdatedAt: string | null;
+  initialEntries: ClientNoteEntryView[];
+}
 
 export function ClientNotesCard({
   clientId,
   initialNotes,
   initialUpdatedAt,
   initialEntries,
-}: {
-  clientId: string;
-  initialNotes: string;
-  initialUpdatedAt: string | null;
-  initialEntries: Array<{ date: string; notes: string; createdAt: string | null }>;
-}) {
+}: Props) {
   const t = useTranslations("clients.detail.notes");
-  const tCommon = useTranslations("common");
-  // The textarea is always a blank composer for a NEW note — the last
-  // saved note already lives in `entries[]` (rendered below). Pre-filling
-  // from `initialNotes` re-surfaced the just-saved text after a reload
-  // and tricked the trainer into double-submitting (260528 bug).
-  void initialNotes;
   const [notes, setNotes] = useState("");
   const [updatedAt, setUpdatedAt] = useState(initialUpdatedAt);
   const [noteDate, setNoteDate] = useState(new Date().toISOString().slice(0, 10));
@@ -33,123 +41,328 @@ export function ClientNotesCard({
   const [isPending, startTransition] = useTransition();
   const [entries, setEntries] = useState(initialEntries);
 
-  const notesForSelectedDay = entries.filter((entry) => entry.date === noteDate);
-  const recentEntries = [...entries]
+  void initialNotes;
+  void updatedAt;
+
+  const entriesForDate = entries
+    .filter((entry) => entry.date === noteDate)
+    .sort((a, b) => (b.createdAt ?? "").localeCompare(a.createdAt ?? ""));
+
+  const recentEntries = entries
     .filter((entry) => entry.date <= noteDate)
-    .sort((a, b) => {
-      const aTime = a.createdAt ? new Date(a.createdAt).getTime() : 0;
-      const bTime = b.createdAt ? new Date(b.createdAt).getTime() : 0;
-      return bTime - aTime;
-    })
+    .sort((a, b) => (b.createdAt ?? "").localeCompare(a.createdAt ?? ""))
     .slice(0, 8);
 
+  // Match an entry by its (createdAt, date) identity — entries have no id.
+  function sameEntry(a: ClientNoteEntryView, b: ClientNoteEntryView): boolean {
+    return a.createdAt === b.createdAt && a.date === b.date;
+  }
+
+  function handleEdited(target: ClientNoteEntryView, newText: string) {
+    setEntries((current) =>
+      current.map((e) =>
+        sameEntry(e, target) ? { ...e, notes: newText } : e,
+      ),
+    );
+  }
+
+  function handleDeleted(target: ClientNoteEntryView) {
+    setEntries((current) => current.filter((e) => !sameEntry(e, target)));
+  }
+
   return (
-    <section className="rounded-md border bg-card p-4">
-      <div className="mb-3 flex items-start justify-between gap-3">
-        <div>
-          <h2 className="flex items-center gap-2 font-medium">
-            <StickyNote className="size-4" />
-            {t("title")}
-          </h2>
-          <p className="text-sm text-muted-foreground">{t("subtitle")}</p>
+    <Card>
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2">
+          <span aria-hidden>📝</span>
+          {t("title")}
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <div className="flex items-center gap-2 text-sm text-muted-foreground">
+          <label htmlFor="note-date">{t("dateLabel")}</label>
+          <input
+            id="note-date"
+            type="date"
+            value={noteDate}
+            onChange={(e) => setNoteDate(e.target.value)}
+            className="rounded-md border bg-background px-2 py-1"
+          />
         </div>
-        {updatedAt ? (
-          <p className="text-xs text-muted-foreground">
-            {t("savedAt", { datetime: new Date(updatedAt).toLocaleString() })}
-          </p>
-        ) : null}
-      </div>
 
-      <div className="mb-3 flex flex-wrap items-center gap-2">
-        <CalendarDays className="size-4 text-muted-foreground" />
-        <input
-          type="date"
-          value={noteDate}
-          onChange={(event) => setNoteDate(event.target.value)}
-          className="rounded-md border bg-background px-3 py-2 text-sm"
-        />
-      </div>
+        <div className="space-y-2">
+          <Textarea
+            value={notes}
+            onChange={(e) => setNotes(e.target.value)}
+            placeholder={t("placeholder")}
+            rows={5}
+            maxLength={10000}
+          />
+          <div className="flex items-center justify-between">
+            <span className="text-xs text-muted-foreground">
+              {notes.length}/10000
+            </span>
+            <Button
+              disabled={isPending || notes.trim().length === 0}
+              onClick={() => {
+                setError(null);
+                const text = notes;
+                const date = noteDate;
+                setNotes("");
+                startTransition(async () => {
+                  try {
+                    const result = await updateClientNotes({
+                      clientId,
+                      notes: text,
+                      date,
+                    });
+                    setUpdatedAt(result.updatedAt);
+                    setEntries((current) => [
+                      ...current,
+                      {
+                        date,
+                        notes: text,
+                        createdAt: new Date().toISOString(),
+                      },
+                    ]);
+                  } catch (err) {
+                    setError(err instanceof Error ? err.message : t("saveFailed"));
+                    setNotes(text);
+                  }
+                });
+              }}
+            >
+              {isPending ? t("saving") : t("addNote")}
+            </Button>
+          </div>
+          {error ? <p className="text-sm text-destructive">{error}</p> : null}
+        </div>
 
-      <Textarea
-        value={notes}
-        onChange={(event) => setNotes(event.target.value)}
-        placeholder={t("placeholder")}
-        className="min-h-32 resize-y"
-        maxLength={10000}
-      />
+        <div className="space-y-2">
+          <h3 className="text-sm font-semibold text-muted-foreground">
+            {t("entriesForDate", { date: noteDate })}
+          </h3>
+          {entriesForDate.length === 0 ? (
+            <p className="text-sm text-muted-foreground">{t("noEntries")}</p>
+          ) : (
+            <ul className="space-y-2">
+              {entriesForDate.map((entry, index) => (
+                <EntryItem
+                  key={`${entry.date}-${entry.createdAt ?? index}`}
+                  clientId={clientId}
+                  entry={entry}
+                  variant="forDate"
+                  onEdited={handleEdited}
+                  onDeleted={handleDeleted}
+                />
+              ))}
+            </ul>
+          )}
+        </div>
 
-      <div className="mt-3 flex items-center justify-between gap-3">
-        <p className="text-xs text-muted-foreground">
-          {t("characterCount", { count: notes.length })}
-        </p>
-        <Button
-          type="button"
-          disabled={isPending || notes.trim().length === 0}
-          onClick={() => {
-            setError(null);
-            const text = notes;
-            const date = noteDate;
-            setNotes("");
-            startTransition(async () => {
-              try {
-                const result = await updateClientNotes({ clientId, notes: text, date });
-                setUpdatedAt(result.updatedAt);
-                setEntries((current) => [
-                  ...current,
-                  { date, notes: text, createdAt: new Date().toISOString() },
-                ]);
-              } catch (err) {
-                setError(err instanceof Error ? err.message : t("saveFailed"));
-                setNotes(text);
-              }
-            });
-          }}
-        >
-          {isPending ? tCommon("saving") : t("addCta")}
-        </Button>
-      </div>
-      {error ? <p className="mt-2 text-sm text-destructive">{error}</p> : null}
+        <div className="space-y-2">
+          <h3 className="text-sm font-semibold text-muted-foreground">
+            {t("recentTitle")}
+          </h3>
+          {recentEntries.length === 0 ? (
+            <p className="text-sm text-muted-foreground">{t("noRecent")}</p>
+          ) : (
+            <ul className="space-y-2">
+              {recentEntries.map((entry, index) => (
+                <EntryItem
+                  key={`recent-${entry.date}-${entry.createdAt ?? index}`}
+                  clientId={clientId}
+                  entry={entry}
+                  variant="recent"
+                  onEdited={handleEdited}
+                  onDeleted={handleDeleted}
+                />
+              ))}
+            </ul>
+          )}
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
 
-      <div className="mt-4 space-y-2">
-        <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
-          {t("notesForDate", { date: noteDate })}
-        </p>
-        {notesForSelectedDay.length === 0 ? (
-          <p className="text-sm text-muted-foreground">{t("noNotesForDay")}</p>
-        ) : (
-          notesForSelectedDay.map((entry, index) => (
-            <div key={`${entry.date}-${index}`} className="rounded-md bg-muted p-3 text-sm">
-              <p className="whitespace-pre-wrap">{entry.notes}</p>
-              <p className="mt-1 text-xs text-muted-foreground">
-                {entry.createdAt
-                  ? new Date(entry.createdAt).toLocaleString()
-                  : tCommon("emDash")}
-              </p>
+function EntryItem({
+  clientId,
+  entry,
+  variant,
+  onEdited,
+  onDeleted,
+}: {
+  clientId: string;
+  entry: ClientNoteEntryView;
+  variant: "forDate" | "recent";
+  onEdited: (target: ClientNoteEntryView, newText: string) => void;
+  onDeleted: (target: ClientNoteEntryView) => void;
+}) {
+  const t = useTranslations("clients.detail.notes");
+  const [editing, setEditing] = useState(false);
+  const [draft, setDraft] = useState(entry.notes);
+  const [confirmingDelete, setConfirmingDelete] = useState(false);
+  const [rowError, setRowError] = useState<string | null>(null);
+  const [isPending, startTransition] = useTransition();
+
+  // Legacy entries with no `createdAt` can't be uniquely targeted — hide the
+  // controls rather than risk editing the wrong row.
+  const canMutate = Boolean(entry.createdAt);
+
+  return (
+    <li
+      className={
+        variant === "forDate"
+          ? "rounded-md border bg-muted/40 p-3 text-sm"
+          : "rounded-md border p-3 text-sm"
+      }
+    >
+      <div className="mb-1 flex items-center justify-between text-xs text-muted-foreground">
+        <span>{entry.date}</span>
+        <div className="flex items-center gap-2">
+          <span>
+            {entry.createdAt
+              ? new Date(entry.createdAt).toLocaleString()
+              : ""}
+          </span>
+          {canMutate && !editing ? (
+            <div className="flex items-center gap-1">
+              <Button
+                type="button"
+                variant="ghost"
+                size="icon"
+                className="h-6 w-6"
+                title={t("edit")}
+                onClick={() => {
+                  setRowError(null);
+                  setDraft(entry.notes);
+                  setEditing(true);
+                }}
+              >
+                <Pencil className="h-3.5 w-3.5" />
+                <span className="sr-only">{t("edit")}</span>
+              </Button>
+              <Button
+                type="button"
+                variant="ghost"
+                size="icon"
+                className="h-6 w-6 text-destructive"
+                title={t("delete")}
+                onClick={() => {
+                  setRowError(null);
+                  setConfirmingDelete(true);
+                }}
+              >
+                <Trash2 className="h-3.5 w-3.5" />
+                <span className="sr-only">{t("delete")}</span>
+              </Button>
             </div>
-          ))
-        )}
+          ) : null}
+        </div>
       </div>
 
-      <div className="mt-5 space-y-2">
-        <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
-          {t("previousNotes")}
-        </p>
-        {recentEntries.length === 0 ? (
-          <p className="text-sm text-muted-foreground">{t("noPreviousNotes")}</p>
-        ) : (
-          recentEntries.map((entry, index) => (
-            <div key={`recent-${entry.date}-${index}`} className="rounded-md border p-3 text-sm">
-              <div className="mb-1 flex items-center justify-between gap-2 text-xs text-muted-foreground">
-                <span>{entry.date}</span>
-                <span>
-                  {entry.createdAt ? new Date(entry.createdAt).toLocaleString() : tCommon("emDash")}
-                </span>
-              </div>
-              <p className="line-clamp-3 whitespace-pre-wrap">{entry.notes}</p>
-            </div>
-          ))
-        )}
-      </div>
-    </section>
+      {editing ? (
+        <div className="space-y-2">
+          <Textarea
+            value={draft}
+            onChange={(e) => setDraft(e.target.value)}
+            rows={4}
+            maxLength={10000}
+          />
+          <div className="flex items-center justify-end gap-2">
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              disabled={isPending}
+              onClick={() => {
+                setEditing(false);
+                setDraft(entry.notes);
+                setRowError(null);
+              }}
+            >
+              {t("cancel")}
+            </Button>
+            <Button
+              type="button"
+              size="sm"
+              disabled={isPending || draft.trim().length === 0}
+              onClick={() => {
+                const newText = draft.trim();
+                setRowError(null);
+                startTransition(async () => {
+                  try {
+                    await editClientNote({
+                      clientId,
+                      entryCreatedAt: entry.createdAt ?? "",
+                      entryDate: entry.date,
+                      notes: newText,
+                    });
+                    onEdited(entry, newText);
+                    setEditing(false);
+                  } catch (err) {
+                    setRowError(
+                      err instanceof Error ? err.message : t("saveFailed"),
+                    );
+                  }
+                });
+              }}
+            >
+              {isPending ? t("saving") : t("save")}
+            </Button>
+          </div>
+        </div>
+      ) : (
+        <p className="whitespace-pre-wrap">{entry.notes}</p>
+      )}
+
+      {confirmingDelete ? (
+        <div className="mt-2 flex items-center justify-between gap-2 rounded-md border border-destructive/40 bg-destructive/5 p-2">
+          <span className="text-xs">{t("deleteConfirm")}</span>
+          <div className="flex items-center gap-2">
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              disabled={isPending}
+              onClick={() => setConfirmingDelete(false)}
+            >
+              {t("cancel")}
+            </Button>
+            <Button
+              type="button"
+              variant="destructive"
+              size="sm"
+              disabled={isPending}
+              onClick={() => {
+                setRowError(null);
+                startTransition(async () => {
+                  try {
+                    await deleteClientNote({
+                      clientId,
+                      entryCreatedAt: entry.createdAt ?? "",
+                      entryDate: entry.date,
+                    });
+                    onDeleted(entry);
+                  } catch (err) {
+                    setRowError(
+                      err instanceof Error ? err.message : t("saveFailed"),
+                    );
+                    setConfirmingDelete(false);
+                  }
+                });
+              }}
+            >
+              {isPending ? t("deleting") : t("delete")}
+            </Button>
+          </div>
+        </div>
+      ) : null}
+
+      {rowError ? (
+        <p className="mt-1 text-xs text-destructive">{rowError}</p>
+      ) : null}
+    </li>
   );
 }

--- a/backoffice/src/app/gc-fitness/clients/[id]/_components/ClientRecentLogsFeed.tsx
+++ b/backoffice/src/app/gc-fitness/clients/[id]/_components/ClientRecentLogsFeed.tsx
@@ -1,12 +1,13 @@
 "use client";
 
-import type { ComponentType } from "react";
+import type { ComponentType, ReactNode } from "react";
 import Link from "next/link";
 import { useMemo, useState } from "react";
 import {
   ArrowRightLeft,
   CalendarClock,
   Camera,
+  ChevronRight,
   Dumbbell,
   Eye,
   Gauge,
@@ -68,6 +69,15 @@ interface Props {
    * 403 for an admin), so admin passes `false`.
    */
   showActions?: boolean;
+  /**
+   * Routing context for making rows clickable. "trainer" links to the trainer
+   * surfaces; "admin" links to the nested admin god-mode detail routes (which
+   * require `coachUid`). A function prop can't cross the server→client boundary,
+   * so the feed computes hrefs internally from these serializable inputs.
+   */
+  linkMode?: "trainer" | "admin";
+  /** Coach uid — required when `linkMode === "admin"` to build the base path. */
+  coachUid?: string;
 }
 
 /**
@@ -75,10 +85,42 @@ interface Props {
  * the trainer client-profile section and the admin god-mode client view. The
  * incoming `logs` are already sorted newest-first by the server action.
  */
-export function ClientRecentLogsFeed({ logs, showActions = true }: Props) {
+export function ClientRecentLogsFeed({
+  logs,
+  showActions = true,
+  linkMode = "trainer",
+  coachUid,
+}: Props) {
   const t = useTranslations("clients.detail.recentLogs");
   const tf = useTranslations("recentLogs.feed");
   const [page, setPage] = useState(0);
+
+  // Detail destination for a row, or null when the category has no detail
+  // surface. Workout + photo are wired in both contexts (trainer routes and the
+  // nested admin god-mode routes). Habit + weight have no detail page yet and
+  // stay non-clickable.
+  function hrefForRow(row: RecentLogRow): string | null {
+    const adminBase =
+      linkMode === "admin" && coachUid
+        ? `/gc-fitness/admin/coaches/${coachUid}/clients/${row.clientId}`
+        : null;
+    // In admin mode without a coachUid we can't build a safe path — don't link.
+    if (linkMode === "admin" && !adminBase) return null;
+
+    switch (row.category) {
+      case "workout":
+        if (!row.workoutLogId) return null;
+        return adminBase
+          ? `${adminBase}/workouts/${row.workoutLogId}`
+          : `/gc-fitness/recent-logs/workouts/${row.workoutLogId}`;
+      case "photo":
+        return adminBase
+          ? `${adminBase}/photos`
+          : `/gc-fitness/clients/${row.clientId}/compare-photos`;
+      default:
+        return null;
+    }
+  }
 
   const pageCount = Math.max(1, Math.ceil(logs.length / PAGE_SIZE));
   const safePage = Math.min(page, pageCount - 1);
@@ -105,7 +147,7 @@ export function ClientRecentLogsFeed({ logs, showActions = true }: Props) {
               key={row.id}
               className="flex items-center gap-3 rounded-lg border bg-card px-3 py-2.5"
             >
-              <div className="min-w-0 flex-1">
+              <RowShell href={hrefForRow(row)}>
                 <div className="flex flex-wrap items-center gap-2">
                   <Badge
                     variant="outline"
@@ -149,7 +191,7 @@ export function ClientRecentLogsFeed({ logs, showActions = true }: Props) {
                   {formatDateTime(row.eventAt)}
                   {row.detail ? ` · ${row.detail}` : ""}
                 </p>
-              </div>
+              </RowShell>
               {showActions ? (
                 <div className="flex shrink-0 items-center gap-1">
                   <Button
@@ -212,6 +254,30 @@ export function ClientRecentLogsFeed({ logs, showActions = true }: Props) {
         </div>
       ) : null}
     </div>
+  );
+}
+
+// Wraps a row's left content: a clickable Link (with a hover chevron) when the
+// category has a detail destination, otherwise an inert div. Keeping the action
+// buttons OUTSIDE this wrapper avoids nesting interactive elements in an anchor.
+function RowShell({
+  href,
+  children,
+}: {
+  href: string | null;
+  children: ReactNode;
+}) {
+  if (!href) {
+    return <div className="min-w-0 flex-1">{children}</div>;
+  }
+  return (
+    <Link
+      href={href}
+      className="group flex min-w-0 flex-1 items-center gap-2 rounded-md outline-none transition-opacity hover:opacity-80 focus-visible:ring-2 focus-visible:ring-ring"
+    >
+      <span className="min-w-0 flex-1">{children}</span>
+      <ChevronRight className="h-4 w-4 shrink-0 text-muted-foreground opacity-0 transition-opacity group-hover:opacity-100" />
+    </Link>
   );
 }
 

--- a/backoffice/src/app/gc-fitness/clients/[id]/page.tsx
+++ b/backoffice/src/app/gc-fitness/clients/[id]/page.tsx
@@ -39,6 +39,7 @@ import { ChatHistoryWidget } from "./_components/ChatHistoryWidget";
 import { BodyWeightTrendChart } from "./_components/BodyWeightTrendChart";
 import { ClientNotesCard } from "./_components/ClientNotesCard";
 import { ProgressPhotosWidget } from "./_components/ProgressPhotosWidget";
+import { ClientRecentLogsWidget } from "./_components/ClientRecentLogsWidget";
 import { listClientGoals } from "@/lib/gc-fitness/client-goal-actions";
 import { getClientNotes } from "@/lib/gc-fitness/client-notes-actions";
 import { listProgressPhotosForClient } from "@/lib/gc-fitness/progress-photo-actions";
@@ -164,6 +165,10 @@ export default async function ClientDetailPage({
         />
 
         <ProgressPhotosWidget photos={progressPhotos} clientId={id} />
+
+        <Suspense fallback={<WidgetSkeleton title={tSkeleton("recentLogs")} />}>
+          <ClientRecentLogsWidget clientId={id} />
+        </Suspense>
       </div>
     </div>
   );

--- a/backoffice/src/lib/gc-fitness/client-notes-actions.ts
+++ b/backoffice/src/lib/gc-fitness/client-notes-actions.ts
@@ -131,3 +131,107 @@ export async function updateClientNotes(input: unknown): Promise<{
 
   return { ok: true, updatedAt: new Date().toISOString() };
 }
+
+// Edit/delete target a single entry. Entries have no stable id, but each
+// carries a per-write ISO `createdAt` string (set on append above) that is
+// unique in practice, so we identify the target by its (createdAt, date) pair —
+// no data migration needed. The `client_notes` update rule already permits
+// mutating `entries` + `updatedAt` (affectedKeys hasOnly ['notes','entries',
+// 'updatedAt']), so rewriting the trimmed/edited array via `{ merge: true }`
+// (touching only `entries` + `updatedAt`) stays within the rule. No rules change.
+
+const editClientNoteSchema = z.object({
+  clientId: z.string().trim().min(1).max(160),
+  entryCreatedAt: z.string().trim().min(1),
+  entryDate: z.string().trim().min(10).max(10),
+  notes: z.string().trim().min(1).max(10000),
+});
+
+const deleteClientNoteSchema = z.object({
+  clientId: z.string().trim().min(1).max(160),
+  entryCreatedAt: z.string().trim().min(1),
+  entryDate: z.string().trim().min(10).max(10),
+});
+
+/** True when a raw entry matches the (createdAt, date) identity. */
+function noteEntryMatches(
+  entry: Record<string, unknown>,
+  createdAt: string,
+  date: string,
+): boolean {
+  const entryCreatedAt =
+    typeof entry.createdAt === "string" ? entry.createdAt : "";
+  const entryDate = typeof entry.date === "string" ? entry.date : "";
+  return entryCreatedAt === createdAt && entryDate === date;
+}
+
+export async function editClientNote(input: unknown): Promise<{
+  ok: true;
+  updatedAt: string;
+}> {
+  const trainer = await getCurrentTrainer();
+  const parsed = editClientNoteSchema.parse(input);
+  await assertOwnsClient(trainer.uid, parsed.clientId);
+
+  const ref = gcFitnessFirestore()
+    .collection(FirestoreCollections.clientNotes)
+    .doc(noteDocId(trainer.uid, parsed.clientId));
+
+  const snap = await ref.get();
+  if (!snap.exists) throw new Error("Note not found.");
+
+  const existing = Array.isArray(snap.get("entries"))
+    ? (snap.get("entries") as Array<Record<string, unknown>>)
+    : [];
+  let found = false;
+  const next = existing.map((entry) => {
+    if (
+      !found &&
+      noteEntryMatches(entry, parsed.entryCreatedAt, parsed.entryDate)
+    ) {
+      found = true;
+      return { ...entry, notes: parsed.notes };
+    }
+    return entry;
+  });
+  if (!found) throw new Error("Note not found.");
+
+  await ref.set(
+    { entries: next, updatedAt: FieldValue.serverTimestamp() },
+    { merge: true },
+  );
+
+  return { ok: true, updatedAt: new Date().toISOString() };
+}
+
+export async function deleteClientNote(input: unknown): Promise<{
+  ok: true;
+  updatedAt: string;
+}> {
+  const trainer = await getCurrentTrainer();
+  const parsed = deleteClientNoteSchema.parse(input);
+  await assertOwnsClient(trainer.uid, parsed.clientId);
+
+  const ref = gcFitnessFirestore()
+    .collection(FirestoreCollections.clientNotes)
+    .doc(noteDocId(trainer.uid, parsed.clientId));
+
+  const snap = await ref.get();
+  if (!snap.exists) throw new Error("Note not found.");
+
+  const existing = Array.isArray(snap.get("entries"))
+    ? (snap.get("entries") as Array<Record<string, unknown>>)
+    : [];
+  const next = existing.filter(
+    (entry) =>
+      !noteEntryMatches(entry, parsed.entryCreatedAt, parsed.entryDate),
+  );
+  if (next.length === existing.length) throw new Error("Note not found.");
+
+  await ref.set(
+    { entries: next, updatedAt: FieldValue.serverTimestamp() },
+    { merge: true },
+  );
+
+  return { ok: true, updatedAt: new Date().toISOString() };
+}

--- a/backoffice/src/lib/gc-fitness/recent-logs-actions.ts
+++ b/backoffice/src/lib/gc-fitness/recent-logs-actions.ts
@@ -1049,6 +1049,34 @@ export async function getWorkoutLogDetail(
 }
 
 /**
+ * Admin god-mode (read-only): workout-log detail for a specific COACH's log.
+ * Mirrors getWorkoutLogDetail but gates on admin and verifies the log belongs
+ * to `coachId` so the URL can't be edited to read another coach's logs.
+ */
+export async function getWorkoutLogDetailAsAdmin(
+  coachId: string,
+  workoutLogId: string,
+): Promise<WorkoutLogDetail> {
+  await getCurrentAdmin();
+  const db = gcFitnessFirestore();
+
+  const logSnap = await db
+    .collection(FirestoreCollections.workoutLogs)
+    .doc(workoutLogId)
+    .get();
+  if (!logSnap.exists) {
+    throw new Error("Workout log not found.");
+  }
+
+  const data = logSnap.data() as Record<string, unknown>;
+  if (data.trainerId !== coachId) {
+    throw new Error("Workout log not found.");
+  }
+
+  return buildWorkoutLogDetail(db, coachId, logSnap.id, data);
+}
+
+/**
  * 260529-ltm — fetch the COMPLETED workout-log's detail BY assignmentId,
  * powering the calendar share card's "completed → share actuals" branch.
  *


### PR DESCRIPTION
PR #77 shipped `ClientRecentLogsWidget` + `listRecentLogsForClient` and merged, but `clients/[id]/page.tsx` was never wired to render it — the import + Suspense block were lost during a messy rebuild. The admin god-mode route renders the feed directly (so it worked), but the trainer client profile showed nothing. This wires the widget into the page grid with its Suspense skeleton. Gates: tsc, next build, jest green. No rules change.