### PR TITLE
fix(pages): add CNAME to preserve goldencrowvs.com custom domain

### DIFF
--- a/pocket-genes/public/CNAME
+++ b/pocket-genes/public/CNAME
@@ -1,0 +1,1 @@
+goldencrowvs.com


### PR DESCRIPTION
## Why

The Pages "Source" setting was on **Deploy from a branch** while the repo deploys via the `actions/deploy-pages@v4` workflow. That mismatch made every deploy fail with `Missing environment`, and the legacy `pages-build-deployment` also failed (it tried to serve the repo root instead of the Astro build in `pocket-genes/dist`).

**Fix already applied (settings):** switched Pages Source → **GitHub Actions** via API. Deploys are green again and https://goldencrowvs.com/ returns 200.

## This PR

Adds `pocket-genes/public/CNAME` containing `goldencrowvs.com` so the built artifact carries the custom domain. With the Actions deploy method, a future deploy can silently reset the custom-domain setting if the artifact lacks a CNAME file — this makes the domain durable.

No code/runtime impact; static-only addition to the build output.