### PR TITLE
Backoffice: roster-activity avatars, reminder info in calendar dialog, habit-detail legacy-type guard

### DIFF
--- a/backoffice/src/app/gc-fitness/dashboard/page.tsx
+++ b/backoffice/src/app/gc-fitness/dashboard/page.tsx
@@ -25,6 +25,7 @@ import {
   CardTitle,
 } from "@/components/ui/card";
 import { cn } from "@/lib/utils";
+import { ClientAvatar } from "@/components/gc-fitness/ClientAvatar";
 import { gcFitnessFirestore } from "@/lib/firebase/gc-fitness-admin";
 import {
   getCurrentTrainer,
@@ -128,6 +129,7 @@ export default async function GCFitnessDashboardPage({
       return {
         uid: client.uid,
         name: client.displayName,
+        photoURL: client.photoURL,
         lastActivityAt: client.lastActivityAt,
         lastActionTitle: latestLog?.title ?? "No activity yet",
         lastActionDetail: latestLog?.detail ?? "No records yet.",
@@ -336,6 +338,7 @@ export default async function GCFitnessDashboardPage({
                     key={row.uid}
                     href={`/gc-fitness/clients/${row.uid}`}
                     name={row.name}
+                    photoURL={row.photoURL}
                     primary={row.lastActionTitle}
                     iso={row.lastActivityAt}
                     category={row.category}
@@ -369,6 +372,7 @@ export default async function GCFitnessDashboardPage({
                     key={`attention-${row.uid}`}
                     href={`/gc-fitness/clients/${row.uid}`}
                     name={row.name}
+                    photoURL={row.photoURL}
                     primary={row.lastActionTitle}
                     iso={row.lastActivityAt}
                     category={row.category}
@@ -469,6 +473,7 @@ const CATEGORY_META: Record<
 function ClientRow({
   href,
   name,
+  photoURL,
   primary,
   iso,
   category,
@@ -476,12 +481,12 @@ function ClientRow({
 }: {
   href: string;
   name: string;
+  photoURL: string | null;
   primary: string;
   iso: string | null;
   category: RecentLogCategory | null;
   rpe: number | null;
 }) {
-  const initial = name.trim().charAt(0).toUpperCase() || "?";
   const cat = category ? CATEGORY_META[category] : null;
   const CatIcon = cat?.icon;
   const timestampLabel = iso ? formatRelative(iso) : "No activity";
@@ -490,12 +495,7 @@ function ClientRow({
       href={href}
       className="group flex items-center gap-3 rounded-md border border-border/70 bg-background/60 px-3 py-2 transition-colors hover:border-primary/40 hover:bg-accent/30"
     >
-      <span
-        aria-hidden
-        className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-muted text-xs font-semibold text-muted-foreground"
-      >
-        {initial}
-      </span>
+      <ClientAvatar name={name} photoURL={photoURL} size="sm" />
       <div className="min-w-0 flex-1">
         <div className="flex items-center gap-2">
           <p className="truncate text-sm font-medium">{name}</p>

--- a/backoffice/src/app/gc-fitness/habits/[id]/page.tsx
+++ b/backoffice/src/app/gc-fitness/habits/[id]/page.tsx
@@ -83,7 +83,12 @@ export default async function HabitDetailPage({ params }: PageParams) {
     redirect("/gc-fitness/forbidden");
   }
 
-  const habitType = (data.type as HabitType) ?? "binary";
+  // Habits are binary-only; any legacy/unknown wire value collapses to binary
+  // so the label-key lookup below never yields undefined.
+  const habitType: HabitType =
+    data.type && HABIT_TYPE_LABEL_KEYS[data.type as HabitType]
+      ? (data.type as HabitType)
+      : "binary";
   const nameEN = data.name?.en ?? t("untitled");
   const nameES = data.name?.es ?? "";
 

--- a/backoffice/src/components/gc-fitness/schedule/habit-detail-dialog.tsx
+++ b/backoffice/src/components/gc-fitness/schedule/habit-detail-dialog.tsx
@@ -17,7 +17,7 @@
 
 import { useEffect, useState } from "react";
 import { useMutation, useQuery } from "@tanstack/react-query";
-import { CalendarDays, CalendarOff, Repeat, Trash2, User } from "lucide-react";
+import { Bell, CalendarDays, CalendarOff, Repeat, Trash2, User } from "lucide-react";
 import { toast } from "sonner";
 
 import {
@@ -51,6 +51,34 @@ interface HabitDetailDialogProps {
 const HABIT_TYPE_LABEL = "Sí / no";
 
 const WEEKDAY_SHORT = ["", "Lun", "Mar", "Mié", "Jue", "Vie", "Sáb", "Dom"];
+
+// Reminder weekdays use Apple's Calendar convention (Sun=1 … Sat=7) — the iOS
+// reminder editor writes DateComponents.weekday — which differs from the
+// schedule weekdays (ISO Mon=1). Keep a separate map so labels are correct.
+const REMINDER_WEEKDAY_SHORT = ["", "Dom", "Lun", "Mar", "Mié", "Jue", "Vie", "Sáb"];
+
+function reminderLabel(h: HabitRow): string {
+  if (!h.reminderEnabled) return "Desactivado";
+  const time = h.reminderTime ?? "—";
+  const cadence = h.reminderCadence ?? "daily";
+  if (cadence === "weekly") {
+    const days = (h.reminderWeekdays ?? [])
+      .slice()
+      .sort((a, b) => a - b)
+      .map((n) => REMINDER_WEEKDAY_SHORT[n] ?? String(n))
+      .join(", ");
+    return days ? `${time} · ${days}` : `${time} · Semanal`;
+  }
+  if (cadence === "monthly") {
+    const monthDays =
+      h.reminderMonthDays ??
+      (typeof h.reminderDayOfMonth === "number" ? [h.reminderDayOfMonth] : []);
+    return monthDays.length
+      ? `${time} · día ${monthDays.slice().sort((a, b) => a - b).join(", ")}`
+      : `${time} · Mensual`;
+  }
+  return `${time} · Diario`;
+}
 
 function recurrenceLabel(h: HabitRow): string {
   if (h.scheduleType === "one-time") return "Única";
@@ -177,6 +205,15 @@ export function HabitDetailDialog({
                   Tipo
                 </p>
                 <p className="font-medium">{HABIT_TYPE_LABEL}</p>
+              </div>
+              <div className="flex items-center gap-2">
+                <Bell className="size-4 text-muted-foreground" />
+                <div>
+                  <p className="text-[10px] uppercase tracking-wide text-muted-foreground">
+                    Recordatorio
+                  </p>
+                  <p className="font-medium">{reminderLabel(data)}</p>
+                </div>
               </div>
               <div>
                 <p className="text-[10px] uppercase tracking-wide text-muted-foreground">


### PR DESCRIPTION
Follow-ups (one PR):

**Roster Activity avatars** — the dashboard 'Last action by client' + 'Needs attention' rows now show the client's cached `ClientAvatar` (photoURL + initials fallback) instead of a bare initial. (The earlier avatars PR covered Top Performers / RosterTable / RecentLogsFeed but not this dashboard component.)

**Reminder info in calendar dialog** — the schedule habit-detail dialog now shows a 'Recordatorio' row (time + cadence/weekdays). Note: reminder weekdays use Apple's Sun=1 convention (≠ the ISO Mon=1 schedule weekdays), so a separate label map is used.

**Habit-detail legacy-type guard** — collapse any legacy/unknown `habit.type` to 'binary' for the label lookup so a pre-migration non-binary habit doc can't yield an undefined translation key.

Gates: `jest` 298 ✅ · `tsc --noEmit` ✅.

⚠️ Not included: the habit-detail **infinite-render-loop** crash — see PR discussion; the /habits/[id] route is server-rendered with no client state, so I couldn't reproduce it from the code and need the non-minified component name.