### PR TITLE
GC Fitness: recent logs use trainer timezone

### DIFF
--- a/backoffice/docs/client-activity-timezone-policy.md
+++ b/backoffice/docs/client-activity-timezone-policy.md
@@ -1,0 +1,20 @@
+# Client Activity Timezone Policy
+
+All client-facing activity lists and detail previews in GC Fitness must render instants in an explicit IANA timezone passed from the server component.
+
+Do not rely on:
+- `Intl.DateTimeFormat().resolvedOptions().timeZone` inside leaf components
+- the host runtime timezone on Vercel or in Jest
+- `new Date(...).toISOString().slice(0, 10)` for anything that is supposed to read as the trainer's or client's local day
+
+Use the shared helpers in `src/lib/gc-fitness/client-activity-time.ts` for:
+- chat history previews
+- recent logs rows
+- client notes timestamps
+- progress photo fallback dates
+- body-weight chart buckets
+- any future client activity timeline
+
+Route-level ownership pages should resolve the client timezone once and thread it down as a prop.
+
+If a component needs a civil date, compute it server-side with `civilDateToday(timezone)` or `civilDateFormat(date, timezone)` and pass the string through. If it needs a displayed instant, format it with the shared client activity helpers.

--- a/backoffice/messages/en.json
+++ b/backoffice/messages/en.json
@@ -1287,6 +1287,8 @@
       "notesBadge": "Notes",
       "sourceCoach": "Coach-run",
       "sourceClient": "Client-run",
+      "today": "Today",
+      "yesterday": "Yesterday",
       "forDay": "For {date}",
       "groupItem": "action",
       "groupItems": "actions",

--- a/backoffice/messages/en.json
+++ b/backoffice/messages/en.json
@@ -1287,6 +1287,8 @@
       "notesBadge": "Notes",
       "sourceCoach": "Coach-run",
       "sourceClient": "Client-run",
+      "timezoneInfoTitle": "Time zone note",
+      "timezoneInfoBody": "Timestamps and day groups are shown in your time zone ({timezone}), not UTC, so the feed matches your local day.",
       "today": "Today",
       "yesterday": "Yesterday",
       "forDay": "For {date}",

--- a/backoffice/messages/es.json
+++ b/backoffice/messages/es.json
@@ -1287,6 +1287,8 @@
       "notesBadge": "Notas",
       "sourceCoach": "Del coach",
       "sourceClient": "Del cliente",
+      "timezoneInfoTitle": "Nota de zona horaria",
+      "timezoneInfoBody": "Las horas y los grupos por día se muestran en tu zona horaria ({timezone}), no en UTC, para que la actividad coincida con tu día local.",
       "today": "Hoy",
       "yesterday": "Ayer",
       "forDay": "Del {date}",

--- a/backoffice/messages/es.json
+++ b/backoffice/messages/es.json
@@ -1287,6 +1287,8 @@
       "notesBadge": "Notas",
       "sourceCoach": "Del coach",
       "sourceClient": "Del cliente",
+      "today": "Hoy",
+      "yesterday": "Ayer",
       "forDay": "Del {date}",
       "groupItem": "acción",
       "groupItems": "acciones",

--- a/backoffice/src/app/gc-fitness/admin/coaches/[uid]/clients/[clientId]/page.tsx
+++ b/backoffice/src/app/gc-fitness/admin/coaches/[uid]/clients/[clientId]/page.tsx
@@ -14,8 +14,10 @@ import Link from "next/link";
 import { notFound, redirect } from "next/navigation";
 
 import { getCurrentAdmin } from "@/lib/gc-fitness/auth-helpers";
+import { FirestoreCollections } from "@/lib/gc-fitness/collections";
 import { listRecentLogsForClientAsAdmin } from "@/lib/gc-fitness/recent-logs-actions";
 import { listProgressPhotosForClientAsAdmin } from "@/lib/gc-fitness/progress-photo-actions";
