### PR TITLE
feat(gc-fitness): show client rest-time edits in coach activity log

### DIFF
--- a/backoffice/src/app/gc-fitness/my-activity/MyActivityFeed.tsx
+++ b/backoffice/src/app/gc-fitness/my-activity/MyActivityFeed.tsx
@@ -11,6 +11,7 @@ import {
   NotebookPen,
   PersonStanding,
   Scale,
+  Timer,
   Trash2,
 } from "lucide-react";
 
@@ -38,6 +39,7 @@ import {
 const TYPE_OPTIONS: Array<[string, string]> = [
   ["all", "Toda la actividad"],
   ["workout_assignment", "Asignaciones"],
+  ["workout_rest_edited", "Descansos editados"],
   ["habit_assignment", "Hábitos"],
   ["progress_photo_request", "Fotos pedidas"],
   ["weight_request", "Peso pedido"],
@@ -53,6 +55,7 @@ const KIND_LABEL: Record<CoachActivityKind, string> = {
   workout_template: "Workout",
   exercise: "Ejercicio",
   workout_assignment: "Asignación",
+  workout_rest_edited: "Descanso",
   habit_assignment: "Hábito",
   progress_photo_request: "Fotos",
   weight_request: "Peso",
@@ -64,6 +67,7 @@ const KIND_ICON = {
   workout_template: Dumbbell,
   exercise: PersonStanding,
   workout_assignment: ClipboardList,
+  workout_rest_edited: Timer,
   habit_assignment: ListChecks,
   progress_photo_request: Camera,
   weight_request: Scale,
@@ -79,6 +83,8 @@ const KIND_TONE: Record<CoachActivityKind, string> = {
     "border-violet-200 bg-violet-50 text-violet-700 dark:border-violet-900 dark:bg-violet-950/40 dark:text-violet-300",
   workout_assignment:
     "border-indigo-200 bg-indigo-50 text-indigo-700 dark:border-indigo-900 dark:bg-indigo-950/40 dark:text-indigo-300",
+  workout_rest_edited:
+    "border-teal-200 bg-teal-50 text-teal-700 dark:border-teal-900 dark:bg-teal-950/40 dark:text-teal-300",
   habit_assignment:
     "border-emerald-200 bg-emerald-50 text-emerald-700 dark:border-emerald-900 dark:bg-emerald-950/40 dark:text-emerald-300",
   progress_photo_request:

--- a/backoffice/src/lib/gc-fitness/coach-activity-actions.ts
+++ b/backoffice/src/lib/gc-fitness/coach-activity-actions.ts
@@ -9,6 +9,7 @@ export type CoachActivityKind =
   | "workout_template"
   | "exercise"
   | "workout_assignment"
+  | "workout_rest_edited"
   | "habit_assignment"
   | "note"
   | "progress_photo_request"

--- a/backoffice/src/lib/gc-fitness/coach-activity-log.ts
+++ b/backoffice/src/lib/gc-fitness/coach-activity-log.ts
@@ -27,6 +27,11 @@ export type CoachActivityLogKind =
   | "workout_template"
   | "exercise"
   | "workout_assignment"
+  // Emitted by the iOS-facing `editAssignmentRests` Cloud Function when a
+  // client edits the rest times of an assigned workout (written from the
+  // functions repo, not the backoffice). Listed here so the kind union stays
+  // consistent across both writers.
+  | "workout_rest_edited"
   | "habit_assignment"
   | "note"
   | "progress_photo_request"


### PR DESCRIPTION
Companion backoffice change for the **client rest-times editing** feature (iOS + Cloud Function live in the `gc-fitness` repo).

When a client edits the rest times of an assigned workout, the `editAssignmentRests` Cloud Function emits a `workout_rest_edited` event into `coach_activity`. This PR makes the coach's **My Activity** feed render it.

## Changes
- `coach-activity-actions.ts` + `coach-activity-log.ts`: add `workout_rest_edited` to both kind-union twins (reader + writer) so the types stay exhaustive.
- `MyActivityFeed.tsx`: label **"Descanso"**, `Timer` icon, teal tone, and a **"Descansos editados"** filter option.

The reader query already surfaces any `kind` for the trainer (no allowlist), so no query change was needed.

## Verification
- `npx tsc --noEmit` — clean (the `satisfies Record<CoachActivityKind, …>` maps enforce exhaustiveness).
- `npx jest` — 367/368 passing. The one red suite (`client-activity-time.test.ts`, `"Jun 2"` vs `"2 June"`) is a **pre-existing locale/date-format environment failure** unrelated to this change (that file is untouched here).

> Not merged — review by a teammate. Note: `main` auto-deploys, so this stays on a branch until approved.