### PR TITLE
fix(admin): data-hygiene server error — scan times out on Storage checks

### DIFF
--- a/backoffice/src/lib/gc-fitness/data-hygiene-actions.ts
+++ b/backoffice/src/lib/gc-fitness/data-hygiene-actions.ts
@@ -83,6 +83,35 @@ function summarize(rows: DataHygieneRow[]): Record<DataHygieneKind, number> {
   return summary;
 }
 
+/**
+ * Run `task` over `items` with a bounded number of concurrent in-flight
+ * promises. Used to parallelize the per-photo Storage existence checks in the
+ * hygiene scan: doing them sequentially made the page-load scan grow O(n) in
+ * round-trips (~400ms each) and blow the Vercel serverless timeout once enough
+ * progress photos accumulated (260604 — a 23-photo scan took ~9s of storage
+ * round-trips alone → 504 on page open). A cap keeps us from firing hundreds of
+ * Storage requests at once when the photo count is large.
+ */
+async function mapWithConcurrency<T, R>(
+  items: readonly T[],
+  limit: number,
+  task: (item: T, index: number) => Promise<R>,
+): Promise<R[]> {
+  const results: R[] = new Array(items.length);
+  let cursor = 0;
+  const workerCount = Math.max(1, Math.min(limit, items.length));
+  const workers = Array.from({ length: workerCount }, async () => {
+    while (true) {
+      const index = cursor;
+      cursor += 1;
+      if (index >= items.length) break;
+      results[index] = await task(items[index], index);
+    }
+  });
+  await Promise.all(workers);
+  return results;
+}
+
 async function deleteStorageObjectIfPresent(storagePath?: string | null): Promise<void> {
   if (!storagePath) return;
   const path = storagePath.trim();
@@ -271,6 +300,30 @@ async function loadPhotoAnomalies(): Promise<DataHygieneRow[]> {
     userMap.set(doc.id, doc.data() as Record<string, unknown>);
   }
 
+  // Pre-resolve every photo's Storage existence IN PARALLEL (bounded) before
+  // building rows. Sequential `.exists()` calls dominated the scan wall-clock
+  // and timed the page out (see mapWithConcurrency). Each result is one of
+  // "ok" (exists), "missing", or "failed" (the check itself errored).
+  const bucket = gcFitnessStorage().bucket();
+  type StorageState = "ok" | "missing" | "failed";
+  const storageStateByPath = new Map<string, StorageState>();
+  const pathsToCheck = Array.from(
+    new Set(
+      photosSnap.docs
+        .map((doc) => safeString((doc.data() as Record<string, unknown>).storagePath))
+        .filter((p): p is string => p !== null),
+    ),
+  );
+  const states = await mapWithConcurrency(pathsToCheck, 12, async (path): Promise<StorageState> => {
+    try {
+      const [exists] = await bucket.file(path).exists();
+      return exists ? "ok" : "missing";
+    } catch {
+      return "failed";
+    }
+  });
+  pathsToCheck.forEach((path, index) => storageStateByPath.set(path, states[index]));
+
   const rows: DataHygieneRow[] = [];
   for (const doc of photosSnap.docs) {
     const data = doc.data() as Record<string, unknown>;
@@ -298,12 +351,10 @@ async function loadPhotoAnomalies(): Promise<DataHygieneRow[]> {
     if (!storagePath) {
       issues.push("Missing storagePath");
     } else {
-      try {
-        const [exists] = await gcFitnessStorage().bucket().file(storagePath).exists();
-        if (!exists) {
-          issues.push("Storage object missing");
-        }
-      } catch {
+      const state = storageStateByPath.get(storagePath);
+      if (state === "missing") {
+        issues.push("Storage object missing");
+      } else if (state === "failed") {
         issues.push("Storage object check failed");
       }
     }


### PR DESCRIPTION
## Symptom
The **Data hygiene** admin page throws a server error on open.

## Root cause (confirmed against production)
I ran the real scan with the Admin SDK + the production service account and timed it:

| Phase | Time |
|---|---|
| Firestore reads (7 collections) | ~1.2s |
| **Per-photo Storage `.exists()` (23 photos, SEQUENTIAL)** | **~9.0s** |
| **Total** | **~10.2s** |

`loadPhotoAnomalies` checked each progress photo's Storage object one-at-a-time (~400ms/round-trip). With 23 photos that's ~9s; the whole scan crosses the **Vercel serverless timeout (~10s) → 504 on page load**. It grows **O(n)** with every new progress photo, so it only gets worse. The page's `try/catch` can't catch a function timeout, which is why it surfaces as a hard server error rather than the inline `loadError`.

## Fix
Pre-resolve every photo's Storage state **in parallel with bounded concurrency (12)** before building rows, instead of sequentially inside the row loop.

**Measured after fix:** storage phase **9000ms → 1001ms**, total scan **10.2s → 2.1s** — well under the timeout, and the cap keeps it from firing hundreds of Storage requests at once as photos accumulate.

No change to the reported issue semantics (`ok` / `missing` / `failed`) — purely a timing fix.

## Tests
- `npx tsc --noEmit`: clean.
- `npx jest`: 382/383 (the 1 red, `client-activity-time.test.ts` `"Jun 2"`/`"2 June"`, is a pre-existing locale/ICU failure on the clean base — unrelated).
- Verified the new parallel path against production data (23/23 objects resolve in ~1s).

🤖 Generated with [Claude Code](https://claude.com/claude-code)