### PR TITLE
fix(habits): detail page crash — compliance query needs an undeployed ASC index

### DIFF
--- a/backoffice/src/lib/gc-fitness/habit-compliance-actions.ts
+++ b/backoffice/src/lib/gc-fitness/habit-compliance-actions.ts
@@ -152,7 +152,13 @@ export async function fetchHabitCompliance(
     .collection(FirestoreCollections.habitLogs)
     .where("habitId", "==", habitId)
     .where("civilDate", ">=", startDate)
-    .orderBy("civilDate", "asc")
+    // orderBy DESC to match the DEPLOYED composite index
+    // (habit_logs: habitId ASC, civilDate DESC). An ASC orderBy needs a
+    // separate (habitId ASC, civilDate ASC) index that is NOT deployed, which
+    // made this query throw FAILED_PRECONDITION and crash the habit detail
+    // page. Order is irrelevant: computeCompliance derives a Set of completed
+    // days and builds dailyCounts from the window, not the input order.
+    .orderBy("civilDate", "desc")
     .get();
 
   const logs: HabitLogRow[] = snap.docs.map((d) => {


### PR DESCRIPTION
## Why entering a habit crashed
Diagnosed by running the exact query against prod Firestore → `FAILED_PRECONDITION: The query requires an index`.

`fetchHabitCompliance` (rendered by the `/gc-fitness/habits/[id]` ComplianceWidget) queries `habit_logs` with `orderBy(civilDate, 'asc')`, but the only deployed composite index is `(habitId ASC, civilDate DESC)`. The ASC orderBy requires a `(habitId ASC, civilDate ASC)` index that isn't deployed → the server component throws → the route error boundary shows 'Algo salió mal.' (it was never an infinite render loop — the minified stack misled me; the error-card screenshot was the truth).

## Fix
Switch the query to `orderBy(civilDate, 'desc')` to reuse the **already-deployed** index — instant, no index build/deploy. Safe because `computeCompliance` derives a `Set` of completed days and builds `dailyCounts` from the window, not from the input log order.

Gates: `jest` (habit-compliance 9/9) ✅ · `tsc --noEmit` ✅.