### PR TITLE
refactor(gc-fitness): binary-only habits in backoffice

### DIFF
--- a/backoffice/src/app/gc-fitness/clients/[id]/_components/BodyWeightTrendChart.tsx
+++ b/backoffice/src/app/gc-fitness/clients/[id]/_components/BodyWeightTrendChart.tsx
@@ -11,11 +11,10 @@
 // but as a server-side redirect link instead of a button.
 //
 // Query budget:
-//   1) habits where (clientId, type == "weight", deleted == false) — N=1-2
-//   2) habit_logs where (habitId IN <habitIds>, loggedAt >= 30 days ago)
-//      orderBy loggedAt ASC
-// Firestore caps the `in` operator at 30 values; we expect 1-2 weight
-// habits per client so this is comfortably safe.
+//   1) users/{uid}/body_weight_logs orderBy recordedAt ASC, limit 180.
+// Body weight lives in its OWN dedicated collection; the legacy
+// `habits` (type == "weight") fallback was removed when habits became
+// binary-only.
 //
 // Trust: the parent page's ownership gate guarantees the trainer owns
 // this client; Firestore rules (P02-11) also enforce. The chart never
@@ -67,9 +66,9 @@ export async function BodyWeightTrendChart({
 
   const thirtyDaysAgo = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000);
 
-  // Primary source for this widget: /users/{uid}/body_weight_logs
-  // (what trainers are currently loading in production for client profile).
-  // If empty, we fall back to weight habit logs.
+  // SOLE source for this widget: /users/{uid}/body_weight_logs. Body weight
+  // is no longer a habit type — there is no `habits (type == "weight")`
+  // fallback.
   const directWeightLogsSnap = await db
     .collection(FirestoreCollections.users)
     .doc(clientId)
@@ -79,7 +78,7 @@ export async function BodyWeightTrendChart({
     .get()
     .catch(() => null);
 
-  let unitLabel = "kg";
+  const unitLabel = "kg";
   let points: WeightPoint[] = (directWeightLogsSnap?.docs ?? [])
     .map((d) => {
       const data = d.data() as {
@@ -94,44 +93,6 @@ export async function BodyWeightTrendChart({
       return { date: date.toISOString().slice(0, 10), weight };
     })
     .filter((p): p is WeightPoint => p !== null);
-
-  if (points.length === 0) {
-    const habitsSnap = await db
-      .collection(FirestoreCollections.habits)
-      .where("clientId", "==", clientId)
-      .where("type", "==", "weight")
-      .where("deleted", "==", false)
-      .get();
-
-    if (!habitsSnap.empty) {
-      const habitIds = habitsSnap.docs.map((d) => d.id);
-      const firstHabit = habitsSnap.docs[0]?.data() as { unit?: string } | undefined;
-      unitLabel =
-        typeof firstHabit?.unit === "string" && firstHabit.unit.length > 0
-          ? firstHabit.unit
-          : "kg";
-      const logsSnap = await db
-        .collection(FirestoreCollections.habitLogs)
-        .where("habitId", "in", habitIds)
-        .where("loggedAt", ">=", thirtyDaysAgo)
-        .orderBy("loggedAt", "asc")
-        .get();
-      points = logsSnap.docs
-    .map((d) => {
-      const data = d.data() as {
-        civilDate?: string;
-        value?: number;
-        deleted?: boolean;
-      };
-      if (data.deleted) return null;
-      if (typeof data.value !== "number" || data.value <= 0) return null;
-      if (!isPlausibleWeightKg(data.value)) return null;
-      if (typeof data.civilDate !== "string") return null;
-      return { date: data.civilDate, weight: data.value };
-    })
-    .filter((p): p is WeightPoint => p !== null);
-    }
-  }
 
   // Keep one point per day (latest wins) to avoid overplot noise.
   const byDate = new Map<string, number>();

--- a/backoffice/src/app/gc-fitness/clients/[id]/_components/HabitTrendsWidget.tsx
+++ b/backoffice/src/app/gc-fitness/clients/[id]/_components/HabitTrendsWidget.tsx
@@ -22,7 +22,6 @@ import { gcFitnessFirestore } from "@/lib/firebase/gc-fitness-admin";
 import { FirestoreCollections } from "@/lib/gc-fitness/collections";
 import { civilDateFormat } from "@/lib/gc-fitness/civil-date";
 import { isHabitScheduledOn } from "@/lib/gc-fitness/habit-schedule";
-import type { HabitType } from "@/lib/gc-fitness/habit-schema";
 import { TREND_RANGES, type TrendRangeKey, addCivilDays } from "./trend-range";
 import { HabitTrendsClient, type HabitTrendRow } from "./HabitTrendsClient";
 
@@ -66,8 +65,6 @@ export async function HabitTrendsWidget({ clientId, timezone }: HabitTrendsWidge
     habitsSnap.docs.map(async (h) => {
       const habit = h.data() as {
         name?: string | { en?: string; es?: string };
-        type?: HabitType;
-        targetValue?: number;
       } & Record<string, unknown>;
 
       const logsSnap = await db
@@ -79,26 +76,13 @@ export async function HabitTrendsWidget({ clientId, timezone }: HabitTrendsWidge
         .get();
 
       const completedDates = new Set<string>();
-      const targetValue =
-        typeof habit.targetValue === "number" ? habit.targetValue : undefined;
-      const habitType = (habit.type ?? "binary") as HabitType;
+      // Habits are binary-only: a log counts iff !deleted && value === true.
       for (const doc of logsSnap.docs) {
         const data = doc.data() as Record<string, unknown>;
         if (data.deleted === true) continue;
         const date = typeof data.civilDate === "string" ? data.civilDate : "";
         if (!date) continue;
-
-        const value = data.value;
-        let completed = false;
-        if (habitType === "binary") {
-          completed = value === true;
-        } else {
-          const numeric = typeof value === "number" ? value : Number(value);
-          completed =
-            Number.isFinite(numeric) &&
-            (targetValue === undefined ? numeric > 0 : numeric >= targetValue);
-        }
-        if (completed) completedDates.add(date);
+        if (data.value === true) completedDates.add(date);
       }
 
       const byRange = {} as Record<

--- a/backoffice/src/app/gc-fitness/clients/[id]/_components/PendingClientPreload.tsx
+++ b/backoffice/src/app/gc-fitness/clients/[id]/_components/PendingClientPreload.tsx
@@ -115,10 +115,7 @@ export async function PendingClientPreload({
     "use server";
     const templateId = String(formData.get("templateId") ?? "").trim();
     const name = String(formData.get("name") ?? "").trim();
-    const type = String(formData.get("type") ?? "binary");
-    const optionsRaw = String(formData.get("options") ?? "").trim();
-    const targetRaw = String(formData.get("targetValue") ?? "").trim();
-    const unitRaw = String(formData.get("unit") ?? "").trim();
+    // Habits are binary-only — `type` is always "binary".
     const scheduleType = String(formData.get("scheduleType") ?? "recurring");
     const startsOn = String(formData.get("startsOn") ?? "").trim();
     const endsOn = String(formData.get("endsOn") ?? "").trim();
@@ -141,24 +138,11 @@ export async function PendingClientPreload({
       ? habitTemplates.find((template) => template.id === templateId)
       : null;
     if (!selectedTemplate && !name) return;
-    const options = optionsRaw
-      .split(",")
-      .map((entry) => entry.trim())
-      .filter((entry) => entry.length > 0);
-    const targetValue = targetRaw.length > 0 ? Number(targetRaw) : undefined;
     const startsOnValue = startsOn || new Date().toISOString().slice(0, 10);
-    const resolvedType = (selectedTemplate?.type ?? type) as "binary" | "multi-choice" | "numeric" | "weight";
+    const resolvedType = "binary" as const;
     const resolvedScheduleType = scheduleType === "one-time" ? "one-time" : "recurring";
     const resolvedCadence =
       scheduleCadence === "weekly" || scheduleCadence === "monthly" ? scheduleCadence : "daily";
-    const parsedTarget =
-      Number.isFinite(targetValue) && resolvedType === "numeric" ? targetValue : undefined;
-    const parsedUnit =
-      unitRaw.length > 0 && (resolvedType === "numeric" || resolvedType === "weight")
-        ? unitRaw
-        : undefined;
-    const parsedOptions =
-      resolvedType === "multi-choice" && options.length > 0 ? options : undefined;
     const parsedWeekdays =
       resolvedScheduleType === "recurring" && resolvedCadence === "weekly" && scheduleWeekdays.length > 0
         ? scheduleWeekdays
@@ -182,12 +166,6 @@ export async function PendingClientPreload({
     await createPendingHabit(normalizedEmail, {
       type: resolvedType,
       name: resolvedName,
-      options: parsedOptions ?? selectedTemplate?.options,
-      targetValue:
-        parsedTarget !== undefined
-          ? parsedTarget
-          : selectedTemplate?.targetValue,
-      unit: parsedUnit ?? selectedTemplate?.unit,
       clientId: `pending:${normalizedEmail}`, // overridden by createPendingHabit
       reminderEnabled: false,
       scheduleType: resolvedScheduleType,
@@ -402,14 +380,13 @@ export async function PendingClientPreload({
           submitAction={submitHabit}
           templates={habitTemplates.map((template) => ({
             id: template.id,
-            label: `${template.name.es || template.name.en || "(sin nombre)"} · ${template.type}`,
-            type: template.type,
+            label: template.name.es || template.name.en || "(sin nombre)",
           }))}
         />
 
         <p className="mt-3 text-xs text-muted-foreground">
-          Pre-carga avanzada: podés definir tipo, opciones, target y unidad
-          antes del primer ingreso del cliente.
+          Pre-carga avanzada: definí el hábito (sí/no) y su recurrencia antes
+          del primer ingreso del cliente.
         </p>
       </section>
     </div>

--- a/backoffice/src/app/gc-fitness/clients/[id]/_components/PendingHabitPreloadForm.tsx
+++ b/backoffice/src/app/gc-fitness/clients/[id]/_components/PendingHabitPreloadForm.tsx
@@ -2,14 +2,13 @@
 
 import { useMemo, useState } from "react";
 
-type HabitType = "binary" | "multi-choice" | "numeric" | "weight";
+// Habits are binary-only (yes/no) now.
 type HabitScheduleType = "one-time" | "recurring";
 type HabitCadence = "daily" | "weekly" | "monthly";
 
 interface HabitTemplateOption {
   id: string;
   label: string;
-  type: HabitType;
 }
 
 interface PendingHabitPreloadFormProps {
@@ -40,20 +39,12 @@ export function PendingHabitPreloadForm({
   submitAction,
 }: PendingHabitPreloadFormProps) {
   const [templateId, setTemplateId] = useState("");
-  const [type, setType] = useState<HabitType>("binary");
   const [scheduleType, setScheduleType] = useState<HabitScheduleType>("recurring");
   const [scheduleCadence, setScheduleCadence] = useState<HabitCadence>("daily");
   const [monthDays, setMonthDays] = useState<number[]>([1]);
 
   const startsOnDefault = useMemo(() => todayCivilDate(), []);
   const templateMode = templateId.length > 0;
-  const selectedTemplateType = templateMode
-    ? templates.find((template) => template.id === templateId)?.type
-    : undefined;
-  const effectiveType = selectedTemplateType ?? type;
-  const showOptions = effectiveType === "multi-choice";
-  const showTarget = effectiveType === "numeric";
-  const showUnit = effectiveType === "numeric" || effectiveType === "weight";
   const showCadence = scheduleType === "recurring";
   const showWeekdays = showCadence && scheduleCadence === "weekly";
   const showMonthDay = showCadence && scheduleCadence === "monthly";
@@ -85,70 +76,21 @@ export function PendingHabitPreloadForm({
       <div className="flex flex-col gap-4">
         <div className="grid gap-3 md:grid-cols-2 lg:grid-cols-5">
           {!templateMode ? (
-            <>
-              <label className="flex flex-col gap-1 text-sm">
-                <span className="font-medium">Nombre del hábito</span>
-                <input
-                  type="text"
-                  name="name"
-                  required
-                  minLength={1}
-                  maxLength={80}
-                  placeholder="Ej: 10 minutos de meditación"
-                  className="rounded border bg-background px-3 py-2 text-sm"
-                />
-              </label>
-              <label className="flex flex-col gap-1 text-sm">
-                <span className="font-medium">Tipo</span>
-                <select
-                  name="type"
-                  value={type}
-                  onChange={(event) => setType(event.target.value as HabitType)}
-                  className="rounded border bg-background px-3 py-2 text-sm"
-                >
-                  <option value="binary">Binary</option>
-                  <option value="multi-choice">Multi-choice</option>
-                  <option value="numeric">Numeric</option>
-                  <option value="weight">Weight</option>
-                </select>
-              </label>
-            </>
-          ) : (
-            <input type="hidden" name="type" value={effectiveType} />
-          )}
-          {showOptions ? (
             <label className="flex flex-col gap-1 text-sm">
-              <span className="font-medium">Opciones (coma separadas)</span>
+              <span className="font-medium">Nombre del hábito</span>
               <input
                 type="text"
-                name="options"
-                placeholder="Alta, Media, Baja"
+                name="name"
+                required
+                minLength={1}
+                maxLength={80}
+                placeholder="Ej: 10 minutos de meditación"
                 className="rounded border bg-background px-3 py-2 text-sm"
               />
             </label>
           ) : null}
-          {showTarget ? (
-            <label className="flex flex-col gap-1 text-sm">
-              <span className="font-medium">Target</span>
-              <input
-                type="number"
-                name="targetValue"
-                step="any"
-                className="rounded border bg-background px-3 py-2 text-sm"
-              />
-            </label>
-          ) : null}
-          {showUnit ? (
-            <label className="flex flex-col gap-1 text-sm">
-              <span className="font-medium">Unidad</span>
-              <input
-                type="text"
-                name="unit"
-                placeholder="kg, reps, min..."
-                className="rounded border bg-background px-3 py-2 text-sm"
-              />
-            </label>
-          ) : null}
+          {/* Habits are binary-only — type is always "binary". */}
+          <input type="hidden" name="type" value="binary" />
         </div>
 
         <div className="grid gap-3 md:grid-cols-2 lg:grid-cols-4">

--- a/backoffice/src/app/gc-fitness/habits/[id]/edit/page.tsx
+++ b/backoffice/src/app/gc-fitness/habits/[id]/edit/page.tsx
@@ -57,9 +57,6 @@ export default async function EditHabitPage({ params }: PageParams) {
     type?: HabitType;
     name?: { en: string; es: string };
     description?: { en: string; es: string };
-    options?: string[];
-    targetValue?: number;
-    unit?: string;
     reminderTime?: string;
     reminderEnabled?: boolean;
     reminderCadence?: "daily" | "weekly" | "monthly";
@@ -88,9 +85,6 @@ export default async function EditHabitPage({ params }: PageParams) {
     type: (data.type as HabitType) ?? "binary",
     name: data.name ?? { en: "", es: "" },
     description: data.description,
-    options: data.options,
-    targetValue: data.targetValue,
-    unit: data.unit,
     reminderTime: data.reminderTime,
     reminderEnabled: data.reminderEnabled ?? false,
     reminderCadence: data.reminderCadence,

--- a/backoffice/src/app/gc-fitness/habits/[id]/page.tsx
+++ b/backoffice/src/app/gc-fitness/habits/[id]/page.tsx
@@ -36,11 +36,9 @@ interface PageParams {
 }
 
 // Maps HabitType → catalog key under `habits.detail.typeLabels.*`.
+// Habits are binary-only now.
 const HABIT_TYPE_LABEL_KEYS: Record<HabitType, string> = {
   binary: "binary",
-  "multi-choice": "multiChoice",
-  numeric: "numeric",
-  weight: "weight",
 };
 
 export default async function HabitDetailPage({ params }: PageParams) {
@@ -68,9 +66,6 @@ export default async function HabitDetailPage({ params }: PageParams) {
     type?: HabitType;
     name?: { en?: string; es?: string };
     description?: { en?: string; es?: string };
-    options?: string[];
-    targetValue?: number;
-    unit?: string;
     reminderEnabled?: boolean;
     reminderTime?: string;
     reminderCadence?: string;
@@ -181,39 +176,6 @@ export default async function HabitDetailPage({ params }: PageParams) {
               </dd>
             </div>
           )}
-          {habitType === "multi-choice" && data.options && (
-            <div className="sm:col-span-2">
-              <dt className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
-                {t("optionsLabel")}
-              </dt>
-              <dd className="mt-1 flex flex-wrap gap-1">
-                {data.options.map((o) => (
-                  <Badge key={o} variant="outline" className="font-normal">
-                    {o}
-                  </Badge>
-                ))}
-              </dd>
-            </div>
-          )}
-          {habitType === "numeric" && data.targetValue !== undefined && (
-            <div>
-              <dt className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
-                {t("dailyTargetLabel")}
-              </dt>
-              <dd className="mt-1">
-                {data.targetValue} {data.unit ?? ""}
-              </dd>
-            </div>
-          )}
-          {(habitType === "weight" || habitType === "numeric") &&
-            data.unit && (
-              <div>
-                <dt className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
-                  {t("unitLabel")}
-                </dt>
-                <dd className="mt-1">{data.unit}</dd>
-              </div>
-            )}
           <div>
             <dt className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
               {t("scheduleLabel")}

--- a/backoffice/src/app/gc-fitness/habits/_components/HabitForm.tsx
+++ b/backoffice/src/app/gc-fitness/habits/_components/HabitForm.tsx
@@ -6,25 +6,19 @@
 //   - mode="create": empty form → `createHabit` → redirect to /gc-fitness/habits
 //   - mode="edit":   defaults from Firestore → `updateHabit` patch
 //
-// Type-conditional rendering (lives in `useWatch("type")` per P04-04 template-
-// form pattern):
-//   - options[] field — RENDERED ONLY when type === "multi-choice"
-//   - targetValue field — RENDERED ONLY when type === "numeric"
-//   - unit field — RENDERED when type is numeric or weight
-//   - reminderTime — RENDERED ONLY when reminderEnabled is true
+// Habits are binary-only (yes/no) — there is no type picker. The only
+// conditional field is `reminderTime`, rendered when `reminderEnabled` is true.
 //
 // The mode is locked at mount; the resolver swaps between
 // `habitCreateSchema` and `habitUpdateSchemaForType(initialValues.type)`
-// based on `mode`. In edit mode, both `clientId` and `type` are rendered
-// as DISABLED inputs (immutable post-create per the schema doc + rule
-// layer enforcement); the values still appear in the form so the trainer
-// sees what they're editing.
+// based on `mode`. In edit mode `clientId` is rendered as a DISABLED input
+// (immutable post-create per the schema doc + rule layer enforcement); the
+// value still appears in the form so the trainer sees what they're editing.
 
-import { useCallback, useState, useTransition } from "react";
+import { useState, useTransition } from "react";
 import { useRouter } from "next/navigation";
 import { useForm, useWatch, Controller } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
-import { Plus, Trash2 } from "lucide-react";
 import { toast } from "sonner";
 import { useTranslations } from "next-intl";
 
@@ -48,13 +42,10 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
-import { Card, CardContent } from "@/components/ui/card";
 
 import {
   habitCreateSchema,
   habitUpdateSchemaForType,
-  HABIT_TYPES,
-  type HabitType,
   type HabitCreateInput,
 } from "@/lib/gc-fitness/habit-schema";
 
@@ -95,16 +86,6 @@ export interface HabitFormProps {
   hideCancelButton?: boolean;
 }
 
-// Translation keys for the four habit-type strings — resolved at render via
-// `t(`typeOptions.${HABIT_TYPE_LABEL_KEYS[type]}`)`. Keeping a static map
-// here means the keys stay grep-able and the runtime lookup is O(1).
-const HABIT_TYPE_LABEL_KEYS: Record<HabitType, string> = {
-  binary: "binary",
-  "multi-choice": "multiChoice",
-  numeric: "numeric",
-  weight: "weight",
-};
-
 const WEEKDAY_KEYS = [
   { value: 1, key: "mon" },
   { value: 2, key: "tue" },
@@ -131,15 +112,12 @@ function buildDefaults(
 
   return {
     clientId: passed?.clientId ?? "",
-    type: passed?.type ?? "binary",
+    type: "binary",
     name: {
       en: passed?.name?.en ?? "",
       es: passed?.name?.es ?? "",
     },
     description: passed?.description,
-    options: passed?.options,
-    targetValue: passed?.targetValue,
-    unit: passed?.unit,
     reminderTime: passed?.reminderTime,
     reminderEnabled: passed?.reminderEnabled ?? false,
     reminderCadence: passed?.reminderCadence ?? "daily",
@@ -176,7 +154,6 @@ export function HabitForm({
   const t = useTranslations("habits.form");
   const [pending, startTransition] = useTransition();
   const [submitError, setSubmitError] = useState<string | null>(null);
-  const [targetValueDraft, setTargetValueDraft] = useState<string>("");
 
   // Resolver swap based on mode. In edit mode the type is closure-captured
   // from the initial defaults; in create mode the type is read from the
@@ -194,11 +171,7 @@ export function HabitForm({
     mode: "onSubmit",
   });
 
-  // Watch `type` + `reminderEnabled` so the conditional field UI re-renders.
-  const watchedType = useWatch({
-    control: form.control,
-    name: "type",
-  });
+  // Watch `reminderEnabled` so the conditional reminder UI re-renders.
   const watchedReminderEnabled = useWatch({
     control: form.control,
     name: "reminderEnabled",
@@ -224,30 +197,6 @@ export function HabitForm({
   const watchedReminderMonthDays =
     useWatch({ control: form.control, name: "reminderMonthDays" }) ?? [];
 
-  // Options is a string[] (not array-of-objects), so RHF's useFieldArray —
-  // which is purpose-built for object arrays — is awkward here. Track the
-  // array via useWatch + form.setValue, with append/remove as memoized
-  // helpers. The Zod superRefine still enforces the ≥ 2 constraint on
-  // submit; this is purely UI plumbing for the in-form list.
-  const watchedOptions =
-    useWatch({ control: form.control, name: "options" }) ?? [];
-  const appendOption = useCallback(() => {
-    const current =
-      (form.getValues("options") as string[] | undefined) ?? [];
-    form.setValue("options", [...current, ""], { shouldDirty: true });
-  }, [form]);
-  const removeOption = useCallback(
-    (index: number) => {
-      const current =
-        (form.getValues("options") as string[] | undefined) ?? [];
-      const next = current.filter((_, i) => i !== index);
-      form.setValue("options", next.length > 0 ? next : undefined, {
-        shouldDirty: true,
-      });
-    },
-    [form],
-  );
-
   const submit = form.handleSubmit((values) => {
     startTransition(async () => {
       setSubmitError(null);
@@ -256,7 +205,7 @@ export function HabitForm({
         // `undefined` values that would re-emit as `null` on read.
         const cleaned: HabitCreateInput = {
           clientId: values.clientId,
-          type: values.type,
+          type: "binary",
           name: values.name,
           reminderEnabled: values.reminderEnabled,
           scheduleType: values.scheduleType,
@@ -270,24 +219,6 @@ export function HabitForm({
             en: descriptionEn || descriptionEs,
             es: descriptionEs || descriptionEn,
           };
-        }
-        if (values.type === "multi-choice" && values.options) {
-          // Drop empty string entries that the trainer left blank.
-          const trimmed = values.options
-            .map((o) => o.trim())
-            .filter((o) => o.length > 0);
-          if (trimmed.length > 0) {
-            cleaned.options = trimmed;
-          }
-        }
-        if (values.type === "numeric" && values.targetValue !== undefined) {
-          cleaned.targetValue = values.targetValue;
-        }
-        if (
-          (values.type === "numeric" || values.type === "weight") &&
-          values.unit
-        ) {
-          cleaned.unit = values.unit;
         }
         if (values.reminderEnabled && values.reminderTime) {
           cleaned.reminderTime = values.reminderTime;
@@ -384,11 +315,6 @@ export function HabitForm({
     });
   });
 
-  const isMultiChoice = watchedType === "multi-choice";
-  const isNumeric = watchedType === "numeric";
-  const isWeight = watchedType === "weight";
-  const showUnit = isNumeric || isWeight;
-
   return (
     <Form {...form}>
       <form onSubmit={submit} className="flex flex-col gap-6" noValidate>
@@ -419,39 +345,6 @@ export function HabitForm({
               </Select>
               {mode === "edit" && (
                 <FormDescription>{t("clientImmutableHint")}</FormDescription>
-              )}
-              <FormMessage />
-            </FormItem>
-          )}
-        />
-
-        {/* Habit type — disabled in edit mode (immutable per schema doc) */}
-        <FormField
-          control={form.control}
-          name="type"
-          render={({ field }) => (
-            <FormItem className="max-w-xs">
-              <FormLabel>{t("typeLabel")}</FormLabel>
-              <Select
-                value={field.value}
-                onValueChange={field.onChange}
-                disabled={mode === "edit"}
-              >
-                <FormControl>
-                  <SelectTrigger>
-                    <SelectValue placeholder={t("typePlaceholder")} />
-                  </SelectTrigger>
-                </FormControl>
-                <SelectContent>
-                  {HABIT_TYPES.map((ht) => (
-                    <SelectItem key={ht} value={ht}>
-                      {t(`typeOptions.${HABIT_TYPE_LABEL_KEYS[ht]}`)}
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
-              {mode === "edit" && (
-                <FormDescription>{t("typeImmutableHint")}</FormDescription>
               )}
               <FormMessage />
             </FormItem>
@@ -528,160 +421,6 @@ export function HabitForm({
             )}
           />
         </div>
-
-        {/* Multi-choice options — type-conditional */}
-        {isMultiChoice && (
-          <div className="flex flex-col gap-3 rounded-md border bg-card p-4">
-            <div className="flex items-center justify-between">
-              <h2 className="font-heading text-base font-semibold tracking-tight">
-                {t("optionsHeading")}
-              </h2>
-              <span className="text-xs text-muted-foreground">
-                {t("optionsCount", { count: watchedOptions.length })}
-              </span>
-            </div>
-            <p className="text-sm text-muted-foreground">{t("optionsHelp")}</p>
-            <ul className="flex flex-col gap-2">
-              {watchedOptions.map((_, index) => (
-                // Index-based React key is acceptable here because options
-                // are primitive strings (not RHF object fields with stable
-                // IDs); a remove always reflows lower entries by one slot.
-                // eslint-disable-next-line react/no-array-index-key
-                <li key={`opt-${index}`}>
-                  <Card>
-                    <CardContent className="flex items-center gap-2 p-3">
-                      <Controller
-                        control={form.control}
-                        name={`options.${index}` as const}
-                        render={({ field: optField, fieldState }) => (
-                          <FormItem className="flex-1">
-                            <FormControl>
-                              <Input
-                                placeholder={t("optionPlaceholder", {
-                                  index: index + 1,
-                                })}
-                                value={optField.value ?? ""}
-                                onChange={optField.onChange}
-                                onBlur={optField.onBlur}
-                                maxLength={40}
-                              />
-                            </FormControl>
-                            {fieldState.error && (
-                              <FormMessage>
-                                {fieldState.error.message}
-                              </FormMessage>
-                            )}
-                          </FormItem>
-                        )}
-                      />
-                      <Button
-                        type="button"
-                        variant="ghost"
-                        size="icon"
-                        onClick={() => removeOption(index)}
-                        aria-label={t("removeOptionAria")}
-                        className="text-destructive hover:text-destructive"
-                      >
-                        <Trash2 className="h-4 w-4" />
-                      </Button>
-                    </CardContent>
-                  </Card>
-                </li>
-              ))}
-            </ul>
-            <Button
-              type="button"
-              variant="outline"
-              onClick={appendOption}
-              disabled={watchedOptions.length >= 8}
-              className="gap-2 self-start"
-            >
-              <Plus className="h-4 w-4" />
-              {t("addOption")}
-            </Button>
-            {form.formState.errors.options &&
-              !Array.isArray(form.formState.errors.options) && (
-                <p className="text-sm text-destructive">
-                  {form.formState.errors.options.message}
-                </p>
-              )}
-          </div>
-        )}
-
-        {/* Numeric — target value */}
-        {isNumeric && (
-          <Controller
-            control={form.control}
-            name="targetValue"
-            render={({ field, fieldState }) => (
-              <FormItem className="max-w-xs">
-                <FormLabel>{t("dailyTargetLabel")}</FormLabel>
-                <FormControl>
-                  <Input
-                    type="number"
-                    step="any"
-                    min={0}
-                    placeholder={t("dailyTargetPlaceholder")}
-                    value={targetValueDraft !== "" ? targetValueDraft : (field.value ?? "")}
-                    onChange={(e) => {
-                      if (e.target.value === "") {
-                        setTargetValueDraft("");
-                        return;
-                      }
-                      const parsed = Number(e.target.value);
-                      if (!Number.isFinite(parsed)) return;
-                      setTargetValueDraft(e.target.value);
-                      field.onChange(parsed);
-                    }}
-                    onBlur={() => {
-                      if (targetValueDraft === "") {
-                        field.onChange(undefined);
-                        field.onBlur();
-                        return;
-                      }
-                      const parsed = Number(targetValueDraft);
-                      if (Number.isFinite(parsed)) {
-                        field.onChange(parsed);
-                      }
-                      setTargetValueDraft("");
-                      field.onBlur();
-                    }}
-                  />
-                </FormControl>
-                <FormDescription>{t("dailyTargetHint")}</FormDescription>
-                {fieldState.error && (
-                  <FormMessage>{fieldState.error.message}</FormMessage>
-                )}
-              </FormItem>
-            )}
-          />
-        )}
-
-        {/* Unit — numeric + weight */}
-        {showUnit && (
-          <FormField
-            control={form.control}
-            name="unit"
-            render={({ field }) => (
-              <FormItem className="max-w-xs">
-                <FormLabel>{t("unitLabel")}</FormLabel>
-                <FormControl>
-                  <Input
-                    placeholder={
-                      isWeight
-                        ? t("unitPlaceholderWeight")
-                        : t("unitPlaceholderGlasses")
-                    }
-                    {...field}
-                    value={field.value ?? ""}
-                  />
-                </FormControl>
-                <FormDescription>{t("unitHint")}</FormDescription>
-                <FormMessage />
-              </FormItem>
-            )}
-          />
-        )}
 
         {/* Reminder block */}
         <div className="flex flex-col gap-3 rounded-md border bg-card p-4">

--- a/backoffice/src/app/gc-fitness/habits/_components/HabitLibraryTable.tsx
+++ b/backoffice/src/app/gc-fitness/habits/_components/HabitLibraryTable.tsx
@@ -17,12 +17,7 @@ import {
   TableRow,
 } from "@/components/ui/table";
 import type { HabitTemplateRow } from "@/lib/gc-fitness/habit-actions";
-import {
-  GoalPill,
-  HabitTypePill,
-  ReminderCell,
-  ScopePill,
-} from "./habit-pills";
+import { ReminderCell, ScopePill } from "./habit-pills";
 
 type TFn = ReturnType<typeof useTranslations>;
 
@@ -46,7 +41,7 @@ export function HabitLibraryTable({
       <Table>
         <TableHeader>
           <TableRow>
-            {[t("name"), t("type"), t("reminder"), t("scope")].map((h, i) => (
+            {[t("name"), t("reminder"), t("scope")].map((h, i) => (
               <TableHead
                 key={i}
                 className="text-xs font-medium uppercase tracking-wide text-muted-foreground"
@@ -60,7 +55,7 @@ export function HabitLibraryTable({
           {isLoading ? (
             <TableRow>
               <TableCell
-                colSpan={4}
+                colSpan={3}
                 className="h-24 text-center text-muted-foreground"
               >
                 {loadingText}
@@ -89,23 +84,13 @@ export function HabitLibraryTable({
                         {tpl.name.en || tpl.name.es || t("untitled")}
                       </span>
                       {/* Recurrence is intentionally NOT shown here: it's a
-                          per-assignment property, not a library/template one.
-                          Only the goal (numeric) is intrinsic to the template. */}
-                      <GoalPill
-                        type={tpl.type}
-                        targetValue={tpl.targetValue}
-                        unit={tpl.unit}
-                        t={t}
-                      />
+                          per-assignment property, not a library/template one. */}
                       {showEs ? (
                         <span className="text-xs text-muted-foreground">
                           {showEs}
                         </span>
                       ) : null}
                     </div>
-                  </TableCell>
-                  <TableCell>
-                    <HabitTypePill type={tpl.type} t={t} />
                   </TableCell>
                   <TableCell>
                     <ReminderCell

--- a/backoffice/src/app/gc-fitness/habits/_components/HabitTemplateDetailDialog.tsx
+++ b/backoffice/src/app/gc-fitness/habits/_components/HabitTemplateDetailDialog.tsx
@@ -41,12 +41,7 @@ import {
   updateHabitTemplate,
   type HabitTemplateRow,
 } from "@/lib/gc-fitness/habit-actions";
-import {
-  GoalPill,
-  HabitTypePill,
-  ReminderCell,
-  ScopePill,
-} from "./habit-pills";
+import { ReminderCell, ScopePill } from "./habit-pills";
 
 export function HabitTemplateDetailDialog({
   open,
@@ -72,15 +67,12 @@ export function HabitTemplateDetailDialog({
   const [nameEs, setNameEs] = useState("");
   const [descEn, setDescEn] = useState("");
   const [descEs, setDescEs] = useState("");
-  const [targetValue, setTargetValue] = useState("");
-  const [unit, setUnit] = useState("");
   const [reminderEnabled, setReminderEnabled] = useState(false);
   const [reminderTime, setReminderTime] = useState("");
 
   if (!template) return null;
 
   const isCustom = template.scope === "trainer";
-  const isNumeric = template.type === "numeric";
   const esName =
     template.name.es && template.name.es !== template.name.en
       ? template.name.es
@@ -94,12 +86,6 @@ export function HabitTemplateDetailDialog({
     setNameEs(template.name.es ?? "");
     setDescEn(template.description?.en ?? "");
     setDescEs(template.description?.es ?? "");
-    setTargetValue(
-      typeof template.targetValue === "number"
-        ? String(template.targetValue)
-        : "",
-    );
-    setUnit(template.unit ?? "");
     setReminderEnabled(template.reminderEnabled);
     setReminderTime(template.reminderTime ?? "");
     setEditing(true);
@@ -120,11 +106,6 @@ export function HabitTemplateDetailDialog({
         description: hasDesc
           ? { en: descEn.trim(), es: descEs.trim() }
           : undefined,
-        targetValue:
-          isNumeric && targetValue.trim().length > 0
-            ? Number(targetValue)
-            : undefined,
-        unit: isNumeric && unit.trim().length > 0 ? unit.trim() : undefined,
         reminderEnabled,
         reminderTime: reminderEnabled ? reminderTime || undefined : undefined,
       });
@@ -215,29 +196,6 @@ export function HabitTemplateDetailDialog({
                   rows={2}
                 />
               </div>
-              {isNumeric ? (
-                <div className="grid grid-cols-2 gap-3">
-                  <div className="flex flex-col gap-1.5">
-                    <Label htmlFor="tpl-target">{tf("dailyTargetLabel")}</Label>
-                    <Input
-                      id="tpl-target"
-                      value={targetValue}
-                      onChange={(e) => setTargetValue(e.target.value)}
-                      inputMode="decimal"
-                      placeholder={tf("dailyTargetPlaceholder")}
-                    />
-                  </div>
-                  <div className="flex flex-col gap-1.5">
-                    <Label htmlFor="tpl-unit">{tf("unitLabel")}</Label>
-                    <Input
-                      id="tpl-unit"
-                      value={unit}
-                      onChange={(e) => setUnit(e.target.value)}
-                      placeholder={tf("unitPlaceholderGlasses")}
-                    />
-                  </div>
-                </div>
-              ) : null}
               <div className="flex flex-col gap-2 rounded-md border p-3">
                 <Label className="flex items-center gap-2 font-normal">
                   <Checkbox
@@ -265,13 +223,6 @@ export function HabitTemplateDetailDialog({
           ) : (
             <div className="flex flex-col gap-4">
               <div className="flex flex-wrap items-center gap-1.5">
-                <HabitTypePill type={template.type} t={tc} />
-                <GoalPill
-                  type={template.type}
-                  targetValue={template.targetValue}
-                  unit={template.unit}
-                  t={tc}
-                />
                 <ScopePill isGlobal={!isCustom} t={tc} />
               </div>
 

--- a/backoffice/src/app/gc-fitness/habits/_components/habit-pills.tsx
+++ b/backoffice/src/app/gc-fitness/habits/_components/habit-pills.tsx
@@ -8,24 +8,13 @@
 // backoffice reads as one app. No per-item rainbow colors: a single muted
 // `secondary` badge for the type, quiet `outline` badges for metadata.
 
-import { CalendarDays, Clock, Repeat, Target } from "lucide-react";
+import { CalendarDays, Clock, Repeat } from "lucide-react";
 import type { useTranslations } from "next-intl";
 
 import { Badge } from "@/components/ui/badge";
-import type {
-  HabitScheduleType,
-  HabitType,
-} from "@/lib/gc-fitness/habit-schema";
+import type { HabitScheduleType } from "@/lib/gc-fitness/habit-schema";
 
 type TFn = ReturnType<typeof useTranslations>;
-
-// HabitType → short label catalog key (resolved via `t(`shortType${...}`)`).
-export const HABIT_SHORT_LABEL_KEYS: Record<HabitType, string> = {
-  binary: "Binary",
-  "multi-choice": "MultiChoice",
-  numeric: "Numeric",
-  weight: "Weight",
-};
 
 // Structural recurrence shape — shared by HabitRow and HabitTemplateRow.
 export interface HabitRecurrence {
@@ -75,14 +64,6 @@ export function recurrenceLabel(
 const META_BADGE =
   "gap-1 px-1.5 py-0 text-[11px] font-normal text-muted-foreground [&>svg]:size-3 [&>svg]:opacity-70";
 
-export function HabitTypePill({ type, t }: { type: HabitType; t: TFn }) {
-  return (
-    <Badge variant="secondary" className="px-1.5 py-0 text-[11px] font-normal">
-      {t(`shortType${HABIT_SHORT_LABEL_KEYS[type]}`)}
-    </Badge>
-  );
-}
-
 export function RecurrencePill({ rec, t }: { rec: HabitRecurrence; t: TFn }) {
   const { label, cadence } = recurrenceLabel(rec, t);
   const Icon = cadence === "daily" ? Repeat : CalendarDays;
@@ -90,26 +71,6 @@ export function RecurrencePill({ rec, t }: { rec: HabitRecurrence; t: TFn }) {
     <Badge variant="outline" className={META_BADGE}>
       <Icon />
       {label}
-    </Badge>
-  );
-}
-
-export function GoalPill({
-  type,
-  targetValue,
-  unit,
-  t,
-}: {
-  type: HabitType;
-  targetValue?: number;
-  unit?: string;
-  t: TFn;
-}) {
-  if (type !== "numeric" || typeof targetValue !== "number") return null;
-  return (
-    <Badge variant="outline" className={META_BADGE}>
-      <Target />
-      {`${t("recGoal")}: ${targetValue}${unit ? ` ${unit}` : ""}`}
     </Badge>
   );
 }

--- a/backoffice/src/app/gc-fitness/habits/client.tsx
+++ b/backoffice/src/app/gc-fitness/habits/client.tsx
@@ -66,7 +66,6 @@ import {
   type HabitRow,
   type HabitTemplateRow,
 } from "@/lib/gc-fitness/habit-actions";
-import { HABIT_TYPES, type HabitType } from "@/lib/gc-fitness/habit-schema";
 import { makeHabitColumns } from "./columns";
 import { HabitLibraryTable } from "./_components/HabitLibraryTable";
 import { HabitTemplateDetailDialog } from "./_components/HabitTemplateDetailDialog";
@@ -91,15 +90,6 @@ export interface HabitsLibraryClientProps {
 
 type HabitsView = "assignments" | "library";
 
-// Maps HabitType → message-catalog key (resolved via
-// `t(`typeLabels.${HABIT_TYPE_LABEL_KEYS[type]}`)`).
-const HABIT_TYPE_LABEL_KEYS: Record<HabitType, string> = {
-  binary: "binary",
-  "multi-choice": "multiChoice",
-  numeric: "numeric",
-  weight: "weight",
-};
-
 export function HabitsLibraryClient({
   clientRoster,
 }: HabitsLibraryClientProps) {
@@ -108,7 +98,6 @@ export function HabitsLibraryClient({
   const queryClient = useQueryClient();
   const [view, setView] = useState<HabitsView>("assignments");
   const [createOpen, setCreateOpen] = useState(false);
-  const [typeFilter, setTypeFilter] = useState<HabitType | "all">("all");
   const [clientFilter, setClientFilter] = useState<string>("all");
   const [search, setSearch] = useState<string>("");
   const [sorting, setSorting] = useState<SortingState>([
@@ -145,7 +134,6 @@ export function HabitsLibraryClient({
     const all = (data ?? []) as HabitRow[];
     const needle = search.trim().toLowerCase();
     return all.filter((r) => {
-      if (typeFilter !== "all" && r.type !== typeFilter) return false;
       if (clientFilter !== "all" && r.clientId !== clientFilter) return false;
       if (needle.length > 0) {
         const hay =
@@ -154,20 +142,19 @@ export function HabitsLibraryClient({
       }
       return true;
     });
-  }, [data, typeFilter, clientFilter, search, clientNameMap]);
+  }, [data, clientFilter, search, clientNameMap]);
 
   const filteredTemplates = useMemo(() => {
     const all = templates as HabitTemplateRow[];
     const needle = search.trim().toLowerCase();
     return all.filter((tpl) => {
-      if (typeFilter !== "all" && tpl.type !== typeFilter) return false;
       if (needle.length > 0) {
         const hay = `${tpl.name.en} ${tpl.name.es}`.toLowerCase();
         if (!hay.includes(needle)) return false;
       }
       return true;
     });
-  }, [templates, typeFilter, search]);
+  }, [templates, search]);
 
   const handlers = useMemo(
     () => ({
@@ -278,22 +265,6 @@ export function HabitsLibraryClient({
           onChange={(e) => setSearch(e.target.value)}
           className="max-w-sm"
         />
-        <Select
-          value={typeFilter}
-          onValueChange={(v) => setTypeFilter(v as HabitType | "all")}
-        >
-          <SelectTrigger className="w-48">
-            <SelectValue placeholder={t("filterByTypePlaceholder")} />
-          </SelectTrigger>
-          <SelectContent>
-            <SelectItem value="all">{t("allTypes")}</SelectItem>
-            {HABIT_TYPES.map((ht) => (
-              <SelectItem key={ht} value={ht}>
-                {t(`typeLabels.${HABIT_TYPE_LABEL_KEYS[ht]}`)}
-              </SelectItem>
-            ))}
-          </SelectContent>
-        </Select>
         {view === "assignments" ? (
           <Select value={clientFilter} onValueChange={(v) => setClientFilter(v)}>
             <SelectTrigger className="w-56">

--- a/backoffice/src/app/gc-fitness/habits/columns.tsx
+++ b/backoffice/src/app/gc-fitness/habits/columns.tsx
@@ -27,8 +27,6 @@ import {
 
 import type { HabitRow } from "@/lib/gc-fitness/habit-actions";
 import {
-  GoalPill,
-  HabitTypePill,
   RecurrencePill,
   ReminderCell,
 } from "./_components/habit-pills";
@@ -80,11 +78,6 @@ export function makeHabitColumns(
       ),
     },
     {
-      accessorKey: "type",
-      header: t("type"),
-      cell: ({ row }) => <HabitTypePill type={row.original.type} t={t} />,
-    },
-    {
       accessorKey: "name.en",
       header: t("name"),
       cell: ({ row }) => {
@@ -97,12 +90,6 @@ export function makeHabitColumns(
             </span>
             <div className="flex flex-wrap items-center gap-1">
               <RecurrencePill rec={row.original} t={t} />
-              <GoalPill
-                type={row.original.type}
-                targetValue={row.original.targetValue}
-                unit={row.original.unit}
-                t={t}
-              />
             </div>
             {showEs ? (
               <span className="text-xs text-muted-foreground">

--- a/backoffice/src/components/gc-fitness/schedule/habit-detail-dialog.tsx
+++ b/backoffice/src/components/gc-fitness/schedule/habit-detail-dialog.tsx
@@ -45,12 +45,8 @@ interface HabitDetailDialogProps {
   onChanged: () => void;
 }
 
-const HABIT_TYPE_LABEL: Record<HabitRow["type"], string> = {
-  binary: "Sí / no",
-  numeric: "Numérico",
-  weight: "Peso",
-  "multi-choice": "Opción múltiple",
-};
+// Habits are binary-only (yes/no) now.
+const HABIT_TYPE_LABEL = "Sí / no";
 
 const WEEKDAY_SHORT = ["", "Lun", "Mar", "Mié", "Jue", "Vie", "Sáb", "Dom"];
 
@@ -178,9 +174,7 @@ export function HabitDetailDialog({
                 <p className="text-[10px] uppercase tracking-wide text-muted-foreground">
                   Tipo
                 </p>
-                <p className="font-medium">
-                  {HABIT_TYPE_LABEL[data.type] ?? data.type}
-                </p>
+                <p className="font-medium">{HABIT_TYPE_LABEL}</p>
               </div>
               <div>
                 <p className="text-[10px] uppercase tracking-wide text-muted-foreground">

--- a/backoffice/src/components/gc-fitness/schedule/new-habit-dialog.tsx
+++ b/backoffice/src/components/gc-fitness/schedule/new-habit-dialog.tsx
@@ -64,12 +64,8 @@ function todayCivilDate(): string {
   return `${y}-${m}-${d}`;
 }
 
-const HABIT_TYPE_LABEL: Record<string, string> = {
-  binary: "Sí / no",
-  numeric: "Numérico",
-  weight: "Peso",
-  "multi-choice": "Opción múltiple",
-};
+// Habits are binary-only (yes/no) now.
+const HABIT_TYPE_LABEL = "Sí / no";
 
 type Tab = "existing" | "new";
 
@@ -89,9 +85,6 @@ function templateToDefaults(
     type: tpl.type,
     name: { en: tpl.name.en, es: tpl.name.es },
     description: tpl.description,
-    options: tpl.options,
-    targetValue: tpl.targetValue,
-    unit: tpl.unit,
     reminderTime: tpl.reminderTime,
     reminderEnabled: tpl.reminderEnabled,
     reminderCadence: tpl.reminderCadence,
@@ -329,7 +322,7 @@ function ExistingHabitPicker({
                     ) : null}
                   </span>
                   <span className="shrink-0 rounded-full border px-2 py-0.5 text-[11px] text-muted-foreground">
-                    {HABIT_TYPE_LABEL[tpl.type] ?? tpl.type}
+                    {HABIT_TYPE_LABEL}
                   </span>
                 </button>
               </li>

--- a/backoffice/src/lib/gc-fitness/__tests__/habit-actions.test.ts
+++ b/backoffice/src/lib/gc-fitness/__tests__/habit-actions.test.ts
@@ -5,7 +5,8 @@
 // Plan 06-05 contract (T-06-05-01 .. T-06-05-07 threat register):
 //  - createHabit must SET trainerId from `getCurrentTrainer().uid`, NEVER
 //    from client input — even when input claims a different trainerId.
-//  - createHabit Zod-parses BEFORE the Firestore write (T-06-05-03/-04).
+//  - createHabit Zod-parses BEFORE the Firestore write — habits are
+//    binary-only, so a non-binary type is rejected before any write.
 //  - updateHabit rejects cross-trainer updates (T-06-05-02).
 //  - updateHabit builds the patch from an affectedKeys whitelist — clientId,
 //    trainerId, type, createdAt, seedSource NEVER appear in the patch.
@@ -118,7 +119,7 @@ function fakeTokens(opts: {
 function fakeHabitSnapshot(opts: {
   exists: boolean;
   trainerId?: string | null;
-  type?: "binary" | "multi-choice" | "numeric" | "weight";
+  type?: "binary";
   id?: string;
 }) {
   return {
@@ -140,7 +141,7 @@ function fakeQuerySnapshot(
     id: string;
     trainerId: string;
     clientId?: string;
-    type?: "binary" | "multi-choice" | "numeric" | "weight";
+    type?: "binary";
     deleted?: boolean;
     reminderEnabled?: boolean;
   }>,
@@ -169,13 +170,14 @@ const VALID_BINARY_HABIT_INPUT = {
   reminderEnabled: false,
 };
 
-const VALID_MULTI_CHOICE_INPUT_BROKEN = {
+// A non-binary (legacy) type → rejected by the binary-only enum before any
+// Firestore write.
+const NON_BINARY_INPUT = {
   clientId: "uid-client-abc",
-  type: "multi-choice" as const,
-  name: { en: "Mood", es: "Humor" },
-  // No options → should fail Zod superRefine before any Firestore write
+  type: "numeric",
+  name: { en: "Water", es: "Agua" },
   reminderEnabled: false,
-};
+} as unknown;
 
 beforeEach(() => {
   jest.clearAllMocks();
@@ -208,12 +210,10 @@ describe("createHabit", () => {
     expect(payload.updatedAt).toBe("SERVER_TIMESTAMP_SENTINEL");
   });
 
-  // T02 — multi-choice missing options → ZodError thrown, never writes
-  it("T02 — rejects multi-choice without options BEFORE Firestore (T-06-05-03)", async () => {
+  // T02 — non-binary type → ZodError thrown, never writes (binary-only)
+  it("T02 — rejects a non-binary habit type BEFORE Firestore", async () => {
     mockedGetTokens.mockResolvedValue(fakeTokens({ role: "trainer" }));
-    await expect(
-      createHabit(VALID_MULTI_CHOICE_INPUT_BROKEN),
-    ).rejects.toThrow();
+    await expect(createHabit(NON_BINARY_INPUT)).rejects.toThrow();
     expect(mockSet).not.toHaveBeenCalled();
   });
 

--- a/backoffice/src/lib/gc-fitness/__tests__/habit-compliance.test.ts
+++ b/backoffice/src/lib/gc-fitness/__tests__/habit-compliance.test.ts
@@ -30,8 +30,9 @@
 //
 // THREAT REGISTER LOCKING (PLAN 06-08):
 //   T-06-08-02 (soft-delete) — T04 + T08 (soft-deleted log excluded).
-//   T-06-08-03 (numeric below-target) — T05 + T06.
 //   T-06-08-04 (cross-surface algorithm drift) — T08 fixture parity lock.
+//
+// Habits are BINARY-ONLY now: a log counts iff `!deleted && value === true`.
 
 import {
   computeCompliance,
@@ -53,130 +54,20 @@ function binaryLog(opts: {
   };
 }
 
-function numericLog(opts: {
-  date: string;
-  value: number;
-  deleted?: boolean;
-}): HabitLogRow {
-  return {
-    habitId: "hab-test",
-    clientId: "client-test",
-    civilDate: opts.date,
-    value: opts.value,
-    deleted: opts.deleted,
-  };
-}
-
-function multiChoiceLog(opts: {
-  date: string;
-  value: string;
-  deleted?: boolean;
-}): HabitLogRow {
-  return {
-    habitId: "hab-test",
-    clientId: "client-test",
-    civilDate: opts.date,
-    value: opts.value,
-    deleted: opts.deleted,
-  };
-}
-
 describe("habit-compliance — logCountsAsCompleted", () => {
   it("binary: returns true iff value === true and not deleted", () => {
     expect(
-      logCountsAsCompleted(
-        binaryLog({ date: "2026-05-19", value: true }),
-        "binary",
-        undefined,
-      ),
+      logCountsAsCompleted(binaryLog({ date: "2026-05-19", value: true })),
     ).toBe(true);
 
     expect(
-      logCountsAsCompleted(
-        binaryLog({ date: "2026-05-19", value: false }),
-        "binary",
-        undefined,
-      ),
+      logCountsAsCompleted(binaryLog({ date: "2026-05-19", value: false })),
     ).toBe(false);
 
     // Soft-delete always overrides even when value === true.
     expect(
       logCountsAsCompleted(
         binaryLog({ date: "2026-05-19", value: true, deleted: true }),
-        "binary",
-        undefined,
-      ),
-    ).toBe(false);
-  });
-
-  it("numeric without targetValue: counts iff value > 0", () => {
-    expect(
-      logCountsAsCompleted(
-        numericLog({ date: "2026-05-19", value: 5 }),
-        "numeric",
-        undefined,
-      ),
-    ).toBe(true);
-
-    expect(
-      logCountsAsCompleted(
-        numericLog({ date: "2026-05-19", value: 0 }),
-        "numeric",
-        undefined,
-      ),
-    ).toBe(false);
-  });
-
-  it("numeric with targetValue: counts iff value >= targetValue", () => {
-    expect(
-      logCountsAsCompleted(
-        numericLog({ date: "2026-05-19", value: 8 }),
-        "numeric",
-        8,
-      ),
-    ).toBe(true);
-
-    expect(
-      logCountsAsCompleted(
-        numericLog({ date: "2026-05-19", value: 7 }),
-        "numeric",
-        8,
-      ),
-    ).toBe(false);
-  });
-
-  it("multi-choice: counts iff value is a non-empty string", () => {
-    expect(
-      logCountsAsCompleted(
-        multiChoiceLog({ date: "2026-05-19", value: "good" }),
-        "multi-choice",
-        undefined,
-      ),
-    ).toBe(true);
-
-    expect(
-      logCountsAsCompleted(
-        multiChoiceLog({ date: "2026-05-19", value: "" }),
-        "multi-choice",
-        undefined,
-      ),
-    ).toBe(false);
-  });
-
-  it("weight: counts iff value > 0", () => {
-    expect(
-      logCountsAsCompleted(
-        numericLog({ date: "2026-05-19", value: 80 }),
-        "weight",
-        undefined,
-      ),
-    ).toBe(true);
-
-    expect(
-      logCountsAsCompleted(
-        numericLog({ date: "2026-05-19", value: 0 }),
-        "weight",
-        undefined,
       ),
     ).toBe(false);
   });
@@ -264,45 +155,6 @@ describe("habit-compliance — computeCompliance", () => {
       undefined,
     );
     // 2 completed (19 + 17), 2026-05-18 excluded by soft-delete
-    expect(result.ratio).toBeCloseTo(2 / 7, 10);
-  });
-
-  // T05 — numeric below target (T-06-08-03)
-  it("T05: numeric value=5 with targetValue=8 → does NOT count", () => {
-    const logs: HabitLogRow[] = [
-      numericLog({ date: "2026-05-19", value: 5 }),
-      numericLog({ date: "2026-05-18", value: 5 }),
-    ];
-    const result = computeCompliance("numeric", logs, 7, "2026-05-19", "UTC", 8);
-    expect(result.ratio).toBe(0);
-  });
-
-  // T06 — numeric meets target (T-06-08-03 complement)
-  it("T06: numeric value=8 with targetValue=8 → counts", () => {
-    const logs: HabitLogRow[] = [
-      numericLog({ date: "2026-05-19", value: 8 }),
-      numericLog({ date: "2026-05-18", value: 10 }),
-      numericLog({ date: "2026-05-17", value: 7 }), // below target — does NOT count
-    ];
-    const result = computeCompliance("numeric", logs, 7, "2026-05-19", "UTC", 8);
-    expect(result.ratio).toBeCloseTo(2 / 7, 10);
-  });
-
-  // T07 — weight habit
-  it("T07: weight habit log value=80 → counts (>0)", () => {
-    const logs: HabitLogRow[] = [
-      numericLog({ date: "2026-05-19", value: 80 }),
-      numericLog({ date: "2026-05-18", value: 79.5 }),
-      numericLog({ date: "2026-05-17", value: 0 }), // zero/negative does NOT count
-    ];
-    const result = computeCompliance(
-      "weight",
-      logs,
-      7,
-      "2026-05-19",
-      "UTC",
-      undefined,
-    );
     expect(result.ratio).toBeCloseTo(2 / 7, 10);
   });
 

--- a/backoffice/src/lib/gc-fitness/__tests__/habit-schema.test.ts
+++ b/backoffice/src/lib/gc-fitness/__tests__/habit-schema.test.ts
@@ -4,15 +4,10 @@
 // `GCFitnessCore/Sources/GCFitnessCore/Schema/Habit.swift` +
 // `HabitType.swift` and the canonical schema doc `.planning/schemas/habits.md`.
 //
-// Plan 06-05 contract:
-//  - 4 habit types: "binary" | "multi-choice" | "numeric" | "weight".
-//  - Type-conditional refinements (4 rules from `habits.md`):
-//      1. multi-choice ⇒ options has ≥ 2 entries
-//      2. !multi-choice ⇒ options must be absent
-//      3. weight ⇒ targetValue must be absent
-//      4. reminderEnabled === true ⇒ reminderTime required
-//  - Server-side fields (trainerId, seedSource, createdAt, updatedAt,
-//    deleted, id) are NEVER on the input — `.parse()` strips them silently.
+// Habits are BINARY-ONLY (yes/no) now. The schema accepts only `type: "binary"`,
+// and the only cross-field rule is `reminderEnabled === true ⇒ reminderTime`.
+// Server-side fields (trainerId, seedSource, createdAt, updatedAt, deleted, id)
+// are NEVER on the input — `.parse()` strips them silently.
 
 import {
   habitCreateSchema,
@@ -26,31 +21,6 @@ const BINARY_VALID = {
   reminderEnabled: false,
 };
 
-const MULTI_CHOICE_VALID = {
-  clientId: "uid-client-abc",
-  type: "multi-choice" as const,
-  name: { en: "Mood check", es: "Estado de ánimo" },
-  options: ["great", "ok", "tired", "stressed"],
-  reminderEnabled: false,
-};
-
-const NUMERIC_VALID = {
-  clientId: "uid-client-abc",
-  type: "numeric" as const,
-  name: { en: "Drink water", es: "Beber agua" },
-  targetValue: 8,
-  unit: "glasses",
-  reminderEnabled: false,
-};
-
-const WEIGHT_VALID = {
-  clientId: "uid-client-abc",
-  type: "weight" as const,
-  name: { en: "Body weight", es: "Peso corporal" },
-  unit: "kg",
-  reminderEnabled: false,
-};
-
 describe("habit-schema", () => {
   // T01 — binary happy path
   it("T01 — accepts a valid binary habit", () => {
@@ -59,60 +29,6 @@ describe("habit-schema", () => {
     if (result.success) {
       expect(result.data.type).toBe("binary");
       expect(result.data.reminderEnabled).toBe(false);
-    }
-  });
-
-  // T02 — multi-choice happy path with 2+ options
-  it("T02 — accepts a multi-choice habit with 2 options", () => {
-    const result = habitCreateSchema.safeParse({
-      ...MULTI_CHOICE_VALID,
-      options: ["yes", "no"],
-    });
-    expect(result.success).toBe(true);
-    if (result.success) {
-      expect(result.data.options).toEqual(["yes", "no"]);
-    }
-  });
-
-  // T03 — multi-choice with 0 options → fail with path=["options"]
-  it("T03 — rejects multi-choice with zero options", () => {
-    const result = habitCreateSchema.safeParse({
-      ...MULTI_CHOICE_VALID,
-      options: undefined,
-    });
-    expect(result.success).toBe(false);
-    if (!result.success) {
-      expect(result.error.issues.some((i) => i.path[0] === "options")).toBe(
-        true,
-      );
-    }
-  });
-
-  // T04 — multi-choice with exactly 1 option → still fails (need ≥ 2)
-  it("T04 — rejects multi-choice with only 1 option", () => {
-    const result = habitCreateSchema.safeParse({
-      ...MULTI_CHOICE_VALID,
-      options: ["solo"],
-    });
-    expect(result.success).toBe(false);
-    if (!result.success) {
-      expect(result.error.issues.some((i) => i.path[0] === "options")).toBe(
-        true,
-      );
-    }
-  });
-
-  // T05 — numeric with negative targetValue → positive constraint fails
-  it("T05 — rejects numeric habit with negative targetValue", () => {
-    const result = habitCreateSchema.safeParse({
-      ...NUMERIC_VALID,
-      targetValue: -5,
-    });
-    expect(result.success).toBe(false);
-    if (!result.success) {
-      expect(
-        result.error.issues.some((i) => i.path[0] === "targetValue"),
-      ).toBe(true);
     }
   });
 
@@ -141,34 +57,6 @@ describe("habit-schema", () => {
     if (!result.success) {
       expect(
         result.error.issues.some((i) => i.path[0] === "reminderTime"),
-      ).toBe(true);
-    }
-  });
-
-  // T08 — numeric habit with options array → options-only-for-multi-choice fails
-  it("T08 — rejects numeric habit that carries an options array", () => {
-    const result = habitCreateSchema.safeParse({
-      ...NUMERIC_VALID,
-      options: ["a", "b"],
-    });
-    expect(result.success).toBe(false);
-    if (!result.success) {
-      expect(result.error.issues.some((i) => i.path[0] === "options")).toBe(
-        true,
-      );
-    }
-  });
-
-  // T09 — weight habit with targetValue → fails per schema doc rule 3
-  it("T09 — rejects weight habit with a targetValue", () => {
-    const result = habitCreateSchema.safeParse({
-      ...WEIGHT_VALID,
-      targetValue: 80,
-    });
-    expect(result.success).toBe(false);
-    if (!result.success) {
-      expect(
-        result.error.issues.some((i) => i.path[0] === "targetValue"),
       ).toBe(true);
     }
   });
@@ -236,10 +124,22 @@ describe("habit-schema", () => {
     });
     expect(result.success).toBe(false);
   });
+
+  // T15 — a non-binary (legacy) habit type is rejected now
+  it("T15 — rejects a non-binary habit type ('numeric')", () => {
+    const result = habitCreateSchema.safeParse({
+      ...BINARY_VALID,
+      type: "numeric" as unknown as "binary",
+    });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues.some((i) => i.path[0] === "type")).toBe(true);
+    }
+  });
 });
 
 describe("habit-schema — habitUpdateSchemaForType", () => {
-  // U01 — update with new name only (closure-captured type=binary, no refinement triggered)
+  // U01 — update with new name only (no refinement triggered)
   it("U01 — accepts a binary update with name change only", () => {
     const schema = habitUpdateSchemaForType("binary");
     const result = schema.safeParse({
@@ -249,29 +149,13 @@ describe("habit-schema — habitUpdateSchemaForType", () => {
     expect(result.success).toBe(true);
   });
 
-  // U02 — update on multi-choice: still must have ≥ 2 options when options are supplied
-  it("U02 — rejects multi-choice update with 1 option", () => {
-    const schema = habitUpdateSchemaForType("multi-choice");
-    const result = schema.safeParse({
-      name: { en: "Mood", es: "Humor" },
-      options: ["solo"],
-      reminderEnabled: false,
-    });
-    expect(result.success).toBe(false);
-    if (!result.success) {
-      expect(result.error.issues.some((i) => i.path[0] === "options")).toBe(
-        true,
-      );
-    }
-  });
-
   // U03 — update strips a client-attempted `type` override (omit'd from base)
   it("U03 — silently strips an attempted type-override on update", () => {
     const schema = habitUpdateSchemaForType("binary");
     const tampered = {
       name: { en: "ok", es: "ok" },
       reminderEnabled: false,
-      type: "weight",
+      type: "binary",
     } as unknown;
     const result = schema.safeParse(tampered);
     expect(result.success).toBe(true);
@@ -282,11 +166,9 @@ describe("habit-schema — habitUpdateSchemaForType", () => {
 
   // U04 — update enforces reminderEnabled⇒reminderTime
   it("U04 — rejects reminderEnabled=true without reminderTime on update", () => {
-    const schema = habitUpdateSchemaForType("numeric");
+    const schema = habitUpdateSchemaForType("binary");
     const result = schema.safeParse({
       name: { en: "Water", es: "Agua" },
-      targetValue: 8,
-      unit: "glasses",
       reminderEnabled: true,
     });
     expect(result.success).toBe(false);

--- a/backoffice/src/lib/gc-fitness/client-roster.ts
+++ b/backoffice/src/lib/gc-fitness/client-roster.ts
@@ -595,7 +595,7 @@ export async function listClientsForRoster(): Promise<ClientRosterRow[]> {
           habitId: hid,
           clientId: (data.clientId as string) ?? "",
           civilDate: typeof data.civilDate === "string" ? data.civilDate : "",
-          value: data.value as boolean | string | number,
+          value: data.value === true,
           unit: typeof data.unit === "string" ? data.unit : undefined,
           deleted: data.deleted === true,
         };

--- a/backoffice/src/lib/gc-fitness/coach-pulse-actions.ts
+++ b/backoffice/src/lib/gc-fitness/coach-pulse-actions.ts
@@ -68,31 +68,12 @@ function habitScheduledOn(
 
 function habitLogCountsAsCompleted(
   data: Record<string, unknown>,
-  habit: Record<string, unknown> | undefined,
+  _habit: Record<string, unknown> | undefined,
 ): boolean {
+  // Habits are binary-only: a log counts iff it isn't soft-deleted AND its
+  // value is `true`. Mirrors `logCountsAsCompleted` in habit-compliance.ts.
   if (data.deleted === true) return false;
-  const value = data.value;
-  const habitType =
-    typeof habit?.type === "string" ? (habit!.type as string) : "binary";
-  switch (habitType) {
-    case "multi-choice":
-      return typeof value === "string" && value.trim().length > 0;
-    case "numeric": {
-      if (typeof value !== "number" || !Number.isFinite(value) || value <= 0) {
-        return false;
-      }
-      const target =
-        typeof habit?.targetValue === "number"
-          ? (habit!.targetValue as number)
-          : null;
-      return target === null ? true : value >= target;
-    }
-    case "weight":
-      return typeof value === "number" && Number.isFinite(value) && value > 0;
-    case "binary":
-    default:
-      return value === true;
-  }
+  return data.value === true;
 }
 
 function buildWindowDays(timezone: string): string[] {

--- a/backoffice/src/lib/gc-fitness/habit-actions.ts
+++ b/backoffice/src/lib/gc-fitness/habit-actions.ts
@@ -13,10 +13,6 @@
 //   T-06-05-02 (Tampering — update foreign trainer's habit)
 //     → get()-based ownership precondition before update; throws Forbidden.
 //       Defense in depth before the rule layer (P06-03).
-//   T-06-05-03 (Tampering — multi-choice without options)
-//     → Zod superRefine in habit-schema.ts fails on parse.
-//   T-06-05-04 (Tampering — weight habit with targetValue)
-//     → Zod superRefine fails on parse.
 //   T-06-05-05 (InfoDisclosure — cross-trainer list leak)
 //     → listHabitsForTrainer scopes by trainerId == session.uid.
 //       listHabitsForClient relies on rule-layer read precondition.
@@ -53,45 +49,19 @@ import { normalizeMirrorEmail } from "./email-normalization";
 const COLLECTION = FirestoreCollections.habits;
 const TEMPLATE_COLLECTION = FirestoreCollections.habitTemplates;
 
+// Global habit templates are BINARY-ONLY (yes/no) now. The former numeric
+// (water/sleep/steps/protein) and multi-choice (energy) templates were
+// dropped when the product collapsed to binary habits; "Water intake" is kept
+// as a yes/no "Drink water" habit so the seed list stays useful.
 const GLOBAL_HABIT_TEMPLATES = [
   {
     id: "global-water",
-    type: "numeric",
-    name: { en: "Water intake", es: "Agua diaria" },
+    type: "binary",
+    name: { en: "Drink water", es: "Beber agua" },
     description: {
-      en: "Hit your daily hydration target.",
-      es: "Cumple tu objetivo diario de hidratacion.",
+      en: "Did you hit your daily hydration goal?",
+      es: "¿Cumpliste tu objetivo diario de hidratación?",
     },
-    targetValue: 2,
-    unit: "L",
-    reminderEnabled: false,
-  },
-  {
-    id: "global-sleep",
-    type: "numeric",
-    name: { en: "Sleep", es: "Sueno" },
-    description: {
-      en: "Track total hours slept.",
-      es: "Registra tus horas totales de sueno.",
-    },
-    targetValue: 7,
-    unit: "h",
-    reminderEnabled: false,
-  },
-  {
-    id: "global-steps",
-    type: "numeric",
-    name: { en: "Steps", es: "Pasos" },
-    targetValue: 8000,
-    unit: "steps",
-    reminderEnabled: false,
-  },
-  {
-    id: "global-protein",
-    type: "numeric",
-    name: { en: "Protein", es: "Proteina" },
-    targetValue: 120,
-    unit: "g",
     reminderEnabled: false,
   },
   {
@@ -116,21 +86,11 @@ const GLOBAL_HABIT_TEMPLATES = [
     name: { en: "Food log", es: "Registro de comidas" },
     reminderEnabled: false,
   },
-  {
-    id: "global-energy",
-    type: "multi-choice",
-    name: { en: "Energy check", es: "Chequeo de energia" },
-    options: ["High", "OK", "Low"],
-    reminderEnabled: false,
-  },
 ] satisfies Array<{
   id: string;
   type: HabitType;
   name: { en: string; es: string };
   description?: { en: string; es: string };
-  options?: string[];
-  targetValue?: number;
-  unit?: string;
   reminderEnabled: boolean;
 }>;
 
@@ -150,9 +110,6 @@ export interface HabitRow {
   type: HabitType;
   name: { en: string; es: string };
   description?: { en: string; es: string };
-  options?: string[];
-  targetValue?: number;
-  unit?: string;
   reminderTime?: string;
   reminderEnabled: boolean;
   reminderCadence?: "daily" | "weekly" | "monthly";
@@ -185,9 +142,6 @@ export interface HabitTemplateRow {
   type: HabitType;
   name: { en: string; es: string };
   description?: { en: string; es: string };
-  options?: string[];
-  targetValue?: number;
-  unit?: string;
   reminderTime?: string;
   reminderEnabled: boolean;
   reminderCadence?: "daily" | "weekly" | "monthly";
@@ -282,12 +236,6 @@ function projectHabitRow(
     type: (data.type as HabitType) ?? "binary",
     name: (data.name as { en: string; es: string }) ?? { en: "", es: "" },
     description: data.description as { en: string; es: string } | undefined,
-    options: Array.isArray(data.options)
-      ? (data.options as string[])
-      : undefined,
-    targetValue:
-      typeof data.targetValue === "number" ? data.targetValue : undefined,
-    unit: typeof data.unit === "string" ? data.unit : undefined,
     reminderTime:
       typeof data.reminderTime === "string" ? data.reminderTime : undefined,
     reminderEnabled: data.reminderEnabled === true,
@@ -357,12 +305,6 @@ function projectHabitTemplateRow(
     type: (data.type as HabitType) ?? "binary",
     name: (data.name as { en: string; es: string }) ?? { en: "", es: "" },
     description: data.description as { en: string; es: string } | undefined,
-    options: Array.isArray(data.options)
-      ? (data.options as string[])
-      : undefined,
-    targetValue:
-      typeof data.targetValue === "number" ? data.targetValue : undefined,
-    unit: typeof data.unit === "string" ? data.unit : undefined,
     reminderTime:
       typeof data.reminderTime === "string" ? data.reminderTime : undefined,
     reminderEnabled: data.reminderEnabled === true,
@@ -461,9 +403,8 @@ async function ensureGlobalHabitTemplates(): Promise<void> {
  *   - `createdAt` / `updatedAt` are server timestamps.
  *   - Doc id follows the canonical `hab-${trainerUid}-${uuid}` scheme.
  *
- * Zod-parses BEFORE any Firestore write so multi-choice-without-options,
- * weight-with-targetValue, malformed reminderTime, etc. are caught
- * client-of-DB — T-06-05-03 / -04.
+ * Zod-parses BEFORE any Firestore write so malformed reminderTime, etc. are
+ * caught client-of-DB.
  */
 export async function createHabit(
   input: unknown,
@@ -635,10 +576,9 @@ export async function listPendingHabits(pendingEmail: string): Promise<Array<{
  *  - the doc's `trainerId` isn't the caller (throws "Not your habit" —
  *    T-06-05-02 defense in depth before the rule layer)
  *
- * Parses against `habitUpdateSchemaForType(existingType)` so the same
- * type-conditional refinements (multi-choice⇒options, weight⇒no targetValue,
- * reminderEnabled⇒reminderTime) apply on update even though the immutable
- * `type` field is stripped from the input.
+ * Parses against `habitUpdateSchemaForType(existingType)` so the
+ * reminderEnabled⇒reminderTime refinement applies on update even though the
+ * immutable `type` field is stripped from the input.
  *
  * The patch is built field-by-field from a whitelist matching the
  * affectedKeys list in P06-03 rules — clientId, trainerId, type,
@@ -668,9 +608,6 @@ export async function updateHabit(
   const parsed = habitUpdateSchemaForType(existingType).parse(input) as {
     name: { en: string; es: string };
     description?: { en: string; es: string };
-    options?: string[];
-    targetValue?: number;
-    unit?: string;
     reminderTime?: string;
     reminderEnabled: boolean;
     reminderCadence?: "daily" | "weekly" | "monthly";
@@ -700,15 +637,6 @@ export async function updateHabit(
   }
   if (parsed.description !== undefined) {
     patch.description = parsed.description;
-  }
-  if (parsed.options !== undefined) {
-    patch.options = parsed.options;
-  }
-  if (parsed.targetValue !== undefined) {
-    patch.targetValue = parsed.targetValue;
-  }
-  if (parsed.unit !== undefined) {
-    patch.unit = parsed.unit;
   }
   if (parsed.reminderTime !== undefined) {
     patch.reminderTime = parsed.reminderTime;
@@ -942,7 +870,7 @@ export async function softDeleteHabitTemplate(
 /**
  * Updates the trainer-editable fields of an own (scope === "trainer") habit
  * template. GLOBAL templates are read-only. Only the intrinsic fields shown in
- * the library detail are editable (name, description, numeric goal, reminder);
+ * the library detail are editable (name, description, reminder);
  * `type` / `scope` / `trainerId` / recurrence are left untouched. The affected
  * keys stay within the Firestore-rules update whitelist.
  */
@@ -971,8 +899,6 @@ export async function updateHabitTemplate(
     withoutUndefined({
       name: parsed.name,
       description: parsed.description,
-      targetValue: parsed.targetValue,
-      unit: parsed.unit,
       reminderEnabled: parsed.reminderEnabled,
       // Only persist a time when the reminder is on.
       reminderTime: parsed.reminderEnabled ? parsed.reminderTime : undefined,
@@ -1030,11 +956,6 @@ export async function assignHabitTemplate(input: unknown): Promise<{
       type: template.type,
       name: template.name,
       ...(template.description ? { description: template.description } : {}),
-      ...(template.options ? { options: template.options } : {}),
-      ...(template.targetValue !== undefined
-        ? { targetValue: template.targetValue }
-        : {}),
-      ...(template.unit ? { unit: template.unit } : {}),
       ...(template.reminderTime ? { reminderTime: template.reminderTime } : {}),
       ...(template.reminderCadence
         ? { reminderCadence: template.reminderCadence }
@@ -1122,11 +1043,6 @@ export async function assignHabitTemplateToPending(input: unknown): Promise<{
     type: template.type,
     name: template.name,
     ...(template.description ? { description: template.description } : {}),
-    ...(template.options ? { options: template.options } : {}),
-    ...(template.targetValue !== undefined
-      ? { targetValue: template.targetValue }
-      : {}),
-    ...(template.unit ? { unit: template.unit } : {}),
     ...(template.reminderTime ? { reminderTime: template.reminderTime } : {}),
     ...(template.reminderCadence
       ? { reminderCadence: template.reminderCadence }

--- a/backoffice/src/lib/gc-fitness/habit-compliance-actions.ts
+++ b/backoffice/src/lib/gc-fitness/habit-compliance-actions.ts
@@ -161,7 +161,7 @@ export async function fetchHabitCompliance(
       habitId: (data.habitId as string) ?? "",
       clientId: (data.clientId as string) ?? "",
       civilDate: (data.civilDate as string) ?? "",
-      value: data.value as boolean | string | number,
+      value: data.value === true,
       unit: typeof data.unit === "string" ? data.unit : undefined,
       loggedAt: toIsoOrEmpty(data.loggedAt),
       deleted: data.deleted === true,

--- a/backoffice/src/lib/gc-fitness/habit-compliance.ts
+++ b/backoffice/src/lib/gc-fitness/habit-compliance.ts
@@ -28,12 +28,9 @@
 // PARITY WITH SWIFT — semantic mapping (HabitStreakCalculator.swift):
 //   - `logCountsAsCompleted(log, habitType, targetValue)` mirrors
 //     Swift `logCountsAsCompleted(_:habitType:targetValue:)`.
-//       binary       → value === true                          && !deleted
-//       multi-choice → typeof value === "string" && !empty     && !deleted
-//       numeric      → typeof value === "number" && value > 0
-//                      && (targetValue === undefined || value >= targetValue)
-//                      && !deleted
-//       weight       → typeof value === "number" && value > 0  && !deleted
+//     Habits are BINARY-ONLY now: a log counts iff `!deleted && value === true`.
+//     `habitType` / `targetValue` are kept in the signature for call-site
+//     parity but are unused (every habit is binary).
 //   - `computeCompliance(habitType, logs, windowDays, today, timezone, targetValue?)`
 //     mirrors Swift `complianceRatio(habitType:logs:windowDays:today:timezoneIdentifier:targetValue:)`.
 //       Edge cases: windowDays <= 0 → 0.0; empty logs → 0.0.
@@ -70,15 +67,14 @@ import type { HabitType } from "./habit-schema";
  * `.planning/schemas/habit-logs.md` (Plan 06-01) + the Swift
  * `HabitLog.swift` Codable struct (Plan 06-02 post-fix `4482452`).
  *
- * `value` is type-erased intentionally — the consumer's `habitType`
- * parameter drives the variant projection. Mirrors the Swift
- * `HabitLogValue` enum's `asBool` / `asString` / `asDouble` accessors.
+ * `value` is a boolean — habits are binary-only (yes/no). Mirrors the Swift
+ * `HabitLog.value` after the binary-only collapse.
  */
 export interface HabitLogRow {
   habitId: string;
   clientId: string;
   civilDate: string; // "YYYY-MM-DD"
-  value: boolean | string | number;
+  value: boolean;
   unit?: string;
   loggedAt?: string; // ISO 8601 when the log was tapped (optional in compliance math)
   deleted?: boolean;
@@ -90,47 +86,19 @@ export interface HabitLogRow {
  * SOLE source of truth for "did this log count?". Re-used by
  * `computeCompliance` so the semantics cannot drift between the trainer
  * surface and any future per-day rollup. Parity-matches the Swift
- * `HabitStreakCalculator.logCountsAsCompleted(_:habitType:targetValue:)`.
+ * `HabitStreakCalculator.logCountsAsCompleted`.
  *
- * Per-type completion rules (from `.planning/schemas/habit-logs.md`
- * § HabitType table):
- *   - binary       → value === true                       && !deleted
- *   - multi-choice → typeof value === "string" && !empty  && !deleted
- *   - numeric      → typeof value === "number" && value > 0
- *                    && (targetValue === undefined ? true : value >= targetValue)
- *                    && !deleted
- *   - weight       → typeof value === "number" && value > 0 && !deleted
- *
- * Soft-deleted logs ALWAYS fail the predicate, regardless of habit type.
+ * Habits are BINARY-ONLY: a log counts iff `!deleted && value === true`.
+ * `_habitType` / `_targetValue` are kept in the signature for call-site
+ * parity (callers still pass them) but are unused.
  */
 export function logCountsAsCompleted(
   log: HabitLogRow,
-  habitType: HabitType,
-  targetValue: number | undefined,
+  _habitType?: HabitType,
+  _targetValue?: number | undefined,
 ): boolean {
   if (log.deleted === true) return false;
-
-  switch (habitType) {
-    case "binary":
-      return log.value === true;
-
-    case "multi-choice":
-      return typeof log.value === "string" && log.value.length > 0;
-
-    case "numeric": {
-      if (typeof log.value !== "number") return false;
-      if (log.value <= 0) return false;
-      if (targetValue !== undefined) return log.value >= targetValue;
-      return true;
-    }
-
-    case "weight":
-      return typeof log.value === "number" && log.value > 0;
-
-    default:
-      // Exhaustive — but TypeScript-narrow the discriminated union path.
-      return false;
-  }
+  return log.value === true;
 }
 
 /**

--- a/backoffice/src/lib/gc-fitness/habit-schema.ts
+++ b/backoffice/src/lib/gc-fitness/habit-schema.ts
@@ -30,28 +30,22 @@
 //   lock this defense-in-depth (mirrors T-04-14 + T-04-15 from P04-04).
 //
 // TYPE-CONDITIONAL VALIDATION:
-//   The `superRefine` block enforces the four cross-field rules from the
-//   schema doc (lines 59-65 of `habits.md`):
-//     1. type === "multi-choice"  ⇒ options has ≥ 2 entries
-//     2. type !== "multi-choice"  ⇒ options must be absent
-//     3. type === "weight"        ⇒ targetValue must be absent
-//     4. reminderEnabled === true ⇒ reminderTime must be present
+//   Habits are BINARY-ONLY (yes/no). The only cross-field rule that remains is:
+//     reminderEnabled === true ⇒ reminderTime must be present
+//   The legacy multi-choice/numeric/weight conditional rules were removed when
+//   the product collapsed to binary-only habits (TS↔Swift parity: the Swift
+//   `HabitType` enum + `firestore.rules` were collapsed in the same change).
 //
-//   `habitUpdateSchemaForType(existingType)` re-applies the same rules using
+//   `habitUpdateSchemaForType(existingType)` re-applies the same rule using
 //   a closure-captured `existingType` because the immutable `type` field is
 //   stripped from the update input (clients cannot mutate `type` — rule
 //   layer P06-03 + this schema both enforce that immutability).
 
 import { z } from "zod";
 
-// HabitType enum — wire raw values mirror the Swift `HabitType` enum
-// (incl. the hyphenated `"multi-choice"`). Locked in `habits.md`.
-export const HABIT_TYPES = [
-  "binary",
-  "multi-choice",
-  "numeric",
-  "weight",
-] as const;
+// HabitType enum — binary-only. Mirrors the now-collapsed Swift `HabitType`
+// enum. Locked in `habits.md`.
+export const HABIT_TYPES = ["binary"] as const;
 
 export const habitTypeSchema = z.enum(HABIT_TYPES);
 
@@ -98,22 +92,6 @@ const habitBaseShape = z.object({
   type: habitTypeSchema,
   name: localizedStringSchema,
   description: localizedDescriptionSchema.optional(),
-  // multi-choice only — array of human-friendly option labels. Max 8 keeps
-  // the iOS Menu picker readable on a 6.1" screen.
-  options: z
-    .array(z.string().trim().min(1).max(40))
-    .max(8, "Maximum 8 options.")
-    .optional(),
-  // numeric only — target value (e.g. 8 glasses of water). Positive finite
-  // float; the streak math reads this when set (≥ targetValue counts).
-  targetValue: z.number().positive().finite().optional(),
-  // numeric + weight — human unit string. Free-form to keep v1 simple.
-  unit: z
-    .string()
-    .trim()
-    .min(1)
-    .max(20, "Keep the unit under 20 characters.")
-    .optional(),
   // HH:mm 24-hour local-time string. Regex matches the schema doc spec.
   // iOS schedules a daily UNCalendarNotificationTrigger at this hour-minute.
   reminderTime: z
@@ -169,14 +147,11 @@ const habitBaseShape = z.object({
     .optional(),
 });
 
-// Shared superRefine logic — applied by both create and update schemas. The
-// `existingType` argument lets the update path enforce the same conditional
-// rules using the immutable parent doc's `type` (since the update input no
-// longer carries `type` itself).
+// Shared superRefine logic — applied by both create and update schemas.
+// Habits are binary-only, so the only cross-field rules left are the
+// reminder/schedule cadence ones.
 function applyTypeConditionalRules(
   data: {
-    options?: string[];
-    targetValue?: number;
     reminderTime?: string;
     reminderEnabled: boolean;
     reminderCadence?: "daily" | "weekly" | "monthly";
@@ -191,41 +166,9 @@ function applyTypeConditionalRules(
     scheduleDayOfMonth?: number;
     scheduleMonthDays?: number[];
   },
-  effectiveType: HabitType,
   ctx: z.RefinementCtx,
 ): void {
-  // Rule 1 + 2: options ↔ multi-choice mutual exclusivity.
-  if (effectiveType === "multi-choice") {
-    if (!data.options || data.options.length < 2) {
-      ctx.addIssue({
-        code: z.ZodIssueCode.custom,
-        path: ["options"],
-        message: "Multi-choice habits need at least 2 options.",
-      });
-    }
-  } else {
-    if (data.options !== undefined) {
-      ctx.addIssue({
-        code: z.ZodIssueCode.custom,
-        path: ["options"],
-        message: "Options are only allowed on multi-choice habits.",
-      });
-    }
-  }
-
-  // Rule 3: weight habits never carry a targetValue (the value is recorded
-  // per-log; a "target weight" makes no sense at the habit definition layer
-  // — that lives on the future Goals collection, V2).
-  if (effectiveType === "weight" && data.targetValue !== undefined) {
-    ctx.addIssue({
-      code: z.ZodIssueCode.custom,
-      path: ["targetValue"],
-      message:
-        "targetValue is not used for weight habits — record per-log value instead.",
-    });
-  }
-
-  // Rule 4: reminderEnabled === true ⇒ reminderTime must be present.
+  // Rule: reminderEnabled === true ⇒ reminderTime must be present.
   // Defense in depth: the iOS UI gates the reminderTime control behind the
   // reminderEnabled toggle, but a hand-crafted Server Action input could
   // try to enable reminders without a time.
@@ -356,7 +299,7 @@ function applyTypeConditionalRules(
 // `trainerId: "victim-uid"` in the input never makes it into the output.
 // `habit-actions.ts` adds `trainerId` from the session AFTER parse.
 export const habitCreateSchema = habitBaseShape.superRefine((data, ctx) => {
-  applyTypeConditionalRules(data, data.type, ctx);
+  applyTypeConditionalRules(data, ctx);
 });
 
 export type HabitCreateInput = z.input<typeof habitCreateSchema>;
@@ -364,7 +307,7 @@ export type HabitCreateInput = z.input<typeof habitCreateSchema>;
 export const habitTemplateCreateSchema = habitBaseShape
   .omit({ clientId: true })
   .superRefine((data, ctx) => {
-    applyTypeConditionalRules(data, data.type, ctx);
+    applyTypeConditionalRules(data, ctx);
   });
 
 export type HabitTemplateCreateInput = z.input<
@@ -375,11 +318,11 @@ export type HabitTemplateCreateInput = z.input<
 // habit's immutable `type`. The update input cannot carry `clientId` (FK,
 // immutable) or `type` (immutable — changing type would invalidate every
 // log's value-variant interpretation per P06-02 doc).
-export function habitUpdateSchemaForType(existingType: HabitType) {
+export function habitUpdateSchemaForType(_existingType: HabitType) {
   return habitBaseShape
     .omit({ clientId: true, type: true })
     .superRefine((data, ctx) => {
-      applyTypeConditionalRules(data, existingType, ctx);
+      applyTypeConditionalRules(data, ctx);
     });
 }
 
@@ -394,8 +337,6 @@ export type HabitUpdateInput = z.input<
 export const habitTemplateUpdateSchema = habitBaseShape.pick({
   name: true,
   description: true,
-  targetValue: true,
-  unit: true,
   reminderEnabled: true,
   reminderTime: true,
 });

--- a/backoffice/src/lib/gc-fitness/recent-logs-actions.ts
+++ b/backoffice/src/lib/gc-fitness/recent-logs-actions.ts
@@ -245,36 +245,15 @@ function habitScheduledOn(
 
 /**
  * Mirrors `logCountsAsCompleted` from habit-compliance.ts (kept inline so
- * recent-logs-actions doesn't add a deep import path). A log counts as
- * "done" iff it's not soft-deleted AND its `value` reads as completed for
- * the habit's type. Numeric habits with a targetValue require value >=
- * target; numeric habits without a target accept value > 0.
+ * recent-logs-actions doesn't add a deep import path). Habits are binary-only:
+ * a log counts as "done" iff it isn't soft-deleted AND its `value` is `true`.
  */
 function habitLogCountsAsCompleted(
   data: Record<string, unknown>,
-  habit: Record<string, unknown> | undefined,
+  _habit: Record<string, unknown> | undefined,
 ): boolean {
   if (data.deleted === true) return false;
-  const value = data.value;
-  const habitType =
-    typeof habit?.type === "string" ? (habit!.type as string) : "binary";
-  switch (habitType) {
-    case "multi-choice":
-      return typeof value === "string" && value.trim().length > 0;
-    case "numeric": {
-      if (typeof value !== "number" || !Number.isFinite(value) || value <= 0) {
-        return false;
-      }
-      const target =
-        typeof habit?.targetValue === "number" ? (habit!.targetValue as number) : null;
-      return target === null ? true : value >= target;
-    }
-    case "weight":
-      return typeof value === "number" && Number.isFinite(value) && value > 0;
-    case "binary":
-    default:
-      return value === true;
-  }
+  return data.value === true;
 }
 
 /**

--- a/backoffice/src/lib/gc-fitness/schedule-month-actions.ts
+++ b/backoffice/src/lib/gc-fitness/schedule-month-actions.ts
@@ -569,7 +569,7 @@ export async function listMonthForClients(input: {
         habitId,
         clientId: (data.clientId as string) ?? "",
         civilDate: civil,
-        value: data.value as boolean | string | number,
+        value: data.value === true,
         unit: typeof data.unit === "string" ? data.unit : undefined,
         deleted: data.deleted === true,
       };


### PR DESCRIPTION
- habit-schema: HABIT_TYPES -> [binary]; drop options/targetValue/unit + their conditional rules; log value narrowed to boolean
- habit-actions: binary-only templates (water converted to yes/no), projection/copy drop options/targetValue/unit
- compliance twins (habit-compliance, coach-pulse, recent-logs): collapse to binary (!deleted && value === true), TS<->Swift parity
- HabitForm: remove type picker + multi-choice/numeric/weight fields
- remove HabitTypePill/GoalPill + per-type labels; list type-filter removed
- BodyWeightTrendChart: drop legacy weight-habit fallback (body_weight_logs only)
- tests updated; jest 293 green, tsc --noEmit clean