### PR TITLE
GC Fitness: show template end dates in the list

### DIFF
--- a/backoffice/messages/en.json
+++ b/backoffice/messages/en.json
@@ -391,6 +391,7 @@
     "columns": {
       "name": "Name",
       "tag": "Tags",
+      "endDate": "End date",
       "exercises": "Exercises",
       "updated": "Updated",
       "untitled": "(untitled)",

--- a/backoffice/messages/es.json
+++ b/backoffice/messages/es.json
@@ -391,6 +391,7 @@
     "columns": {
       "name": "Nombre",
       "tag": "Etiquetas",
+      "endDate": "Fecha de fin",
       "exercises": "Ejercicios",
       "updated": "Actualizado",
       "untitled": "(sin título)",

--- a/backoffice/src/app/gc-fitness/templates/client.tsx
+++ b/backoffice/src/app/gc-fitness/templates/client.tsx
@@ -70,6 +70,7 @@ const DRAFT_STORAGE_KEY_NEW = "gc-fitness:template-draft:new";
 interface NewTemplateDraft {
   name?: { en?: string; es?: string };
   description?: { en?: string; es?: string };
+  endsOn?: string;
   tag?: string;
   tags?: string[];
   exercises?: Array<unknown>;
@@ -144,6 +145,7 @@ export function TemplatesLibraryClient({ trainerUid }: TemplatesLibraryClientPro
         es: newDraft.name?.es ?? "",
       },
       description: undefined,
+      endsOn: typeof newDraft.endsOn === "string" ? newDraft.endsOn : undefined,
       // Cast: the draft can hold any free-form tag the trainer typed; for list
       // rendering we only need the string. The Badge / filter logic tolerates
       // arbitrary strings already.

--- a/backoffice/src/components/gc-fitness/templates/columns.tsx
+++ b/backoffice/src/components/gc-fitness/templates/columns.tsx
@@ -7,9 +7,10 @@
 //
 //   1. Name (EN primary, ES subtitle) — sortable
 //   2. Tag — Badge (push/pull/legs/full-body/upper/lower/custom)
-//   3. Exercise count
-//   4. Updated — relative time via Intl.RelativeTimeFormat — sortable
-//   5. Actions — DropdownMenu (Edit + Delete)
+//   3. End date — compact badge when present
+//   4. Exercise count
+//   5. Updated — relative time via Intl.RelativeTimeFormat — sortable
+//   6. Actions — DropdownMenu (Edit + Delete)
 //
 // Sortable columns use `column.toggleSorting(column.getIsSorted() === "asc")`
 // per RESEARCH §Pattern 6. Per-row handlers (`onEdit`, `onDelete`) are
@@ -95,6 +96,11 @@ const TAG_LABELS: Record<string, string> = {
   custom: "Custom",
 };
 
+function formatCivilDateBadge(civilDate?: string | null): string {
+  if (!civilDate) return "—";
+  return civilDate;
+}
+
 type TFn = ReturnType<typeof useTranslations>;
 
 export function makeTemplateColumns(
@@ -179,6 +185,19 @@ export function makeTemplateColumns(
           </div>
         );
       },
+      enableSorting: false,
+    },
+    {
+      accessorKey: "endsOn",
+      header: t("endDate"),
+      cell: ({ row }) => (
+        <Badge
+          variant={row.original.endsOn ? "outline" : "ghost"}
+          className={row.original.endsOn ? "font-mono tabular-nums" : "text-muted-foreground"}
+        >
+          {formatCivilDateBadge(row.original.endsOn)}
+        </Badge>
+      ),
       enableSorting: false,
     },
     {


### PR DESCRIPTION
## What
- Adds an end-date badge column to the workout templates list.
- Surfaces the same field on the virtual draft row so the list matches the form state.
- Adds the i18n label for the new column in EN/ES.

## Verification
- npx tsc --noEmit --pretty false
- git diff --check
