### PR TITLE
Backoffice fixes: exercise no-equipment, habit delete-from-date, agenda mobile UI

### DIFF
--- a/backoffice/src/components/gc-fitness/schedule/habit-detail-dialog.tsx
+++ b/backoffice/src/components/gc-fitness/schedule/habit-detail-dialog.tsx
@@ -8,7 +8,9 @@
 //
 //   • "Quitar de este día"  → skipHabitOccurrence (adds civilDate to the
 //     habit's skippedDates; recurring habits only).
-//   • "Eliminar el hábito"  → softDeleteHabit (removes the whole recurrence).
+//   • "Eliminar el hábito"  → deleteHabitRecurrenceFromDate (caps endsOn to
+//     the day before the tapped civilDate — removes the tapped day forward,
+//     keeps past occurrences + logs intact).
 //
 // Mirrors WorkoutDetailDialog's structure (useQuery load + confirm-then-mutate
 // footer). Each destructive action requires an inline confirm tap.
@@ -31,7 +33,7 @@ import { Skeleton } from "@/components/ui/skeleton";
 import {
   getHabit,
   skipHabitOccurrence,
-  softDeleteHabit,
+  deleteHabitRecurrenceFromDate,
   type HabitRow,
 } from "@/lib/gc-fitness/habit-actions";
 
