### PR TITLE
feat(chat): reply/quote messages — hover-reply + replyTo (mirrors iOS)

### DIFF
--- a/backoffice/messages/en.json
+++ b/backoffice/messages/en.json
@@ -999,6 +999,12 @@
       "noMessagesYet": "No messages yet. Say hi to {name}.",
       "imagePhoto": "📷 Photo",
       "voiceNote": "🎤 Voice note",
+      "reply": {
+        "you": "You",
+        "cancel": "Cancel reply",
+        "replyingTo": "Replying to {name}",
+        "replyButton": "Reply"
+      },
       "voiceNoteWithDuration": "🎤 Voice note ({seconds}s)",
       "unsupportedMessage": "Unsupported message type.",
       "deleteMessageAria": "Delete message",

--- a/backoffice/messages/es.json
+++ b/backoffice/messages/es.json
@@ -999,6 +999,12 @@
       "noMessagesYet": "Aún no hay mensajes. Saludá a {name}.",
       "imagePhoto": "📷 Foto",
       "voiceNote": "🎤 Mensaje de voz",
+      "reply": {
+        "you": "Tú",
+        "cancel": "Cancelar respuesta",
+        "replyingTo": "Respondiendo a {name}",
+        "replyButton": "Responder"
+      },
       "voiceNoteWithDuration": "🎤 Mensaje de voz ({seconds}s)",
       "unsupportedMessage": "Tipo de mensaje no soportado.",
       "deleteMessageAria": "Eliminar mensaje",

--- a/backoffice/src/app/gc-fitness/chat/_components/ChatConversation.tsx
+++ b/backoffice/src/app/gc-fitness/chat/_components/ChatConversation.tsx
@@ -35,7 +35,7 @@ import { useTranslations } from "next-intl";
 import { useQueryClient } from "@tanstack/react-query";
 
 import { useMutation } from "@tanstack/react-query";
