### PR TITLE
feat(schedule): tell trainer a reminder push is sent when assigning with a time

### DIFF
--- a/backoffice/messages/en.json
+++ b/backoffice/messages/en.json
@@ -1086,7 +1086,7 @@
       "dayLabel": "Day",
       "scheduledFor": "Scheduled for {date}",
       "timeLabel": "Time",
-      "timeHint": "Optional for live or virtual sessions.",
+      "timeHint": "Optional for live or virtual sessions. If you set a time, the client gets a reminder push before the session (if notifications are on).",
       "meetingNotesLabel": "Meeting notes",
       "meetingNotesPlaceholder": "Zoom / Meet link, instructions, prep notes...",
       "exerciseOverridesTitle": "Per-client workout overrides",

--- a/backoffice/messages/es.json
+++ b/backoffice/messages/es.json
@@ -1086,7 +1086,7 @@
       "dayLabel": "Día",
       "scheduledFor": "Programado para {date}",
       "timeLabel": "Hora",
-      "timeHint": "Opcional para sesiones en vivo o virtuales.",
+      "timeHint": "Opcional para sesiones en vivo o virtuales. Si configurás una hora, el cliente recibe un recordatorio push antes de la sesión (si tiene las notificaciones activadas).",
       "meetingNotesLabel": "Notas de la sesión",
       "meetingNotesPlaceholder": "Link de Zoom / Meet, instrucciones, notas de preparación...",
       "exerciseOverridesTitle": "Ajustes por cliente",


### PR DESCRIPTION
The assign-workout 'Hora' field controls the workout reminder push (30 min before `scheduledTime`). The hint didn't mention it, so trainers had no signal the client gets notified.

Appended to `schedule.assignModal.timeHint` (es + en): if a time is set, the client gets a reminder push before the session (if notifications are on).

Note: this covers the single-assign modal (`assign-template-modal`). If you want the same line on the bulk-assign form / edit dialog, say so — quick follow-up.

Gate: `jest` 298 ✅ (value-only message change, key parity intact).