+import { gcFitnessFirestore } from "@/lib/firebase/gc-fitness-admin";
 import { Badge } from "@/components/ui/badge";
 import {
   Card,
@@ -59,6 +61,13 @@ export default async function AdminCoachClientPage({
   }
 
   const clientName = logs.clients[0]?.name ?? clientId;
+  const clientSnap = await gcFitnessFirestore()
+    .collection(FirestoreCollections.users)
+    .doc(clientId)
+    .get();
+  const storedTimezone = clientSnap.get("timezone");
+  const timezone =
+    typeof storedTimezone === "string" && storedTimezone ? storedTimezone : "UTC";
 
   return (
     <div className="mx-auto flex w-full max-w-5xl flex-col gap-6 px-4 py-8">
@@ -91,6 +100,7 @@ export default async function AdminCoachClientPage({
           <ClientRecentLogsFeed
             logs={logs.logs}
             clientId={clientId}
+            timezone={timezone}
             initialCursor={logs.nextCursor}
             initialHasMore={logs.hasMore}
             showActions={false}

--- a/backoffice/src/app/gc-fitness/admin/coaches/[uid]/clients/[clientId]/page.tsx
+++ b/backoffice/src/app/gc-fitness/admin/coaches/[uid]/clients/[clientId]/page.tsx
@@ -116,7 +116,7 @@ export default async function AdminCoachClientPage({
         </CardHeader>
         <CardContent>
           {photos.length > 0 ? (
-            <ProgressPhotosGridClient photos={photos} />
+            <ProgressPhotosGridClient photos={photos} timezone={timezone} />
           ) : (
             <p className="text-sm text-muted-foreground">
               No progress photos yet.

--- a/backoffice/src/app/gc-fitness/admin/coaches/[uid]/clients/[clientId]/photos/page.tsx
+++ b/backoffice/src/app/gc-fitness/admin/coaches/[uid]/clients/[clientId]/photos/page.tsx
@@ -10,7 +10,9 @@ import { ChevronLeft } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { getCurrentAdmin } from "@/lib/gc-fitness/auth-helpers";
+import { FirestoreCollections } from "@/lib/gc-fitness/collections";
 import { listProgressPhotosForClientAsAdmin } from "@/lib/gc-fitness/progress-photo-actions";
+import { gcFitnessFirestore } from "@/lib/firebase/gc-fitness-admin";
 import { ProgressPhotoCompareEditor } from "@/app/gc-fitness/clients/[id]/compare-photos/photo-compare-editor";
 
 export const dynamic = "force-dynamic";
@@ -36,6 +38,13 @@ export default async function AdminClientPhotosPage({
   } catch {
     notFound();
   }
+  const clientSnap = await gcFitnessFirestore()
+    .collection(FirestoreCollections.users)
+    .doc(clientId)
+    .get();
+  const storedTimezone = clientSnap.get("timezone");
+  const timezone =
+    typeof storedTimezone === "string" && storedTimezone ? storedTimezone : "UTC";
 
   return (
     <div className="mx-auto flex w-full max-w-[1800px] flex-col gap-4 px-4 py-6 sm:px-6">
@@ -52,7 +61,7 @@ export default async function AdminClientPhotosPage({
         </Button>
       </div>
       {photos.length > 0 ? (
-        <ProgressPhotoCompareEditor photos={photos} />
+        <ProgressPhotoCompareEditor photos={photos} timezone={timezone} />
       ) : (
         <p className="text-sm text-muted-foreground">No progress photos yet.</p>
       )}

--- a/backoffice/src/app/gc-fitness/chat/_components/ChatConversation.tsx
+++ b/backoffice/src/app/gc-fitness/chat/_components/ChatConversation.tsx
@@ -38,6 +38,11 @@ import { useMutation } from "@tanstack/react-query";
 import { Trash2 } from "lucide-react";
 import { toast } from "sonner";
 
+import {
+  clientActivityCivilDateKey,
+  formatClientActivityDate,
+  formatClientActivityTime,
+} from "@/lib/gc-fitness/client-activity-time";
 import { CHATS_BASE_KEY, useChatMessages } from "@/lib/gc-fitness/chat-listener";
 import {
   deleteTrainerChatMessage,
@@ -64,6 +69,7 @@ import { MessageInput } from "./MessageInput";
 export interface ChatConversationProps {
   chatId: string;
   trainerUid: string;
+  timezone: string;
   clientRoster: ClientRosterEntry[];
   isPendingClient?: boolean;
 }
@@ -71,6 +77,7 @@ export interface ChatConversationProps {
 export function ChatConversation({
   chatId,
   trainerUid,
+  timezone,
   clientRoster,
   isPendingClient = false,
 }: ChatConversationProps) {
@@ -172,7 +179,7 @@ export function ChatConversation({
   // Day-separator grouping — civil-date bucket via toDateString(). The
   // iOS edge uses `DaySeparatorGrouper` (P08-02 — pure-function module);
   // a TS port for Pitfall 7 same-source-of-truth is a V2 carry-forward.
-  const rows = useMemo(() => groupByCivilDate(messages), [messages]);
+  const rows = useMemo(() => groupByCivilDate(messages, timezone), [messages, timezone]);
 
   // 260524 — auto-scroll the message pane to the most recent message
   // when:
@@ -288,7 +295,7 @@ export function ChatConversation({
               row.kind === "separator" ? (
                 <DaySeparator
                   key={`sep-${row.civilDate}`}
-                  civilDate={row.civilDate}
+                  label={row.label}
                 />
               ) : (
                 <MessageBubble
@@ -296,6 +303,7 @@ export function ChatConversation({
                   chatId={chatId}
                   message={row.message}
                   isOwn={row.message.senderId === trainerUid}
+                  timezone={timezone}
                   onAttachmentLoaded={handleAttachmentLoaded}
                   onDeleted={() => {
                     void queryClient.invalidateQueries({
@@ -318,12 +326,12 @@ export function ChatConversation({
 
 // ── Internal helpers (V2 may hoist to shared modules) ──────────────────
 
-function DaySeparator({ civilDate }: { civilDate: string }) {
+function DaySeparator({ label }: { label: string }) {
   return (
     <div className="flex items-center gap-3 py-2">
       <div className="h-px flex-1 bg-border" />
       <span className="text-xs uppercase tracking-wide text-muted-foreground">
-        {civilDate}
+        {label}
       </span>
       <div className="h-px flex-1 bg-border" />
     </div>
@@ -334,6 +342,7 @@ interface MessageBubbleProps {
   chatId: string;
   message: MessageRow;
   isOwn: boolean;
+  timezone: string;
   onAttachmentLoaded?: () => void;
   onDeleted?: () => void;
 }
@@ -342,6 +351,7 @@ function MessageBubble({
   chatId,
   message,
   isOwn,
+  timezone,
   onAttachmentLoaded,
   onDeleted,
 }: MessageBubbleProps) {
@@ -425,7 +435,7 @@ function MessageBubble({
         {message.reactions && Object.keys(message.reactions).length > 0 ? (
           <ReactionRow reactions={message.reactions} />
         ) : null}
-        <TimeStamp iso={message.createdAt} isOwn={isOwn} />
+        <TimeStamp iso={message.createdAt} isOwn={isOwn} timezone={timezone} />
       </div>
       {!isOwn ? (
         <button
@@ -680,17 +690,16 @@ function ReactionRow({ reactions }: { reactions: Record<string, string> }) {
 function TimeStamp({
   iso,
   isOwn,
+  timezone,
 }: {
   iso: string | null | undefined;
   isOwn: boolean;
+  timezone: string;
 }) {
   if (!iso) return null;
   const d = new Date(iso);
   if (Number.isNaN(d.getTime())) return null;
-  const label = d.toLocaleTimeString([], {
-    hour: "2-digit",
-    minute: "2-digit",
-  });
+  const label = formatClientActivityTime(iso, timezone);
   return (
     <p
       className={`mt-1 text-[10px] ${
@@ -712,22 +721,28 @@ function TimeStamp({
 // is a one-bucket-per-locale-civil-date stub).
 
 type GroupedRow =
-  | { kind: "separator"; civilDate: string }
+  | { kind: "separator"; civilDate: string; label: string }
   | { kind: "message"; message: MessageRow };
 
-function groupByCivilDate(messages: MessageRow[]): GroupedRow[] {
+function groupByCivilDate(messages: MessageRow[], timezone: string): GroupedRow[] {
   const rows: GroupedRow[] = [];
   let lastBucket: string | null = null;
   for (const m of messages) {
     let bucket: string;
     if (m.createdAt) {
       const d = new Date(m.createdAt);
-      bucket = Number.isNaN(d.getTime()) ? "(pending)" : d.toDateString();
+      bucket = Number.isNaN(d.getTime())
+        ? "(pending)"
+        : clientActivityCivilDateKey(m.createdAt, timezone);
     } else {
       bucket = "(pending)";
     }
     if (bucket !== lastBucket) {
-      rows.push({ kind: "separator", civilDate: bucket });
+      rows.push({
+        kind: "separator",
+        civilDate: bucket,
+        label: m.createdAt ? formatClientActivityDate(m.createdAt, timezone) : bucket,
+      });
       lastBucket = bucket;
     }
     rows.push({ kind: "message", message: m });

--- a/backoffice/src/app/gc-fitness/chat/_components/ChatThreadList.tsx
+++ b/backoffice/src/app/gc-fitness/chat/_components/ChatThreadList.tsx
@@ -25,6 +25,7 @@ import { useMemo, useState } from "react";
 import { useTranslations } from "next-intl";
 import Image from "next/image";
 
+import { formatClientActivityDate } from "@/lib/gc-fitness/client-activity-time";
 import { useTrainerChats } from "@/lib/gc-fitness/chat-listener";
 import type { ChatRow } from "@/lib/gc-fitness/chat-schema";
 
@@ -33,6 +34,8 @@ import type { ClientRosterEntry } from "../client";
 interface Props {
   /** Trainer's Firebase Auth UID — used to read per-uid unread count. */
   trainerUid: string;
+  /** IANA timezone used to render timestamps in the trainer's local day. */
+  timezone: string;
   /** Currently selected chatId (from `?chatId=...`). */
   activeChatId: string | null;
   /** Row click → set the `?chatId=` search param. */
@@ -43,6 +46,7 @@ interface Props {
 
 export function ChatThreadList({
   trainerUid,
+  timezone,
   activeChatId,
   onSelect,
   clientRoster,
@@ -131,6 +135,7 @@ export function ChatThreadList({
           key={chat.id}
           chat={chat}
           trainerUid={trainerUid}
+          timezone={timezone}
           displayName={nameByUid.get(chat.clientId) ?? chat.clientId}
           photoURL={photoByUid.get(chat.clientId) ?? null}
           isActive={chat.id === activeChatId}
@@ -146,6 +151,7 @@ export function ChatThreadList({
 interface ChatThreadRowProps {
   chat: ChatRow;
   trainerUid: string;
+  timezone: string;
   displayName: string;
   photoURL: string | null;
   isActive: boolean;
@@ -155,6 +161,7 @@ interface ChatThreadRowProps {
 function ChatThreadRow({
   chat,
   trainerUid,
+  timezone,
   displayName,
   photoURL,
   isActive,
@@ -179,7 +186,7 @@ function ChatThreadRow({
         <div className="min-w-0 flex-1">
           <div className="flex items-baseline justify-between gap-2">
             <div className="truncate font-medium">{displayName}</div>
-            <RelativeTime iso={previewIso} />
+            <RelativeTime iso={previewIso} timezone={timezone} />
           </div>
           <div className="mt-1 flex items-center gap-2">
             <p className="min-w-0 flex-1 truncate text-sm text-muted-foreground">
@@ -230,7 +237,13 @@ function Avatar({ name, photoURL }: { name: string; photoURL?: string | null }) 
   );
 }
 
-function RelativeTime({ iso }: { iso: string | null | undefined }) {
+function RelativeTime({
+  iso,
+  timezone,
+}: {
+  iso: string | null | undefined;
+  timezone: string;
+}) {
   const t = useTranslations("chat.threadList");
   if (!iso) return null;
   const date = new Date(iso);
@@ -244,7 +257,7 @@ function RelativeTime({ iso }: { iso: string | null | undefined }) {
     label = t("hoursShort", { count: Math.floor(diffSec / 3600) });
   else if (diffSec < 86400 * 7)
     label = t("daysShort", { count: Math.floor(diffSec / 86400) });
-  else label = date.toLocaleDateString();
+  else label = formatClientActivityDate(iso, timezone);
   return (
     <span className="flex-shrink-0 text-xs text-muted-foreground">
       {label}

--- a/backoffice/src/app/gc-fitness/chat/client.tsx
+++ b/backoffice/src/app/gc-fitness/chat/client.tsx
@@ -47,12 +47,15 @@ export interface ClientRosterEntry {
 export interface ChatInboxClientProps {
   /** Trainer's Firebase Auth UID — resolved server-side via getCurrentTrainer(). */
   trainerUid: string;
+  /** IANA timezone used to render chat timestamps in the trainer's local day. */
+  timezone: string;
   /** Client roster from listClients() — uid → displayName lookup map source. */
   clientRoster: ClientRosterEntry[];
 }
 
 export function ChatInboxClient({
   trainerUid,
+  timezone,
   clientRoster,
 }: ChatInboxClientProps) {
   const t = useTranslations("chat.inbox");
@@ -86,6 +89,7 @@ export function ChatInboxClient({
       >
         <ChatThreadList
           trainerUid={trainerUid}
+          timezone={timezone}
           activeChatId={activeChatId}
           onSelect={setActiveChatId}
           clientRoster={clientRoster}
@@ -108,6 +112,7 @@ export function ChatInboxClient({
             <ChatConversation
               chatId={activeChatId}
               trainerUid={trainerUid}
+              timezone={timezone}
               clientRoster={clientRoster}
               isPendingClient={activeClientIsPending}
             />

--- a/backoffice/src/app/gc-fitness/chat/page.tsx
+++ b/backoffice/src/app/gc-fitness/chat/page.tsx
@@ -39,6 +39,7 @@ import {
   type CurrentTrainer,
 } from "@/lib/gc-fitness/auth-helpers";
 import { listClients } from "@/lib/gc-fitness/client-roster";
+import { getTrainerTimezone } from "@/lib/gc-fitness/trainer-timezone";
 import { ChatInboxClient } from "./client";
 
 export const dynamic = "force-dynamic";
@@ -56,6 +57,7 @@ export default async function ChatPage() {
   }
 
   const clients = await listClients();
+  const timezone = await getTrainerTimezone();
   const clientRoster = clients.map((c) => ({
     uid: c.uid,
     displayName: c.displayName,
@@ -78,6 +80,7 @@ export default async function ChatPage() {
       <ChatInboxClient
         trainerUid={trainer.uid}
         clientRoster={clientRoster}
+        timezone={timezone}
       />
     </div>
   );

--- a/backoffice/src/app/gc-fitness/clients/[id]/_components/BodyWeightTrendChart.tsx
+++ b/backoffice/src/app/gc-fitness/clients/[id]/_components/BodyWeightTrendChart.tsx
@@ -24,6 +24,7 @@
 
 import { getTranslations } from "next-intl/server";
 
+import { civilDateFormat } from "@/lib/gc-fitness/civil-date";
 import { gcFitnessFirestore } from "@/lib/firebase/gc-fitness-admin";
 import { FirestoreCollections } from "@/lib/gc-fitness/collections";
 import { BodyWeightTrendChartClient } from "./BodyWeightTrendChartClient";
@@ -60,6 +61,7 @@ function toDate(v: unknown): Date | null {
 
 export async function BodyWeightTrendChart({
   clientId,
+  timezone,
 }: BodyWeightTrendChartProps) {
   const t = await getTranslations("clients.detail.bodyWeightChart");
   const db = gcFitnessFirestore();
@@ -90,7 +92,7 @@ export async function BodyWeightTrendChart({
       if (weight === null || !date) return null;
       if (!isPlausibleWeightKg(weight)) return null;
       if (date < thirtyDaysAgo) return null;
-      return { date: date.toISOString().slice(0, 10), weight };
+      return { date: civilDateFormat(date, timezone), weight };
     })
     .filter((p): p is WeightPoint => p !== null);
 

--- a/backoffice/src/app/gc-fitness/clients/[id]/_components/BodyWeightTrendChartClient.tsx
+++ b/backoffice/src/app/gc-fitness/clients/[id]/_components/BodyWeightTrendChartClient.tsx
@@ -9,6 +9,9 @@ import {
   XAxis,
   YAxis,
 } from "recharts";
+import { useLocale } from "next-intl";
+
+import { formatCivilDateLabel } from "@/lib/gc-fitness/civil-date";
 
 export interface BodyWeightPoint {
   date: string;
@@ -22,6 +25,7 @@ export function BodyWeightTrendChartClient({
   data: BodyWeightPoint[];
   unitLabel: string;
 }) {
+  const locale = useLocale();
   return (
     <div className="h-60 w-full rounded-md border bg-muted/20 p-2 sm:p-3">
       <ResponsiveContainer width="100%" height="100%">
@@ -40,8 +44,11 @@ export function BodyWeightTrendChartClient({
             axisLine={false}
             minTickGap={24}
             tickFormatter={(value: string) => {
-              const d = new Date(`${value}T00:00:00`);
-              return d.toLocaleDateString(undefined, { month: "short", day: "numeric" });
+              return formatCivilDateLabel(
+                value,
+                { month: "short", day: "numeric" },
+                locale,
+              );
             }}
           />
           <YAxis
@@ -61,8 +68,15 @@ export function BodyWeightTrendChartClient({
             }}
             formatter={(value) => [`${Number(value).toFixed(1)} ${unitLabel}`, "Peso"]}
             labelFormatter={(label) => {
-              const d = new Date(`${String(label)}T00:00:00`);
-              return d.toLocaleDateString();
+              return formatCivilDateLabel(
+                String(label),
+                {
+                  year: "numeric",
+                  month: "short",
+                  day: "numeric",
+                },
+                locale,
+              );
             }}
           />
           <Area

--- a/backoffice/src/app/gc-fitness/clients/[id]/_components/ChatHistoryWidget.tsx
+++ b/backoffice/src/app/gc-fitness/clients/[id]/_components/ChatHistoryWidget.tsx
@@ -24,10 +24,16 @@ import { getTranslations } from "next-intl/server";
 
 import { gcFitnessFirestore } from "@/lib/firebase/gc-fitness-admin";
 import { FirestoreCollections } from "@/lib/gc-fitness/collections";
+import {
+  clientActivityGroupKey,
+  formatClientActivityDayHeader,
+  formatClientActivityTime,
+} from "@/lib/gc-fitness/client-activity-time";
 
 export interface ChatHistoryWidgetProps {
   clientId: string;
   trainerUid: string;
+  timezone: string;
 }
 
 interface MessagePreviewRow {
@@ -59,6 +65,7 @@ function toDate(v: unknown): Date | null {
 export async function ChatHistoryWidget({
   clientId,
   trainerUid,
+  timezone,
 }: ChatHistoryWidgetProps) {
   const t = await getTranslations("clients.detail.chatHistory");
   const tCommon = await getTranslations("common");
@@ -103,15 +110,9 @@ export async function ChatHistoryWidget({
 
   const groups: MessageGroup[] = [];
   for (const row of rows) {
-    const key = row.createdAt
-      ? row.createdAt.toISOString().slice(0, 13)
-      : "unknown";
+    const key = clientActivityGroupKey(row.createdAt?.toISOString() ?? null, timezone);
     const label = row.createdAt
-      ? row.createdAt.toLocaleString(undefined, {
-          month: "short",
-          day: "numeric",
-          hour: "2-digit",
-        })
+      ? formatClientActivityDayHeader(row.createdAt.toISOString(), timezone)
       : tCommon("emDash");
     const last = groups[groups.length - 1];
     if (last && last.key === key) {
@@ -145,16 +146,14 @@ export async function ChatHistoryWidget({
                     <p
                       className={
                         row.isTrainer
-                          ? "mt-1 text-[10px] text-primary-foreground/70"
+                      ? "mt-1 text-[10px] text-primary-foreground/70"
                           : "mt-1 text-[10px] text-emerald-900/70 dark:text-emerald-50/70"
                       }
                     >
-                      {row.createdAt
-                        ? row.createdAt.toLocaleTimeString(undefined, {
-                            hour: "2-digit",
-                            minute: "2-digit",
-                          })
-                        : tCommon("emDash")}
+                      {formatClientActivityTime(
+                        row.createdAt ? row.createdAt.toISOString() : null,
+                        timezone,
+                      )}
                     </p>
                   ) : null}
                 </div>

--- a/backoffice/src/app/gc-fitness/clients/[id]/_components/ClientDailyTimeline.tsx
+++ b/backoffice/src/app/gc-fitness/clients/[id]/_components/ClientDailyTimeline.tsx
@@ -20,6 +20,10 @@ import {
   getClientDailyTimelineDay,
   type ClientDailyTimelineDay,
 } from "@/lib/gc-fitness/client-daily-timeline-actions";
+import {
+  formatClientActivityDate,
+  formatClientActivityDateTime,
+} from "@/lib/gc-fitness/client-activity-time";
 import { Button } from "@/components/ui/button";
 import { WorkoutAssignmentDeleteDialog } from "@/components/gc-fitness/workout-assignment-delete-dialog";
 
@@ -28,11 +32,13 @@ export function ClientDailyTimeline({
   availableDates,
   initialDay,
   todayCivil,
+  timezone,
 }: {
   clientId: string;
   availableDates: string[];
   initialDay: ClientDailyTimelineDay;
   todayCivil: string;
+  timezone: string;
 }) {
   const t = useTranslations("clients.detail.timeline");
   const tCommon = useTranslations("common");
@@ -360,7 +366,7 @@ export function ClientDailyTimeline({
                           <span className="text-xs text-muted-foreground">
                             {photo.checkInDate ??
                               (photo.takenAt || photo.createdAt
-                                ? new Date(photo.takenAt ?? photo.createdAt ?? "").toLocaleDateString()
+                                ? formatClientActivityDate(photo.takenAt ?? photo.createdAt ?? null, timezone)
                                 : tCommon("noDate"))}
                           </span>
                         </div>
@@ -412,7 +418,9 @@ export function ClientDailyTimeline({
                   <div key={note.id} className="rounded-md bg-muted px-3 py-2 text-sm">
                     <p className="whitespace-pre-wrap">{note.body}</p>
                     <p className="mt-1 text-xs text-muted-foreground">
-                      {note.createdAt ? new Date(note.createdAt).toLocaleString() : tCommon("emDash")}
+                      {note.createdAt
+                        ? formatClientActivityDateTime(note.createdAt, timezone)
+                        : tCommon("emDash")}
                     </p>
                   </div>
                 ))}

--- a/backoffice/src/app/gc-fitness/clients/[id]/_components/ClientDailyTimeline.tsx
+++ b/backoffice/src/app/gc-fitness/clients/[id]/_components/ClientDailyTimeline.tsx
@@ -14,7 +14,7 @@ import {
   Plus,
   Trash2,
 } from "lucide-react";
-import { useTranslations } from "next-intl";
+import { useLocale, useTranslations } from "next-intl";
 
 import {
   getClientDailyTimelineDay,
@@ -24,6 +24,7 @@ import {
   formatClientActivityDate,
   formatClientActivityDateTime,
 } from "@/lib/gc-fitness/client-activity-time";
+import { formatCivilDateLabel } from "@/lib/gc-fitness/civil-date";
 import { Button } from "@/components/ui/button";
 import { WorkoutAssignmentDeleteDialog } from "@/components/gc-fitness/workout-assignment-delete-dialog";
 
@@ -40,6 +41,7 @@ export function ClientDailyTimeline({
   todayCivil: string;
   timezone: string;
 }) {
+  const locale = useLocale();
   const t = useTranslations("clients.detail.timeline");
   const tCommon = useTranslations("common");
   const initialDate =
@@ -197,7 +199,7 @@ export function ClientDailyTimeline({
                   : "bg-background hover:bg-muted",
               ].join(" ")}
             >
-              <span className="block font-medium">{shortDate(day)}</span>
+              <span className="block font-medium">{shortDate(day, locale)}</span>
               <span
                 className={
                   isSelected ? "text-primary-foreground/75" : "text-muted-foreground"
@@ -282,7 +284,13 @@ export function ClientDailyTimeline({
                       <p className="mt-2 inline-flex items-center gap-1 text-xs font-medium text-amber-700 dark:text-amber-400">
                         <ArrowRightLeft className="size-3" aria-hidden="true" />
                         <span>
-                          {`Originalmente ${formatTimelineCivilDate(workout.originallyScheduledFor)}, el cliente lo movió a ${formatTimelineCivilDate(selected.date)}.`}
+                          {`Originalmente ${formatTimelineCivilDate(
+                            workout.originallyScheduledFor,
+                            locale,
+                          )}, el cliente lo movió a ${formatTimelineCivilDate(
+                            selected.date,
+                            locale,
+                          )}.`}
                         </span>
                       </p>
                     ) : null}
@@ -460,18 +468,16 @@ export function ClientDailyTimeline({
  * label stable across regions; the trainer reads it as a civil-date
  * label, not a moment in time.
  */
-function formatTimelineCivilDate(civilDate: string): string {
-  const parts = civilDate.split("-");
-  if (parts.length !== 3) return civilDate;
-  const [y, m, d] = parts.map(Number);
-  if (!y || !m || !d) return civilDate;
-  const date = new Date(Date.UTC(y, m - 1, d));
-  return new Intl.DateTimeFormat("es-AR", {
-    weekday: "long",
-    day: "numeric",
-    month: "short",
-    timeZone: "UTC",
-  }).format(date);
+function formatTimelineCivilDate(civilDate: string, locale: string): string {
+  return formatCivilDateLabel(
+    civilDate,
+    {
+      weekday: "long",
+      day: "numeric",
+      month: "short",
+    },
+    locale,
+  );
 }
 
 function hasActivity(day: ClientDailyTimelineDay): boolean {
@@ -525,7 +531,6 @@ function Empty({ children }: { children: React.ReactNode }) {
   return <p className="text-sm text-muted-foreground">{children}</p>;
 }
 
-function shortDate(date: string): string {
-  const parsed = new Date(`${date}T00:00:00`);
-  return parsed.toLocaleDateString(undefined, { month: "short", day: "numeric" });
+function shortDate(date: string, locale: string): string {
+  return formatCivilDateLabel(date, { month: "short", day: "numeric" }, locale);
 }

--- a/backoffice/src/app/gc-fitness/clients/[id]/_components/ClientNotesCard.tsx
+++ b/backoffice/src/app/gc-fitness/clients/[id]/_components/ClientNotesCard.tsx
@@ -13,6 +13,7 @@ import {
   editClientNote,
   updateClientNotes,
 } from "@/lib/gc-fitness/client-notes-actions";
+import { formatClientActivityDateTime } from "@/lib/gc-fitness/client-activity-time";
 
 interface ClientNoteEntryView {
   date: string;
@@ -22,6 +23,8 @@ interface ClientNoteEntryView {
 
 interface Props {
   clientId: string;
+  timezone: string;
+  todayCivil: string;
   initialNotes: string;
   initialUpdatedAt: string | null;
   initialEntries: ClientNoteEntryView[];
@@ -29,6 +32,8 @@ interface Props {
 
 export function ClientNotesCard({
   clientId,
+  timezone,
+  todayCivil,
   initialNotes,
   initialUpdatedAt,
   initialEntries,
@@ -36,7 +41,7 @@ export function ClientNotesCard({
   const t = useTranslations("clients.detail.notes");
   const [notes, setNotes] = useState("");
   const [updatedAt, setUpdatedAt] = useState(initialUpdatedAt);
-  const [noteDate, setNoteDate] = useState(new Date().toISOString().slice(0, 10));
+  const [noteDate, setNoteDate] = useState(todayCivil);
   const [error, setError] = useState<string | null>(null);
   const [isPending, startTransition] = useTransition();
   const [entries, setEntries] = useState(initialEntries);
@@ -151,6 +156,7 @@ export function ClientNotesCard({
                   key={`${entry.date}-${entry.createdAt ?? index}`}
                   clientId={clientId}
                   entry={entry}
+                  timezone={timezone}
                   variant="forDate"
                   onEdited={handleEdited}
                   onDeleted={handleDeleted}
@@ -173,6 +179,7 @@ export function ClientNotesCard({
                   key={`recent-${entry.date}-${entry.createdAt ?? index}`}
                   clientId={clientId}
                   entry={entry}
+                  timezone={timezone}
                   variant="recent"
                   onEdited={handleEdited}
                   onDeleted={handleDeleted}
@@ -189,12 +196,14 @@ export function ClientNotesCard({
 function EntryItem({
   clientId,
   entry,
+  timezone,
   variant,
   onEdited,
   onDeleted,
 }: {
   clientId: string;
   entry: ClientNoteEntryView;
+  timezone: string;
   variant: "forDate" | "recent";
   onEdited: (target: ClientNoteEntryView, newText: string) => void;
   onDeleted: (target: ClientNoteEntryView) => void;
@@ -223,7 +232,7 @@ function EntryItem({
         <div className="flex items-center gap-2">
           <span>
             {entry.createdAt
-              ? new Date(entry.createdAt).toLocaleString()
+              ? formatClientActivityDateTime(entry.createdAt, timezone)
               : ""}
           </span>
           {canMutate && !editing ? (

--- a/backoffice/src/app/gc-fitness/clients/[id]/_components/ClientRecentLogsFeed.tsx
+++ b/backoffice/src/app/gc-fitness/clients/[id]/_components/ClientRecentLogsFeed.tsx
@@ -72,6 +72,8 @@ interface Props {
   logs: RecentLogRow[];
   /** The single client this feed belongs to — used for "load more" fetches. */
   clientId: string;
+  /** IANA timezone used to render timestamps in the client's local time. */
+  timezone: string;
   /** Cursor for the next page (from the server). Null/absent ⇒ no more to load. */
   initialCursor?: string | null;
   /** Whether another page may exist beyond the initially-loaded rows. */
@@ -104,6 +106,7 @@ interface Props {
 export function ClientRecentLogsFeed({
   logs,
   clientId,
+  timezone,
   initialCursor = null,
   initialHasMore = false,
   showActions = true,
@@ -254,7 +257,7 @@ export function ClientRecentLogsFeed({
                   ) : null}
                 </div>
                 <p className="mt-0.5 truncate text-xs text-muted-foreground">
-                  {formatDateTime(row.eventAt)}
+                  {formatDateTime(row.eventAt, timezone)}
                   {row.detail ? ` · ${row.detail}` : ""}
                 </p>
               </RowShell>
@@ -347,7 +350,7 @@ function RowShell({
   );
 }
 
-function formatDateTime(iso: string): string {
+function formatDateTime(iso: string, timeZone: string): string {
   const date = new Date(iso);
   if (Number.isNaN(date.getTime())) return iso;
   return date.toLocaleString(undefined, {
@@ -355,6 +358,7 @@ function formatDateTime(iso: string): string {
     day: "2-digit",
     hour: "2-digit",
     minute: "2-digit",
+    timeZone,
   });
 }
 

--- a/backoffice/src/app/gc-fitness/clients/[id]/_components/ClientRecentLogsFeed.tsx
+++ b/backoffice/src/app/gc-fitness/clients/[id]/_components/ClientRecentLogsFeed.tsx
@@ -3,6 +3,7 @@
 import type { ComponentType, ReactNode } from "react";
 import Link from "next/link";
 import { useMemo, useState } from "react";
+import { useLocale, useTranslations } from "next-intl";
 import {
   ArrowRightLeft,
   CalendarClock,
@@ -17,7 +18,6 @@ import {
   StickyNote,
   User,
 } from "lucide-react";
-import { useTranslations } from "next-intl";
 
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -26,6 +26,7 @@ import {
   listRecentLogsForClientAsAdmin,
   type RecentLogRow,
 } from "@/lib/gc-fitness/recent-logs-actions";
+import { formatCivilDateLabel } from "@/lib/gc-fitness/civil-date";
 
 // Must match the server page size (listRecentLogsForClient default). The feed
 // pages through already-loaded rows in memory; only when the user crosses the
@@ -113,6 +114,7 @@ export function ClientRecentLogsFeed({
   linkMode = "trainer",
   coachUid,
 }: Props) {
+  const locale = useLocale();
   const t = useTranslations("clients.detail.recentLogs");
   const tf = useTranslations("recentLogs.feed");
   const [page, setPage] = useState(0);
@@ -224,7 +226,9 @@ export function ClientRecentLogsFeed({
                       className="gap-1 border-amber-200 bg-amber-50 px-1.5 py-0 text-[10px] font-normal text-amber-700 [&>svg]:size-3 dark:border-amber-900 dark:bg-amber-950/40 dark:text-amber-300"
                     >
                       <CalendarClock />
-                      {tf("forDay", { date: formatCivilDate(row.forCivilDate) })}
+                      {tf("forDay", {
+                        date: formatCivilDate(row.forCivilDate, locale),
+                      })}
                     </Badge>
                   ) : null}
                   {row.workout?.rpe != null ? (
@@ -364,10 +368,10 @@ function formatDateTime(iso: string, timeZone: string): string {
 
 // Render a "YYYY-MM-DD" civil date as a short day label. Construct from parts
 // (NOT `new Date(iso)`) so a negative-offset host doesn't shift the day back.
-function formatCivilDate(civil: string): string {
-  const [y, m, d] = civil.split("-").map((n) => Number.parseInt(n, 10));
-  if (!y || !m || !d) return civil;
-  const date = new Date(y, m - 1, d);
-  if (Number.isNaN(date.getTime())) return civil;
-  return date.toLocaleDateString(undefined, { month: "short", day: "numeric" });
+function formatCivilDate(civil: string, locale: string): string {
+  return formatCivilDateLabel(
+    civil,
+    { month: "short", day: "numeric" },
+    locale,
+  );
 }

--- a/backoffice/src/app/gc-fitness/clients/[id]/_components/ClientRecentLogsWidget.tsx
+++ b/backoffice/src/app/gc-fitness/clients/[id]/_components/ClientRecentLogsWidget.tsx
@@ -18,8 +18,10 @@ import { ClientRecentLogsFeed } from "./ClientRecentLogsFeed";
  */
 export async function ClientRecentLogsWidget({
   clientId,
+  timezone,
 }: {
   clientId: string;
+  timezone: string;
 }) {
   const t = await getTranslations("clients.detail.recentLogs");
   const { logs, nextCursor, hasMore } = await listRecentLogsForClient(clientId);
@@ -32,6 +34,7 @@ export async function ClientRecentLogsWidget({
         <ClientRecentLogsFeed
           logs={logs}
           clientId={clientId}
+          timezone={timezone}
           initialCursor={nextCursor}
           initialHasMore={hasMore}
           showActions

--- a/backoffice/src/app/gc-fitness/clients/[id]/_components/ClientSummaryCard.tsx
+++ b/backoffice/src/app/gc-fitness/clients/[id]/_components/ClientSummaryCard.tsx
@@ -1,5 +1,6 @@
 import { getTranslations } from "next-intl/server";
 
+import { civilDateToday } from "@/lib/gc-fitness/civil-date";
 import { gcFitnessFirestore } from "@/lib/firebase/gc-fitness-admin";
 import { FirestoreCollections } from "@/lib/gc-fitness/collections";
 import type { ClientGoalRow } from "@/lib/gc-fitness/client-goal-actions";
@@ -18,10 +19,12 @@ const WEEKDAY_LABELS_WORKOUT: Record<number, string> = {
 export async function ClientSummaryCard({
   clientId,
   clientName,
+  timezone,
   goals,
 }: {
   clientId: string;
   clientName: string;
+  timezone: string;
   goals: ClientGoalRow[];
 }) {
   const t = await getTranslations("clients.detail.summary");
@@ -68,8 +71,8 @@ export async function ClientSummaryCard({
   // assignments. Mirrors the iOS dashboard chip's `workoutStreak` so
   // trainer + client see the same number. Uses the SAME 80-doc fetch
   // above (no extra query).
-  const workoutStreak = computeWorkoutStreak(assignmentsSnap.docs);
-  const todayCivil = new Date().toISOString().slice(0, 10);
+  const todayCivil = civilDateToday(timezone);
+  const workoutStreak = computeWorkoutStreak(assignmentsSnap.docs, todayCivil);
   const visibleWorkouts = workouts.filter((row) => row.isRecurring || row.scheduledFor >= todayCivil);
   const pastWorkouts = workouts.filter((row) => !row.isRecurring && row.scheduledFor < todayCivil);
   const workoutsGrouped = groupWorkouts(visibleWorkouts);
@@ -301,8 +304,8 @@ function habitCadenceLabel(
  */
 function computeWorkoutStreak(
   docs: Array<{ data: () => Record<string, unknown> }>,
+  todayCivil: string,
 ): number {
-  const todayCivil = new Date().toISOString().slice(0, 10);
   const rows = docs
     .map((doc) => {
       const data = doc.data();

--- a/backoffice/src/app/gc-fitness/clients/[id]/_components/ProgressPhotoCompare.tsx
+++ b/backoffice/src/app/gc-fitness/clients/[id]/_components/ProgressPhotoCompare.tsx
@@ -4,9 +4,16 @@ import Image from "next/image";
 import { useMemo, useState } from "react";
 import { useTranslations } from "next-intl";
 
+import { formatClientActivityDate } from "@/lib/gc-fitness/client-activity-time";
 import type { ProgressPhotoRow } from "@/lib/gc-fitness/progress-photo-actions";
 
-export function ProgressPhotoCompare({ photos }: { photos: ProgressPhotoRow[] }) {
+export function ProgressPhotoCompare({
+  photos,
+  timezone,
+}: {
+  photos: ProgressPhotoRow[];
+  timezone: string;
+}) {
   const t = useTranslations("clients.detail.photoCompare");
   const tPhotos = useTranslations("clients.detail.photos");
   const [angle, setAngle] = useState<"front" | "side" | "back">("front");
@@ -44,7 +51,7 @@ export function ProgressPhotoCompare({ photos }: { photos: ProgressPhotoRow[] })
           <option value="">{t("before")}</option>
           {angled.map((photo) => (
             <option key={photo.id} value={photo.id}>
-              {photo.checkInDate ?? dateLabel(photo)}
+              {photo.checkInDate ?? dateLabel(photo, timezone)}
             </option>
           ))}
         </select>
@@ -56,7 +63,7 @@ export function ProgressPhotoCompare({ photos }: { photos: ProgressPhotoRow[] })
           <option value="">{t("after")}</option>
           {angled.map((photo) => (
             <option key={photo.id} value={photo.id}>
-              {photo.checkInDate ?? dateLabel(photo)}
+              {photo.checkInDate ?? dateLabel(photo, timezone)}
             </option>
           ))}
         </select>
@@ -108,7 +115,7 @@ function CompareImage({ photo, alt }: { photo: ProgressPhotoRow; alt: string }) 
   );
 }
 
-function dateLabel(photo: ProgressPhotoRow): string {
+function dateLabel(photo: ProgressPhotoRow, timezone: string): string {
   const value = photo.takenAt ?? photo.createdAt;
-  return value ? new Date(value).toLocaleDateString() : photo.id;
+  return value ? formatClientActivityDate(value, timezone) : photo.id;
 }

--- a/backoffice/src/app/gc-fitness/clients/[id]/_components/ProgressPhotosGridClient.tsx
+++ b/backoffice/src/app/gc-fitness/clients/[id]/_components/ProgressPhotosGridClient.tsx
@@ -5,12 +5,20 @@ import { useMemo, useState } from "react";
 import { useTranslations } from "next-intl";
 
 import { Button } from "@/components/ui/button";
+import { civilDateFormat } from "@/lib/gc-fitness/civil-date";
 import type { ProgressPhotoRow } from "@/lib/gc-fitness/progress-photo-actions";
+import { formatClientActivityDate } from "@/lib/gc-fitness/client-activity-time";
 
 const PAGE_GROUPS = 3;
 const ANGLE_ORDER: Record<string, number> = { front: 0, side: 1, back: 2 };
 
-export function ProgressPhotosGridClient({ photos }: { photos: ProgressPhotoRow[] }) {
+export function ProgressPhotosGridClient({
+  photos,
+  timezone,
+}: {
+  photos: ProgressPhotoRow[];
+  timezone: string;
+}) {
   const t = useTranslations("clients.detail.photos");
   const tCommon = useTranslations("common");
   const [visibleGroups, setVisibleGroups] = useState(PAGE_GROUPS);
@@ -18,7 +26,7 @@ export function ProgressPhotosGridClient({ photos }: { photos: ProgressPhotoRow[
   const grouped = useMemo(() => {
     const map = new Map<string, ProgressPhotoRow[]>();
     for (const photo of photos) {
-      const key = photo.checkInDate ?? dateKey(photo);
+      const key = photo.checkInDate ?? dateKey(photo, timezone);
       const list = map.get(key) ?? [];
       list.push(photo);
       map.set(key, list);
@@ -34,7 +42,7 @@ export function ProgressPhotosGridClient({ photos }: { photos: ProgressPhotoRow[
           return (ANGLE_ORDER[angleA] ?? 99) - (ANGLE_ORDER[angleB] ?? 99);
         }),
       }));
-  }, [photos]);
+  }, [photos, timezone]);
 
   const visible = grouped.slice(0, visibleGroups);
   const hasMore = visibleGroups < grouped.length;
@@ -66,10 +74,11 @@ export function ProgressPhotosGridClient({ photos }: { photos: ProgressPhotoRow[
                     {photo.angle ?? t("photoFallback")}
                   </p>
                   <p className="text-xs text-muted-foreground">
-                    {photo.checkInDate ??
-                      (photo.takenAt || photo.createdAt
-                        ? new Date(photo.takenAt ?? photo.createdAt ?? "").toLocaleDateString()
-                        : tCommon("noDate"))}
+                    {photo.checkInDate
+                      ? photo.checkInDate
+                      : photo.takenAt || photo.createdAt
+                        ? formatClientActivityDate(photo.takenAt ?? photo.createdAt ?? null, timezone)
+                        : tCommon("noDate")}
                   </p>
                 </div>
                 {photo.caption ? <p className="line-clamp-2 text-sm">{photo.caption}</p> : null}
@@ -90,9 +99,10 @@ export function ProgressPhotosGridClient({ photos }: { photos: ProgressPhotoRow[
   );
 }
 
-function dateKey(photo: ProgressPhotoRow): string {
+function dateKey(photo: ProgressPhotoRow, timezone: string): string {
   const source = photo.takenAt ?? photo.createdAt;
   if (!source) return "0000-00-00";
-  return new Date(source).toISOString().slice(0, 10);
+  const date = new Date(source);
+  if (Number.isNaN(date.getTime())) return "0000-00-00";
+  return civilDateFormat(date, timezone);
 }
-

--- a/backoffice/src/app/gc-fitness/clients/[id]/_components/ProgressPhotosWidget.tsx
+++ b/backoffice/src/app/gc-fitness/clients/[id]/_components/ProgressPhotosWidget.tsx
@@ -9,9 +9,11 @@ import { Button } from "@/components/ui/button";
 export async function ProgressPhotosWidget({
   photos,
   clientId,
+  timezone,
 }: {
   photos: ProgressPhotoRow[];
   clientId: string;
+  timezone: string;
 }) {
   const t = await getTranslations("clients.detail.photos");
   return (
@@ -37,7 +39,7 @@ export async function ProgressPhotosWidget({
               </Link>
             </Button>
           </div>
-          <ProgressPhotosGridClient photos={photos} />
+          <ProgressPhotosGridClient photos={photos} timezone={timezone} />
         </div>
       )}
     </section>

--- a/backoffice/src/app/gc-fitness/clients/[id]/_components/WorkoutTrendsClient.tsx
+++ b/backoffice/src/app/gc-fitness/clients/[id]/_components/WorkoutTrendsClient.tsx
@@ -6,6 +6,7 @@
 // the server shipped one lightweight point per counted session.
 
 import { useMemo, useState } from "react";
+import { useLocale } from "next-intl";
 import {
   Bar,
   BarChart,
@@ -24,6 +25,7 @@ import {
   type TrendRangeKey,
 } from "./trend-range";
 import { TrendRangeSelector } from "./TrendRangeSelector";
+import { formatCivilDateLabel } from "@/lib/gc-fitness/civil-date";
 
 export interface WorkoutTrendPoint {
   /** civilDate YYYY-MM-DD of the session start. */
@@ -57,14 +59,8 @@ interface Bucket {
   count: number;
 }
 
-function formatCivilShort(civilDate: string): string {
-  const d = new Date(`${civilDate}T12:00:00Z`);
-  if (Number.isNaN(d.getTime())) return civilDate;
-  return d.toLocaleDateString(undefined, {
-    month: "short",
-    day: "numeric",
-    timeZone: "UTC",
-  });
+function formatCivilShort(civilDate: string, locale: string): string {
+  return formatCivilDateLabel(civilDate, { month: "short", day: "numeric" }, locale);
 }
 
 function formatVolume(kg: number): string {
@@ -79,6 +75,7 @@ export function WorkoutTrendsClient({
   rangeStarts,
   labels,
 }: WorkoutTrendsClientProps) {
+  const locale = useLocale();
   const [range, setRange] = useState<TrendRangeKey>(DEFAULT_TREND_RANGE);
 
   const { buckets, totals } = useMemo(() => {
@@ -102,7 +99,7 @@ export function WorkoutTrendsClient({
     if (granularity === "day") {
       for (let i = 0; i <= span; i += 1) {
         const day = addCivilDays(start, i);
-        buckets.push({ key: day, label: formatCivilShort(day), count: 0 });
+        buckets.push({ key: day, label: formatCivilShort(day, locale), count: 0 });
       }
       const byKey = new Map(buckets.map((b) => [b.key, b]));
       for (const p of inRange) {
@@ -116,7 +113,7 @@ export function WorkoutTrendsClient({
         bucketStarts.push(addCivilDays(start, i));
       }
       for (const bs of bucketStarts) {
-        buckets.push({ key: bs, label: formatCivilShort(bs), count: 0 });
+        buckets.push({ key: bs, label: formatCivilShort(bs, locale), count: 0 });
       }
       for (const p of inRange) {
         const offset = civilDiffDays(p.date, start);

--- a/backoffice/src/app/gc-fitness/clients/[id]/compare-photos/page.tsx
+++ b/backoffice/src/app/gc-fitness/clients/[id]/compare-photos/page.tsx
@@ -27,10 +27,16 @@ export default async function ComparePhotosPage({
 
   const clientSnap = await gcFitnessFirestore().collection(FirestoreCollections.users).doc(id).get();
   if (!clientSnap.exists) notFound();
-  const client = clientSnap.data() as { coachId?: string; displayName?: string; email?: string };
+  const client = clientSnap.data() as {
+    coachId?: string;
+    displayName?: string;
+    email?: string;
+    timezone?: string;
+  };
   if (client.coachId !== trainer.uid) notFound();
 
   const photos = await listProgressPhotosForClient(id);
+  const timezone = client.timezone ?? "UTC";
 
   return (
     <div className="mx-auto flex w-full max-w-[1800px] flex-col gap-4 px-4 py-6 sm:px-6">
@@ -43,8 +49,7 @@ export default async function ComparePhotosPage({
           <Link href={`/gc-fitness/clients/${id}#progress-photos`}>Volver al perfil</Link>
         </Button>
       </div>
-      <ProgressPhotoCompareEditor photos={photos} />
+      <ProgressPhotoCompareEditor photos={photos} timezone={timezone} />
     </div>
   );
 }
-

--- a/backoffice/src/app/gc-fitness/clients/[id]/compare-photos/photo-compare-editor.tsx
+++ b/backoffice/src/app/gc-fitness/clients/[id]/compare-photos/photo-compare-editor.tsx
@@ -4,12 +4,19 @@ import Image from "next/image";
 import { useMemo, useRef, useState } from "react";
 import { useSearchParams } from "next/navigation";
 import type { ProgressPhotoRow } from "@/lib/gc-fitness/progress-photo-actions";
+import { formatClientActivityDate } from "@/lib/gc-fitness/client-activity-time";
 
 type Angle = "front" | "side" | "back";
 type Transform = { scale: number; x: number; y: number };
 type CompareMode = "side-by-side" | "slider";
 
-export function ProgressPhotoCompareEditor({ photos }: { photos: ProgressPhotoRow[] }) {
+export function ProgressPhotoCompareEditor({
+  photos,
+  timezone,
+}: {
+  photos: ProgressPhotoRow[];
+  timezone: string;
+}) {
   const params = useSearchParams();
   const initialAngle = (params.get("angle") as Angle) || "front";
   const [angle, setAngle] = useState<Angle>(initialAngle);
@@ -71,10 +78,10 @@ export function ProgressPhotoCompareEditor({ photos }: { photos: ProgressPhotoRo
           <option value="front">Front</option><option value="side">Side</option><option value="back">Back</option>
         </select>
         <select className="h-10 rounded-md border px-2" value={beforeId} onChange={(e) => setBeforeId(e.target.value)}>
-          <option value="">Before</option>{angled.map((p) => <option key={p.id} value={p.id}>{p.checkInDate ?? p.id}</option>)}
+          <option value="">Before</option>{angled.map((p) => <option key={p.id} value={p.id}>{p.checkInDate ?? dateFromRow(p, timezone)}</option>)}
         </select>
         <select className="h-10 rounded-md border px-2" value={afterId} onChange={(e) => setAfterId(e.target.value)}>
-          <option value="">After</option>{angled.map((p) => <option key={p.id} value={p.id}>{p.checkInDate ?? p.id}</option>)}
+          <option value="">After</option>{angled.map((p) => <option key={p.id} value={p.id}>{p.checkInDate ?? dateFromRow(p, timezone)}</option>)}
         </select>
       </div>
       {before?.url && after?.url ? (
@@ -110,9 +117,10 @@ export function ProgressPhotoCompareEditor({ photos }: { photos: ProgressPhotoRo
                       afterT,
                       cssWidth: rect.width,
                       cssHeight: rect.height,
+                      timezone,
                     });
                   } else {
-                    await exportSideBySideJpg({ before, after });
+                    await exportSideBySideJpg({ before, after, timezone });
                   }
                 } catch (err) {
                   // eslint-disable-next-line no-console
@@ -146,8 +154,16 @@ export function ProgressPhotoCompareEditor({ photos }: { photos: ProgressPhotoRo
           ) : (
             <div className="space-y-3">
               <div className="grid grid-cols-1 gap-3 lg:grid-cols-2">
-                <CompareStaticImage url={before.url} alt="before" date={before.checkInDate ?? dateFromRow(before)} />
-                <CompareStaticImage url={after.url} alt="after" date={after.checkInDate ?? dateFromRow(after)} />
+                <CompareStaticImage
+                  url={before.url}
+                  alt="before"
+                  date={before.checkInDate ?? dateFromRow(before, timezone)}
+                />
+                <CompareStaticImage
+                  url={after.url}
+                  alt="after"
+                  date={after.checkInDate ?? dateFromRow(after, timezone)}
+                />
               </div>
             </div>
           )}
@@ -171,17 +187,19 @@ function CompareStaticImage({ url, alt, date }: { url: string; alt: string; date
   );
 }
 
-function dateFromRow(photo: ProgressPhotoRow): string {
+function dateFromRow(photo: ProgressPhotoRow, timezone: string): string {
   const source = photo.takenAt ?? photo.createdAt;
-  return source ? new Date(source).toLocaleDateString() : photo.id;
+  return source ? formatClientActivityDate(source, timezone) : photo.id;
 }
 
 async function exportSideBySideJpg({
   before,
   after,
+  timezone,
 }: {
   before: ProgressPhotoRow;
   after: ProgressPhotoRow;
+  timezone: string;
 }) {
   if (!before.url || !after.url) return;
 
@@ -212,7 +230,7 @@ async function exportSideBySideJpg({
     y: outerMargin + gap,
     width: panelWidth,
     height: panelHeight,
-    label: before.checkInDate ?? dateFromRow(before),
+    label: before.checkInDate ?? dateFromRow(before, timezone),
     title: "Before",
     labelHeight,
     radius: cornerRadius,
@@ -225,7 +243,7 @@ async function exportSideBySideJpg({
     y: outerMargin + gap,
     width: panelWidth,
     height: panelHeight,
-    label: after.checkInDate ?? dateFromRow(after),
+    label: after.checkInDate ?? dateFromRow(after, timezone),
     title: "After",
     labelHeight,
     radius: cornerRadius,
@@ -254,6 +272,7 @@ async function exportSliderSnapshotJpg({
   afterT,
   cssWidth,
   cssHeight,
+  timezone,
 }: {
   before: ProgressPhotoRow;
   after: ProgressPhotoRow;
@@ -262,6 +281,7 @@ async function exportSliderSnapshotJpg({
   afterT: Transform;
   cssWidth: number;
   cssHeight: number;
+  timezone: string;
 }) {
   if (!before.url || !after.url) return;
   if (cssWidth <= 0 || cssHeight <= 0) throw new Error("Empty slider bounds");
@@ -336,8 +356,8 @@ async function exportSliderSnapshotJpg({
   ctx.restore();
 
   // Bottom labels (Before — date | After — date) outside the rounded panel.
-  const beforeLabel = before.checkInDate ?? dateFromRow(before);
-  const afterLabel = after.checkInDate ?? dateFromRow(after);
+  const beforeLabel = before.checkInDate ?? dateFromRow(before, timezone);
+  const afterLabel = after.checkInDate ?? dateFromRow(after, timezone);
   ctx.fillStyle = "#111111";
   ctx.font = "700 54px system-ui, -apple-system, sans-serif";
   const labelY = panelY + panelH + 86;

--- a/backoffice/src/app/gc-fitness/clients/[id]/page.tsx
+++ b/backoffice/src/app/gc-fitness/clients/[id]/page.tsx
@@ -28,6 +28,7 @@ import {
   getCurrentTrainer,
   type CurrentTrainer,
 } from "@/lib/gc-fitness/auth-helpers";
+import { civilDateToday } from "@/lib/gc-fitness/civil-date";
 import { gcFitnessFirestore } from "@/lib/firebase/gc-fitness-admin";
 import { FirestoreCollections } from "@/lib/gc-fitness/collections";
 import { Skeleton } from "@/components/ui/skeleton";
@@ -124,6 +125,9 @@ export default async function ClientDetailPage({
 
   const displayName = client.displayName ?? client.email ?? id;
   const timezone = client.timezone ?? "UTC";
+  // Contract: every client activity surface below reads this explicit IANA
+  // timezone. Leaf components must not infer UTC or the host timezone.
+  const todayCivil = civilDateToday(timezone);
   const [notes, progressPhotos, goals] = await Promise.all([
     getClientNotes(id).catch(() => ({ notes: "", updatedAt: null, entries: [] })),
     listProgressPhotosForClient(id),
@@ -161,7 +165,12 @@ export default async function ClientDetailPage({
         }
       />
 
-      <ClientSummaryCard clientId={id} clientName={displayName} goals={goals} />
+      <ClientSummaryCard
+        clientId={id}
+        clientName={displayName}
+        timezone={timezone}
+        goals={goals}
+      />
 
       <div className="grid grid-cols-1 gap-5 xl:grid-cols-2">
         <Suspense fallback={<WidgetSkeleton title={tSkeleton("workoutTrends")} />}>
@@ -173,7 +182,7 @@ export default async function ClientDetailPage({
         </Suspense>
 
         <Suspense fallback={<WidgetSkeleton title={tSkeleton("recentMessages")} />}>
-          <ChatHistoryWidget clientId={id} trainerUid={trainer.uid} />
+          <ChatHistoryWidget clientId={id} trainerUid={trainer.uid} timezone={timezone} />
         </Suspense>
 
         <Suspense fallback={<WidgetSkeleton title={tSkeleton("bodyWeight")} />}>
@@ -182,12 +191,14 @@ export default async function ClientDetailPage({
 
         <ClientNotesCard
           clientId={id}
+          timezone={timezone}
+          todayCivil={todayCivil}
           initialNotes={notes.notes}
           initialUpdatedAt={notes.updatedAt}
           initialEntries={notes.entries}
         />
 
-        <ProgressPhotosWidget photos={progressPhotos} clientId={id} />
+        <ProgressPhotosWidget photos={progressPhotos} clientId={id} timezone={timezone} />
 
         <Suspense fallback={<WidgetSkeleton title={tSkeleton("recentLogs")} />}>
           <ClientRecentLogsWidget clientId={id} timezone={timezone} />

--- a/backoffice/src/app/gc-fitness/clients/[id]/page.tsx
+++ b/backoffice/src/app/gc-fitness/clients/[id]/page.tsx
@@ -190,7 +190,7 @@ export default async function ClientDetailPage({
         <ProgressPhotosWidget photos={progressPhotos} clientId={id} />
 
         <Suspense fallback={<WidgetSkeleton title={tSkeleton("recentLogs")} />}>
-          <ClientRecentLogsWidget clientId={id} />
+          <ClientRecentLogsWidget clientId={id} timezone={timezone} />
         </Suspense>
       </div>
     </div>

--- a/backoffice/src/app/gc-fitness/clients/[id]/sessions/[assignmentId]/run/_components/active-workout-session.tsx
+++ b/backoffice/src/app/gc-fitness/clients/[id]/sessions/[assignmentId]/run/_components/active-workout-session.tsx
@@ -106,16 +106,6 @@ export function ActiveWorkoutSession({
     return map;
   }, [blocks]);
 
-  // Auto-start rest when a working set is completed (superset-aware).
-  useEffect(() => {
-    live.registerOnSetCompleted((ex) => {
-      const decision = restDecision[ex.exerciseId];
-      if (decision?.rest && decision.seconds > 0) {
-        timer.start(decision.seconds);
-      }
-    });
-  }, [live, restDecision, timer]);
-
   async function finishWorkout(
     mode: FinalizeMode,
     notes: string | null,
@@ -170,7 +160,13 @@ export function ActiveWorkoutSession({
         onWeight={(i, v) => live.setWeight(ex.exerciseId, i, v)}
         onReps={(i, v) => live.setReps(ex.exerciseId, i, v)}
         onDuration={(i, v) => live.setDuration(ex.exerciseId, i, v)}
-        onToggleDone={(i) => live.toggleDone(ex.exerciseId, i)}
+        onToggleDone={(i) => {
+          const becameDone = live.toggleDone(ex.exerciseId, i);
+          const decision = restDecision[ex.exerciseId];
+          if (becameDone && decision?.rest && decision.seconds > 0) {
+            timer.start(decision.seconds);
+          }
+        }}
         onToggleWarmup={(i) => live.toggleWarmup(ex.exerciseId, i)}
         onAddSet={() => live.addSet(ex.exerciseId)}
         onRemoveSet={(i) => live.removeSet(ex.exerciseId, i)}
@@ -230,15 +226,45 @@ export function ActiveWorkoutSession({
           {live.doneCount} / {live.totalPlanned} series completadas
         </p>
         {timer.active ? (
-          <div className="mt-3 flex items-center justify-between gap-3 rounded-xl border border-amber-400/50 bg-amber-500/10 px-3 py-2 text-sm">
-            <span className="inline-flex items-center gap-2 font-medium text-amber-700 dark:text-amber-300">
-              <Timer className="h-4 w-4" />
-              Descanso en curso
-            </span>
-            <span className="font-mono tabular-nums text-amber-700 dark:text-amber-300">
-              {Math.floor(timer.remainingSeconds / 60)}:
-              {String(timer.remainingSeconds % 60).padStart(2, "0")}
-            </span>
+          <div className="mt-3 overflow-hidden rounded-2xl border border-amber-400/50 bg-gradient-to-r from-amber-500/12 via-amber-400/8 to-background px-3 py-3 shadow-sm">
+            <div className="flex items-center justify-between gap-3">
+              <div className="flex items-center gap-2">
+                <Timer className="h-4 w-4 text-amber-600 dark:text-amber-300" />
+                <div>
+                  <p className="text-sm font-semibold text-amber-700 dark:text-amber-300">
+                    Descanso en curso
+                  </p>
+                  <p className="text-xs text-muted-foreground">
+                    Termina y suena solo cuando llegue a cero.
+                  </p>
+                </div>
+              </div>
+              <button
+                type="button"
+                onClick={timer.sheetOpen ? timer.minimize : timer.expand}
+                className="rounded-full border border-amber-500/30 bg-background/80 px-3 py-1.5 text-xs font-medium text-amber-700 shadow-sm transition-colors hover:bg-background dark:text-amber-300"
+              >
+                {timer.sheetOpen ? "Minimizar" : "Abrir"}
+              </button>
+            </div>
+            <div className="mt-3 flex items-end justify-between gap-4">
+              <div className="font-mono text-4xl font-semibold tabular-nums text-amber-700 dark:text-amber-300">
+                {Math.floor(timer.remainingSeconds / 60)}:
+                {String(timer.remainingSeconds % 60).padStart(2, "0")}
+              </div>
+              <div className="flex items-center gap-2">
+                <span className="rounded-full bg-amber-500/15 px-2.5 py-1 text-[11px] font-medium uppercase tracking-wide text-amber-700 dark:text-amber-300">
+                  {timer.isPaused ? "Pausado" : "Corriendo"}
+                </span>
+                <button
+                  type="button"
+                  onClick={timer.skip}
+                  className="rounded-full border border-border/80 bg-background px-3 py-1.5 text-xs font-medium text-muted-foreground transition-colors hover:bg-muted"
+                >
+                  Saltar descanso
+                </button>
+              </div>
+            </div>
           </div>
         ) : null}
 

--- a/backoffice/src/app/gc-fitness/clients/[id]/sessions/[assignmentId]/run/_components/active-workout-session.tsx
+++ b/backoffice/src/app/gc-fitness/clients/[id]/sessions/[assignmentId]/run/_components/active-workout-session.tsx
@@ -226,7 +226,7 @@ export function ActiveWorkoutSession({
   return (
     <div className="mx-auto w-full max-w-2xl pb-28">
       {/* Header */}
-      <div className="sticky top-0 z-10 -mx-4 flex items-center justify-between border-b border-border/60 bg-background/80 px-4 py-3 backdrop-blur">
+      <div className="sticky top-0 z-10 -mx-4 grid grid-cols-[auto_1fr_auto] items-center border-b border-border/60 bg-background/80 px-4 py-3 backdrop-blur">
         <Button
           variant="ghost"
           size="icon"
@@ -235,8 +235,29 @@ export function ActiveWorkoutSession({
         >
           <X className="h-5 w-5" />
         </Button>
-        <span className="font-mono text-lg tabular-nums">{elapsed}</span>
-        <span className="w-9" />
+        <div className="flex justify-center">
+          <span className="font-mono text-lg tabular-nums">{elapsed}</span>
+        </div>
+        <div className="flex justify-end">
+          {timer.active ? (
+            <button
+              type="button"
+              onClick={timer.sheetOpen ? timer.minimize : timer.expand}
+              className="inline-flex items-center gap-2 rounded-full border border-amber-400/40 bg-amber-500/10 px-3 py-1.5 text-xs font-medium text-amber-700 transition-colors hover:bg-amber-500/15 dark:text-amber-300"
+            >
+              <span className="h-1.5 w-1.5 rounded-full bg-amber-500" />
+              <Timer className="h-3.5 w-3.5" />
+              <span className="font-mono tabular-nums">
+                {formatMmss(timer.remainingSeconds)}
+              </span>
+              <span className="hidden sm:inline">
+                {timer.isPaused ? "Pausado" : "Descanso"}
+              </span>
+            </button>
+          ) : (
+            <span className="w-9" />
+          )}
+        </div>
       </div>
 
       <div className="px-1 pt-4">

--- a/backoffice/src/app/gc-fitness/clients/[id]/sessions/[assignmentId]/run/_components/active-workout-session.tsx
+++ b/backoffice/src/app/gc-fitness/clients/[id]/sessions/[assignmentId]/run/_components/active-workout-session.tsx
@@ -243,9 +243,17 @@ export function ActiveWorkoutSession({
             <button
               type="button"
               onClick={timer.sheetOpen ? timer.minimize : timer.expand}
-              className="inline-flex items-center gap-2 rounded-full border border-amber-400/40 bg-amber-500/10 px-3 py-1.5 text-xs font-medium text-amber-700 transition-colors hover:bg-amber-500/15 dark:text-amber-300"
+              className={`inline-flex items-center gap-2 rounded-full border px-3 py-1.5 text-xs font-medium transition-colors ${
+                timer.isPaused
+                  ? "border-slate-400/40 bg-slate-500/10 text-slate-700 hover:bg-slate-500/15 dark:text-slate-300"
+                  : "border-amber-400/40 bg-amber-500/10 text-amber-700 hover:bg-amber-500/15 dark:text-amber-300"
+              }`}
             >
-              <span className="h-1.5 w-1.5 rounded-full bg-amber-500" />
+              <span
+                className={`h-1.5 w-1.5 rounded-full ${
+                  timer.isPaused ? "bg-slate-500" : "bg-amber-500"
+                }`}
+              />
               <Timer className="h-3.5 w-3.5" />
               <span className="font-mono tabular-nums">
                 {formatMmss(timer.remainingSeconds)}
@@ -269,9 +277,21 @@ export function ActiveWorkoutSession({
           <div className="mt-3 overflow-hidden rounded-2xl border border-amber-400/50 bg-gradient-to-r from-amber-500/12 via-amber-400/8 to-background px-3 py-3 shadow-sm">
             <div className="flex items-center justify-between gap-3">
               <div className="flex items-center gap-2">
-                <Timer className="h-4 w-4 text-amber-600 dark:text-amber-300" />
+                <Timer
+                  className={`h-4 w-4 ${
+                    timer.isPaused
+                      ? "text-slate-500 dark:text-slate-300"
+                      : "text-amber-600 dark:text-amber-300"
+                  }`}
+                />
                 <div>
-                  <p className="text-sm font-semibold text-amber-700 dark:text-amber-300">
+                  <p
+                    className={`text-sm font-semibold ${
+                      timer.isPaused
+                        ? "text-slate-700 dark:text-slate-300"
+                        : "text-amber-700 dark:text-amber-300"
+                    }`}
+                  >
                     Descanso en curso
                   </p>
                   <p className="text-xs text-muted-foreground">
@@ -282,18 +302,34 @@ export function ActiveWorkoutSession({
               <button
                 type="button"
                 onClick={timer.sheetOpen ? timer.minimize : timer.expand}
-                className="rounded-full border border-amber-500/30 bg-background/80 px-3 py-1.5 text-xs font-medium text-amber-700 shadow-sm transition-colors hover:bg-background dark:text-amber-300"
+                className={`rounded-full border bg-background/80 px-3 py-1.5 text-xs font-medium shadow-sm transition-colors hover:bg-background ${
+                  timer.isPaused
+                    ? "border-slate-500/30 text-slate-700 dark:text-slate-300"
+                    : "border-amber-500/30 text-amber-700 dark:text-amber-300"
+                }`}
               >
                 {timer.sheetOpen ? "Minimizar" : "Abrir"}
               </button>
             </div>
             <div className="mt-3 flex items-end justify-between gap-4">
-              <div className="font-mono text-4xl font-semibold tabular-nums text-amber-700 dark:text-amber-300">
+              <div
+                className={`font-mono text-4xl font-semibold tabular-nums ${
+                  timer.isPaused
+                    ? "text-slate-700 dark:text-slate-300"
+                    : "text-amber-700 dark:text-amber-300"
+                }`}
+              >
                 {Math.floor(timer.remainingSeconds / 60)}:
                 {String(timer.remainingSeconds % 60).padStart(2, "0")}
               </div>
               <div className="flex items-center gap-2">
-                <span className="rounded-full bg-amber-500/15 px-2.5 py-1 text-[11px] font-medium uppercase tracking-wide text-amber-700 dark:text-amber-300">
+                <span
+                  className={`rounded-full px-2.5 py-1 text-[11px] font-medium uppercase tracking-wide ${
+                    timer.isPaused
+                      ? "bg-slate-500/15 text-slate-700 dark:text-slate-300"
+                      : "bg-amber-500/15 text-amber-700 dark:text-amber-300"
+                  }`}
+                >
                   {timer.isPaused ? "Pausado" : "Corriendo"}
                 </span>
                 <button

--- a/backoffice/src/app/gc-fitness/clients/[id]/sessions/[assignmentId]/run/_components/active-workout-session.tsx
+++ b/backoffice/src/app/gc-fitness/clients/[id]/sessions/[assignmentId]/run/_components/active-workout-session.tsx
@@ -51,6 +51,12 @@ function isUrl(value: string): boolean {
   return /^https?:\/\//i.test(value.trim());
 }
 
+function formatMmss(totalSeconds: number): string {
+  const minutes = Math.floor(totalSeconds / 60);
+  const seconds = totalSeconds % 60;
+  return `${minutes}:${String(seconds).padStart(2, "0")}`;
+}
+
 export interface ActiveWorkoutSessionProps {
   clientId: string;
   assignmentId: string;
@@ -70,6 +76,7 @@ export function ActiveWorkoutSession({
   const live = useLiveSession(assignmentId, previous, initialSession);
   const elapsed = useElapsed(live.session?.startedAt ?? null);
   const timer = useRestTimer();
+  const [restingExerciseId, setRestingExerciseId] = useState<string | null>(null);
   const [finishing, setFinishing] = useState(false);
   const [finalizeOpen, setFinalizeOpen] = useState(false);
   const [cancelOpen, setCancelOpen] = useState(false);
@@ -105,6 +112,12 @@ export function ActiveWorkoutSession({
     }
     return map;
   }, [blocks]);
+
+  useEffect(() => {
+    if (!timer.active) {
+      setRestingExerciseId(null);
+    }
+  }, [timer.active]);
 
   async function finishWorkout(
     mode: FinalizeMode,
@@ -164,6 +177,7 @@ export function ActiveWorkoutSession({
           const becameDone = live.toggleDone(ex.exerciseId, i);
           const decision = restDecision[ex.exerciseId];
           if (becameDone && decision?.rest && decision.seconds > 0) {
+            setRestingExerciseId(ex.exerciseId);
             timer.start(decision.seconds);
           }
         }}
@@ -171,6 +185,11 @@ export function ActiveWorkoutSession({
         onAddSet={() => live.addSet(ex.exerciseId)}
         onRemoveSet={(i) => live.removeSet(ex.exerciseId, i)}
         onMove={(dir) => live.moveExercise(ex.exerciseId, dir)}
+        restCountdown={
+          timer.active && restingExerciseId === ex.exerciseId
+            ? formatMmss(timer.remainingSeconds)
+            : null
+        }
         highlightNextRow={
           nextTarget?.exerciseId === ex.exerciseId ? nextTarget.rowIndex : null
         }

--- a/backoffice/src/app/gc-fitness/clients/[id]/sessions/[assignmentId]/run/_components/rest-timer-overlay.tsx
+++ b/backoffice/src/app/gc-fitness/clients/[id]/sessions/[assignmentId]/run/_components/rest-timer-overlay.tsx
@@ -27,7 +27,7 @@ export function RestTimerOverlay({ timer }: { timer: RestTimerApi }) {
       <button
         type="button"
         onClick={timer.expand}
-        className="fixed bottom-24 left-1/2 z-30 flex -translate-x-1/2 items-center gap-2 rounded-full border border-border bg-card px-4 py-2 shadow-lg"
+        className="fixed bottom-24 left-1/2 z-50 flex -translate-x-1/2 items-center gap-2 rounded-full border border-border bg-card px-4 py-2 shadow-lg"
       >
         <Timer className="h-4 w-4 text-amber-500" />
         <span className="font-mono text-sm tabular-nums">
@@ -42,7 +42,7 @@ export function RestTimerOverlay({ timer }: { timer: RestTimerApi }) {
   const offset = C * (1 - Math.max(0, Math.min(1, timer.progress)));
 
   return (
-    <div className="fixed inset-x-0 bottom-0 z-30 px-4 pb-4">
+    <div className="fixed inset-x-0 bottom-0 z-50 px-4 pb-4">
       <div className="mx-auto max-w-md rounded-3xl border border-border bg-card p-5 shadow-2xl">
         <div className="flex items-center justify-between">
           <span className="text-sm font-medium text-muted-foreground">

--- a/backoffice/src/app/gc-fitness/clients/[id]/sessions/[assignmentId]/run/_components/session-exercise-card.tsx
+++ b/backoffice/src/app/gc-fitness/clients/[id]/sessions/[assignmentId]/run/_components/session-exercise-card.tsx
@@ -124,6 +124,7 @@ export interface SessionExerciseCardProps {
   exercise: SessionExercise;
   rows: SetRowState[];
   previous?: PreviousSetSummary;
+  restCountdown?: string | null;
   highlightNextRow?: number | null;
   onWeight: (idx: number, value: number) => void;
   onReps: (idx: number, value: number) => void;
@@ -142,6 +143,7 @@ export function SessionExerciseCard({
   exercise,
   rows,
   previous,
+  restCountdown,
   highlightNextRow,
   onWeight,
   onReps,
@@ -207,6 +209,12 @@ export function SessionExerciseCard({
             {rows.length} {rows.length === 1 ? "serie" : "series"} ·{" "}
             {formatRest(exercise.restSeconds)}
           </p>
+          {restCountdown ? (
+            <div className="mt-2 inline-flex items-center gap-2 rounded-full border border-amber-400/40 bg-amber-500/10 px-2.5 py-1 text-xs font-medium text-amber-700 dark:text-amber-300">
+              <span className="h-1.5 w-1.5 rounded-full bg-amber-500" />
+              Descanso activo: {restCountdown}
+            </div>
+          ) : null}
         </div>
         <div className="flex shrink-0 items-center gap-1">
           <div className="mr-1 flex flex-col">

--- a/backoffice/src/app/gc-fitness/clients/[id]/sessions/[assignmentId]/run/_components/use-live-session.ts
+++ b/backoffice/src/app/gc-fitness/clients/[id]/sessions/[assignmentId]/run/_components/use-live-session.ts
@@ -130,7 +130,7 @@ export interface LiveSessionApi {
   setReps: (exerciseId: string, idx: number, value: number) => void;
   setDuration: (exerciseId: string, idx: number, value: number) => void;
   toggleWarmup: (exerciseId: string, idx: number) => void;
-  toggleDone: (exerciseId: string, idx: number) => void;
+  toggleDone: (exerciseId: string, idx: number) => boolean;
   addSet: (exerciseId: string) => void;
   removeSet: (exerciseId: string, idx: number) => void;
   moveExercise: (exerciseId: string, dir: -1 | 1) => void;
@@ -326,6 +326,7 @@ export function useLiveSession(
           onCompletedRef.current(ex);
         }
       }
+      return becameDone;
     },
     [mutateRow, exercises, rowsByExercise],
   );

--- a/backoffice/src/app/gc-fitness/clients/[id]/sessions/[assignmentId]/run/_components/use-rest-timer.ts
+++ b/backoffice/src/app/gc-fitness/clients/[id]/sessions/[assignmentId]/run/_components/use-rest-timer.ts
@@ -30,12 +30,7 @@ export interface RestTimerApi {
 
 function beep() {
   try {
-    const Ctx =
-      window.AudioContext ||
-      (window as unknown as { webkitAudioContext?: typeof AudioContext })
-        .webkitAudioContext;
-    if (!Ctx) return;
-    const ctx = new Ctx();
+    const ctx = ensureAudioContext();
     const osc = ctx.createOscillator();
     const gain = ctx.createGain();
     osc.connect(gain);
@@ -50,6 +45,25 @@ function beep() {
   } catch {
     /* audio not available — visual cue only */
   }
+}
+
+function ensureAudioContext(): AudioContext {
+  const win = window as Window & {
+    __gcFitnessRestTimerAudioContext?: AudioContext;
+    webkitAudioContext?: typeof AudioContext;
+  } & {
+    AudioContext?: typeof AudioContext;
+  };
+  if (win.__gcFitnessRestTimerAudioContext) {
+    return win.__gcFitnessRestTimerAudioContext;
+  }
+  const Ctx = win.AudioContext ?? win.webkitAudioContext;
+  if (!Ctx) {
+    throw new Error("AudioContext unavailable");
+  }
+  const ctx = new Ctx();
+  win.__gcFitnessRestTimerAudioContext = ctx;
+  return ctx;
 }
 
 export function useRestTimer(): RestTimerApi {
@@ -90,6 +104,14 @@ export function useRestTimer(): RestTimerApi {
   const start = useCallback((seconds: number) => {
     const s = Math.max(1, Math.round(seconds));
     firedRef.current = false;
+    try {
+      const ctx = ensureAudioContext();
+      if (ctx.state === "suspended") {
+        void ctx.resume().catch(() => {});
+      }
+    } catch {
+      /* audio not available — visual cue only */
+    }
     setTotalSeconds(s);
     setPausedRemaining(null);
     setEndsAt(Date.now() + s * 1000);

--- a/backoffice/src/app/gc-fitness/clients/[id]/sessions/[assignmentId]/run/_components/use-rest-timer.ts
+++ b/backoffice/src/app/gc-fitness/clients/[id]/sessions/[assignmentId]/run/_components/use-rest-timer.ts
@@ -31,17 +31,26 @@ export interface RestTimerApi {
 function beep() {
   try {
     const ctx = ensureAudioContext();
-    const osc = ctx.createOscillator();
-    const gain = ctx.createGain();
-    osc.connect(gain);
-    gain.connect(ctx.destination);
-    osc.frequency.value = 880;
-    gain.gain.setValueAtTime(0.0001, ctx.currentTime);
-    gain.gain.exponentialRampToValueAtTime(0.2, ctx.currentTime + 0.02);
-    gain.gain.exponentialRampToValueAtTime(0.0001, ctx.currentTime + 0.45);
-    osc.start();
-    osc.stop(ctx.currentTime + 0.5);
-    osc.onended = () => ctx.close().catch(() => {});
+    const playTone = (frequency: number, startDelay: number, duration: number, volume: number) => {
+      const osc = ctx.createOscillator();
+      const gain = ctx.createGain();
+      osc.type = "sine";
+      osc.frequency.value = frequency;
+      osc.connect(gain);
+      gain.connect(ctx.destination);
+      const startAt = ctx.currentTime + startDelay;
+      gain.gain.setValueAtTime(0.0001, startAt);
+      gain.gain.exponentialRampToValueAtTime(volume, startAt + 0.02);
+      gain.gain.exponentialRampToValueAtTime(0.0001, startAt + duration);
+      osc.start(startAt);
+      osc.stop(startAt + duration + 0.02);
+      return osc;
+    };
+    const tones = [
+      playTone(880, 0, 0.45, 0.18),
+      playTone(1320, 0.08, 0.22, 0.08),
+    ];
+    tones[tones.length - 1].onended = () => ctx.close().catch(() => {});
   } catch {
     /* audio not available — visual cue only */
   }

--- a/backoffice/src/app/gc-fitness/clients/_components/RelativeTime.tsx
+++ b/backoffice/src/app/gc-fitness/clients/_components/RelativeTime.tsx
@@ -52,9 +52,5 @@ export function RelativeTime({
   else if (day < 365) text = `${Math.floor(day / 30)}mo ago`;
   else text = `${Math.floor(day / 365)}y ago`;
 
-  return (
-    <time dateTime={iso} title={then.toLocaleString()}>
-      {text}
-    </time>
-  );
+  return <time dateTime={iso} title={then.toISOString()}>{text}</time>;
 }

--- a/backoffice/src/app/gc-fitness/dashboard/_components/coach-pulse.tsx
+++ b/backoffice/src/app/gc-fitness/dashboard/_components/coach-pulse.tsx
@@ -1,9 +1,11 @@
 "use client";
 
 import Link from "next/link";
+import { useLocale } from "next-intl";
 
 import { cn } from "@/lib/utils";
 import { ClientAvatar } from "@/components/gc-fitness/ClientAvatar";
+import { formatCivilDateLabel } from "@/lib/gc-fitness/civil-date";
 import {
   Tooltip,
   TooltipContent,
@@ -24,6 +26,7 @@ interface DailyBarsProps {
 }
 
 export function DailyBars({ data, emptyLabel, unitLabel }: DailyBarsProps) {
+  const locale = useLocale();
   const hasAnyData = data.some((d) => d.denominator > 0);
   if (!hasAnyData) {
     return (
@@ -76,7 +79,7 @@ export function DailyBars({ data, emptyLabel, unitLabel }: DailyBarsProps) {
                 </button>
               </TooltipTrigger>
               <TooltipContent side="top" className="text-[11px] leading-tight">
-                <div className="font-semibold">{formatTooltipDate(d.civilDate)}</div>
+                <div className="font-semibold">{formatTooltipDate(d.civilDate, locale)}</div>
                 <div className="text-background/85">
                   {d.denominator === 0
                     ? `Nothing scheduled`
@@ -96,15 +99,16 @@ function tooltipLabel(d: DailyMetric, unit: string): string {
   return `${d.weekdayLabel}: ${d.numerator} of ${d.denominator} ${unit} (${d.percentage}%)`;
 }
 
-function formatTooltipDate(civilDate: string): string {
-  const date = new Date(`${civilDate}T12:00:00Z`);
-  if (Number.isNaN(date.getTime())) return civilDate;
-  return date.toLocaleDateString(undefined, {
-    weekday: "short",
-    month: "short",
-    day: "numeric",
-    timeZone: "UTC",
-  });
+function formatTooltipDate(civilDate: string, locale: string): string {
+  return formatCivilDateLabel(
+    civilDate,
+    {
+      weekday: "short",
+      month: "short",
+      day: "numeric",
+    },
+    locale,
+  );
 }
 
 interface TopPerformersProps {

--- a/backoffice/src/app/gc-fitness/my-activity/MyActivityFeed.tsx
+++ b/backoffice/src/app/gc-fitness/my-activity/MyActivityFeed.tsx
@@ -15,6 +15,11 @@ import {
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import {
+  clientActivityCivilDateKey,
+  formatClientActivityDate,
+  formatClientActivityTime,
+} from "@/lib/gc-fitness/client-activity-time";
+import {
   Select,
   SelectContent,
   SelectItem,
@@ -86,11 +91,13 @@ export function MyActivityFeed({
   initialCursor,
   initialHasMore,
   clients,
+  timezone,
 }: {
   initialRows: MyCoachActivityRow[];
   initialCursor: string | null;
   initialHasMore: boolean;
   clients: MyActivityClientOption[];
+  timezone: string;
 }) {
   const [rows, setRows] = useState(initialRows);
   const [cursor, setCursor] = useState(initialCursor);
@@ -137,7 +144,7 @@ export function MyActivityFeed({
   // Group the flat row list into day sections so the date isn't repeated on
   // every row — the day is shown once as a section heading and each row only
   // carries its time.
-  const dayGroups = useMemo(() => groupRowsByDay(rows), [rows]);
+  const dayGroups = useMemo(() => groupRowsByDay(rows, timezone), [rows, timezone]);
 
   return (
     <div className="flex flex-col">
@@ -198,7 +205,7 @@ export function MyActivityFeed({
               </h3>
               <div className="divide-y">
                 {group.rows.map((row) => (
-                  <ActivityRow key={row.id} row={row} />
+                  <ActivityRow key={row.id} row={row} timezone={timezone} />
                 ))}
               </div>
             </section>
@@ -217,7 +224,13 @@ export function MyActivityFeed({
   );
 }
 
-function ActivityRow({ row }: { row: MyCoachActivityRow }) {
+function ActivityRow({
+  row,
+  timezone,
+}: {
+  row: MyCoachActivityRow;
+  timezone: string;
+}) {
   const Icon = row.deleted ? Trash2 : KIND_ICON[row.kind];
   const tone = row.deleted ? DELETED_TONE : KIND_TONE[row.kind];
   const label = row.deleted ? "Eliminado" : KIND_LABEL[row.kind];
@@ -239,7 +252,7 @@ function ActivityRow({ row }: { row: MyCoachActivityRow }) {
           </span>
         </div>
         <p className="mt-0.5 text-xs text-muted-foreground">
-          {formatTime(row.occurredAt)}
+          {formatTime(row.occurredAt, timezone)}
           {row.clientName ? ` · ${row.clientName}` : ""}
           {row.detail ? ` · ${row.detail}` : ""}
         </p>
@@ -250,52 +263,36 @@ function ActivityRow({ row }: { row: MyCoachActivityRow }) {
 
 function groupRowsByDay(
   rows: MyCoachActivityRow[],
+  timezone: string,
 ): Array<{ key: string; label: string; rows: MyCoachActivityRow[] }> {
   const groups = new Map<
     string,
     { key: string; label: string; rows: MyCoachActivityRow[] }
   >();
   for (const row of rows) {
-    const key = dayKeyFromIso(row.occurredAt);
+    const key = clientActivityCivilDateKey(row.occurredAt, timezone);
     const existing = groups.get(key);
     if (existing) {
       existing.rows.push(row);
       continue;
     }
-    groups.set(key, { key, label: formatDayHeading(row.occurredAt), rows: [row] });
+    groups.set(key, { key, label: formatDayHeading(row.occurredAt, timezone), rows: [row] });
   }
   return Array.from(groups.values());
 }
 
-function dayKeyFromIso(iso: string | null): string {
-  if (!iso) return "no-date";
-  const date = new Date(iso);
-  if (Number.isNaN(date.getTime())) return iso.slice(0, 10);
-  const y = date.getFullYear();
-  const m = String(date.getMonth() + 1).padStart(2, "0");
-  const d = String(date.getDate()).padStart(2, "0");
-  return `${y}-${m}-${d}`;
-}
-
-function formatDayHeading(iso: string | null): string {
+function formatDayHeading(iso: string | null, timezone: string): string {
   if (!iso) return "Sin fecha";
-  const date = new Date(iso);
-  if (Number.isNaN(date.getTime())) return iso;
   const today = new Date();
   const yesterday = new Date();
   yesterday.setDate(today.getDate() - 1);
-  const key = dayKeyFromIso(iso);
-  if (key === dayKeyFromIso(today.toISOString())) return "Hoy";
-  if (key === dayKeyFromIso(yesterday.toISOString())) return "Ayer";
-  return date.toLocaleDateString(undefined, { month: "long", day: "numeric" });
+  const key = clientActivityCivilDateKey(iso, timezone);
+  if (key === clientActivityCivilDateKey(today.toISOString(), timezone)) return "Hoy";
+  if (key === clientActivityCivilDateKey(yesterday.toISOString(), timezone)) return "Ayer";
+  return formatClientActivityDate(iso, timezone);
 }
 
-function formatTime(iso: string | null): string {
+function formatTime(iso: string | null, timezone: string): string {
   if (!iso) return "Sin fecha";
-  const date = new Date(iso);
-  if (Number.isNaN(date.getTime())) return iso;
-  return date.toLocaleTimeString(undefined, {
-    hour: "2-digit",
-    minute: "2-digit",
-  });
+  return formatClientActivityTime(iso, timezone);
 }

--- a/backoffice/src/app/gc-fitness/my-activity/page.tsx
+++ b/backoffice/src/app/gc-fitness/my-activity/page.tsx
@@ -2,6 +2,7 @@ import { redirect } from "next/navigation";
 
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { getCurrentTrainer } from "@/lib/gc-fitness/auth-helpers";
+import { getTrainerTimezone } from "@/lib/gc-fitness/trainer-timezone";
 import {
   listMyActivityClients,
   listMyCoachActivityPage,
@@ -23,6 +24,7 @@ export default async function MyActivityPage() {
 
   // Load a full page (50) so the whole of today's activity is present on first
   // paint — a coach must see everything they did, not a truncated slice.
+  const timezone = await getTrainerTimezone();
   const [firstPage, clients] = await Promise.all([
     listMyCoachActivityPage(null, 50),
     listMyActivityClients(),
@@ -46,12 +48,13 @@ export default async function MyActivityPage() {
         <CardContent className="p-0">
           <MyActivityFeed
             initialRows={firstPage.rows}
-            initialCursor={firstPage.nextCursor}
-            initialHasMore={firstPage.hasMore}
-            clients={clients}
-          />
-        </CardContent>
-      </Card>
+          initialCursor={firstPage.nextCursor}
+          initialHasMore={firstPage.hasMore}
+          clients={clients}
+          timezone={timezone}
+        />
+      </CardContent>
+    </Card>
     </div>
   );
 }

--- a/backoffice/src/app/gc-fitness/notifications/page.tsx
+++ b/backoffice/src/app/gc-fitness/notifications/page.tsx
@@ -74,7 +74,8 @@ export default async function NotificationsPage() {
 
   const locale = (await getLocale()) as Locale;
   const t = await getTranslations("notifications");
-  const todayCivil = civilDateToday(await getTrainerTimezone());
+  const trainerTimezone = await getTrainerTimezone();
+  const todayCivil = civilDateToday(trainerTimezone);
   const renewalWindowEnd = addCivilDays(todayCivil, 14);
 
   const [activeWorkoutSummaries, workoutActivity, habits, activations, clients] =
@@ -177,7 +178,7 @@ export default async function NotificationsPage() {
             <EmptyState label={t("noRenewals")} />
           ) : (
             renewalNotifications.map((item) => (
-              <NotificationRow key={item.id} title={item.title} detail={item.detail} meta={formatMeta(item.occurredAtISO, item.clientName, item.dueLabel, locale)} actionHref={item.actionHref} actionLabel={item.actionLabel} icon={<CalendarClock className="h-4 w-4" />} />
+              <NotificationRow key={item.id} title={item.title} detail={item.detail} meta={formatMeta(item.occurredAtISO, item.clientName, item.dueLabel, locale, trainerTimezone)} actionHref={item.actionHref} actionLabel={item.actionLabel} icon={<CalendarClock className="h-4 w-4" />} />
             ))
           )}
         </CardContent>
@@ -200,7 +201,7 @@ export default async function NotificationsPage() {
                 key={item.id}
                 title={t("clientActivated")}
                 detail={item.detail}
-                meta={formatMeta(item.occurredAtISO, item.clientName, null, locale)}
+                meta={formatMeta(item.occurredAtISO, item.clientName, null, locale, trainerTimezone)}
                 actionHref={item.actionHref}
                 actionLabel={item.actionLabel}
                 icon={<Bell className="h-4 w-4" />}
@@ -463,22 +464,24 @@ function formatMeta(
   clientName: string,
   secondary: string | null,
   locale: Locale,
+  timezone: string,
 ): string {
   const bits = [
-    occurredAtISO ? formatClock(occurredAtISO, locale) : null,
+    occurredAtISO ? formatClock(occurredAtISO, locale, timezone) : null,
     clientName,
   ];
   if (secondary) bits.push(secondary);
   return bits.filter(Boolean).join(" · ");
 }
 
-function formatClock(iso: string | null, locale: Locale): string {
+function formatClock(iso: string | null, locale: Locale, timezone: string): string {
   if (!iso) return locale === "es" ? "Sin hora" : "No time";
   const dt = new Date(iso);
   if (Number.isNaN(dt.getTime())) return locale === "es" ? "Sin hora" : "No time";
   return new Intl.DateTimeFormat(locale === "es" ? "es-AR" : "en-US", {
     hour: "2-digit",
     minute: "2-digit",
+    timeZone: timezone,
   }).format(dt);
 }
 

--- a/backoffice/src/app/gc-fitness/recent-logs/_components/RecentLogsFeed.tsx
+++ b/backoffice/src/app/gc-fitness/recent-logs/_components/RecentLogsFeed.tsx
@@ -18,7 +18,7 @@ import {
   StickyNote,
   User,
 } from "lucide-react";
-import { useTranslations } from "next-intl";
+import { useLocale, useTranslations } from "next-intl";
 
 import { Button } from "@/components/ui/button";
 import { ClientAvatar } from "@/components/gc-fitness/ClientAvatar";
@@ -41,12 +41,18 @@ import {
   listRecentLogsForTrainerPage,
   type RecentLogRow,
 } from "@/lib/gc-fitness/recent-logs-actions";
+import {
+  formatRecentLogDayHeading,
+  formatRecentLogTime,
+  recentLogDayKeyFromIso,
+} from "@/lib/gc-fitness/recent-logs-time";
 
 const PAGE_SIZE = 20;
 
 interface Props {
   logs: RecentLogRow[];
   clients: Array<{ id: string; name: string }>;
+  trainerTimezone: string;
   /** Cursor for the next page (from the server). Null ⇒ nothing more to load. */
   initialCursor?: string | null;
   /** Whether another page may exist beyond the initially-loaded rows. */
@@ -99,19 +105,15 @@ const UTC_DATE_FORMAT = new Intl.DateTimeFormat("en-US", {
   timeZone: "UTC",
 });
 
-const UTC_TIME_FORMAT = new Intl.DateTimeFormat("en-US", {
-  hour: "2-digit",
-  minute: "2-digit",
-  timeZone: "UTC",
-});
-
 export function RecentLogsFeed({
   logs,
   clients,
+  trainerTimezone,
   initialCursor = null,
   initialHasMore = false,
 }: Props) {
   const t = useTranslations("recentLogs.feed");
+  const locale = useLocale();
   const router = useRouter();
   const [clientFilter, setClientFilter] = useState<string>("all");
   const [typeFilter, setTypeFilter] = useState<string>("all");
@@ -169,7 +171,10 @@ export function RecentLogsFeed({
   // Flat rows grouped under day headings so the date moves out of every row
   // into a single per-day header. (Per-client grouping was removed — the Client
   // filter above covers that need.)
-  const chronoSections = useMemo(() => groupRowsByDayFlat(filtered), [filtered]);
+  const chronoSections = useMemo(
+    () => groupRowsByDayFlat(filtered, trainerTimezone, locale, t("today"), t("yesterday")),
+    [filtered, locale, t, trainerTimezone],
+  );
 
   return (
     <div className="flex flex-col gap-4">
@@ -242,7 +247,14 @@ export function RecentLogsFeed({
               {section.label}
             </h3>
             {section.rows.map((row) => (
-              <RecentLogItem key={row.id} row={row} router={router} t={t} />
+              <RecentLogItem
+                key={row.id}
+                row={row}
+                router={router}
+                t={t}
+                timezone={trainerTimezone}
+                locale={locale}
+              />
             ))}
           </div>
         ))}
@@ -268,10 +280,14 @@ function RecentLogItem({
   row,
   router,
   t,
+  timezone,
+  locale,
 }: {
   row: RecentLogRow;
   router: ReturnType<typeof useRouter>;
   t: ReturnType<typeof useTranslations>;
+  timezone: string;
+  locale: string;
 }) {
   const CatIcon = CATEGORY_ICON[row.category];
   const openProfile = () => router.push(`/gc-fitness/clients/${row.clientId}`);
@@ -340,7 +356,7 @@ function RecentLogItem({
           ) : null}
         </div>
         <p className="mt-0.5 break-words text-xs text-muted-foreground sm:truncate">
-          {row.clientName} · {formatTime(row.eventAt)}
+          {row.clientName} · {formatRecentLogTime(row.eventAt, timezone, locale)}
           {row.detail ? ` · ${row.detail}` : ""}
         </p>
       </div>
@@ -370,42 +386,29 @@ function RecentLogItem({
   );
 }
 
-function formatTime(iso: string): string {
-  const date = new Date(iso);
-  if (Number.isNaN(date.getTime())) return iso;
-  return UTC_TIME_FORMAT.format(date);
-}
-
-function dayKeyFromIso(iso: string): string {
-  const date = new Date(iso);
-  if (Number.isNaN(date.getTime())) return iso.slice(0, 10);
-  return date.toISOString().slice(0, 10);
-}
-
-function formatDayHeading(iso: string): string {
-  const date = new Date(iso);
-  if (Number.isNaN(date.getTime())) return iso;
-  const key = dayKeyFromIso(iso);
-  const todayKey = dayKeyFromIso(new Date().toISOString());
-  const yesterday = new Date(Date.now() - 86_400_000);
-  const yesterdayKey = dayKeyFromIso(yesterday.toISOString());
-  if (key === todayKey) return "Hoy";
-  if (key === yesterdayKey) return "Ayer";
-  return UTC_DATE_FORMAT.format(date);
-}
-
 function groupRowsByDayFlat(
   rows: RecentLogRow[],
+  timezone: string,
+  locale: string,
+  todayLabel: string,
+  yesterdayLabel: string,
 ): Array<{ key: string; label: string; rows: RecentLogRow[] }> {
   const map = new Map<string, { key: string; label: string; rows: RecentLogRow[] }>();
   for (const row of rows) {
-    const key = dayKeyFromIso(row.eventAt);
+    const key = recentLogDayKeyFromIso(row.eventAt, timezone);
     const existing = map.get(key);
     if (existing) {
       existing.rows.push(row);
       continue;
     }
-    map.set(key, { key, label: formatDayHeading(row.eventAt), rows: [row] });
+    map.set(key, {
+      key,
+      label: formatRecentLogDayHeading(row.eventAt, timezone, locale, {
+        today: todayLabel,
+        yesterday: yesterdayLabel,
+      }),
+      rows: [row],
+    });
   }
   return Array.from(map.values());
 }

--- a/backoffice/src/app/gc-fitness/recent-logs/_components/RecentLogsFeed.tsx
+++ b/backoffice/src/app/gc-fitness/recent-logs/_components/RecentLogsFeed.tsx
@@ -37,6 +37,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
+import { formatCivilDateLabel } from "@/lib/gc-fitness/civil-date";
 import {
   listRecentLogsForTrainerPage,
   type RecentLogRow,
@@ -98,12 +99,6 @@ const CATEGORY_TONE: Record<RecentLogRow["category"], string> = {
   signup:
     "border-sky-200 bg-sky-50 text-sky-700 dark:border-sky-900 dark:bg-sky-950/40 dark:text-sky-300",
 };
-
-const UTC_DATE_FORMAT = new Intl.DateTimeFormat("en-US", {
-  month: "short",
-  day: "numeric",
-  timeZone: "UTC",
-});
 
 export function RecentLogsFeed({
   logs,
@@ -323,7 +318,7 @@ function RecentLogItem({
               className="gap-1 border-amber-200 bg-amber-50 px-1.5 py-0 text-[10px] font-normal text-amber-700 [&>svg]:size-3 dark:border-amber-900 dark:bg-amber-950/40 dark:text-amber-300"
             >
               <CalendarClock />
-              {t("forDay", { date: formatCivilDate(row.forCivilDate) })}
+              {t("forDay", { date: formatCivilDate(row.forCivilDate, locale) })}
             </Badge>
           ) : null}
           {row.workout?.rpe != null ? (
@@ -417,10 +412,6 @@ function groupRowsByDayFlat(
 // Construct from parts (NOT `new Date(iso)`) so the local-time constructor is
 // used instead of UTC-midnight parsing — otherwise a negative-offset host
 // shifts the day back by one.
-function formatCivilDate(civil: string): string {
-  const [y, m, d] = civil.split("-").map((n) => Number.parseInt(n, 10));
-  if (!y || !m || !d) return civil;
-  const date = new Date(Date.UTC(y, m - 1, d));
-  if (Number.isNaN(date.getTime())) return civil;
-  return UTC_DATE_FORMAT.format(date);
+function formatCivilDate(civil: string, locale: string): string {
+  return formatCivilDateLabel(civil, { month: "short", day: "numeric" }, locale);
 }

--- a/backoffice/src/app/gc-fitness/recent-logs/page.tsx
+++ b/backoffice/src/app/gc-fitness/recent-logs/page.tsx
@@ -6,6 +6,7 @@ import {
   getCurrentTrainer,
   type CurrentTrainer,
 } from "@/lib/gc-fitness/auth-helpers";
+import { getTrainerTimezone } from "@/lib/gc-fitness/trainer-timezone";
 import { listRecentLogsForTrainerPage } from "@/lib/gc-fitness/recent-logs-actions";
 import { RecentLogsFeed } from "./_components/RecentLogsFeed";
 
@@ -26,6 +27,7 @@ export default async function RecentLogsPage() {
   }
 
   const tCommon = await getTranslations("common");
+  const trainerTimezone = await getTrainerTimezone();
 
   // Plan 20-06: catch Server-Action failures (Firestore unavailable, index
   // missing, transient network) so the trainer sees a tasteful recovery card
@@ -67,6 +69,7 @@ export default async function RecentLogsPage() {
         <RecentLogsFeed
           logs={logs}
           clients={clients}
+          trainerTimezone={trainerTimezone}
           initialCursor={nextCursor}
           initialHasMore={hasMore}
         />

--- a/backoffice/src/app/gc-fitness/recent-logs/page.tsx
+++ b/backoffice/src/app/gc-fitness/recent-logs/page.tsx
@@ -1,5 +1,6 @@
 import { redirect } from "next/navigation";
 import { getTranslations } from "next-intl/server";
+import { Info } from "lucide-react";
 
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import {
@@ -27,6 +28,7 @@ export default async function RecentLogsPage() {
   }
 
   const tCommon = await getTranslations("common");
+  const tRecent = await getTranslations("recentLogs");
   const trainerTimezone = await getTrainerTimezone();
 
   // Plan 20-06: catch Server-Action failures (Firestore unavailable, index
@@ -66,13 +68,28 @@ export default async function RecentLogsPage() {
           </CardContent>
         </Card>
       ) : (
-        <RecentLogsFeed
-          logs={logs}
-          clients={clients}
-          trainerTimezone={trainerTimezone}
-          initialCursor={nextCursor}
-          initialHasMore={hasMore}
-        />
+        <div className="flex flex-col gap-4">
+          <Card className="border-primary/15 bg-primary/5">
+            <CardHeader className="pb-2">
+              <CardTitle className="flex items-center gap-2 text-base">
+                <Info className="h-4 w-4" />
+                {tRecent("timezoneInfoTitle")}
+              </CardTitle>
+            </CardHeader>
+            <CardContent className="pt-0">
+              <p className="text-sm text-muted-foreground">
+                {tRecent("timezoneInfoBody", { timezone: trainerTimezone })}
+              </p>
+            </CardContent>
+          </Card>
+          <RecentLogsFeed
+            logs={logs}
+            clients={clients}
+            trainerTimezone={trainerTimezone}
+            initialCursor={nextCursor}
+            initialHasMore={hasMore}
+          />
+        </div>
       )}
     </div>
   );

--- a/backoffice/src/app/gc-fitness/templates/client.tsx
+++ b/backoffice/src/app/gc-fitness/templates/client.tsx
@@ -14,7 +14,7 @@ import { useCallback, useEffect, useMemo, useState } from "react";
 import { useRouter } from "next/navigation";
 import { useQueryClient } from "@tanstack/react-query";
 import { Plus } from "lucide-react";
-import { useTranslations } from "next-intl";
+import { useLocale, useTranslations } from "next-intl";
 import {
   flexRender,
   getCoreRowModel,
@@ -94,6 +94,7 @@ export interface TemplatesLibraryClientProps {
 
 export function TemplatesLibraryClient({ trainerUid }: TemplatesLibraryClientProps) {
   const router = useRouter();
+  const locale = useLocale();
   const t = useTranslations("templates.list");
   const tFilters = useTranslations("exercises.filters");
   const queryClient = useQueryClient();
@@ -226,8 +227,8 @@ export function TemplatesLibraryClient({ trainerUid }: TemplatesLibraryClientPro
 
   const columnsT = useTranslations("templates.columns");
   const columns = useMemo(
-    () => makeTemplateColumns(handlers, columnsT),
-    [handlers, columnsT],
+    () => makeTemplateColumns(handlers, columnsT, locale),
+    [handlers, columnsT, locale],
   );
 
   const table = useReactTable({

--- a/backoffice/src/components/gc-fitness/schedule/assign-template-modal.tsx
+++ b/backoffice/src/components/gc-fitness/schedule/assign-template-modal.tsx
@@ -145,6 +145,7 @@ export function AssignTemplateModal({
       number,
       {
         rest_seconds: string;
+        transition_rest_seconds: string;
         notes: string;
         setRows: Array<{ reps: string; kg: string; duration?: string }>;
       }
@@ -200,6 +201,7 @@ export function AssignTemplateModal({
         setOverrideDrafts(
           detail.exercises.reduce<Record<number, {
             rest_seconds: string;
+            transition_rest_seconds: string;
             notes: string;
             setRows: Array<{ reps: string; kg: string; duration?: string }>;
           }>>((acc, exercise) => {
@@ -258,6 +260,9 @@ export function AssignTemplateModal({
             }));
             acc[exercise.index] = {
               rest_seconds: String(exercise.rest_seconds),
+              transition_rest_seconds: String(
+                exercise.transition_rest_seconds ?? 60,
+              ),
               notes: exercise.notes ?? "",
               setRows,
             };
@@ -338,6 +343,7 @@ export function AssignTemplateModal({
           .map((n) => (Number.isFinite(n) ? n : 60));
 
         const nextRest = Number(draft.rest_seconds);
+        const nextTransitionRest = Number(draft.transition_rest_seconds);
         const nextNotes = draft.notes.trim();
 
         const baseRepsBySet = Array.isArray(exercise.repsBySet) ? exercise.repsBySet : [];
@@ -362,6 +368,9 @@ export function AssignTemplateModal({
           : baseWeightBySetKg.length > 0;
         const changedRest =
           Number.isFinite(nextRest) && nextRest !== exercise.rest_seconds;
+        const changedTransitionRest =
+          Number.isFinite(nextTransitionRest) &&
+          nextTransitionRest !== (exercise.transition_rest_seconds ?? 60);
         const changedNotes = nextNotes !== (exercise.notes ?? "").trim();
         // 26-03 — Duration change detection (only relevant when time).
         const changedDurations =
@@ -377,6 +386,7 @@ export function AssignTemplateModal({
           !changedRepsBySet &&
           !changedWeights &&
           !changedRest &&
+          !changedTransitionRest &&
           !changedNotes &&
           !changedDurations
         ) {
@@ -401,6 +411,14 @@ export function AssignTemplateModal({
           ...(changedWeights && !finalWeights ? { weightBySetKg: [] } : {}),
           ...(changedRest
             ? { rest_seconds: Math.max(0, Math.min(600, Math.round(nextRest))) }
+            : {}),
+          ...(changedTransitionRest
+            ? {
+                transition_rest_seconds: Math.max(
+                  0,
+                  Math.min(600, Math.round(nextTransitionRest)),
+                ),
+              }
             : {}),
           ...(changedNotes ? { notes: nextNotes } : {}),
           // 26-03 — Duration override write (time exercises only).
@@ -933,8 +951,26 @@ export function AssignTemplateModal({
                         className="h-8 w-20 rounded-md border bg-background px-2 text-sm"
                         />
                       </div>
-                    <p className="text-[11px] text-muted-foreground">
-                      {t("exerciseOverridesTransitionRest")}: {exercise.transition_rest_seconds}s
+                    <p className="flex items-center gap-1 text-[11px] text-muted-foreground">
+                      <span>{t("exerciseOverridesTransitionRest")}:</span>
+                      <input
+                        type="text"
+                        inputMode="numeric"
+                        pattern="[0-9]*"
+                        value={draft.transition_rest_seconds}
+                        onChange={(event) => {
+                          const value = event.target.value;
+                          setOverrideDrafts((prev) => ({
+                            ...prev,
+                            [exercise.index]: {
+                              ...prev[exercise.index],
+                              transition_rest_seconds: value,
+                            },
+                          }));
+                        }}
+                        className="h-8 w-20 rounded-md border bg-background px-2 text-sm"
+                      />
+                      <span>s</span>
                     </p>
                   </div>
                   {/* Per-set table — one row per prescribed set. Mirrors the

--- a/backoffice/src/components/gc-fitness/templates/columns.tsx
+++ b/backoffice/src/components/gc-fitness/templates/columns.tsx
@@ -42,6 +42,7 @@ import {
   TooltipProvider,
   TooltipTrigger,
 } from "@/components/ui/tooltip";
+import { formatCivilDateLabel } from "@/lib/gc-fitness/civil-date";
 
 import type { WorkoutTemplateRow } from "@/lib/gc-fitness/workout-template-actions";
 
@@ -96,9 +97,9 @@ const TAG_LABELS: Record<string, string> = {
   custom: "Custom",
 };
 
-function formatCivilDateBadge(civilDate?: string | null): string {
+function formatCivilDateBadge(civilDate?: string | null, locale?: string): string {
   if (!civilDate) return "—";
-  return civilDate;
+  return formatCivilDateLabel(civilDate, { month: "short", day: "numeric" }, locale);
 }
 
 type TFn = ReturnType<typeof useTranslations>;
@@ -106,6 +107,7 @@ type TFn = ReturnType<typeof useTranslations>;
 export function makeTemplateColumns(
   handlers: TemplateColumnHandlers,
   t: TFn,
+  locale: string,
 ): ColumnDef<TemplateListRow>[] {
   return [
     {
@@ -195,7 +197,7 @@ export function makeTemplateColumns(
           variant={row.original.endsOn ? "outline" : "ghost"}
           className={row.original.endsOn ? "font-mono tabular-nums" : "text-muted-foreground"}
         >
-          {formatCivilDateBadge(row.original.endsOn)}
+          {formatCivilDateBadge(row.original.endsOn, locale)}
         </Badge>
       ),
       enableSorting: false,

--- a/backoffice/src/lib/gc-fitness/__tests__/civil-date.test.ts
+++ b/backoffice/src/lib/gc-fitness/__tests__/civil-date.test.ts
@@ -28,7 +28,11 @@
 //   - .planning/phases/04-workout-templates-assignments/04-RESEARCH.md §Pitfall 1
 //   - .planning/phases/04-workout-templates-assignments/04-RESEARCH.md §Pitfall 2
 
-import { civilDateFormat, civilDateToday } from "../civil-date";
+import {
+  civilDateFormat,
+  civilDateToday,
+  formatCivilDateLabel,
+} from "../civil-date";
 
 // Shared fixture epochs (seconds).
 const MXC_NOON_2026_06_01 = 1780336800;
@@ -122,6 +126,22 @@ describe("civilDateToday(timezone, now)", () => {
     expect(today[4]).toBe("-");
     expect(today[7]).toBe("-");
     expect(/^\d{4}-\d{2}-\d{2}$/.test(today)).toBe(true);
+  });
+});
+
+describe("formatCivilDateLabel(civilDate, options)", () => {
+  it("formats civil dates without host timezone drift", () => {
+    expect(
+      formatCivilDateLabel("2026-06-01", {
+        weekday: "long",
+        day: "numeric",
+        month: "short",
+      }, "en-US"),
+    ).toBe("Monday, Jun 1");
+  });
+
+  it("returns the original string for malformed civil dates", () => {
+    expect(formatCivilDateLabel("not-a-date")).toBe("not-a-date");
   });
 });
 

--- a/backoffice/src/lib/gc-fitness/__tests__/client-activity-time.test.ts
+++ b/backoffice/src/lib/gc-fitness/__tests__/client-activity-time.test.ts
@@ -1,0 +1,44 @@
+import {
+  clientActivityGroupKey,
+  formatClientActivityDate,
+  formatClientActivityDateTime,
+  formatClientActivityTime,
+} from "@/lib/gc-fitness/client-activity-time";
+
+describe("client activity timezone helpers", () => {
+  test("formats instants in the provided timezone", () => {
+    expect(
+      formatClientActivityDateTime(
+        "2026-06-03T14:08:00.000Z",
+        "America/Argentina/Buenos_Aires",
+      ),
+    ).toContain("11:08");
+  });
+
+  test("uses the provided timezone for time-only labels", () => {
+    expect(
+      formatClientActivityTime(
+        "2026-06-03T14:08:00.000Z",
+        "America/Argentina/Buenos_Aires",
+      ),
+    ).toContain("11:08");
+  });
+
+  test("uses the provided timezone for fallback photo dates", () => {
+    expect(
+      formatClientActivityDate(
+        "2026-06-03T02:59:00.000Z",
+        "America/Argentina/Buenos_Aires",
+      ),
+    ).toBe("Jun 2");
+  });
+
+  test("groups messages by local day and hour rather than UTC", () => {
+    expect(
+      clientActivityGroupKey(
+        "2026-06-03T02:59:00.000Z",
+        "America/Argentina/Buenos_Aires",
+      ),
+    ).toBe("2026-06-02T23");
+  });
+});

--- a/backoffice/src/lib/gc-fitness/__tests__/recent-logs-time.test.ts
+++ b/backoffice/src/lib/gc-fitness/__tests__/recent-logs-time.test.ts
@@ -1,0 +1,54 @@
+import {
+  addCivilDays,
+  formatRecentLogDayHeading,
+  formatRecentLogTime,
+  recentLogDayKeyFromIso,
+} from "@/lib/gc-fitness/recent-logs-time";
+
+describe("recent logs time helpers", () => {
+  test("formats event times in the trainer timezone", () => {
+    expect(
+      formatRecentLogTime(
+        "2026-06-03T14:08:00.000Z",
+        "America/Argentina/Buenos_Aires",
+        "en-US",
+      ),
+    ).toBe("11:08 AM");
+  });
+
+  test("uses the trainer timezone when grouping by day", () => {
+    expect(recentLogDayKeyFromIso("2026-06-03T02:59:00.000Z", "UTC")).toBe("2026-06-03");
+    expect(
+      recentLogDayKeyFromIso("2026-06-03T02:59:00.000Z", "America/Argentina/Buenos_Aires"),
+    ).toBe("2026-06-02");
+  });
+
+  test("labels today and yesterday relative to the trainer timezone", () => {
+    const now = new Date("2026-06-03T15:00:00.000Z");
+
+    expect(
+      formatRecentLogDayHeading(
+        "2026-06-03T02:59:00.000Z",
+        "America/Argentina/Buenos_Aires",
+        "en-US",
+        { today: "Today", yesterday: "Yesterday" },
+        now,
+      ),
+    ).toBe("Yesterday");
+
+    expect(
+      formatRecentLogDayHeading(
+        "2026-06-03T14:08:00.000Z",
+        "America/Argentina/Buenos_Aires",
+        "en-US",
+        { today: "Today", yesterday: "Yesterday" },
+        now,
+      ),
+    ).toBe("Today");
+  });
+
+  test("adds civil days across month boundaries", () => {
+    expect(addCivilDays("2026-03-01", -1)).toBe("2026-02-28");
+    expect(addCivilDays("2024-03-01", -1)).toBe("2024-02-29");
+  });
+});

--- a/backoffice/src/lib/gc-fitness/__tests__/workout-assignment-actions.test.ts
+++ b/backoffice/src/lib/gc-fitness/__tests__/workout-assignment-actions.test.ts
@@ -256,13 +256,22 @@ describe("assignTemplate", () => {
       clientId: CLIENT_UID,
       scheduledFor: "2026-06-01",
       timezone: "America/Mexico_City",
+      exerciseOverrides: [
+        {
+          index: 0,
+          rest_seconds: 45,
+          transition_rest_seconds: 75,
+          notes: "Tempo control",
+        },
+      ],
     });
 
     // calls[0] is the assignment doc write; a 2nd set() writes the
     // best-effort coach_activity event log (see coach-activity-log.ts).
     expect(mockSet).toHaveBeenCalled();
     const payload = mockSet.mock.calls[0][0];
-    expect(payload.templateSnapshot).toEqual(VALID_TEMPLATE);
+    expect(payload.templateSnapshot.exercises[0].rest_seconds).toBe(45);
+    expect(payload.templateSnapshot.exercises[0].transition_rest_seconds).toBe(75);
     expect(payload.templateId).toBe("tpl-abc");
     expect(payload.clientId).toBe(CLIENT_UID);
     expect(payload.trainerId).toBe(ALLOWED_UID);

--- a/backoffice/src/lib/gc-fitness/__tests__/workout-assignment-schema.test.ts
+++ b/backoffice/src/lib/gc-fitness/__tests__/workout-assignment-schema.test.ts
@@ -25,6 +25,14 @@ describe("assignTemplateSchema", () => {
       scheduledTime: "19:30",
       meetingNotes: "Meet on Google Meet.",
       timezone: "America/Mexico_City",
+      exerciseOverrides: [
+        {
+          index: 0,
+          rest_seconds: 45,
+          transition_rest_seconds: 75,
+          notes: "Tempo control",
+        },
+      ],
     });
     expect(result.success).toBe(true);
   });

--- a/backoffice/src/lib/gc-fitness/civil-date.ts
+++ b/backoffice/src/lib/gc-fitness/civil-date.ts
@@ -66,6 +66,38 @@ export function civilDateFormat(date: Date, timezone: string): string {
   return assemble(parts);
 }
 
+/**
+ * Formats a civil date (`YYYY-MM-DD`) for display without letting the host
+ * timezone reinterpret it as an instant.
+ *
+ * The input is treated as a calendar date in UTC noon and rendered with an
+ * explicit `timeZone: "UTC"` so browser/server locale differences cannot
+ * shift the visible day.
+ */
+export function formatCivilDateLabel(
+  civilDate: string,
+  options: Intl.DateTimeFormatOptions = {
+    month: "short",
+    day: "numeric",
+  },
+  locale?: string,
+): string {
+  const date = parseCivilDate(civilDate);
+  if (!date) return civilDate;
+  try {
+    return new Intl.DateTimeFormat(locale, {
+      ...options,
+      calendar: "gregory",
+      timeZone: "UTC",
+    }).format(date);
+  } catch {
+    return new Intl.DateTimeFormat(locale, {
+      ...options,
+      calendar: "gregory",
+    }).format(date);
+  }
+}
+
 // MARK: - Helpers
 
 /**
@@ -88,6 +120,18 @@ function formatPartsInZone(date: Date, timezone: string): Intl.DateTimeFormatPar
     // `TimeZone(identifier:) ?? .current` fallback.
     return new Intl.DateTimeFormat(undefined, CALENDAR_OPTIONS).formatToParts(date);
   }
+}
+
+function parseCivilDate(civilDate: string): Date | null {
+  const [yearText, monthText, dayText] = civilDate.split("-");
+  const year = Number.parseInt(yearText ?? "", 10);
+  const month = Number.parseInt(monthText ?? "", 10);
+  const day = Number.parseInt(dayText ?? "", 10);
+  if (!year || !month || !day) return null;
+
+  const date = new Date(Date.UTC(year, month - 1, day, 12, 0, 0));
+  if (civilDateFormat(date, "UTC") !== civilDate) return null;
+  return date;
 }
 
 function assemble(parts: readonly Intl.DateTimeFormatPart[]): string {

--- a/backoffice/src/lib/gc-fitness/client-activity-time.ts
+++ b/backoffice/src/lib/gc-fitness/client-activity-time.ts
@@ -76,3 +76,13 @@ export function clientActivityGroupKey(
   });
   return `${day}T${hour}`;
 }
+
+export function clientActivityCivilDateKey(
+  iso: string | null,
+  timezone: string,
+): string {
+  if (!iso) return "unknown";
+  const date = new Date(iso);
+  if (Number.isNaN(date.getTime())) return iso.slice(0, 10);
+  return civilDateFormat(date, timezone);
+}

--- a/backoffice/src/lib/gc-fitness/client-activity-time.ts
+++ b/backoffice/src/lib/gc-fitness/client-activity-time.ts
@@ -1,0 +1,78 @@
+import { civilDateFormat } from "./civil-date";
+
+function formatInZone(
+  iso: string | null,
+  timezone: string,
+  options: Intl.DateTimeFormatOptions,
+): string {
+  if (!iso) return "—";
+  const date = new Date(iso);
+  if (Number.isNaN(date.getTime())) return "—";
+
+  try {
+    return new Intl.DateTimeFormat(undefined, {
+      ...options,
+      timeZone: timezone,
+    }).format(date);
+  } catch {
+    return new Intl.DateTimeFormat(undefined, options).format(date);
+  }
+}
+
+export function formatClientActivityDateTime(
+  iso: string | null,
+  timezone: string,
+): string {
+  return formatInZone(iso, timezone, {
+    month: "short",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+}
+
+export function formatClientActivityTime(
+  iso: string | null,
+  timezone: string,
+): string {
+  return formatInZone(iso, timezone, {
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+}
+
+export function formatClientActivityDate(
+  iso: string | null,
+  timezone: string,
+): string {
+  return formatInZone(iso, timezone, {
+    month: "short",
+    day: "numeric",
+  });
+}
+
+export function formatClientActivityDayHeader(
+  iso: string | null,
+  timezone: string,
+): string {
+  return formatInZone(iso, timezone, {
+    month: "short",
+    day: "numeric",
+    hour: "2-digit",
+  });
+}
+
+export function clientActivityGroupKey(
+  iso: string | null,
+  timezone: string,
+): string {
+  if (!iso) return "unknown";
+  const date = new Date(iso);
+  if (Number.isNaN(date.getTime())) return iso.slice(0, 10);
+  const day = civilDateFormat(date, timezone);
+  const hour = formatInZone(iso, timezone, {
+    hour: "2-digit",
+    hour12: false,
+  });
+  return `${day}T${hour}`;
+}

--- a/backoffice/src/lib/gc-fitness/recent-logs-time.ts
+++ b/backoffice/src/lib/gc-fitness/recent-logs-time.ts
@@ -1,0 +1,76 @@
+import { civilDateFormat, civilDateToday } from "./civil-date";
+
+export interface RecentLogsDayLabels {
+  today: string;
+  yesterday: string;
+}
+
+export function formatRecentLogTime(
+  iso: string,
+  timezone: string,
+  locale: string,
+): string {
+  const date = new Date(iso);
+  if (Number.isNaN(date.getTime())) return iso;
+
+  try {
+    return new Intl.DateTimeFormat(locale, {
+      hour: "2-digit",
+      minute: "2-digit",
+      timeZone: timezone,
+    }).format(date);
+  } catch {
+    return new Intl.DateTimeFormat(locale, {
+      hour: "2-digit",
+      minute: "2-digit",
+    }).format(date);
+  }
+}
+
+export function recentLogDayKeyFromIso(iso: string, timezone: string): string {
+  const date = new Date(iso);
+  if (Number.isNaN(date.getTime())) return iso.slice(0, 10);
+  return civilDateFormat(date, timezone);
+}
+
+export function formatRecentLogDayHeading(
+  iso: string,
+  timezone: string,
+  locale: string,
+  labels: RecentLogsDayLabels,
+  now: Date = new Date(),
+): string {
+  const date = new Date(iso);
+  if (Number.isNaN(date.getTime())) return iso;
+
+  const key = recentLogDayKeyFromIso(iso, timezone);
+  const todayKey = civilDateToday(timezone, now);
+  const yesterdayKey = addCivilDays(todayKey, -1);
+
+  if (key === todayKey) return labels.today;
+  if (key === yesterdayKey) return labels.yesterday;
+
+  try {
+    return new Intl.DateTimeFormat(locale, {
+      month: "short",
+      day: "numeric",
+      timeZone: timezone,
+    }).format(date);
+  } catch {
+    return new Intl.DateTimeFormat(locale, {
+      month: "short",
+      day: "numeric",
+    }).format(date);
+  }
+}
+
+export function addCivilDays(civilDate: string, days: number): string {
+  const [year, month, day] = civilDate.split("-").map((part) => Number.parseInt(part, 10));
+  if (!year || !month || !day) return civilDate;
+
+  const date = new Date(Date.UTC(year, month - 1, day));
+  if (Number.isNaN(date.getTime())) return civilDate;
+
+  date.setUTCDate(date.getUTCDate() + days);
+  return date.toISOString().slice(0, 10);
+}

--- a/backoffice/src/lib/gc-fitness/workout-assignment-actions.ts
+++ b/backoffice/src/lib/gc-fitness/workout-assignment-actions.ts
@@ -216,6 +216,7 @@ function applyExerciseOverrides(
         sets?: number;
         reps?: number;
         rest_seconds?: number;
+        transition_rest_seconds?: number;
         notes?: string;
         weightBySetKg?: number[];
         repsBySet?: number[];
@@ -235,6 +236,9 @@ function applyExerciseOverrides(
       ...(override.reps !== undefined ? { reps: override.reps } : {}),
       ...(override.rest_seconds !== undefined
         ? { rest_seconds: override.rest_seconds }
+        : {}),
+      ...(override.transition_rest_seconds !== undefined
+        ? { transition_rest_seconds: override.transition_rest_seconds }
         : {}),
       ...(override.notes !== undefined ? { notes: override.notes } : {}),
       ...(override.weightBySetKg !== undefined

--- a/backoffice/src/lib/gc-fitness/workout-assignment-schema.ts
+++ b/backoffice/src/lib/gc-fitness/workout-assignment-schema.ts
@@ -66,6 +66,7 @@ const assignmentExerciseOverrideSchema = z.object({
   sets: z.number().int().min(1).max(10).optional(),
   reps: z.number().int().min(1).max(50).optional(),
   rest_seconds: z.number().int().min(0).max(600).optional(),
+  transition_rest_seconds: z.number().int().min(0).max(600).optional(),
   notes: z.string().max(500).optional(),
   weightBySetKg: z.array(z.number().min(0).max(500)).max(10).optional(),
   repsBySet: z.array(z.number().int().min(1).max(50)).max(10).optional(),

--- a/backoffice/src/lib/test-utils/next-intl-stub.tsx
+++ b/backoffice/src/lib/test-utils/next-intl-stub.tsx
@@ -12,6 +12,8 @@
 //     that walks the EN message catalog by `${namespace}.${key}` and
 //     interpolates `{var}` placeholders. Unknown keys return the dotted
 //     path verbatim so failures surface obviously in assertions.
+//   - `useLocale()` — returns `en` so locale-aware formatting code has a
+//     deterministic default in tests.
 //   - `NextIntlClientProvider` — a pass-through wrapper (no provider
 //     plumbing needed when the stub `useTranslations` reads the catalog
 //     directly).
@@ -105,6 +107,10 @@ function makeTFn(namespace?: string): TFn {
 
 export function useTranslations(namespace?: string): TFn {
   return makeTFn(namespace);
+}
+
+export function useLocale(): string {
+  return "en";
 }
 
 export function NextIntlClientProvider({


### PR DESCRIPTION
Fixes the recent activity feed so row times and day groupings use the trainer's IANA timezone instead of UTC.

Changes:
- Pass  from the server page into the recent logs feed
- Format timestamps and day headings in that timezone
- Localize Today/Yesterday labels
- Add helper tests for timezone grouping and time formatting

Validation:
- npx tsc --noEmit --pretty false
- npx jest src/lib/gc-fitness/__tests__/recent-logs-time.test.ts --runInBand
- git diff --check