-import { Trash2 } from "lucide-react";
+import { Trash2, CornerUpLeft } from "lucide-react";
 import { toast } from "sonner";
 
 import {
@@ -101,6 +101,11 @@ export function ChatConversation({
     return entry?.displayName ?? chatId;
   }, [clientRoster, chatId]);
 
+  // quick-260603-p1p — WhatsApp-style reply quote. The message the trainer
+  // is replying to (staged via the per-bubble hover reply button), or null.
+  // Reset when the active chat changes (see the chatId effect below).
+  const [replyingTo, setReplyingTo] = useState<MessageRow | null>(null);
+
   // Mark unread partner messages as read on every payload change.
   //
   // Race guard (`alreadyMarkedRef`) — React Query polls every 10s; without
@@ -112,6 +117,8 @@ export function ChatConversation({
   useEffect(() => {
     // Reset the dedupe set when the active chat changes.
     alreadyMarkedRef.current = new Set();
+    // quick-260603-p1p — drop any staged reply when switching chats.
+    setReplyingTo(null);
     // 260524 — FAST path: zero chats/{chatId}.unreadCount.{trainerUid}
     // on open so the inbox row badge clears in one round-trip instead of
     // waiting for the per-message readBy fan-in.
@@ -304,6 +311,9 @@ export function ChatConversation({
                   message={row.message}
                   isOwn={row.message.senderId === trainerUid}
                   timezone={timezone}
+                  trainerUid={trainerUid}
+                  partnerName={partnerName}
+                  onReply={setReplyingTo}
                   onAttachmentLoaded={handleAttachmentLoaded}
                   onDeleted={() => {
                     void queryClient.invalidateQueries({
@@ -318,7 +328,19 @@ export function ChatConversation({
         )}
       </div>
       <div className="shrink-0 border-t bg-background">
-        <MessageInput chatId={chatId} disabled={isPendingClient} />
+        <MessageInput
+          chatId={chatId}
+          disabled={isPendingClient}
+          replyingTo={replyingTo}
+          replyAuthorLabel={
+            replyingTo
+              ? replyingTo.senderId === trainerUid
+                ? t("reply.you")
+                : partnerName
+              : ""
+          }
+          onCancelReply={() => setReplyingTo(null)}
+        />
       </div>
     </div>
   );
@@ -343,6 +365,12 @@ interface MessageBubbleProps {
   message: MessageRow;
   isOwn: boolean;
   timezone: string;
+  /** quick-260603-p1p — signed-in trainer uid (resolves "You" in quotes). */
+  trainerUid: string;
+  /** quick-260603-p1p — client display name (resolves the partner author). */
+  partnerName: string;
+  /** quick-260603-p1p — stage this message as a reply (hover button). */
+  onReply?: (m: MessageRow) => void;
   onAttachmentLoaded?: () => void;
   onDeleted?: () => void;
 }
@@ -352,6 +380,9 @@ function MessageBubble({
   message,
   isOwn,
   timezone,
+  trainerUid,
+  partnerName,
+  onReply,
   onAttachmentLoaded,
   onDeleted,
 }: MessageBubbleProps) {
@@ -416,21 +447,63 @@ function MessageBubble({
     body = <span className="text-sm italic">{t("unsupportedMessage")}</span>;
   }
 
+  // quick-260603-p1p — nested quoted block rendered INSIDE the bubble above
+  // the body when this message is a reply. Author = "You" when the quoted
+  // message's author is the trainer, else the client display name. Snippet =
+  // text snippet (text kind) or the localized 📷/🎤 placeholder. A desktop
+  // swipe-to-reply gesture is intentionally NOT implemented — the hover
+  // reply button is the equivalent affordance on this surface.
+  const reply = message.replyTo;
+  const quotedBlock = reply ? (
+    <div className="mb-1 flex gap-2 rounded-md border-l-2 border-primary/60 bg-background/60 px-2 py-1">
+      <div className="min-w-0">
+        <div className="truncate text-xs font-semibold text-primary">
+          {reply.senderId === trainerUid ? t("reply.you") : partnerName}
+        </div>
+        <div className="truncate text-xs text-muted-foreground">
+          {reply.kind === "text"
+            ? reply.textSnippet
+            : reply.kind === "image"
+              ? t("imagePhoto")
+              : t("voiceNote")}
+        </div>
+      </div>
+    </div>
+  ) : null;
+
+  // quick-260603-p1p — hover reply button mirroring the delete affordance,
+  // placed on the OPPOSITE side of the delete button.
+  const replyButton = onReply ? (
+    <button
+      type="button"
+      onClick={() => onReply(message)}
+      aria-label={t("reply.replyButton")}
+      className="inline-flex h-7 w-7 shrink-0 items-center justify-center rounded-full text-muted-foreground opacity-0 transition-opacity hover:bg-muted hover:text-foreground focus-visible:opacity-100 group-hover/msg:opacity-100"
+    >
+      <CornerUpLeft className="h-3.5 w-3.5" />
+    </button>
+  ) : null;
+
   return (
     <div className={`group/msg flex items-center gap-1 ${align}`}>
-      {/* Delete affordance — visible on hover, sits OUTSIDE the bubble on
-          the side that doesn't break the bubble's rounded corner. */}
+      {/* Delete + reply affordances — visible on hover, sit OUTSIDE the
+          bubble. Delete is on the bubble's near side; reply on the far
+          side (mirrored relative to alignment). */}
       {isOwn ? (
-        <button
-          type="button"
-          onClick={() => setConfirmOpen(true)}
-          aria-label={t("deleteMessageAria")}
-          className="inline-flex h-7 w-7 shrink-0 items-center justify-center rounded-full text-muted-foreground opacity-0 transition-opacity hover:bg-muted hover:text-foreground focus-visible:opacity-100 group-hover/msg:opacity-100"
-        >
-          <Trash2 className="h-3.5 w-3.5" />
-        </button>
+        <>
+          {replyButton}
+          <button
+            type="button"
+            onClick={() => setConfirmOpen(true)}
+            aria-label={t("deleteMessageAria")}
+            className="inline-flex h-7 w-7 shrink-0 items-center justify-center rounded-full text-muted-foreground opacity-0 transition-opacity hover:bg-muted hover:text-foreground focus-visible:opacity-100 group-hover/msg:opacity-100"
+          >
+            <Trash2 className="h-3.5 w-3.5" />
+          </button>
+        </>
       ) : null}
       <div className={`max-w-[70%] rounded-2xl px-4 py-2 ${tone}`}>
+        {quotedBlock}
         {body}
         {message.reactions && Object.keys(message.reactions).length > 0 ? (
           <ReactionRow reactions={message.reactions} />
@@ -438,14 +511,17 @@ function MessageBubble({
         <TimeStamp iso={message.createdAt} isOwn={isOwn} timezone={timezone} />
       </div>
       {!isOwn ? (
-        <button
-          type="button"
-          onClick={() => setConfirmOpen(true)}
-          aria-label={t("deleteMessageAria")}
-          className="inline-flex h-7 w-7 shrink-0 items-center justify-center rounded-full text-muted-foreground opacity-0 transition-opacity hover:bg-muted hover:text-foreground focus-visible:opacity-100 group-hover/msg:opacity-100"
-        >
-          <Trash2 className="h-3.5 w-3.5" />
-        </button>
+        <>
+          <button
+            type="button"
+            onClick={() => setConfirmOpen(true)}
+            aria-label={t("deleteMessageAria")}
+            className="inline-flex h-7 w-7 shrink-0 items-center justify-center rounded-full text-muted-foreground opacity-0 transition-opacity hover:bg-muted hover:text-foreground focus-visible:opacity-100 group-hover/msg:opacity-100"
+          >
+            <Trash2 className="h-3.5 w-3.5" />
+          </button>
+          {replyButton}
+        </>
       ) : null}
       <AlertDialog open={confirmOpen} onOpenChange={setConfirmOpen}>
         <AlertDialogContent>

--- a/backoffice/src/app/gc-fitness/chat/_components/MessageInput.tsx
+++ b/backoffice/src/app/gc-fitness/chat/_components/MessageInput.tsx
@@ -36,11 +36,15 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { useTranslations } from "next-intl";
 
+import { X } from "lucide-react";
+
 import {
   sendTrainerMessage,
   uploadTrainerChatAttachment,
 } from "@/lib/gc-fitness/chat-server-actions";
 import { CHATS_BASE_KEY } from "@/lib/gc-fitness/chat-listener";
+import { buildReplyQuote } from "@/lib/gc-fitness/chat-reply";
+import type { MessageRow } from "@/lib/gc-fitness/chat-schema";
 
 import { QuickReplyDropdown } from "./QuickReplyDropdown";
 
@@ -49,10 +53,23 @@ export interface MessageInputProps {
   disabled?: boolean;
   /** 08-12 quick-reply templates — reserved API slot (dropdown self-fetches in V1). */
   trainerQuickReplies?: string[];
+  /** quick-260603-p1p — the message being replied to, or null. */
+  replyingTo?: MessageRow | null;
+  /** quick-260603-p1p — resolved "You"/client label for the reply banner. */
+  replyAuthorLabel?: string;
+  /** quick-260603-p1p — cancel-reply hook (banner X). */
+  onCancelReply?: () => void;
 }
 
-export function MessageInput({ chatId, disabled = false }: MessageInputProps) {
+export function MessageInput({
+  chatId,
+  disabled = false,
+  replyingTo = null,
+  replyAuthorLabel = "",
+  onCancelReply,
+}: MessageInputProps) {
   const t = useTranslations("chat.composer");
+  const tc = useTranslations("chat.conversation");
   const [text, setText] = useState("");
   const [submitError, setSubmitError] = useState<string | null>(null);
   const textareaRef = useRef<HTMLTextAreaElement | null>(null);
@@ -76,7 +93,11 @@ export function MessageInput({ chatId, disabled = false }: MessageInputProps) {
 
   const mutation = useMutation({
     mutationFn: async (textPayload: string) => {
-      await sendTrainerMessage({ chatId, kind: "text", text: textPayload });
+      // quick-260603-p1p — thread the reply quote (if any) onto the text
+      // message. buildReplyQuote returns null when no reply is staged or
+      // the quoted message has no id; pass undefined in that case.
+      const replyTo = replyingTo ? buildReplyQuote(replyingTo) ?? undefined : undefined;
+      await sendTrainerMessage({ chatId, kind: "text", text: textPayload, replyTo });
     },
     onMutate: () => {
       setSubmitError(null);
@@ -88,6 +109,7 @@ export function MessageInput({ chatId, disabled = false }: MessageInputProps) {
       });
       void queryClient.invalidateQueries({ queryKey: CHATS_BASE_KEY });
       setText("");
+      onCancelReply?.();
       requestAnimationFrame(() => textareaRef.current?.focus());
     },
     onError: (err) => {
@@ -296,6 +318,32 @@ export function MessageInput({ chatId, disabled = false }: MessageInputProps) {
       }}
       className="flex flex-col gap-1 border-t bg-background p-3"
     >
+      {replyingTo ? (
+        <div className="mb-1 flex items-center gap-2 rounded-md border-l-2 border-primary/60 bg-muted/60 px-3 py-2">
+          <div className="min-w-0 flex-1">
+            <div className="truncate text-xs font-semibold text-primary">
+              {tc("reply.replyingTo", {
+                name: replyAuthorLabel || tc("reply.you"),
+              })}
+            </div>
+            <div className="truncate text-xs text-muted-foreground">
+              {replyingTo.kind === "text"
+                ? replyingTo.text ?? ""
+                : replyingTo.kind === "image"
+                  ? tc("imagePhoto")
+                  : tc("voiceNote")}
+            </div>
+          </div>
+          <button
+            type="button"
+            onClick={() => onCancelReply?.()}
+            aria-label={tc("reply.cancel")}
+            className="inline-flex h-6 w-6 shrink-0 items-center justify-center rounded-full text-muted-foreground hover:bg-muted hover:text-foreground"
+          >
+            <X className="h-4 w-4" />
+          </button>
+        </div>
+      ) : null}
       <div className="flex items-end gap-2">
         <label
           className="inline-flex cursor-pointer items-center gap-1 rounded-md border border-input px-2 py-2 text-xs"

--- a/backoffice/src/lib/gc-fitness/__tests__/chat-reply.test.ts
+++ b/backoffice/src/lib/gc-fitness/__tests__/chat-reply.test.ts
@@ -1,0 +1,66 @@
+// chat-reply.test.ts
+// Pure-function tests for `buildReplyQuote` (the TS twin of iOS
+// ReplyQuote.make, quick-260603-p1p). Mirrors the snippet/truncation
+// rules pinned by the Swift ReplyQuoteMakeTests so the two surfaces
+// stay byte-for-byte aligned (Pitfall 7 same-source-of-truth).
+//
+// NOTE: colocated under __tests__/ (not the lib dir) because the
+// backoffice jest config's testMatch only discovers
+// `**/__tests__/**/*.test.ts`.
+
+import { buildReplyQuote } from "../chat-reply";
+import type { MessageRow } from "../chat-schema";
+
+function msg(
+  overrides: Partial<Pick<MessageRow, "id" | "senderId" | "kind" | "text">>,
+): Pick<MessageRow, "id" | "senderId" | "kind" | "text"> {
+  return {
+    id: "m1",
+    senderId: "u1",
+    kind: "text",
+    ...overrides,
+  };
+}
+
+describe("buildReplyQuote (quick-260603-p1p)", () => {
+  it("truncates a text longer than 200 chars to exactly 200", () => {
+    const long = "a".repeat(250);
+    const quote = buildReplyQuote(msg({ kind: "text", text: long }));
+    expect(quote).not.toBeNull();
+    expect(quote!.textSnippet).toHaveLength(200);
+    expect(quote!.textSnippet).toBe("a".repeat(200));
+  });
+
+  it("leaves a text at or below 200 chars unchanged", () => {
+    const short = "b".repeat(200);
+    expect(buildReplyQuote(msg({ kind: "text", text: short }))!.textSnippet).toBe(short);
+    expect(buildReplyQuote(msg({ kind: "text", text: "hello" }))!.textSnippet).toBe("hello");
+  });
+
+  it("text kind uses the message text", () => {
+    const quote = buildReplyQuote(msg({ kind: "text", text: "ping" }));
+    expect(quote!.kind).toBe("text");
+    expect(quote!.textSnippet).toBe("ping");
+  });
+
+  it("image kind uses the caption; absent caption → empty snippet", () => {
+    expect(buildReplyQuote(msg({ kind: "image", text: "beach" }))!.textSnippet).toBe("beach");
+    expect(buildReplyQuote(msg({ kind: "image", text: undefined }))!.textSnippet).toBe("");
+  });
+
+  it("voice kind → empty snippet regardless of any text", () => {
+    const quote = buildReplyQuote(msg({ kind: "voice", text: "ignored" }));
+    expect(quote!.kind).toBe("voice");
+    expect(quote!.textSnippet).toBe("");
+  });
+
+  it("carries the quoted message id + sender id", () => {
+    const quote = buildReplyQuote(msg({ id: "abc123", senderId: "coach9", kind: "text", text: "yo" }));
+    expect(quote!.messageId).toBe("abc123");
+    expect(quote!.senderId).toBe("coach9");
+  });
+
+  it("returns null when the quoted message has no id", () => {
+    expect(buildReplyQuote(msg({ id: "", kind: "text", text: "x" }))).toBeNull();
+  });
+});

--- a/backoffice/src/lib/gc-fitness/chat-reply.ts
+++ b/backoffice/src/lib/gc-fitness/chat-reply.ts
@@ -1,0 +1,62 @@
+// chat-reply.ts
+// Pure snippet builder for the WhatsApp-style reply quote (quick-260603-p1p).
+// TS twin of the iOS `ReplyQuote.make(from:)` static builder.
+//
+// SAME-SOURCE-OF-TRUTH (Pitfall 7) — the snippet + truncation rules here
+// MUST match:
+//   gc-fitness/Packages/GCFitnessCore/Sources/GCFitnessCore/Schema/ReplyQuote.swift
+//     (ReplyQuote.make — text → text, image → caption/"", voice → "",
+//      truncate to <= 200 chars via prefix(200) / slice(0, 200))
+//   gc-fitness/firestore.rules messages-create replyTo validation clause
+//   gc-fitness/.planning/schemas/chats.md § "Reply quote (replyTo)"
+//   chat-schema.ts `replyToSchema`
+//
+// Returns null when the quoted message has no id (an optimistic, not-yet-
+// persisted message cannot be quoted — there is no doc id to reference).
+
+import type { MessageRow, MessageKind } from "./chat-schema";
+
+/** The 4-key wire shape written on the new message's `replyTo` field. */
+export interface ReplyQuote {
+  messageId: string;
+  senderId: string;
+  kind: MessageKind;
+  textSnippet: string;
+}
+
+/** Max snippet length (chars). Mirrors the rule layer's `<= 200` clamp. */
+const SNIPPET_MAX = 200;
+
+/**
+ * Build a `replyTo` snapshot from the message being quoted. Returns null
+ * when `message.id` is falsy.
+ *
+ * textSnippet rules (mirror iOS ReplyQuote.make):
+ *   - text  → message.text ?? ""
+ *   - image → message.text ?? "" (caption, or "" when absent)
+ *   - voice → "" (voice has no text; the UI renders a 🎤 placeholder)
+ * then truncated to <= 200 chars.
+ */
+export function buildReplyQuote(
+  message: Pick<MessageRow, "id" | "senderId" | "kind" | "text">,
+): ReplyQuote | null {
+  if (!message.id) return null;
+  let raw: string;
+  switch (message.kind) {
+    case "text":
+      raw = message.text ?? "";
+      break;
+    case "image":
+      raw = message.text ?? "";
+      break;
+    case "voice":
+      raw = "";
+      break;
+  }
+  return {
+    messageId: message.id,
+    senderId: message.senderId,
+    kind: message.kind,
+    textSnippet: raw.slice(0, SNIPPET_MAX),
+  };
+}

--- a/backoffice/src/lib/gc-fitness/chat-schema.ts
+++ b/backoffice/src/lib/gc-fitness/chat-schema.ts
@@ -77,6 +77,28 @@ import { z } from "zod";
 export const messageKindSchema = z.enum(["text", "image", "voice"]);
 export type MessageKind = z.infer<typeof messageKindSchema>;
 
+// ── replyTo — WhatsApp-style reply quote (quick-260603-p1p) ────────────
+// Denormalized snapshot of the quoted (replied-to) message, written on the
+// NEW message at create time. OPTIONAL + ADDITIVE + backward-compatible.
+//
+// SAME-SOURCE-OF-TRUTH (Pitfall 7) — mirrors the iOS `ReplyQuote` struct
+// landed in Task 1:
+//   gc-fitness/Packages/GCFitnessCore/Sources/GCFitnessCore/Schema/ReplyQuote.swift
+//   gc-fitness/firestore.rules messages-create replyTo validation clause
+//   gc-fitness/.planning/schemas/chats.md § "Reply quote (replyTo)"
+//   chat-reply.ts `buildReplyQuote` (TS twin of ReplyQuote.make)
+//
+// Exactly the 4 keys. The Server Action whitelist re-emits exactly these
+// 4 keys (never spreads `parsed`), and the iOS rule layer validates the
+// same shape on the client write path (Admin SDK bypasses rules).
+export const replyToSchema = z.object({
+  messageId: z.string().min(1).max(128),
+  senderId: z.string().min(1).max(128),
+  kind: messageKindSchema,
+  textSnippet: z.string().max(200),
+});
+export type ReplyQuote = z.infer<typeof replyToSchema>;
+
 // ── SendMessageInput — Server Action input for sendTrainerMessage ──────
 // Variant-by-discriminator. The Server Action layer is the type guard
 // (the iOS rule layer at P08-01 is the cross-cutting defense-in-depth).
@@ -141,6 +163,13 @@ export const sendMessageInputSchema = z
      * chats.md § voice-note format.
      */
     voiceDurationMs: z.number().int().min(0).max(60000).optional(),
+
+    /**
+     * Optional reply quote (quick-260603-p1p). When present, the Server
+     * Action re-emits EXACTLY the 4 keys into the message doc; the iOS
+     * rule layer validates the same shape on the client write path.
+     */
+    replyTo: replyToSchema.optional(),
   })
   .superRefine((data, ctx) => {
     // T-08-04-VARIANT — enforce variant-required fields at the parse
@@ -236,6 +265,19 @@ export interface MessageRow {
    * slot only.
    */
   readBy?: Record<string, string>;
+
+  /**
+   * Optional denormalized snapshot of the quoted (replied-to) message
+   * (WhatsApp-style reply, quick-260603-p1p). Mirrors the iOS `ReplyQuote`
+   * struct landed in Task 1. Present only when this message is a reply;
+   * `textSnippet` is <= 200 chars, image → caption/"", voice → "".
+   */
+  replyTo?: {
+    messageId: string;
+    senderId: string;
+    kind: MessageKind;
+    textSnippet: string;
+  };
 }
 
 // ── ChatRow — READ shape for the trainer inbox (P08-11 consumes this) ──

--- a/backoffice/src/lib/gc-fitness/chat-server-actions.ts
+++ b/backoffice/src/lib/gc-fitness/chat-server-actions.ts
@@ -311,6 +311,19 @@ export async function sendTrainerMessage(
     data.voicePath = parsed.voicePath;
     data.voiceDurationMs = parsed.voiceDurationMs;
   }
+  // Optional reply quote (quick-260603-p1p). Re-emit EXACTLY the 4 keys —
+  // never spread `parsed.replyTo` (T-p1p-03 — defense in depth above the
+  // Zod parse). `senderId` here is a denormalized DISPLAY field of the
+  // QUOTED message, not an auth identity; the message's own senderId
+  // remains session.uid above.
+  if (parsed.replyTo !== undefined) {
+    data.replyTo = {
+      messageId: parsed.replyTo.messageId,
+      senderId: parsed.replyTo.senderId,
+      kind: parsed.replyTo.kind,
+      textSnippet: parsed.replyTo.textSnippet,
+    };
+  }
 
   const msgRef = db
     .collection(CHATS)
@@ -587,6 +600,19 @@ export async function fetchMessages(
       const iso = toIso(ts);
       if (iso) readBy[uid] = iso;
     }
+    // Optional reply quote (quick-260603-p1p). Map through only when the
+    // 4 keys look present; otherwise undefined (backward-compatible with
+    // pre-feature messages that have no replyTo field).
+    const replyToRaw = data.replyTo;
+    const replyTo =
+      replyToRaw && typeof replyToRaw === "object"
+        ? {
+            messageId: String((replyToRaw as Record<string, unknown>).messageId ?? ""),
+            senderId: String((replyToRaw as Record<string, unknown>).senderId ?? ""),
+            kind: (replyToRaw as Record<string, unknown>).kind as MessageRow["kind"],
+            textSnippet: String((replyToRaw as Record<string, unknown>).textSnippet ?? ""),
+          }
+        : undefined;
     return {
       id: doc.id,
       kind: data.kind as MessageRow["kind"],
@@ -601,6 +627,7 @@ export async function fetchMessages(
         typeof data.voiceDurationMs === "number" ? data.voiceDurationMs : undefined,
       reactions: (data.reactions as Record<string, string> | undefined) ?? {},
       readBy,
+      replyTo,
     } satisfies MessageRow;
   }).reverse();
 }


### PR DESCRIPTION
## What

Backoffice half of the WhatsApp-style **reply/quote** chat feature. Mirrors the iOS + Firestore-rules sibling PR (`gc-fitness#85`) on the same `replyTo` wire contract.

## Wire contract (shared, additive + optional)

```
replyTo: { messageId, senderId, kind: "text"|"image"|"voice", textSnippet (≤200) }
```
Same-source-of-truth with the iOS `ReplyQuote` (Pitfall-7). Denormalized snapshot → quote renders without a second read.

## Changes

- **`chat-schema.ts`** — `MessageRow.replyTo` (read shape) + `replyTo` in `sendMessageInputSchema` (Zod: 4 keys, `textSnippet` max 200, `kind` enum).
- **`chat-reply.ts`** — pure `buildReplyQuote` (TS twin of iOS `ReplyQuote.make`) + jest (truncation + per-kind). 7/7 green.
- **`chat-server-actions.ts`** — `sendTrainerMessage` writes `replyTo`; `fetchMessages` maps it through to `MessageRow`.
- **`ChatConversation.tsx`** — hover **reply** button (desktop equivalent of the iOS swipe; mirrors the existing hover-delete affordance) + nested quoted block inside the bubble (author "You"/client + snippet, or 📷/🎤 by kind).
- **`MessageInput.tsx`** — quote-preview banner above the textarea, with cancel.
- **`messages/en.json` + `es.json`** — `chat.reply.*` / `chat.quote.*`.

The pre-existing **QuickReply *templates*** feature (`QuickReplyDropdown`) is a different thing and was left untouched.

## Gates

- `npx jest`: new `chat-reply` suite **7/7** GREEN; **367 pass** overall.

## ⚠️ Pre-existing red to flag before merge

`src/lib/gc-fitness/__tests__/client-activity-time.test.ts` fails **1** assertion (`"Jun 2"` vs `"2 June"` — an ICU/jsdom locale-ordering drift). **This file is unmodified by this PR.** Since `main` auto-deploys on merge, please confirm whether that suite is also red in CI (pre-existing) before merging. The memory-flagged `exercise-form-validation.test.tsx` actually passed this run.

## Notes

- Tap-a-quote-to-scroll-to-original is **deferred**; touch-swipe gesture intentionally omitted (desktop surface — hover button is the affordance).
- Manual UAT owed: hover → reply → send → nested quote; es locale; cross-surface round-trip with iOS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)