### PR TITLE
fix(backoffice): descripción del roster en varias líneas (no cortada)

### DIFF
--- a/backoffice/src/app/gc-fitness/dashboard/page.tsx
+++ b/backoffice/src/app/gc-fitness/dashboard/page.tsx
@@ -503,11 +503,11 @@ function ClientRow({
             {timestampLabel}
           </span>
         </div>
-        <div className="mt-0.5 flex min-w-0 items-center gap-1.5">
+        <div className="mt-0.5 flex min-w-0 flex-wrap items-start gap-1.5">
           {cat ? (
             <Badge
               variant="secondary"
-              className="gap-1 px-1.5 py-0 text-[10px] font-normal [&>svg]:size-3 [&>svg]:opacity-70"
+              className="shrink-0 gap-1 px-1.5 py-0 text-[10px] font-normal [&>svg]:size-3 [&>svg]:opacity-70"
             >
               {CatIcon ? <CatIcon /> : null}
               {cat.label}
@@ -516,13 +516,15 @@ function ClientRow({
           {category === "workout" && rpe !== null ? (
             <Badge
               variant="outline"
-              className="gap-1 px-1.5 py-0 text-[10px] font-normal text-muted-foreground [&>svg]:size-3 [&>svg]:opacity-70"
+              className="shrink-0 gap-1 px-1.5 py-0 text-[10px] font-normal text-muted-foreground [&>svg]:size-3 [&>svg]:opacity-70"
             >
               <Gauge />
               RPE {rpe}
             </Badge>
           ) : null}
-          <p className="truncate text-xs text-muted-foreground">{primary}</p>
+          <p className="min-w-0 flex-1 break-words text-xs text-muted-foreground">
+            {primary}
+          </p>
         </div>
       </div>
       <ChevronRight className="h-4 w-4 shrink-0 text-muted-foreground/60 transition-transform group-hover:translate-x-0.5 group-hover:text-foreground" />


### PR DESCRIPTION
## Qué

En el roster ("Last action by client" / actividad reciente), la descripción de la acción quedaba **cortada en una sola línea** (`truncate` = `nowrap` + ellipsis). Textos como "El Colo completed: 1 Fruit. 1/3 habits done today" no entraban en la card.

## Fix

Ahora la descripción **se va a varias líneas**:
- La fila pasa a `items-start` + `flex-wrap` (alineada arriba).
- Los badges de tipo/RPE mantienen su tamaño con `shrink-0`.
- La descripción usa `flex-1 break-words` (sin `truncate`), así fluye en cuantas líneas haga falta.

Aplica a **ambas cards** del dashboard (comparten el componente `ClientRow`).

## Antes / Después (comportamiento)
- Antes: `Ezcurra - Workout com...` (cortado)
- Después: el texto completo envuelve a 2-3 líneas dentro de la card.

## Test gate
- ✅ `npx jest` → **30 suites / 298 tests passing**.
- ✅ `npx tsc --noEmit` → sin errores.

Cambio sólo de presentación (classNames + estructura JSX), sin tocar datos ni lógica.
