### PR TITLE
Add client request actions and activity logging

### DIFF
--- a/backoffice/docs/client-request-push-flow.md
+++ b/backoffice/docs/client-request-push-flow.md
@@ -1,0 +1,36 @@
+# Client Request Push Flow
+
+This surface uses a derived request state instead of a scheduled cleanup job.
+
+## State model
+
+- `progressPhotosRequestedAt`
+- `bodyWeightRequestedAt`
+
+The backoffice treats each timestamp as the source of truth.
+
+## UI contract
+
+- A request is considered active for 3 days from `requestedAt`.
+- While active, the client card shows `Pedido el {fecha}` and disables the CTA.
+- After the TTL, the same timestamp becomes historical and the card shows `Ultima petición {fecha}`.
+- No background job flips the state back. The UI derives the status from the timestamp on render.
+
+## Push contract
+
+- Requests are sent as `nudge` pushes.
+- The push payload includes a `deepLink`:
+  - `gcfitness://progress/check-in`
+  - `gcfitness://progress/log-weight`
+- The iOS app must route those links directly into the corresponding Progress screen flows.
+
+## Activity log contract
+
+- Every request action is recorded in `coach_activity` so `my-activity` can show the audit trail.
+- If a request is already active, the action is skipped and no duplicate log entry is written.
+
+## Why this is explicit
+
+- It avoids a timer-based state machine in Firestore.
+- It keeps the push behavior and the UI status derived from the same timestamp.
+- It makes the deep-link contract stable for future app changes.

--- a/backoffice/messages/en.json
+++ b/backoffice/messages/en.json
@@ -182,6 +182,31 @@
       "openChat": "Open chat",
       "assignWorkout": "Assign workout",
       "assignHabit": "Assign habit",
