### PR TITLE
Keep rest timer visible across skipped sets

### DIFF
--- a/backoffice/src/app/gc-fitness/clients/[id]/sessions/[assignmentId]/run/_components/active-workout-session.tsx
+++ b/backoffice/src/app/gc-fitness/clients/[id]/sessions/[assignmentId]/run/_components/active-workout-session.tsx
@@ -126,12 +126,6 @@ export function ActiveWorkoutSession({
     return map;
   }, [blocks]);
 
-  useEffect(() => {
-    if (!timer.active) {
-      setRestingExerciseId(null);
-    }
-  }, [timer.active]);
-
   async function finishWorkout(
     mode: FinalizeMode,
     notes: string | null,


### PR DESCRIPTION
## Summary
- Prevents the live workout rest UI from being cleared by a stale effect after the coach uses "Siguiente serie" and immediately completes the next set.
- The timer visibility still depends on `timer.active`, so removing the extra cleanup keeps the active-rest card stable across fast consecutive actions.

## Changes
- Removes the reactive `restingExerciseId` reset on `timer.active` transitions.
- Keeps the current rest target latched until the next rest starts or the workout ends.

## Validation
- `npx tsc --noEmit --pretty false`
- `git diff --check`