@@ -103,9 +105,9 @@ export function HabitDetailDialog({
   });
 
   const deleteMutation = useMutation({
-    mutationFn: () => softDeleteHabit(habitId),
+    mutationFn: () => deleteHabitRecurrenceFromDate(habitId, civilDate),
     onSuccess: () => {
-      toast.success("Hábito eliminado");
+      toast.success("Hábito eliminado desde este día en adelante");
       onChanged();
     },
     onError: (err) =>
@@ -200,7 +202,7 @@ export function HabitDetailDialog({
             />
           ) : confirm === "delete" ? (
             <ConfirmRow
-              label="Elimina el hábito y toda su recurrencia para el cliente."
+              label={`Elimina el hábito desde el ${civilDate} en adelante. El historial anterior se conserva.`}
               confirmLabel="Eliminar el hábito"
               pending={deleteMutation.isPending}
               onConfirm={() => deleteMutation.mutate()}
@@ -226,7 +228,7 @@ export function HabitDetailDialog({
                 onClick={() => setConfirm("delete")}
               >
                 <Trash2 className="size-4" />
-                {isRecurring ? "Eliminar el hábito (toda la recurrencia)" : "Eliminar el hábito"}
+                {isRecurring ? "Eliminar el hábito (desde este día)" : "Eliminar el hábito"}
               </Button>
               <Button variant="ghost" onClick={() => onOpenChange(false)}>
                 Cerrar

--- a/backoffice/src/components/gc-fitness/schedule/month-calendar.tsx
+++ b/backoffice/src/components/gc-fitness/schedule/month-calendar.tsx
@@ -943,7 +943,10 @@ function DayCell({
         "group relative flex flex-col rounded-lg border bg-card p-2.5 transition-colors",
         cellMinHClass,
         !inMonth && "bg-muted/20 opacity-60",
-        isToday && "ring-2 ring-amber-500",
+        // ring-inset so the today highlight draws INSIDE the rounded card —
+        // an outset ring-2 gets clipped/doubled by the column/scroll container
+        // (esp. in the tall week / 3-day columns on mobile).
+        isToday && "ring-2 ring-inset ring-amber-500",
         isDragOver && "border-amber-500 bg-amber-50/50 dark:bg-amber-900/10",
       )}
     >
@@ -1199,7 +1202,8 @@ function AddPopover({
         type="button"
         className={cn(
           "rounded-full p-1 text-muted-foreground hover:bg-muted hover:text-foreground focus:opacity-100",
-          "opacity-0 group-hover:opacity-100",
+          // Always visible on touch (no hover); reveal-on-hover only where hover exists.
+          "opacity-100 [@media(hover:hover)]:opacity-0 [@media(hover:hover)]:group-hover:opacity-100",
         )}
         aria-label={`Asignar ${only === "workout" ? "workout" : "hábito"} el ${civil}`}
         onClick={() => onPick(only)}
@@ -1216,7 +1220,10 @@ function AddPopover({
           type="button"
           className={cn(
             "rounded-full p-1 text-muted-foreground hover:bg-muted hover:text-foreground focus:opacity-100",
-            open ? "opacity-100" : "opacity-0 group-hover:opacity-100",
+            // Always visible on touch (no hover); reveal-on-hover only where hover exists.
+            open
+              ? "opacity-100"
+              : "opacity-100 [@media(hover:hover)]:opacity-0 [@media(hover:hover)]:group-hover:opacity-100",
           )}
           aria-label={`Asignar el ${civil}`}
         >

--- a/backoffice/src/lib/gc-fitness/__tests__/exercise-schema.test.ts
+++ b/backoffice/src/lib/gc-fitness/__tests__/exercise-schema.test.ts
@@ -161,4 +161,16 @@ describe("exerciseSchema", () => {
     const parsed = exerciseSchema.parse({ ...VALID_INPUT, equipment: [] });
     expect(parsed.equipment).toEqual(["bodyweight"]);
   });
+
+  it("normalizes missing/undefined equipment to bodyweight", () => {
+    const { equipment: _omit, ...withoutEquipment } = VALID_INPUT;
+    void _omit;
+    const parsed = exerciseSchema.parse(withoutEquipment);
+    expect(parsed.equipment).toEqual(["bodyweight"]);
+  });
+
+  it("normalizes a deselected single-select ([\"\"]) to bodyweight", () => {
+    const parsed = exerciseSchema.parse({ ...VALID_INPUT, equipment: [""] });
+    expect(parsed.equipment).toEqual(["bodyweight"]);
+  });
 });

--- a/backoffice/src/lib/gc-fitness/__tests__/habit-actions.test.ts
+++ b/backoffice/src/lib/gc-fitness/__tests__/habit-actions.test.ts
@@ -91,6 +91,7 @@ import {
   createHabit,
   updateHabit,
   softDeleteHabit,
+  deleteHabitRecurrenceFromDate,
   listHabitsForTrainer,
   listHabitsForClient,
 } from "../habit-actions";
@@ -121,6 +122,7 @@ function fakeHabitSnapshot(opts: {
   trainerId?: string | null;
   type?: "binary";
   id?: string;
+  startsOn?: string;
 }) {
   return {
     exists: opts.exists,
@@ -132,6 +134,7 @@ function fakeHabitSnapshot(opts: {
       name: { en: "Test", es: "Prueba" },
       reminderEnabled: false,
       deleted: false,
+      ...(opts.startsOn ? { startsOn: opts.startsOn } : {}),
     }),
   } as unknown as DocumentSnapshot;
 }
@@ -370,6 +373,52 @@ describe("softDeleteHabit", () => {
 
     await expect(
       softDeleteHabit("hab-different-trainer-uid-abc"),
+    ).rejects.toThrow(/not your habit/i);
+    expect(mockUpdate).not.toHaveBeenCalled();
+  });
+});
+
+describe("deleteHabitRecurrenceFromDate", () => {
+  // Caps endsOn to the day BEFORE the tapped date — past stays, future goes.
+  it("sets endsOn = (fromCivilDate − 1 day), preserving past occurrences", async () => {
+    mockedGetTokens.mockResolvedValue(fakeTokens({ role: "trainer" }));
+    mockGet.mockResolvedValue(
+      fakeHabitSnapshot({ exists: true, trainerId: ALLOWED_UID, startsOn: "2026-01-01" }),
+    );
+    mockUpdate.mockResolvedValue(undefined);
+
+    await deleteHabitRecurrenceFromDate(`hab-${ALLOWED_UID}-abc`, "2026-05-20");
+
+    expect(mockUpdate).toHaveBeenCalledTimes(1);
+    const patch = mockUpdate.mock.calls[0][0];
+    expect(patch.endsOn).toBe("2026-05-19");
+    expect(patch.deleted).toBeUndefined();
+    expect(patch.updatedAt).toBe("SERVER_TIMESTAMP_SENTINEL");
+  });
+
+  // Deleting from at/before the start has no past to keep → full soft-delete.
+  it("falls back to deleted=true when the cutoff precedes startsOn", async () => {
+    mockedGetTokens.mockResolvedValue(fakeTokens({ role: "trainer" }));
+    mockGet.mockResolvedValue(
+      fakeHabitSnapshot({ exists: true, trainerId: ALLOWED_UID, startsOn: "2026-05-20" }),
+    );
+    mockUpdate.mockResolvedValue(undefined);
+
+    await deleteHabitRecurrenceFromDate(`hab-${ALLOWED_UID}-abc`, "2026-05-20");
+
+    const patch = mockUpdate.mock.calls[0][0];
+    expect(patch.deleted).toBe(true);
+    expect(patch.endsOn).toBeUndefined();
+  });
+
+  it("rejects when caller is not the doc's trainerId", async () => {
+    mockedGetTokens.mockResolvedValue(fakeTokens({ role: "trainer" }));
+    mockGet.mockResolvedValue(
+      fakeHabitSnapshot({ exists: true, trainerId: "different-trainer-uid" }),
+    );
+
+    await expect(
+      deleteHabitRecurrenceFromDate("hab-different-trainer-uid-abc", "2026-05-20"),
     ).rejects.toThrow(/not your habit/i);
     expect(mockUpdate).not.toHaveBeenCalled();
   });

--- a/backoffice/src/lib/gc-fitness/exercise-schema.ts
+++ b/backoffice/src/lib/gc-fitness/exercise-schema.ts
@@ -119,7 +119,16 @@ const metricSchema = z.enum(["reps", "time"]).default("reps");
 const sourceSchema = z.enum(["wger", "trainer", "free-exercise-db"]);
 
 const equipmentListSchema = z.preprocess(
-  (value) => (Array.isArray(value) && value.length === 0 ? ["bodyweight"] : value),
+  // Normalize a missing/empty selection to the "bodyweight" sentinel so an
+  // exercise can be created without picking equipment. Covers every shape the
+  // form / quick-create can emit: undefined/null, [], and [""] (a deselected
+  // single-select). Real values pass through unchanged.
+  (value) => {
+    const arr = Array.isArray(value)
+      ? value.filter((v): v is string => typeof v === "string" && v.length > 0)
+      : [];
+    return arr.length === 0 ? ["bodyweight"] : arr;
+  },
   z.array(equipmentSchema).max(8),
 );
 

--- a/backoffice/src/lib/gc-fitness/habit-actions.ts
+++ b/backoffice/src/lib/gc-fitness/habit-actions.ts
@@ -699,6 +699,62 @@ export async function softDeleteHabit(
   return { ok: true };
 }
 
+/** "YYYY-MM-DD" → the previous civil day (UTC-safe string arithmetic). */
+function previousCivilDate(civilDate: string): string {
+  const [y, m, d] = civilDate.split("-").map((n) => parseInt(n, 10));
+  const dt = new Date(Date.UTC(y, m - 1, d));
+  dt.setUTCDate(dt.getUTCDate() - 1);
+  return dt.toISOString().slice(0, 10);
+}
+
+/**
+ * "Delete from this day forward" — backs the schedule's habit-detail dialog
+ * delete action. Soft-deleting the whole habit (`deleted: true`) wrongly hides
+ * ALL of it including past occurrences/history. Instead we cap the recurrence
+ * by setting `endsOn` to the day BEFORE `fromCivilDate`: the clicked day and
+ * everything after stop showing, while past occurrences + logs stay intact.
+ * `endsOn` is an INCLUSIVE upper bound in the schedule visibility predicate
+ * (`isHabitScheduledOn`), hence the −1 day.
+ *
+ * If the cutoff falls before the habit's `startsOn` (deleting from at/before
+ * the start), there is no past to preserve, so we fall back to a full
+ * soft-delete.
+ */
+export async function deleteHabitRecurrenceFromDate(
+  id: string,
+  fromCivilDate: string,
+): Promise<{ ok: true }> {
+  const trainer = await getCurrentTrainer();
+
+  const db = gcFitnessFirestore();
+  const docRef = db.collection(COLLECTION).doc(id);
+  const snap = await docRef.get();
+  if (!snap.exists) {
+    throw new Error("Not found");
+  }
+  const existing = snap.data() as { trainerId?: string; startsOn?: string };
+  if (existing.trainerId !== trainer.uid) {
+    throw new Error("Not your habit.");
+  }
+
+  const newEndsOn = previousCivilDate(fromCivilDate);
+
+  if (existing.startsOn && newEndsOn < existing.startsOn) {
+    await docRef.update({
+      deleted: true,
+      updatedAt: FieldValue.serverTimestamp(),
+    });
+    return { ok: true };
+  }
+
+  await docRef.update({
+    endsOn: newEndsOn,
+    updatedAt: FieldValue.serverTimestamp(),
+  });
+
+  return { ok: true };
+}
+
 /**
  * Reads a single habit by id (ownership-checked). Backs the calendar's
  * habit-detail dialog, which needs the full recurrence to render + the


### PR DESCRIPTION
Three backoffice fixes (one PR):

**1. Crear ejercicio sin equipment fallaba** — el preprocess del schema solo normalizaba arrays vacíos; ahora también cubre `undefined`/`null`/`[""]` (single-select deseleccionado, ej. quick-create) → `['bodyweight']`. Crear sin equipment ya no falla. +tests.

**2. Eliminar hábito borraba el pasado** — el delete de la recurrencia desde la agenda usaba `softDeleteHabit` (`deleted:true`) y ocultaba TODO incl. historial. Nuevo `deleteHabitRecurrenceFromDate` setea `endsOn` al día anterior al día tocado → borra desde ese día en adelante, conserva el pasado + logs. Fallback a soft-delete completo si el corte es anterior a `startsOn`. +tests +copy.

**3. Agenda mobile** — el botón `+` del día era `opacity-0 group-hover` (invisible en touch): ahora visible por defecto, reveal-on-hover solo donde hay hover (`[@media(hover:hover)]`). Y el borde del día actual (ring-2 outset) se veía cortado/doble en las columnas altas de semana/3-días → `ring-inset`.

Gates: `jest` 298 ✅ · `tsc --noEmit` ✅.