### PR TITLE
Show cached client avatars in Roster Activity + Actividad Reciente

### DIFF
--- a/backoffice/src/app/gc-fitness/clients/_components/RosterTable.tsx
+++ b/backoffice/src/app/gc-fitness/clients/_components/RosterTable.tsx
@@ -40,6 +40,7 @@ import { Badge } from "@/components/ui/badge";
 import { Progress } from "@/components/ui/progress";
 import { Button } from "@/components/ui/button";
 
+import { ClientAvatar } from "@/components/gc-fitness/ClientAvatar";
 import type { ClientRosterRow } from "@/lib/gc-fitness/client-roster";
 import type { AttentionReason } from "@/lib/gc-fitness/client-attention";
 import { RelativeTime } from "./RelativeTime";
@@ -110,6 +111,11 @@ export function RosterTable({ rows }: RosterTableProps) {
           const title = t("needsAttentionTitle", { reasons: reasonText });
           return (
             <div className="flex items-center gap-2">
+              <ClientAvatar
+                name={row.original.displayName}
+                photoURL={row.original.photoURL}
+                size="sm"
+              />
               <span className="font-medium">{row.original.displayName}</span>
               {row.original.pendingProvisioning ? (
                 <Badge variant="secondary">{tCommon("pendingSignIn")}</Badge>

--- a/backoffice/src/app/gc-fitness/dashboard/_components/coach-pulse.tsx
+++ b/backoffice/src/app/gc-fitness/dashboard/_components/coach-pulse.tsx
@@ -3,6 +3,7 @@
 import Link from "next/link";
 
 import { cn } from "@/lib/utils";
+import { ClientAvatar } from "@/components/gc-fitness/ClientAvatar";
 import {
   Tooltip,
   TooltipContent,
@@ -139,6 +140,11 @@ export function TopPerformers({ performers, emptyLabel }: TopPerformersProps) {
             >
               {idx + 1}
             </span>
+            <ClientAvatar
+              name={performer.name}
+              photoURL={performer.photoURL}
+              size="sm"
+            />
             <span className="min-w-0 flex-1 truncate text-sm font-medium group-hover:text-foreground">
               {performer.name}
             </span>

--- a/backoffice/src/app/gc-fitness/recent-logs/_components/RecentLogsFeed.tsx
+++ b/backoffice/src/app/gc-fitness/recent-logs/_components/RecentLogsFeed.tsx
@@ -21,6 +21,7 @@ import {
 import { useTranslations } from "next-intl";
 
 import { Button } from "@/components/ui/button";
+import { ClientAvatar } from "@/components/gc-fitness/ClientAvatar";
 import {
   Card,
   CardContent,
@@ -237,6 +238,11 @@ export function RecentLogsFeed({
               }}
               className="group flex cursor-pointer items-start gap-3 rounded-lg border bg-card px-3 py-2.5 transition-colors hover:border-primary/30 hover:bg-accent/40 sm:items-center"
             >
+              <ClientAvatar
+                name={row.clientName}
+                photoURL={row.clientPhotoURL}
+                size="md"
+              />
               <div className="min-w-0 flex-1">
                 <div className="flex flex-wrap items-center gap-2">
                   <Badge

--- a/backoffice/src/components/gc-fitness/ClientAvatar.tsx
+++ b/backoffice/src/components/gc-fitness/ClientAvatar.tsx
@@ -1,0 +1,92 @@
+"use client";
+
+// ClientAvatar.tsx — reusable cached client profile avatar.
+//
+// Renders the client's `photoURL` (Google profile photo or Firebase Storage
+// upload) through `next/image` WITHOUT `unoptimized`, so Next's Image
+// Optimization pipeline + browser/CDN cache the bytes (the whole point of this
+// component vs. the chat's old inline `unoptimized` Avatar). Falls back to the
+// client's initials when there is no photoURL or the image fails to load
+// (404 / expired Storage signature / CORS) instead of a broken-image icon.
+//
+// Hosts must be allow-listed in `next.config.ts` `images.remotePatterns`
+// (`lh3.googleusercontent.com` for Google photos, `storage.googleapis.com` for
+// uploads) — both are present. A photoURL on any other host won't optimize and
+// will trigger the initials fallback via the error path rather than throwing.
+
+import { useState } from "react";
+import Image from "next/image";
+
+import { cn } from "@/lib/utils";
+
+type AvatarSize = "sm" | "md";
+
+const SIZE_PX: Record<AvatarSize, number> = {
+  sm: 24,
+  md: 40,
+};
+
+const SIZE_CLASS: Record<AvatarSize, string> = {
+  sm: "h-6 w-6 text-[10px]",
+  md: "h-10 w-10 text-sm",
+};
+
+function initialsFromName(name: string): string {
+  return (
+    name
+      .trim()
+      .split(/\s+/)
+      .map((w) => w[0])
+      .filter(Boolean)
+      .slice(0, 2)
+      .join("")
+      .toUpperCase() || "·"
+  );
+}
+
+export interface ClientAvatarProps {
+  /** Client display name — drives the initials fallback. */
+  name: string;
+  /** Client `users/{uid}.photoURL` — Google photo or Storage upload, or null. */
+  photoURL?: string | null;
+  /** Visual size. `md` (40px) is the default for feed/list rows; `sm` (24px). */
+  size?: AvatarSize;
+  className?: string;
+}
+
+export function ClientAvatar({
+  name,
+  photoURL,
+  size = "md",
+  className,
+}: ClientAvatarProps) {
+  // Local per-render error flag: if the optimized image fails (expired URL,
+  // CORS, host not allow-listed), fall back to initials.
+  const [failed, setFailed] = useState(false);
+  const px = SIZE_PX[size];
+  const showImage = !!photoURL && !failed;
+
+  return (
+    <div
+      aria-hidden="true"
+      className={cn(
+        "flex shrink-0 items-center justify-center overflow-hidden rounded-full bg-primary/10 font-medium text-primary",
+        SIZE_CLASS[size],
+        className,
+      )}
+    >
+      {showImage ? (
+        <Image
+          src={photoURL!}
+          alt=""
+          width={px}
+          height={px}
+          className="h-full w-full rounded-full object-cover"
+          onError={() => setFailed(true)}
+        />
+      ) : (
+        initialsFromName(name)
+      )}
+    </div>
+  );
+}

--- a/backoffice/src/lib/gc-fitness/client-roster.ts
+++ b/backoffice/src/lib/gc-fitness/client-roster.ts
@@ -84,6 +84,9 @@ export interface ClientRosterRow {
   uid: string;
   email: string;
   displayName: string;
+  /** Client profile photo (`users/{uid}.photoURL`) — Google photo or Storage
+   *  upload, or null. Rendered as a cached avatar in the roster name column. */
+  photoURL: string | null;
   timezone: string | null;
   source: "active" | "pending";
   pendingProvisioning: boolean;
@@ -763,6 +766,7 @@ export async function listClientsForRoster(): Promise<ClientRosterRow[]> {
         uid: c.uid,
         email: c.email,
         displayName: c.displayName,
+        photoURL: c.photoURL,
         timezone: c.timezone,
         source: isPending ? "pending" : "active",
         pendingProvisioning: isPending,

--- a/backoffice/src/lib/gc-fitness/coach-pulse-actions.ts
+++ b/backoffice/src/lib/gc-fitness/coach-pulse-actions.ts
@@ -20,6 +20,9 @@ export interface DailyMetric {
 export interface PerformerRow {
   uid: string;
   name: string;
+  /** Client profile photo (`users/{uid}.photoURL`) — Google photo or Storage
+   *  upload, or null. Rendered as a cached avatar in the performers list. */
+  photoURL: string | null;
   pct: number;
   numerator: number;
   denominator: number;
@@ -449,6 +452,7 @@ function pickTopPerformers(
     rows.push({
       uid,
       name: client.displayName,
+      photoURL: client.photoURL,
       pct,
       numerator: stat.num,
       denominator: stat.den,

--- a/backoffice/src/lib/gc-fitness/recent-logs-actions.ts
+++ b/backoffice/src/lib/gc-fitness/recent-logs-actions.ts
@@ -25,6 +25,9 @@ export interface RecentLogRow {
   eventAt: string;
   clientId: string;
   clientName: string;
+  /** Client profile photo (`users/{uid}.photoURL`) — Google photo or Storage
+   *  upload, or null. Rendered as a cached avatar next to the client name. */
+  clientPhotoURL: string | null;
   title: string;
   detail: string;
   workoutLogId: string | null;
@@ -294,6 +297,9 @@ async function buildRecentLogs(params: {
 
   const clients = params.clients;
   const nameByClientId = new Map(clients.map((c) => [c.uid, c.displayName]));
+  const photoByClientId = new Map<string, string | null>(
+    clients.map((c) => [c.uid, c.photoURL]),
+  );
   const clientList = clients.map((c) => ({ id: c.uid, name: c.displayName }));
 
   const pageMode = params.page ?? null;
@@ -807,6 +813,7 @@ async function buildRecentLogs(params: {
       eventAt: createdAt,
       clientId,
       clientName: nameByClientId.get(clientId) ?? clientId,
+      clientPhotoURL: photoByClientId.get(clientId) ?? null,
       title: `${nameByClientId.get(clientId) ?? clientId} completed first sign-in`,
       detail: "Pending client converted to active user",
       workoutLogId: null,
@@ -875,6 +882,7 @@ async function buildRecentLogs(params: {
       eventAt: completedAt ?? startedAt,
       clientId,
       clientName: nameByClientId.get(clientId) ?? clientId,
+      clientPhotoURL: photoByClientId.get(clientId) ?? null,
       title:
         status === "completed"
           ? `${nameByClientId.get(clientId) ?? clientId} - Workout completed: ${templateName}`
@@ -925,6 +933,7 @@ async function buildRecentLogs(params: {
       eventAt,
       clientId,
       clientName: nameByClientId.get(clientId) ?? clientId,
+      clientPhotoURL: photoByClientId.get(clientId) ?? null,
       title: `${nameByClientId.get(clientId) ?? clientId} moved ${templateName} from ${fromLabel} to ${toLabel}`,
       detail: `Originally ${fromLabel} → ${toLabel}`,
       workoutLogId: null,
@@ -1006,6 +1015,7 @@ async function buildRecentLogs(params: {
       eventAt,
       clientId,
       clientName: nameByClientId.get(clientId) ?? clientId,
+      clientPhotoURL: photoByClientId.get(clientId) ?? null,
       title: completed
         ? `${titlePrefix}${nameByClientId.get(clientId) ?? clientId} completed: ${habitName}${titleSuffix}`
         : `${nameByClientId.get(clientId) ?? clientId} updated: ${habitName}${titleSuffix}`,
@@ -1087,6 +1097,7 @@ async function buildRecentLogs(params: {
       eventAt: bucket.latestIso,
       clientId: bucket.clientId,
       clientName: nameByClientId.get(bucket.clientId) ?? bucket.clientId,
+      clientPhotoURL: photoByClientId.get(bucket.clientId) ?? null,
       title: `${nameByClientId.get(bucket.clientId) ?? bucket.clientId} - Uploaded progress photos`,
       detail,
       workoutLogId: null,
@@ -1110,6 +1121,7 @@ async function buildRecentLogs(params: {
         eventAt,
         clientId: client.uid,
         clientName: nameByClientId.get(client.uid) ?? client.uid,
+        clientPhotoURL: photoByClientId.get(client.uid) ?? null,
         title: `${nameByClientId.get(client.uid) ?? client.uid} - Logged body weight`,
         detail: `${kg.toFixed(1)} kg`,
         workoutLogId: null,


### PR DESCRIPTION
Adds client profile photos (avatars) to Roster Activity, Actividad Reciente (recent logs), and dashboard Top Performers — like chat already does — with proper image caching.

- New `ClientAvatar` using `next/image` (optimized + cached, **no** `unoptimized`) with initials fallback.
- `photoURL` plumbed into `ClientRosterRow` / `RecentLogRow` / `PerformerRow`.
- Hosts already covered by `next.config.ts` remotePatterns (googleusercontent + storage.googleapis.com).

Gates: `jest` 293 ✅ · `tsc --noEmit` ✅.