+      "requests": {
+        "title": "Client requests",
+        "subtitle": "Quick prompts that open the right flow in the app and stay active for 3 days.",
+        "progressPhotos": {
+          "title": "Request progress photos",
+          "description": "Ask {clientName} for a fresh set of progress photos."
+        },
+        "weight": {
+          "title": "Request weight",
+          "description": "Ask {clientName} to log their body weight."
+        },
+        "request": {
+          "cta": "Request"
+        },
+        "status": {
+          "never": "No requests yet",
+          "neverHelp": "You can send the first request now.",
+          "requestedOn": "Requested on {date}",
+          "lastRequestedOn": "Last request {date}",
+          "reactivatesOn": "Reactivates on {date}",
+          "readyHelp": "You can request it again now.",
+          "active": "Request is active for 3 days",
+          "ready": "Ready to request"
+        }
+      },
       "skeleton": {
         "workoutTrends": "Workouts",
         "habitTrends": "Habits",

--- a/backoffice/messages/es.json
+++ b/backoffice/messages/es.json
@@ -182,6 +182,31 @@
       "openChat": "Abrir chat",
       "assignWorkout": "Asignar entrenamiento",
       "assignHabit": "Asignar hábito",
+      "requests": {
+        "title": "Pedidos al cliente",
+        "subtitle": "Pedidos rápidos que abren el flujo correcto en la app y quedan activos por 3 días.",
+        "progressPhotos": {
+          "title": "Pedir Progress Photos",
+          "description": "Pedile a {clientName} un nuevo set de fotos de progreso."
+        },
+        "weight": {
+          "title": "Pedir peso",
+          "description": "Pedile a {clientName} que registre su peso corporal."
+        },
+        "request": {
+          "cta": "Pedir"
+        },
+        "status": {
+          "never": "Sin pedidos todavía",
+          "neverHelp": "Podés enviar el primer pedido ahora.",
+          "requestedOn": "Pedido el {date}",
+          "lastRequestedOn": "Última petición {date}",
+          "reactivatesOn": "Se reactiva el {date}",
+          "readyHelp": "Podés volver a pedirlo ahora.",
+          "active": "El pedido queda activo por 3 días",
+          "ready": "Listo para pedir"
+        }
+      },
       "skeleton": {
         "workoutTrends": "Workouts",
         "habitTrends": "Hábitos",

--- a/backoffice/src/app/gc-fitness/clients/[id]/_components/ClientRequestActionsCard.tsx
+++ b/backoffice/src/app/gc-fitness/clients/[id]/_components/ClientRequestActionsCard.tsx
@@ -1,0 +1,182 @@
+import { getLocale, getTranslations } from "next-intl/server";
+import { revalidatePath } from "next/cache";
+
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import {
+  getClientRequestStatus,
+  runClientRequest,
+} from "@/lib/gc-fitness/client-request-actions";
+
+type RequestState = {
+  statusText: string;
+  helperText: string;
+  isActive: boolean;
+};
+
+export default async function ClientRequestActionsCard({
+  clientId,
+  clientName,
+  timezone,
+  progressPhotosRequestedAt,
+  bodyWeightRequestedAt,
+}: {
+  clientId: string;
+  clientName: string;
+  timezone: string;
+  progressPhotosRequestedAt: unknown;
+  bodyWeightRequestedAt: unknown;
+}) {
+  const locale = await getLocale();
+  const t = await getTranslations("clients.detail.requests");
+  const now = new Date();
+  const progressPhotos = requestState(progressPhotosRequestedAt, now, timezone, locale, t);
+  const bodyWeight = requestState(bodyWeightRequestedAt, now, timezone, locale, t);
+
+  async function requestProgressPhotos() {
+    "use server";
+    await runClientRequest(clientId, "progressPhotos");
+    revalidatePath(`/gc-fitness/clients/${clientId}`);
+    revalidatePath("/gc-fitness/my-activity");
+  }
+
+  async function requestWeight() {
+    "use server";
+    await runClientRequest(clientId, "weight");
+    revalidatePath(`/gc-fitness/clients/${clientId}`);
+    revalidatePath("/gc-fitness/my-activity");
+  }
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>{t("title")}</CardTitle>
+        <CardDescription>{t("subtitle")}</CardDescription>
+      </CardHeader>
+      <CardContent className="grid gap-4 md:grid-cols-2">
+        <RequestRow
+          title={t("progressPhotos.title")}
+          description={t("progressPhotos.description", { clientName })}
+          state={progressPhotos}
+          action={requestProgressPhotos}
+          submitLabel={t("request.cta")}
+          activeLabel={t("status.active")}
+          readyLabel={t("status.ready")}
+        />
+        <RequestRow
+          title={t("weight.title")}
+          description={t("weight.description", { clientName })}
+          state={bodyWeight}
+          action={requestWeight}
+          submitLabel={t("request.cta")}
+          activeLabel={t("status.active")}
+          readyLabel={t("status.ready")}
+        />
+      </CardContent>
+    </Card>
+  );
+}
+
+function requestState(
+  requestedAt: unknown,
+  now: Date,
+  timezone: string,
+  locale: string,
+  t: Awaited<ReturnType<typeof getTranslations>>,
+): RequestState {
+  const status = getClientRequestStatus(requestedAt, now);
+  if (!status.requestedAt) {
+    return {
+      statusText: t("status.never"),
+      helperText: t("status.neverHelp"),
+      isActive: false,
+    };
+  }
+
+  const requestedAtLabel = formatDate(status.requestedAt, timezone, locale);
+  const expiresAtLabel = status.expiresAt
+    ? formatDate(status.expiresAt, timezone, locale, true)
+    : null;
+  if (status.isActive) {
+    return {
+      statusText: t("status.requestedOn", { date: requestedAtLabel }),
+      helperText: t("status.reactivatesOn", {
+        date: expiresAtLabel ?? "—",
+      }),
+      isActive: true,
+    };
+  }
+
+  return {
+    statusText: t("status.lastRequestedOn", { date: requestedAtLabel }),
+    helperText: t("status.readyHelp"),
+    isActive: false,
+  };
+}
+
+function formatDate(
+  value: Date,
+  timezone: string,
+  locale: string,
+  includeTime = false,
+): string {
+  try {
+    return new Intl.DateTimeFormat(locale, {
+      timeZone: timezone,
+      day: "2-digit",
+      month: "short",
+      year: "numeric",
+      ...(includeTime ? { hour: "2-digit", minute: "2-digit" } : {}),
+    }).format(value);
+  } catch {
+    return new Intl.DateTimeFormat(locale, {
+      day: "2-digit",
+      month: "short",
+      year: "numeric",
+      ...(includeTime ? { hour: "2-digit", minute: "2-digit" } : {}),
+    }).format(value);
+  }
+}
+
+function RequestRow({
+  title,
+  description,
+  state,
+  action,
+  submitLabel,
+  activeLabel,
+  readyLabel,
+}: {
+  title: string;
+  description: string;
+  state: RequestState;
+  action: () => Promise<void>;
+  submitLabel: string;
+  activeLabel: string;
+  readyLabel: string;
+}) {
+  return (
+    <form action={action} className="rounded-xl border bg-muted/20 p-4">
+      <div className="flex h-full flex-col gap-3">
+        <div className="space-y-1">
+          <h3 className="text-base font-semibold">{title}</h3>
+          <p className="text-sm text-muted-foreground">{description}</p>
+        </div>
+        <div className="flex flex-wrap items-center gap-2">
+          <span className="rounded-full border bg-background px-3 py-1 text-xs text-muted-foreground">
+            {state.statusText}
+          </span>
+          <span className="text-xs text-muted-foreground">{state.helperText}</span>
+        </div>
+        <div className="mt-auto flex items-center justify-between gap-3">
+          <p className="text-xs text-muted-foreground">
+            {state.isActive ? activeLabel : readyLabel}
+          </p>
+          <Button type="submit" variant={state.isActive ? "secondary" : "default"} disabled={state.isActive}>
+            {submitLabel}
+          </Button>
+        </div>
+      </div>
+    </form>
+  );
+}

--- a/backoffice/src/app/gc-fitness/clients/[id]/_components/ClientRequestActionsCard.tsx
+++ b/backoffice/src/app/gc-fitness/clients/[id]/_components/ClientRequestActionsCard.tsx
@@ -3,10 +3,8 @@ import { revalidatePath } from "next/cache";
 
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
-import {
-  getClientRequestStatus,
-  runClientRequest,
-} from "@/lib/gc-fitness/client-request-actions";
+import { runClientRequest } from "@/lib/gc-fitness/client-request-actions";
+import { getClientRequestStatus } from "@/lib/gc-fitness/client-request-state";
 
 type RequestState = {
   statusText: string;

--- a/backoffice/src/app/gc-fitness/clients/[id]/_components/PendingHabitPreloadForm.tsx
+++ b/backoffice/src/app/gc-fitness/clients/[id]/_components/PendingHabitPreloadForm.tsx
@@ -1,6 +1,11 @@
 "use client";
 
-import { useMemo, useState } from "react";
+import { useEffect, useRef, useState } from "react";
+import {
+  addCivilMonths,
+  END_DATE_PRESET_MONTHS,
+  type EndDatePresetMonths,
+} from "@/lib/gc-fitness/end-date-presets";
 
 // Habits are binary-only (yes/no) now.
 type HabitScheduleType = "one-time" | "recurring";
@@ -42,15 +47,35 @@ export function PendingHabitPreloadForm({
   const [scheduleType, setScheduleType] = useState<HabitScheduleType>("recurring");
   const [scheduleCadence, setScheduleCadence] = useState<HabitCadence>("daily");
   const [monthDays, setMonthDays] = useState<number[]>([1]);
+  const [startsOn, setStartsOn] = useState(() => todayCivilDate());
+  const [endsOn, setEndsOn] = useState(() => addCivilMonths(todayCivilDate(), 3));
+  const [selectedEndPresetMonths, setSelectedEndPresetMonths] =
+    useState<EndDatePresetMonths>(3);
+  const formRef = useRef<HTMLFormElement>(null);
 
-  const startsOnDefault = useMemo(() => todayCivilDate(), []);
   const templateMode = templateId.length > 0;
   const showCadence = scheduleType === "recurring";
   const showWeekdays = showCadence && scheduleCadence === "weekly";
   const showMonthDay = showCadence && scheduleCadence === "monthly";
 
+  useEffect(() => {
+    setEndsOn(addCivilMonths(startsOn, selectedEndPresetMonths));
+  }, [selectedEndPresetMonths, startsOn]);
+
+  async function handleSubmit(formData: FormData) {
+    await submitAction(formData);
+    setTemplateId("");
+    setScheduleType("recurring");
+    setScheduleCadence("daily");
+    setMonthDays([1]);
+    setStartsOn(todayCivilDate());
+    setEndsOn(addCivilMonths(todayCivilDate(), 3));
+    setSelectedEndPresetMonths(3);
+    formRef.current?.reset();
+  }
+
   return (
-    <form action={submitAction} className="flex flex-col gap-4">
+    <form ref={formRef} action={handleSubmit} className="flex flex-col gap-4">
       <div className="grid gap-3">
         <label className="flex flex-col gap-1 text-sm">
           <span className="font-medium">Hábito existente (opcional)</span>
@@ -111,18 +136,46 @@ export function PendingHabitPreloadForm({
             <input
               type="date"
               name="startsOn"
-              defaultValue={startsOnDefault}
+              value={startsOn}
+              onChange={(event) => setStartsOn(event.target.value)}
               className="rounded border bg-background px-3 py-2 text-sm"
             />
           </label>
-          <label className="flex flex-col gap-1 text-sm">
+          <div className="flex flex-col gap-2 text-sm">
             <span className="font-medium">Fin (opcional)</span>
+            <div className="flex flex-wrap gap-2">
+              {END_DATE_PRESET_MONTHS.map((months) => {
+                const active =
+                  selectedEndPresetMonths === months &&
+                  endsOn === addCivilMonths(startsOn, months);
+                return (
+                  <button
+                    key={months}
+                    type="button"
+                    onClick={() => {
+                      setSelectedEndPresetMonths(months);
+                      setEndsOn(addCivilMonths(startsOn, months));
+                    }}
+                    className={`rounded-full border px-3 py-1 text-xs font-medium transition ${
+                      active
+                        ? "border-primary bg-primary text-primary-foreground"
+                        : "border-border bg-background text-foreground hover:bg-muted"
+                    }`}
+                    aria-pressed={active}
+                  >
+                    {months} mes{months === 1 ? "" : "es"}
+                  </button>
+                );
+              })}
+            </div>
             <input
               type="date"
               name="endsOn"
+              value={endsOn}
+              onChange={(event) => setEndsOn(event.target.value)}
               className="rounded border bg-background px-3 py-2 text-sm"
             />
-          </label>
+          </div>
           {showCadence ? (
             <label className="flex flex-col gap-1 text-sm">
               <span className="font-medium">Cadencia</span>

--- a/backoffice/src/app/gc-fitness/clients/[id]/_components/PendingWorkoutAssignForm.tsx
+++ b/backoffice/src/app/gc-fitness/clients/[id]/_components/PendingWorkoutAssignForm.tsx
@@ -1,6 +1,11 @@
 "use client";
 
-import { useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
+import {
+  addCivilMonths,
+  END_DATE_PRESET_MONTHS,
+  type EndDatePresetMonths,
+} from "@/lib/gc-fitness/end-date-presets";
 
 interface WorkoutTemplateOption {
   id: string;
@@ -29,10 +34,23 @@ export function PendingWorkoutAssignForm({
   submitAction,
 }: PendingWorkoutAssignFormProps) {
   const [mode, setMode] = useState<AssignMode>("once");
+  const [scheduledFor, setScheduledFor] = useState("");
+  const [endDate, setEndDate] = useState("");
+  const [selectedEndPresetMonths, setSelectedEndPresetMonths] =
+    useState<EndDatePresetMonths>(3);
   const formRef = useRef<HTMLFormElement>(null);
   const isRecurring = mode !== "once";
   const showWeekdays = mode === "weekly";
   const showEveryN = mode === "everyN";
+
+  useEffect(() => {
+    if (!scheduledFor) {
+      setEndDate("");
+      return;
+    }
+    if (!isRecurring) return;
+    setEndDate(addCivilMonths(scheduledFor, selectedEndPresetMonths));
+  }, [isRecurring, scheduledFor, selectedEndPresetMonths]);
 
   // Wrap the server action so we can reset React-controlled state (`mode`)
   // and the native form fields together. Without this the controlled `mode`
@@ -42,6 +60,9 @@ export function PendingWorkoutAssignForm({
   async function handleSubmit(formData: FormData) {
     await submitAction(formData);
     setMode("once");
+    setScheduledFor("");
+    setEndDate("");
+    setSelectedEndPresetMonths(3);
     formRef.current?.reset();
   }
 
@@ -70,6 +91,8 @@ export function PendingWorkoutAssignForm({
             name="scheduledFor"
             required
             className="rounded border bg-background px-3 py-2 text-sm"
+            value={scheduledFor}
+            onChange={(event) => setScheduledFor(event.target.value)}
           />
         </label>
       </div>
@@ -106,14 +129,47 @@ export function PendingWorkoutAssignForm({
         ) : null}
 
         {isRecurring ? (
-          <label className="flex flex-col gap-1 text-sm">
+          <div className="flex flex-col gap-2 text-sm md:col-span-2 lg:col-span-4">
             <span className="font-medium">Fin (opcional)</span>
+            <div className="flex flex-wrap gap-2">
+              {END_DATE_PRESET_MONTHS.map((months) => {
+                const active =
+                  scheduledFor.length > 0 &&
+                  selectedEndPresetMonths === months &&
+                  endDate === addCivilMonths(scheduledFor, months);
+                return (
+                  <button
+                    key={months}
+                    type="button"
+                    onClick={() => {
+                      setSelectedEndPresetMonths(months);
+                      if (scheduledFor.length > 0) {
+                        setEndDate(addCivilMonths(scheduledFor, months));
+                      }
+                    }}
+                    className={`rounded-full border px-3 py-1 text-xs font-medium transition ${
+                      active
+                        ? "border-primary bg-primary text-primary-foreground"
+                        : "border-border bg-background text-foreground hover:bg-muted"
+                    }`}
+                    aria-pressed={active}
+                  >
+                    {months} mes{months === 1 ? "" : "es"}
+                  </button>
+                );
+              })}
+            </div>
             <input
               type="date"
               name="endDate"
               className="rounded border bg-background px-3 py-2 text-sm"
+              value={endDate}
+              min={scheduledFor || undefined}
+              onChange={(event) => {
+                setEndDate(event.target.value);
+              }}
             />
-          </label>
+          </div>
         ) : null}
 
         <label className="flex flex-col gap-1 text-sm">

--- a/backoffice/src/app/gc-fitness/clients/[id]/page.tsx
+++ b/backoffice/src/app/gc-fitness/clients/[id]/page.tsx
@@ -41,6 +41,7 @@ import { BodyWeightTrendChart } from "./_components/BodyWeightTrendChart";
 import { ClientNotesCard } from "./_components/ClientNotesCard";
 import { ProgressPhotosWidget } from "./_components/ProgressPhotosWidget";
 import { ClientRecentLogsWidget } from "./_components/ClientRecentLogsWidget";
+import ClientRequestActionsCard from "./_components/ClientRequestActionsCard";
 import { listClientGoals } from "@/lib/gc-fitness/client-goal-actions";
 import { getClientNotes } from "@/lib/gc-fitness/client-notes-actions";
 import { listProgressPhotosForClient } from "@/lib/gc-fitness/progress-photo-actions";
@@ -117,6 +118,8 @@ export default async function ClientDetailPage({
     timezone?: string;
     heightCm?: number;
     bodyWeightKg?: number;
+    progressPhotosRequestedAt?: unknown;
+    bodyWeightRequestedAt?: unknown;
     preferences?: {
       workoutPrefillSource?: string;
     };
@@ -170,6 +173,14 @@ export default async function ClientDetailPage({
         clientName={displayName}
         timezone={timezone}
         goals={goals}
+      />
+
+      <ClientRequestActionsCard
+        clientId={id}
+        clientName={displayName}
+        timezone={timezone}
+        progressPhotosRequestedAt={client.progressPhotosRequestedAt ?? null}
+        bodyWeightRequestedAt={client.bodyWeightRequestedAt ?? null}
       />
 
       <div className="grid grid-cols-1 gap-5 xl:grid-cols-2">

--- a/backoffice/src/app/gc-fitness/clients/[id]/sessions/[assignmentId]/run/_components/active-workout-session.tsx
+++ b/backoffice/src/app/gc-fitness/clients/[id]/sessions/[assignmentId]/run/_components/active-workout-session.tsx
@@ -274,7 +274,7 @@ export function ActiveWorkoutSession({
           {live.doneCount} / {live.totalPlanned} series completadas
         </p>
         {timer.active ? (
-          <div className="mt-3 overflow-hidden rounded-2xl border border-amber-400/50 bg-gradient-to-r from-amber-500/12 via-amber-400/8 to-background px-3 py-3 shadow-sm">
+          <div className="sticky top-16 z-20 mt-3 overflow-hidden rounded-2xl border border-amber-400/60 bg-gradient-to-r from-amber-500/18 via-amber-400/10 to-background px-3 py-3 shadow-lg ring-1 ring-amber-400/20 backdrop-blur">
             <div className="flex items-center justify-between gap-3">
               <div className="flex items-center gap-2">
                 <Timer
@@ -302,7 +302,7 @@ export function ActiveWorkoutSession({
               <button
                 type="button"
                 onClick={timer.sheetOpen ? timer.minimize : timer.expand}
-                className={`rounded-full border bg-background/80 px-3 py-1.5 text-xs font-medium shadow-sm transition-colors hover:bg-background ${
+                className={`rounded-full border bg-background/85 px-3 py-1.5 text-xs font-medium shadow-sm transition-colors hover:bg-background ${
                   timer.isPaused
                     ? "border-slate-500/30 text-slate-700 dark:text-slate-300"
                     : "border-amber-500/30 text-amber-700 dark:text-amber-300"

--- a/backoffice/src/app/gc-fitness/my-activity/MyActivityFeed.tsx
+++ b/backoffice/src/app/gc-fitness/my-activity/MyActivityFeed.tsx
@@ -4,11 +4,13 @@ import { useMemo, useState, useTransition } from "react";
 import type { ComponentType } from "react";
 import {
   ClipboardList,
+  Camera,
   Dumbbell,
   ListChecks,
   MessageSquare,
   NotebookPen,
   PersonStanding,
+  Scale,
   Trash2,
 } from "lucide-react";
 
@@ -37,6 +39,8 @@ const TYPE_OPTIONS: Array<[string, string]> = [
   ["all", "Toda la actividad"],
   ["workout_assignment", "Asignaciones"],
   ["habit_assignment", "Hábitos"],
+  ["progress_photo_request", "Fotos pedidas"],
+  ["weight_request", "Peso pedido"],
   ["workout_template", "Workouts"],
   ["exercise", "Ejercicios"],
   ["note", "Notas"],
@@ -50,6 +54,8 @@ const KIND_LABEL: Record<CoachActivityKind, string> = {
   exercise: "Ejercicio",
   workout_assignment: "Asignación",
   habit_assignment: "Hábito",
+  progress_photo_request: "Fotos",
+  weight_request: "Peso",
   note: "Nota",
   chat: "Chat",
 };
@@ -59,6 +65,8 @@ const KIND_ICON = {
   exercise: PersonStanding,
   workout_assignment: ClipboardList,
   habit_assignment: ListChecks,
+  progress_photo_request: Camera,
+  weight_request: Scale,
   note: NotebookPen,
   chat: MessageSquare,
 } satisfies Record<CoachActivityKind, ComponentType<{ className?: string }>>;
@@ -73,6 +81,10 @@ const KIND_TONE: Record<CoachActivityKind, string> = {
     "border-indigo-200 bg-indigo-50 text-indigo-700 dark:border-indigo-900 dark:bg-indigo-950/40 dark:text-indigo-300",
   habit_assignment:
     "border-emerald-200 bg-emerald-50 text-emerald-700 dark:border-emerald-900 dark:bg-emerald-950/40 dark:text-emerald-300",
+  progress_photo_request:
+    "border-fuchsia-200 bg-fuchsia-50 text-fuchsia-700 dark:border-fuchsia-900 dark:bg-fuchsia-950/40 dark:text-fuchsia-300",
+  weight_request:
+    "border-amber-200 bg-amber-50 text-amber-700 dark:border-amber-900 dark:bg-amber-950/40 dark:text-amber-300",
   exercise:
     "border-sky-200 bg-sky-50 text-sky-700 dark:border-sky-900 dark:bg-sky-950/40 dark:text-sky-300",
   note:

--- a/backoffice/src/app/gc-fitness/my-activity/page.tsx
+++ b/backoffice/src/app/gc-fitness/my-activity/page.tsx
@@ -37,7 +37,7 @@ export default async function MyActivityPage() {
           Mi actividad
         </h1>
         <p className="text-sm text-muted-foreground">
-          Acciones recientes del coach: workouts, ejercicios, asignaciones, hábitos, notas y chats.
+          Acciones recientes del coach: workouts, ejercicios, asignaciones, hábitos, notas, chats y pedidos de fotos/peso.
         </p>
       </div>
 

--- a/backoffice/src/app/gc-fitness/recent-logs/page.tsx
+++ b/backoffice/src/app/gc-fitness/recent-logs/page.tsx
@@ -28,7 +28,7 @@ export default async function RecentLogsPage() {
   }
 
   const tCommon = await getTranslations("common");
-  const tRecent = await getTranslations("recentLogs");
+  const tRecent = await getTranslations("recentLogs.feed");
   const trainerTimezone = await getTrainerTimezone();
 
   // Plan 20-06: catch Server-Action failures (Firestore unavailable, index

--- a/backoffice/src/lib/gc-fitness/__tests__/client-request-actions.test.ts
+++ b/backoffice/src/lib/gc-fitness/__tests__/client-request-actions.test.ts
@@ -1,4 +1,7 @@
-import { CLIENT_REQUEST_TTL_MS, getClientRequestStatus } from "../client-request-actions";
+import {
+  CLIENT_REQUEST_TTL_MS,
+  getClientRequestStatus,
+} from "../client-request-state";
 
 describe("client-request-actions", () => {
   const now = new Date("2026-06-03T15:00:00.000Z");

--- a/backoffice/src/lib/gc-fitness/__tests__/client-request-actions.test.ts
+++ b/backoffice/src/lib/gc-fitness/__tests__/client-request-actions.test.ts
@@ -1,0 +1,32 @@
+import { CLIENT_REQUEST_TTL_MS, getClientRequestStatus } from "../client-request-actions";
+
+describe("client-request-actions", () => {
+  const now = new Date("2026-06-03T15:00:00.000Z");
+
+  it("returns inactive when there was no request", () => {
+    const status = getClientRequestStatus(null, now);
+
+    expect(status.requestedAt).toBeNull();
+    expect(status.expiresAt).toBeNull();
+    expect(status.isActive).toBe(false);
+  });
+
+  it("keeps the request active for three days", () => {
+    const requestedAt = new Date("2026-06-02T15:00:00.000Z");
+    const status = getClientRequestStatus(requestedAt, now);
+
+    expect(status.requestedAt?.toISOString()).toBe(requestedAt.toISOString());
+    expect(status.expiresAt?.toISOString()).toBe(
+      new Date(requestedAt.getTime() + CLIENT_REQUEST_TTL_MS).toISOString(),
+    );
+    expect(status.isActive).toBe(true);
+  });
+
+  it("turns inactive after the TTL passes", () => {
+    const requestedAt = new Date("2026-05-30T15:00:00.000Z");
+    const status = getClientRequestStatus(requestedAt, now);
+
+    expect(status.requestedAt?.toISOString()).toBe(requestedAt.toISOString());
+    expect(status.isActive).toBe(false);
+  });
+});

--- a/backoffice/src/lib/gc-fitness/client-request-actions.ts
+++ b/backoffice/src/lib/gc-fitness/client-request-actions.ts
@@ -11,16 +11,7 @@ import {
   weightRequestedEvent,
 } from "./coach-activity-log";
 import { FirestoreCollections } from "./collections";
-
-export const CLIENT_REQUEST_TTL_MS = 3 * 24 * 60 * 60 * 1000;
-
-export type ClientRequestKind = "progressPhotos" | "weight";
-
-export interface ClientRequestStatus {
-  requestedAt: Date | null;
-  expiresAt: Date | null;
-  isActive: boolean;
-}
+import { getClientRequestStatus, type ClientRequestKind } from "./client-request-state";
 
 export interface ClientRequestResult {
   ok: true;
@@ -32,39 +23,6 @@ function requestField(kind: ClientRequestKind): string {
   return kind === "progressPhotos"
     ? "progressPhotosRequestedAt"
     : "bodyWeightRequestedAt";
-}
-
-function requestLabel(kind: ClientRequestKind): string {
-  return kind === "progressPhotos" ? "fotos de progreso" : "peso";
-}
-
-export function getClientRequestStatus(
-  requestedAt: unknown,
-  now: Date,
-): ClientRequestStatus {
-  const requestedDate = toDate(requestedAt);
-  if (!requestedDate) {
-    return { requestedAt: null, expiresAt: null, isActive: false };
-  }
-  const expiresAt = new Date(requestedDate.getTime() + CLIENT_REQUEST_TTL_MS);
-  return {
-    requestedAt: requestedDate,
-    expiresAt,
-    isActive: expiresAt.getTime() > now.getTime(),
-  };
-}
-
-function toDate(value: unknown): Date | null {
-  if (!value) return null;
-  if (value instanceof Date) return value;
-  if (typeof (value as { toDate?: () => Date }).toDate === "function") {
-    return (value as { toDate: () => Date }).toDate();
-  }
-  if (typeof value === "string") {
-    const parsed = new Date(value);
-    return Number.isNaN(parsed.getTime()) ? null : parsed;
-  }
-  return null;
 }
 
 async function assertOwnsClient(
@@ -134,8 +92,4 @@ export async function runClientRequest(
     skipped: false,
     requestedAt,
   };
-}
-
-export function formatClientRequestLabel(kind: ClientRequestKind): string {
-  return requestLabel(kind);
 }

--- a/backoffice/src/lib/gc-fitness/client-request-actions.ts
+++ b/backoffice/src/lib/gc-fitness/client-request-actions.ts
@@ -1,0 +1,141 @@
+"use server";
+
+import { FieldValue } from "firebase-admin/firestore";
+
+import { gcFitnessFirestore } from "@/lib/firebase/gc-fitness-admin";
+
+import { getCurrentTrainer } from "./auth-helpers";
+import {
+  recordCoachActivityEvent,
+  progressPhotoRequestedEvent,
+  weightRequestedEvent,
+} from "./coach-activity-log";
+import { FirestoreCollections } from "./collections";
+
+export const CLIENT_REQUEST_TTL_MS = 3 * 24 * 60 * 60 * 1000;
+
+export type ClientRequestKind = "progressPhotos" | "weight";
+
+export interface ClientRequestStatus {
+  requestedAt: Date | null;
+  expiresAt: Date | null;
+  isActive: boolean;
+}
+
+export interface ClientRequestResult {
+  ok: true;
+  skipped: boolean;
+  requestedAt: string | null;
+}
+
+function requestField(kind: ClientRequestKind): string {
+  return kind === "progressPhotos"
+    ? "progressPhotosRequestedAt"
+    : "bodyWeightRequestedAt";
+}
+
+function requestLabel(kind: ClientRequestKind): string {
+  return kind === "progressPhotos" ? "fotos de progreso" : "peso";
+}
+
+export function getClientRequestStatus(
+  requestedAt: unknown,
+  now: Date,
+): ClientRequestStatus {
+  const requestedDate = toDate(requestedAt);
+  if (!requestedDate) {
+    return { requestedAt: null, expiresAt: null, isActive: false };
+  }
+  const expiresAt = new Date(requestedDate.getTime() + CLIENT_REQUEST_TTL_MS);
+  return {
+    requestedAt: requestedDate,
+    expiresAt,
+    isActive: expiresAt.getTime() > now.getTime(),
+  };
+}
+
+function toDate(value: unknown): Date | null {
+  if (!value) return null;
+  if (value instanceof Date) return value;
+  if (typeof (value as { toDate?: () => Date }).toDate === "function") {
+    return (value as { toDate: () => Date }).toDate();
+  }
+  if (typeof value === "string") {
+    const parsed = new Date(value);
+    return Number.isNaN(parsed.getTime()) ? null : parsed;
+  }
+  return null;
+}
+
+async function assertOwnsClient(
+  trainerUid: string,
+  clientId: string,
+): Promise<Record<string, unknown>> {
+  const db = gcFitnessFirestore();
+  const snap = await db.collection(FirestoreCollections.users).doc(clientId).get();
+  if (!snap.exists) {
+    throw new Error("Forbidden");
+  }
+  const data = snap.data() as Record<string, unknown>;
+  if (data.coachId !== trainerUid) {
+    throw new Error("Forbidden");
+  }
+  return data;
+}
+
+export async function runClientRequest(
+  clientId: string,
+  kind: ClientRequestKind,
+): Promise<ClientRequestResult> {
+  const trainer = await getCurrentTrainer();
+  const db = gcFitnessFirestore();
+  const client = await assertOwnsClient(trainer.uid, clientId);
+  const now = new Date();
+  const current = getClientRequestStatus(client[requestField(kind)], now);
+  if (current.isActive) {
+    return {
+      ok: true,
+      skipped: true,
+      requestedAt: current.requestedAt?.toISOString() ?? null,
+    };
+  }
+
+  const requestedAt = now.toISOString();
+  await db.collection(FirestoreCollections.users).doc(clientId).update({
+    [requestField(kind)]: now,
+    updatedAt: FieldValue.serverTimestamp(),
+  });
+
+  await recordCoachActivityEvent(
+    db,
+    kind === "progressPhotos"
+      ? progressPhotoRequestedEvent({
+          trainerId: trainer.uid,
+          clientId,
+          clientName:
+            (typeof client.displayName === "string" && client.displayName.trim()) ||
+            (typeof client.email === "string" && client.email.trim()) ||
+            clientId,
+          requestedAt: now,
+        })
+      : weightRequestedEvent({
+          trainerId: trainer.uid,
+          clientId,
+          clientName:
+            (typeof client.displayName === "string" && client.displayName.trim()) ||
+            (typeof client.email === "string" && client.email.trim()) ||
+            clientId,
+          requestedAt: now,
+        }),
+  );
+
+  return {
+    ok: true,
+    skipped: false,
+    requestedAt,
+  };
+}
+
+export function formatClientRequestLabel(kind: ClientRequestKind): string {
+  return requestLabel(kind);
+}

--- a/backoffice/src/lib/gc-fitness/client-request-state.ts
+++ b/backoffice/src/lib/gc-fitness/client-request-state.ts
@@ -1,0 +1,46 @@
+export const CLIENT_REQUEST_TTL_MS = 3 * 24 * 60 * 60 * 1000;
+
+export type ClientRequestKind = "progressPhotos" | "weight";
+
+export interface ClientRequestStatus {
+  requestedAt: Date | null;
+  expiresAt: Date | null;
+  isActive: boolean;
+}
+
+function requestLabel(kind: ClientRequestKind): string {
+  return kind === "progressPhotos" ? "fotos de progreso" : "peso";
+}
+
+export function getClientRequestStatus(
+  requestedAt: unknown,
+  now: Date,
+): ClientRequestStatus {
+  const requestedDate = toDate(requestedAt);
+  if (!requestedDate) {
+    return { requestedAt: null, expiresAt: null, isActive: false };
+  }
+  const expiresAt = new Date(requestedDate.getTime() + CLIENT_REQUEST_TTL_MS);
+  return {
+    requestedAt: requestedDate,
+    expiresAt,
+    isActive: expiresAt.getTime() > now.getTime(),
+  };
+}
+
+export function formatClientRequestLabel(kind: ClientRequestKind): string {
+  return requestLabel(kind);
+}
+
+function toDate(value: unknown): Date | null {
+  if (!value) return null;
+  if (value instanceof Date) return value;
+  if (typeof (value as { toDate?: () => Date }).toDate === "function") {
+    return (value as { toDate: () => Date }).toDate();
+  }
+  if (typeof value === "string") {
+    const parsed = new Date(value);
+    return Number.isNaN(parsed.getTime()) ? null : parsed;
+  }
+  return null;
+}

--- a/backoffice/src/lib/gc-fitness/coach-activity-actions.ts
+++ b/backoffice/src/lib/gc-fitness/coach-activity-actions.ts
@@ -11,6 +11,8 @@ export type CoachActivityKind =
   | "workout_assignment"
   | "habit_assignment"
   | "note"
+  | "progress_photo_request"
+  | "weight_request"
   | "chat";
 
 export interface MyCoachActivityRow {

--- a/backoffice/src/lib/gc-fitness/coach-activity-log.ts
+++ b/backoffice/src/lib/gc-fitness/coach-activity-log.ts
@@ -28,7 +28,9 @@ export type CoachActivityLogKind =
   | "exercise"
   | "workout_assignment"
   | "habit_assignment"
-  | "note";
+  | "note"
+  | "progress_photo_request"
+  | "weight_request";
 
 export interface CoachActivityEvent {
   /** Deterministic id so re-runs / per-occurrence triggers are idempotent. */
@@ -205,6 +207,44 @@ export function noteAddedEvent(args: {
     clientId: args.clientId,
     pendingEmail: null,
     occurredAt: args.occurredAt ?? null,
+  };
+}
+
+/** Coach requested new progress photos from a client. eventId `req:photo:{uid}:{stamp}`. */
+export function progressPhotoRequestedEvent(args: {
+  trainerId: string;
+  clientId: string;
+  clientName: string;
+  requestedAt: Date;
+}): CoachActivityEvent {
+  return {
+    eventId: `req:photo:${args.clientId}:${args.requestedAt.toISOString()}`,
+    trainerId: args.trainerId,
+    kind: "progress_photo_request",
+    title: `Pedir fotos de progreso: ${args.clientName}`,
+    detail: "Válido durante 3 días",
+    clientId: args.clientId,
+    pendingEmail: null,
+    occurredAt: args.requestedAt,
+  };
+}
+
+/** Coach requested a body-weight check-in from a client. eventId `req:weight:{uid}:{stamp}`. */
+export function weightRequestedEvent(args: {
+  trainerId: string;
+  clientId: string;
+  clientName: string;
+  requestedAt: Date;
+}): CoachActivityEvent {
+  return {
+    eventId: `req:weight:${args.clientId}:${args.requestedAt.toISOString()}`,
+    trainerId: args.trainerId,
+    kind: "weight_request",
+    title: `Pedir peso: ${args.clientName}`,
+    detail: "Válido durante 3 días",
+    clientId: args.clientId,
+    pendingEmail: null,
+    occurredAt: args.requestedAt,
   };
 }
 


### PR DESCRIPTION
## Summary
- Adds client profile buttons to request progress photos and body weight from the trainer backoffice.
- Tracks request timestamps for 3 days, surfaces the state in My Activity, and localizes the supporting copy.
- Pending-client workout and habit preload forms now also expose 1/3/6/12 month end-date pills and default to 3 months.
- Also includes the recent logs timezone notice and workout timer visibility polish that are already part of this branch.

## Changes
- New client request card and derived request state.
- Activity log entries for request actions.
- My Activity and recent logs copy/state updates.
- Pending-client preload forms now auto-fill end dates from the selected start date.
- Workout live-session timer visibility fix.

## Validation
- `npx tsc --noEmit --pretty false`
- `npm run build`
- `git diff --check`