### PR TITLE
Hard redirect canceled workouts to notifications

### DIFF
--- a/backoffice/src/app/gc-fitness/clients/[id]/sessions/[assignmentId]/run/_components/active-workout-session.tsx
+++ b/backoffice/src/app/gc-fitness/clients/[id]/sessions/[assignmentId]/run/_components/active-workout-session.tsx
@@ -140,13 +140,13 @@ export function ActiveWorkoutSession({
       const ok = await live.cancel();
       if (ok) {
         close();
-        void queryClient.invalidateQueries({ queryKey: activeWorkoutSummariesKey() });
-        void queryClient.invalidateQueries({ queryKey: activeSessionKey(assignmentId) });
+        queryClient.removeQueries({ queryKey: activeWorkoutSummariesKey() });
+        queryClient.removeQueries({ queryKey: activeSessionKey(assignmentId) });
         toast.success("Entrenamiento cancelado · volvió a programado");
         // Cancel is an operational action, not a client-detail action.
         // Send the coach back to the notifications hub so the canceled
         // workout does not re-enter the client profile flow.
-        router.replace("/gc-fitness/notifications");
+        window.location.replace("/gc-fitness/notifications");
       }
     } finally {
       setFinishing(false);


### PR DESCRIPTION
## Summary\n- After canceling a live workout, force navigation to /gc-fitness/notifications using a hard browser redirect.\n- Clear the active workout query cache first so the canceled session cannot rehydrate from client state.\n\n## Validation\n- npx tsc --noEmit --pretty false\n- git diff --check\n\n## Notes\n- This specifically prevents the canceled workout from re-entering the client/workout flow after the cancel action completes.