### PR TITLE
Simplify workout weight pre-fill (backoffice half)

### DIFF
--- a/backoffice/messages/en.json
+++ b/backoffice/messages/en.json
@@ -514,7 +514,20 @@
       "title": "Edit template",
       "subtitlePrefix": "Changes save when you click ",
       "subtitleCta": "Save",
-      "subtitleSuffix": ". If this template is already scheduled, you'll be asked whether to push the update to those sessions."
+      "subtitleSuffix": ". If this template is already scheduled, you'll be asked whether to push the update to those sessions.",
+      "propagateDialog": {
+        "title": "Apply changes to existing schedules?",
+        "summary": "The template was saved. It's currently scheduled for {sessions, plural, one {<strong># upcoming session</strong>} other {<strong># upcoming sessions</strong>}} across {clients, plural, one {<strong># client</strong>} other {<strong># clients</strong>}}.",
+        "explainer": "Notes and structure (sets, reps, rest, order) always update on those days. Completed and in-progress sessions are never modified.",
+        "clientLine": "{name} — {sessions, plural, one {# session} other {# sessions}} (next {next})",
+        "pushWeightsLabel": "Also update clients' weights",
+        "pushWeightsHelp": "Off: each client keeps their current weights. On: clients see the new plan weights once, then their own again.",
+        "keepCta": "Keep existing schedules",
+        "updateCta": "{count, plural, one {Update # scheduled session} other {Update # scheduled sessions}}",
+        "updating": "Updating…",
+        "updatedToast": "{count, plural, one {Updated # scheduled session.} other {Updated # scheduled sessions.}}",
+        "updateFailedToast": "Could not update scheduled sessions."
+      }
     },
     "list": {
       "pageHeading": "Workout Templates",

--- a/backoffice/messages/en.json
+++ b/backoffice/messages/en.json
@@ -1216,6 +1216,10 @@
     "preferences": {
       "title": "Preferences"
     },
+    "weightPrefill": {
+      "title": "How weight pre-fill works",
+      "body": "Clients see your planned weights the first time. After they log a workout, they see their own last weights. When you change a workout's weights (edit + 'update occurrences', or a per-assignment override), the client sees the new plan once, then it goes back to remembering theirs."
+    },
     "language": {
       "title": "Language",
       "subtitle": "Choose the language for the backoffice. Persists across devices.",

--- a/backoffice/messages/en.json
+++ b/backoffice/messages/en.json
@@ -468,14 +468,6 @@
         "loading": "Loading…",
         "previous": "Previous",
         "next": "Next"
-      },
-      "preferences": {
-        "title": "Client preferences",
-        "workoutPrefillLabel": "Starting weights in the app",
-        "workoutPrefillPrevious": "Previous workout",
-        "workoutPrefillPreviousDescription": "The app starts each set from the last logged weights/reps when history exists. The client can change this in Settings.",
-        "workoutPrefillTemplate": "Trainer plan",
-        "workoutPrefillTemplateDescription": "The app starts each set from the workout plan weights/reps. The client can still tap Previous to copy the last log."
       }
     }
   },

--- a/backoffice/messages/es.json
+++ b/backoffice/messages/es.json
@@ -1216,6 +1216,10 @@
     "preferences": {
       "title": "Preferencias"
     },
+    "weightPrefill": {
+      "title": "Cómo funciona el pre-llenado de pesos",
+      "body": "Los clientes ven los pesos que planificaste la primera vez. Después de registrar un entrenamiento, ven sus propios últimos pesos. Cuando cambiás los pesos de un entrenamiento (editar + 'actualizar ocurrencias', o un ajuste por asignación), el cliente ve el nuevo plan una vez y luego vuelve a recordar los suyos."
+    },
     "language": {
       "title": "Idioma",
       "subtitle": "Elegí el idioma del backoffice. Persiste entre dispositivos.",

--- a/backoffice/messages/es.json
+++ b/backoffice/messages/es.json
@@ -514,7 +514,20 @@
       "title": "Editar plantilla",
       "subtitlePrefix": "Los cambios se guardan al tocar ",
       "subtitleCta": "Guardar",
-      "subtitleSuffix": ". Si la plantilla ya está agendada, te preguntamos si querés aplicar los cambios a esas sesiones."
+      "subtitleSuffix": ". Si la plantilla ya está agendada, te preguntamos si querés aplicar los cambios a esas sesiones.",
+      "propagateDialog": {
+        "title": "¿Aplicar los cambios a las sesiones agendadas?",
+        "summary": "La plantilla se guardó. Actualmente está agendada en {sessions, plural, one {<strong># sesión próxima</strong>} other {<strong># sesiones próximas</strong>}} para {clients, plural, one {<strong># cliente</strong>} other {<strong># clientes</strong>}}.",
+        "explainer": "Las notas y la estructura (series, repeticiones, descanso, orden) siempre se actualizan en esos días. Las sesiones completadas o en curso nunca se modifican.",
+        "clientLine": "{name} — {sessions, plural, one {# sesión} other {# sesiones}} (próxima {next})",
+        "pushWeightsLabel": "Actualizar también los pesos de los clientes",
+        "pushWeightsHelp": "Desactivado: cada cliente conserva sus pesos actuales. Activado: los clientes ven los pesos del nuevo plan una vez y luego vuelven a los suyos.",
+        "keepCta": "Mantener las sesiones agendadas",
+        "updateCta": "{count, plural, one {Actualizar # sesión agendada} other {Actualizar # sesiones agendadas}}",
+        "updating": "Actualizando…",
+        "updatedToast": "{count, plural, one {Se actualizó # sesión agendada.} other {Se actualizaron # sesiones agendadas.}}",
+        "updateFailedToast": "No se pudieron actualizar las sesiones agendadas."
+      }
     },
     "list": {
       "pageHeading": "Plantillas de entrenamiento",

--- a/backoffice/messages/es.json
+++ b/backoffice/messages/es.json
@@ -468,14 +468,6 @@
         "loading": "Cargando…",
         "previous": "Anterior",
         "next": "Siguiente"
-      },
-      "preferences": {
-        "title": "Preferencias del cliente",
-        "workoutPrefillLabel": "Pesos iniciales en la app",
-        "workoutPrefillPrevious": "Entrenamiento anterior",
-        "workoutPrefillPreviousDescription": "La app empieza cada serie con los últimos pesos/reps registrados cuando hay historial. El cliente puede cambiarlo en Ajustes.",
-        "workoutPrefillTemplate": "Rutina del coach",
-        "workoutPrefillTemplateDescription": "La app empieza cada serie con los pesos/reps planificados en la rutina. El cliente igual puede tocar Anterior para copiar el último registro."
       }
     }
   },

--- a/backoffice/src/app/gc-fitness/clients/[id]/page.tsx
+++ b/backoffice/src/app/gc-fitness/clients/[id]/page.tsx
@@ -124,9 +124,6 @@ export default async function ClientDetailPage({
     bodyWeightKg?: number;
     progressPhotosRequestedAt?: unknown;
     bodyWeightRequestedAt?: unknown;
-    preferences?: {
-      workoutPrefillSource?: string;
-    };
   };
   if (client.coachId !== trainer.uid) notFound();
 
@@ -151,11 +148,6 @@ export default async function ClientDetailPage({
     progressPhotos,
   );
   const tSkeleton = await getTranslations("clients.detail.skeleton");
-  const tPreferences = await getTranslations("clients.detail.preferences");
-  const workoutPrefillSource =
-    client.preferences?.workoutPrefillSource === "template"
-      ? "template"
-      : "previousWorkout";
 
   return (
     <div className="gc-page flex w-full flex-col gap-6">
@@ -167,21 +159,6 @@ export default async function ClientDetailPage({
         heightCm={typeof client.heightCm === "number" ? client.heightCm : null}
         bodyWeightKg={typeof client.bodyWeightKg === "number" ? client.bodyWeightKg : null}
       />
-      <ClientWorkoutPreferencesCard
-        title={tPreferences("title")}
-        label={tPreferences("workoutPrefillLabel")}
-        value={
-          workoutPrefillSource === "template"
-            ? tPreferences("workoutPrefillTemplate")
-            : tPreferences("workoutPrefillPrevious")
-        }
-        description={
-          workoutPrefillSource === "template"
-            ? tPreferences("workoutPrefillTemplateDescription")
-            : tPreferences("workoutPrefillPreviousDescription")
-        }
-      />
-
       <ClientSummaryCard
         clientId={id}
         clientName={displayName}
@@ -232,33 +209,6 @@ export default async function ClientDetailPage({
         </Suspense>
       </div>
     </div>
-  );
-}
-
-function ClientWorkoutPreferencesCard({
-  title,
-  label,
-  value,
-  description,
-}: {
-  title: string;
-  label: string;
-  value: string;
-  description: string;
-}) {
-  return (
-    <section className="rounded-[1.25rem] border border-border bg-card p-5 shadow-sm">
-      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
-        <div>
-          <p className="section-eyebrow">{title}</p>
-          <h2 className="text-lg font-semibold">{label}</h2>
-          <p className="mt-1 text-sm text-muted-foreground">{description}</p>
-        </div>
-        <span className="w-fit rounded-full border border-border bg-muted px-3 py-1 text-sm font-medium">
-          {value}
-        </span>
-      </div>
-    </section>
   );
 }
 

--- a/backoffice/src/app/gc-fitness/clients/[id]/sessions/[assignmentId]/run/_components/use-live-session.ts
+++ b/backoffice/src/app/gc-fitness/clients/[id]/sessions/[assignmentId]/run/_components/use-live-session.ts
@@ -62,14 +62,35 @@ function isTimeMetric(ex: SessionExercise): boolean {
   return ex.metric === "time";
 }
 
-/** The assignment's prescription-freshness anchor as a Date (or null). The
- *  Server Action surfaces `prescriptionUpdatedAt ?? createdAt` already, so a
- *  null here only happens on the rare doc with neither stamp. */
-function parsePrescriptionUpdatedAt(session: ActiveSession): Date | null {
-  const iso = session.prescriptionUpdatedAt;
+/** Parse an ISO string to a Date, or null when absent/unparseable. */
+function parseIsoDate(iso: string | null | undefined): Date | null {
   if (!iso) return null;
   const d = new Date(iso);
   return Number.isNaN(d.getTime()) ? null : d;
+}
+
+/** The assignment's DOC-LEVEL prescription-freshness anchor as a Date (or
+ *  null). The Server Action surfaces `prescriptionUpdatedAt ?? createdAt`
+ *  already, so a null here only happens on the rare doc with neither stamp.
+ *  This is the per-exercise resolver's FALLBACK when no per-exercise override
+ *  exists. */
+function parsePrescriptionUpdatedAt(session: ActiveSession): Date | null {
+  return parseIsoDate(session.prescriptionUpdatedAt);
+}
+
+/** The per-exercise prescription anchor for `exerciseId`:
+ *  `prescriptionUpdatedAtByExerciseId[exerciseId] ?? prescriptionUpdatedAt
+ *  (?? createdAt, already folded into docLevel)`. Lets a coach push the routine
+ *  for ONE exercise without resetting the others. */
+function prescriptionUpdatedAtForExercise(
+  session: ActiveSession,
+  exerciseId: string,
+  docLevel: Date | null,
+): Date | null {
+  const perExercise = parseIsoDate(
+    session.prescriptionUpdatedAtByExerciseId?.[exerciseId],
+  );
+  return perExercise ?? docLevel;
 }
 
 /** Build the initial rows for an exercise via the SHARED weight-prefill rule
@@ -84,6 +105,9 @@ function parsePrescriptionUpdatedAt(session: ActiveSession): Date | null {
 function initialRows(
   ex: SessionExercise,
   previous: PreviousSessionMap,
+  /** The PER-EXERCISE prescription anchor for `ex`
+   *  (`prescriptionUpdatedAtByExerciseId[ex.exerciseId] ?? doc-level`).
+   *  Resolved by the caller via `prescriptionUpdatedAtForExercise`. */
   prescriptionUpdatedAt: Date | null,
 ): SetRowState[] {
   const count = Math.max(1, ex.sets);
@@ -188,9 +212,17 @@ export function useLiveSession(
     () => {
       if (!bootstrapSession) return {};
       const base: Record<string, SetRowState[]> = {};
-      const prescriptionUpdatedAt = parsePrescriptionUpdatedAt(bootstrapSession);
+      const docLevel = parsePrescriptionUpdatedAt(bootstrapSession);
       for (const ex of bootstrapSession.exercises) {
-        base[ex.exerciseId] = initialRows(ex, previousRef.current, prescriptionUpdatedAt);
+        base[ex.exerciseId] = initialRows(
+          ex,
+          previousRef.current,
+          prescriptionUpdatedAtForExercise(
+            bootstrapSession,
+            ex.exerciseId,
+            docLevel,
+          ),
+        );
       }
       return hydrateLoggedSets(base, bootstrapSession.sets);
     },
@@ -211,8 +243,13 @@ export function useLiveSession(
         const s = await startWorkoutSession({ assignmentId });
         if (cancelled) return;
         const base: Record<string, SetRowState[]> = {};
-        const prescriptionUpdatedAt = parsePrescriptionUpdatedAt(s);
-        for (const ex of s.exercises) base[ex.exerciseId] = initialRows(ex, previousRef.current, prescriptionUpdatedAt);
+        const docLevel = parsePrescriptionUpdatedAt(s);
+        for (const ex of s.exercises)
+          base[ex.exerciseId] = initialRows(
+            ex,
+            previousRef.current,
+            prescriptionUpdatedAtForExercise(s, ex.exerciseId, docLevel),
+          );
         setSession(s);
         setExercises(s.exercises);
         setRowsByExercise(hydrateLoggedSets(base, s.sets));

--- a/backoffice/src/app/gc-fitness/clients/[id]/sessions/[assignmentId]/run/_components/use-live-session.ts
+++ b/backoffice/src/app/gc-fitness/clients/[id]/sessions/[assignmentId]/run/_components/use-live-session.ts
@@ -24,6 +24,7 @@ import type {
   SessionExercise,
   SessionSetLog,
 } from "@/lib/gc-fitness/live-workout-types";
+import { resolveSetPrefill } from "@/lib/gc-fitness/weight-prefill";
 
 export interface SetRowState {
   /** Stable lowercased UUID — the SetLog id (arrayUnion dedup key). */
@@ -61,31 +62,59 @@ function isTimeMetric(ex: SessionExercise): boolean {
   return ex.metric === "time";
 }
 
-/** Build the initial rows for an exercise, prefilling from the template
- *  prescription, then the previous-session map, then zeros. */
+/** The assignment's prescription-freshness anchor as a Date (or null). The
+ *  Server Action surfaces `prescriptionUpdatedAt ?? createdAt` already, so a
+ *  null here only happens on the rare doc with neither stamp. */
+function parsePrescriptionUpdatedAt(session: ActiveSession): Date | null {
+  const iso = session.prescriptionUpdatedAt;
+  if (!iso) return null;
+  const d = new Date(iso);
+  return Number.isNaN(d.getTime()) ? null : d;
+}
+
+/** Build the initial rows for an exercise via the SHARED weight-prefill rule
+ *  (`resolveSetPrefill` — the TS twin of Swift `WeightPrefillResolver`):
+ *  "most recent intent wins". First time → coach's routine; after the client
+ *  logged → their last value; coach changed the plan after that → routine once.
+ *
+ *  Per-set-index history is not available on the backoffice side — the
+ *  PreviousSessionMap carries ONE representative (heaviest) prior value per
+ *  exercise plus its `lastLoggedAt`, so we feed that same `previous` to every
+ *  set index (matching the column the coach already sees in "ANTERIOR"). */
 function initialRows(
   ex: SessionExercise,
   previous: PreviousSessionMap,
+  prescriptionUpdatedAt: Date | null,
 ): SetRowState[] {
   const count = Math.max(1, ex.sets);
   const prev = previous[ex.exerciseId];
   const time = isTimeMetric(ex);
+  const lastLoggedAt = prev?.lastLoggedAt ? new Date(prev.lastLoggedAt) : null;
+  const previousValue = prev
+    ? {
+        weightKg: prev.weightKg,
+        reps: prev.reps,
+        durationSeconds: prev.durationSeconds ?? null,
+      }
+    : null;
   return Array.from({ length: count }, (_, idx) => {
-    const weightKg =
-      ex.weightBySetKg?.[idx] ?? prev?.weightKg ?? 0;
-    const reps =
-      ex.repsBySet?.[idx] ?? (ex.reps || prev?.reps || 0);
-    const durationSeconds = time
-      ? ex.durationBySetSeconds?.[idx] ??
-        ex.durationSeconds ??
-        prev?.durationSeconds ??
-        null
-      : null;
+    const resolved = resolveSetPrefill({
+      templateWeightKg: ex.weightBySetKg?.[idx] ?? null,
+      templateReps: ex.repsBySet?.[idx] ?? (ex.reps || null),
+      templateDurationSeconds: time
+        ? ex.durationBySetSeconds?.[idx] ?? ex.durationSeconds ?? null
+        : null,
+      exerciseDefaultReps: ex.reps || 0,
+      exerciseDefaultDurationSeconds: time ? ex.durationSeconds ?? null : null,
+      previous: previousValue,
+      prescriptionUpdatedAt,
+      lastLoggedAt,
+    });
     return {
       id: newId(),
-      weightKg,
-      reps,
-      durationSeconds,
+      weightKg: resolved.weightKg,
+      reps: resolved.reps,
+      durationSeconds: time ? resolved.durationSeconds : null,
       isWarmup: false,
       done: false,
       completedAt: null,
@@ -159,8 +188,9 @@ export function useLiveSession(
     () => {
       if (!bootstrapSession) return {};
       const base: Record<string, SetRowState[]> = {};
+      const prescriptionUpdatedAt = parsePrescriptionUpdatedAt(bootstrapSession);
       for (const ex of bootstrapSession.exercises) {
-        base[ex.exerciseId] = initialRows(ex, previousRef.current);
+        base[ex.exerciseId] = initialRows(ex, previousRef.current, prescriptionUpdatedAt);
       }
       return hydrateLoggedSets(base, bootstrapSession.sets);
     },
@@ -181,7 +211,8 @@ export function useLiveSession(
         const s = await startWorkoutSession({ assignmentId });
         if (cancelled) return;
         const base: Record<string, SetRowState[]> = {};
-        for (const ex of s.exercises) base[ex.exerciseId] = initialRows(ex, previousRef.current);
+        const prescriptionUpdatedAt = parsePrescriptionUpdatedAt(s);
+        for (const ex of s.exercises) base[ex.exerciseId] = initialRows(ex, previousRef.current, prescriptionUpdatedAt);
         setSession(s);
         setExercises(s.exercises);
         setRowsByExercise(hydrateLoggedSets(base, s.sets));

--- a/backoffice/src/app/gc-fitness/settings/settings-sections.tsx
+++ b/backoffice/src/app/gc-fitness/settings/settings-sections.tsx
@@ -19,6 +19,7 @@
 import { useEffect, useState, type ReactNode } from "react";
 import {
   ChevronRight,
+  Dumbbell,
   Languages,
   MessageSquareText,
   MoonStar,
@@ -267,6 +268,7 @@ export function SettingsSections({
   const tLang = useTranslations("settings.language");
   const tPrefs = useTranslations("settings.preferences");
   const tTheme = useTranslations("settings.theme");
+  const tWeight = useTranslations("settings.weightPrefill");
 
   return (
     <div className="flex flex-col gap-6">
@@ -289,6 +291,27 @@ export function SettingsSections({
             trailing={<ThemeSegmentedControl />}
             last
           />
+        </Section>
+      </div>
+
+      {/* How client weight pre-fill behaves — the "most recent intent wins"
+          rule shared with the iOS/watch apps (resolveSetPrefill twin). A
+          static explainer so coaches understand why a client sometimes sees
+          their own last weights and sometimes the freshly-planned ones. */}
+      <div className="flex flex-col gap-2">
+        <SectionLabel>{tSettings("preferencesGroup")}</SectionLabel>
+        <Section>
+          <div className="flex items-start gap-3 px-4 py-3.5">
+            <IconChip tone="success" icon={<Dumbbell />} />
+            <div className="min-w-0 flex-1">
+              <p className="text-sm font-semibold text-foreground">
+                {tWeight("title")}
+              </p>
+              <p className="mt-1 text-sm text-muted-foreground">
+                {tWeight("body")}
+              </p>
+            </div>
+          </div>
         </Section>
       </div>
 

--- a/backoffice/src/app/gc-fitness/templates/[id]/edit/client.tsx
+++ b/backoffice/src/app/gc-fitness/templates/[id]/edit/client.tsx
@@ -9,9 +9,16 @@
 //
 // Existing snapshots are deliberately preserved by default (Plan 04-05's
 // WTPL-07 immutability decision). The propagation path is opt-in.
+//
+// Weight handling within the propagation: notes + structure (sets/reps/rest)
+// ALWAYS flow through, but each client's own per-exercise WEIGHTS are preserved
+// unless the trainer opts in via the "Also update clients' weights" toggle
+// (default OFF). Off keeps each client's remembered weights and avoids a
+// spurious "coach updated" alert; on replaces them with the plan weights once.
 
 import { useCallback, useState } from "react";
 import { useRouter } from "next/navigation";
+import { useTranslations } from "next-intl";
 import { toast } from "sonner";
 
 import {
@@ -24,6 +31,7 @@ import {
   AlertDialogHeader,
   AlertDialogTitle,
 } from "@/components/ui/alert-dialog";
+import { Checkbox } from "@/components/ui/checkbox";
 import { TemplateForm } from "@/components/gc-fitness/template-form";
 import { updateWorkoutTemplate } from "@/lib/gc-fitness/workout-template-actions";
 import {
@@ -40,8 +48,12 @@ export interface EditTemplateClientProps {
 
 export function EditTemplateClient({ id, defaults }: EditTemplateClientProps) {
   const router = useRouter();
+  const t = useTranslations("templates.editPage.propagateDialog");
   const [preview, setPreview] = useState<TemplatePropagationPreview | null>(null);
   const [propagating, setPropagating] = useState(false);
+  // Default OFF: preserve each client's own weights. Reset whenever a new
+  // preview opens so the choice never leaks across template saves.
+  const [pushWeights, setPushWeights] = useState(false);
 
   const handleSubmit = useCallback(
     async (input: WorkoutTemplateInput) => {
@@ -55,6 +67,7 @@ export function EditTemplateClient({ id, defaults }: EditTemplateClientProps) {
         console.error("[template-edit] preview failed", err);
       }
       if (nextPreview && nextPreview.assignmentCount > 0) {
+        setPushWeights(false);
         setPreview(nextPreview);
         return { ok: true as const, deferNavigation: true };
       }
@@ -71,25 +84,21 @@ export function EditTemplateClient({ id, defaults }: EditTemplateClientProps) {
   const handlePropagate = useCallback(async () => {
     setPropagating(true);
     try {
-      const result = await propagateTemplateToFutureAssignments(id);
-      toast.success(
-        result.updatedCount === 1
-          ? "Updated 1 scheduled session."
-          : `Updated ${result.updatedCount} scheduled sessions.`,
-      );
+      const result = await propagateTemplateToFutureAssignments(id, {
+        pushWeights,
+      });
+      toast.success(t("updatedToast", { count: result.updatedCount }));
       setPreview(null);
       router.back();
     } catch (err) {
       console.error("[template-edit] propagate failed", err);
       const message =
-        err instanceof Error
-          ? err.message
-          : "Could not update scheduled sessions.";
+        err instanceof Error ? err.message : t("updateFailedToast");
       toast.error(message);
     } finally {
       setPropagating(false);
     }
-  }, [id, router]);
+  }, [id, pushWeights, router, t]);
 
   return (
     <>
@@ -112,56 +121,61 @@ export function EditTemplateClient({ id, defaults }: EditTemplateClientProps) {
       >
         <AlertDialogContent>
           <AlertDialogHeader>
-            <AlertDialogTitle>Apply changes to existing schedules?</AlertDialogTitle>
+            <AlertDialogTitle>{t("title")}</AlertDialogTitle>
             <AlertDialogDescription asChild>
               <div className="space-y-3 text-sm text-muted-foreground">
                 <p>
-                  The template was saved. It’s currently scheduled for{" "}
-                  <strong className="text-foreground">
-                    {preview?.assignmentCount ?? 0} upcoming session
-                    {preview?.assignmentCount === 1 ? "" : "s"}
-                  </strong>{" "}
-                  across{" "}
-                  <strong className="text-foreground">
-                    {preview?.clients.length ?? 0} client
-                    {preview?.clients.length === 1 ? "" : "s"}
-                  </strong>
-                  . By default those sessions keep the version your clients
-                  were originally given.
+                  {t.rich("summary", {
+                    sessions: preview?.assignmentCount ?? 0,
+                    clients: preview?.clients.length ?? 0,
+                    strong: (chunks) => (
+                      <strong className="text-foreground">{chunks}</strong>
+                    ),
+                  })}
                 </p>
                 {preview && preview.clients.length > 0 ? (
                   <ul className="max-h-48 list-disc space-y-1 overflow-y-auto rounded-md border border-border/70 bg-background/40 px-4 py-2 text-xs text-foreground">
                     {preview.clients.map((client) => (
                       <li key={client.uid}>
-                        <span className="font-medium">{client.name}</span>
-                        <span className="text-muted-foreground">
-                          {" "}
-                          — {client.sessions} session
-                          {client.sessions === 1 ? "" : "s"} (next{" "}
-                          {client.nextScheduledFor})
-                        </span>
+                        {t("clientLine", {
+                          name: client.name,
+                          sessions: client.sessions,
+                          next: client.nextScheduledFor,
+                        })}
                       </li>
                     ))}
                   </ul>
                 ) : null}
-                <p className="text-xs">
-                  Updating will replace the workout the client sees on those
-                  days with the new version. Completed and in-progress sessions
-                  are never modified.
-                </p>
+                <p className="text-xs">{t("explainer")}</p>
+                <label className="flex items-start gap-3 rounded-md border border-border/70 bg-background/40 px-4 py-3 text-foreground">
+                  <Checkbox
+                    checked={pushWeights}
+                    onCheckedChange={(checked) =>
+                      setPushWeights(checked === true)
+                    }
+                    disabled={propagating}
+                    className="mt-0.5"
+                  />
+                  <span className="space-y-1">
+                    <span className="block text-sm font-medium">
+                      {t("pushWeightsLabel")}
+                    </span>
+                    <span className="block text-xs text-muted-foreground">
+                      {t("pushWeightsHelp")}
+                    </span>
+                  </span>
+                </label>
               </div>
             </AlertDialogDescription>
           </AlertDialogHeader>
           <AlertDialogFooter>
             <AlertDialogCancel onClick={handleKeep} disabled={propagating}>
-              Keep existing schedules
+              {t("keepCta")}
             </AlertDialogCancel>
             <AlertDialogAction onClick={handlePropagate} disabled={propagating}>
               {propagating
-                ? "Updating…"
-                : `Update ${preview?.assignmentCount ?? 0} scheduled session${
-                    preview?.assignmentCount === 1 ? "" : "s"
-                  }`}
+                ? t("updating")
+                : t("updateCta", { count: preview?.assignmentCount ?? 0 })}
             </AlertDialogAction>
           </AlertDialogFooter>
         </AlertDialogContent>

--- a/backoffice/src/app/gc-fitness/templates/[id]/edit/client.tsx
+++ b/backoffice/src/app/gc-fitness/templates/[id]/edit/client.tsx
@@ -119,11 +119,13 @@ export function EditTemplateClient({ id, defaults }: EditTemplateClientProps) {
           }
         }}
       >
-        <AlertDialogContent>
+        <AlertDialogContent className="max-h-[calc(100vh-2rem)] max-w-[calc(100vw-2rem)] overflow-y-auto sm:max-w-2xl">
           <AlertDialogHeader>
-            <AlertDialogTitle>{t("title")}</AlertDialogTitle>
-            <AlertDialogDescription asChild>
-              <div className="space-y-3 text-sm text-muted-foreground">
+            <AlertDialogTitle className="text-left leading-snug">
+              {t("title")}
+            </AlertDialogTitle>
+            <AlertDialogDescription asChild className="text-left">
+              <div className="min-w-0 space-y-3 text-left text-sm text-muted-foreground">
                 <p>
                   {t.rich("summary", {
                     sessions: preview?.assignmentCount ?? 0,
@@ -136,7 +138,7 @@ export function EditTemplateClient({ id, defaults }: EditTemplateClientProps) {
                 {preview && preview.clients.length > 0 ? (
                   <ul className="max-h-48 list-disc space-y-1 overflow-y-auto rounded-md border border-border/70 bg-background/40 px-4 py-2 text-xs text-foreground">
                     {preview.clients.map((client) => (
-                      <li key={client.uid}>
+                      <li key={client.uid} className="break-words">
                         {t("clientLine", {
                           name: client.name,
                           sessions: client.sessions,
@@ -156,11 +158,11 @@ export function EditTemplateClient({ id, defaults }: EditTemplateClientProps) {
                     disabled={propagating}
                     className="mt-0.5"
                   />
-                  <span className="space-y-1">
-                    <span className="block text-sm font-medium">
+                  <span className="min-w-0 space-y-1">
+                    <span className="block break-words text-sm font-medium">
                       {t("pushWeightsLabel")}
                     </span>
-                    <span className="block text-xs text-muted-foreground">
+                    <span className="block break-words text-xs text-muted-foreground">
                       {t("pushWeightsHelp")}
                     </span>
                   </span>
@@ -168,11 +170,19 @@ export function EditTemplateClient({ id, defaults }: EditTemplateClientProps) {
               </div>
             </AlertDialogDescription>
           </AlertDialogHeader>
-          <AlertDialogFooter>
-            <AlertDialogCancel onClick={handleKeep} disabled={propagating}>
+          <AlertDialogFooter className="flex-col-reverse gap-2 sm:flex-row sm:flex-wrap">
+            <AlertDialogCancel
+              onClick={handleKeep}
+              disabled={propagating}
+              className="h-auto min-h-9 whitespace-normal text-center"
+            >
               {t("keepCta")}
             </AlertDialogCancel>
-            <AlertDialogAction onClick={handlePropagate} disabled={propagating}>
+            <AlertDialogAction
+              onClick={handlePropagate}
+              disabled={propagating}
+              className="h-auto min-h-9 whitespace-normal text-center"
+            >
               {propagating
                 ? t("updating")
                 : t("updateCta", { count: preview?.assignmentCount ?? 0 })}

--- a/backoffice/src/components/gc-fitness/schedule/workout-assignment-edit-dialog.tsx
+++ b/backoffice/src/components/gc-fitness/schedule/workout-assignment-edit-dialog.tsx
@@ -224,8 +224,18 @@ export function WorkoutAssignmentEditDialog({
         </DialogHeader>
 
         <div className="flex flex-1 min-h-0 flex-col gap-4 overflow-y-auto -mx-4 px-4">
+          <div className="flex items-start gap-2 rounded-lg border bg-muted/40 px-3 py-2 text-sm text-muted-foreground">
+            <Info className="mt-0.5 h-4 w-4 shrink-0" />
+            <span>
+              Si cambiás los <strong className="font-medium text-foreground">pesos</strong>, el
+              alumno verá los nuevos la próxima vez que haga esta rutina y después
+              vuelve a usar los suyos. Cambiar solo notas o descanso{" "}
+              <strong className="font-medium text-foreground">no toca</strong> los pesos
+              que ya viene usando.
+            </span>
+          </div>
           {isSeries ? (
-            <div className="rounded-lg border border-amber-400/40 bg-amber-500/5 px-3 py-2 text-sm text-amber-100">
+            <div className="rounded-lg border border-amber-400/40 bg-amber-500/5 px-3 py-2 text-sm text-amber-700 dark:text-amber-100">
               Esta asignación pertenece a una recurrencia. Elegí abajo si los
               cambios aplican solo a esta fecha o también a las siguientes
               ocurrencias antes de guardar.
@@ -262,7 +272,7 @@ export function WorkoutAssignmentEditDialog({
                           className="h-8 w-20 rounded-md border bg-background px-2 text-sm text-foreground"
                         />
                       </label>
-                      <label className="flex items-center gap-1.5 rounded-full border border-amber-400/60 bg-amber-500/5 px-2 py-1 text-xs text-amber-100">
+                      <label className="flex items-center gap-1.5 rounded-full border border-amber-400/60 bg-amber-500/5 px-2 py-1 text-xs text-amber-700 dark:text-amber-100">
                         Descanso entre ejercicios (s)
                         <InfoTooltip
                           text="Este es el descanso que el cliente ve después de terminar el ejercicio anterior. Si el siguiente ejercicio planificado es distinto, se usa como pausa antes de empezar el siguiente bloque."

--- a/backoffice/src/components/gc-fitness/schedule/workout-assignment-edit-dialog.tsx
+++ b/backoffice/src/components/gc-fitness/schedule/workout-assignment-edit-dialog.tsx
@@ -296,12 +296,17 @@ export function WorkoutAssignmentEditDialog({
                     <span>Kg</span>
                     <span />
                   </div>
-                  {draft.setRows.map((row, rowIdx) => (
+                  {draft.setRows.map((row, rowIdx) => {
+                    const lastLogged =
+                      data.lastLoggedSetsByExerciseId?.[ex.exerciseId]?.[
+                        rowIdx
+                      ];
+                    return (
                     <div
                       key={rowIdx}
-                      className="mt-1 grid grid-cols-[28px_minmax(80px,1fr)_minmax(80px,1fr)_max-content] items-center gap-2"
+                      className="mt-1 grid grid-cols-[28px_minmax(80px,1fr)_minmax(80px,1fr)_max-content] items-start gap-2"
                     >
-                      <span className="text-xs text-muted-foreground">
+                      <span className="pt-2 text-xs text-muted-foreground">
                         {rowIdx + 1}
                       </span>
                       <input
@@ -313,17 +318,24 @@ export function WorkoutAssignmentEditDialog({
                         }
                         className="h-9 rounded-md border bg-background px-2 text-sm"
                       />
-                      <input
-                        type="text"
-                        inputMode="decimal"
-                        value={row.kg}
-                        placeholder="Kg"
-                        onChange={(e) =>
-                          patchRow(ex.index, rowIdx, { kg: e.target.value })
-                        }
-                        className="h-9 rounded-md border bg-background px-2 text-sm"
-                      />
-                      <div className="flex items-center justify-end gap-1">
+                      <div className="flex flex-col gap-0.5">
+                        <input
+                          type="text"
+                          inputMode="decimal"
+                          value={row.kg}
+                          placeholder="Kg"
+                          onChange={(e) =>
+                            patchRow(ex.index, rowIdx, { kg: e.target.value })
+                          }
+                          className="h-9 rounded-md border bg-background px-2 text-sm"
+                        />
+                        {lastLogged ? (
+                          <span className="px-0.5 text-[10px] text-muted-foreground">
+                            Último: {lastLogged.weightKg}kg × {lastLogged.reps}
+                          </span>
+                        ) : null}
+                      </div>
+                      <div className="flex items-center justify-end gap-1 pt-1">
                         {rowIdx === 0 ? (
                           <button
                             type="button"
@@ -353,7 +365,8 @@ export function WorkoutAssignmentEditDialog({
                         </button>
                       </div>
                     </div>
-                  ))}
+                    );
+                  })}
                   <button
                     type="button"
                     tabIndex={-1}

--- a/backoffice/src/components/gc-fitness/template-form.tsx
+++ b/backoffice/src/components/gc-fitness/template-form.tsx
@@ -1954,8 +1954,8 @@ export function TemplateForm({
                                     className={cn(
                                       "inline-flex h-8 items-center rounded-full border px-3 text-xs font-medium transition-colors",
                                       active
-                                        ? "border-amber-400 bg-amber-400/15 text-amber-100"
-                                        : "border-border/70 bg-background text-foreground hover:border-amber-400/60 hover:text-amber-100",
+                                        ? "border-amber-400 bg-amber-400/15 text-amber-700 dark:text-amber-100"
+                                        : "border-border/70 bg-background text-foreground hover:border-amber-400/60 hover:text-amber-700 dark:text-amber-100",
                                     )}
                                   >
                                     {group}
@@ -2004,7 +2004,7 @@ export function TemplateForm({
                     />
                     <div className="rounded-lg border border-amber-500/40 bg-amber-500/5 p-3">
                       <div className="flex items-center gap-2">
-                        <FormLabel className="text-amber-100">
+                        <FormLabel className="text-amber-700 dark:text-amber-100">
                           {t("transitionRestSeconds")}
                         </FormLabel>
                         <InfoTooltip

--- a/backoffice/src/lib/gc-fitness/__tests__/weight-diff.test.ts
+++ b/backoffice/src/lib/gc-fitness/__tests__/weight-diff.test.ts
@@ -1,0 +1,121 @@
+// __tests__/weight-diff.test.ts
+// Unit tests for the pure weight-diff helper that decides WHEN a prescription
+// write should bump the `prescriptionUpdatedAt` freshness anchor. This is
+// sensitive logic — a false positive nags every client and resets their
+// remembered weights; a false negative silently swallows a real coach change.
+
+import {
+  weightsDifferBetweenSnapshots,
+  exercisesOf,
+  type WeightComparableExercise,
+} from "../weight-diff";
+
+const ex = (
+  exerciseId: string,
+  weightBySetKg: number[] | undefined,
+  extra: Record<string, unknown> = {},
+): WeightComparableExercise => ({
+  exerciseId,
+  ...(weightBySetKg !== undefined ? { weightBySetKg } : {}),
+  ...extra,
+});
+
+describe("weightsDifferBetweenSnapshots", () => {
+  it("notes-only change → false", () => {
+    const before = [ex("a", [20, 20], { notes: "old" })];
+    const after = [ex("a", [20, 20], { notes: "totally different note" })];
+    expect(weightsDifferBetweenSnapshots(before, after)).toBe(false);
+  });
+
+  it("identical weights with reps/rest changes → false", () => {
+    const before = [ex("a", [40, 40], { reps: 8, rest_seconds: 90 })];
+    const after = [ex("a", [40, 40], { reps: 12, rest_seconds: 120 })];
+    expect(weightsDifferBetweenSnapshots(before, after)).toBe(false);
+  });
+
+  it("changed weight value → true", () => {
+    const before = [ex("a", [20, 20])];
+    const after = [ex("a", [20, 25])];
+    expect(weightsDifferBetweenSnapshots(before, after)).toBe(true);
+  });
+
+  it("added a set (extra weight entry) → true", () => {
+    const before = [ex("a", [20, 20])];
+    const after = [ex("a", [20, 20, 20])];
+    expect(weightsDifferBetweenSnapshots(before, after)).toBe(true);
+  });
+
+  it("removed a set (fewer weight entries) → true", () => {
+    const before = [ex("a", [20, 20, 20])];
+    const after = [ex("a", [20, 20])];
+    expect(weightsDifferBetweenSnapshots(before, after)).toBe(true);
+  });
+
+  it("added a NEW weighted exercise → true", () => {
+    const before = [ex("a", [20])];
+    const after = [ex("a", [20]), ex("b", [30])];
+    expect(weightsDifferBetweenSnapshots(before, after)).toBe(true);
+  });
+
+  it("added a new BODYWEIGHT exercise (no/empty weights) → false", () => {
+    // A new exercise that carries no load doesn't change any weight.
+    const before = [ex("a", [20])];
+    const after = [ex("a", [20]), ex("b", [])];
+    expect(weightsDifferBetweenSnapshots(before, after)).toBe(false);
+  });
+
+  it("removed a weighted exercise → true", () => {
+    const before = [ex("a", [20]), ex("b", [30])];
+    const after = [ex("a", [20])];
+    expect(weightsDifferBetweenSnapshots(before, after)).toBe(true);
+  });
+
+  it("reordering exercises with identical weights → false (matched by id)", () => {
+    const before = [ex("a", [20]), ex("b", [30])];
+    const after = [ex("b", [30]), ex("a", [20])];
+    expect(weightsDifferBetweenSnapshots(before, after)).toBe(false);
+  });
+
+  it("missing weightBySetKg ↔ empty array are equivalent → false", () => {
+    const before = [ex("a", undefined)];
+    const after = [ex("a", [])];
+    expect(weightsDifferBetweenSnapshots(before, after)).toBe(false);
+  });
+
+  it("missing weightBySetKg → non-empty weights → true", () => {
+    const before = [ex("a", undefined)];
+    const after = [ex("a", [20])];
+    expect(weightsDifferBetweenSnapshots(before, after)).toBe(true);
+  });
+
+  it("both empty exercise lists → false", () => {
+    expect(weightsDifferBetweenSnapshots([], [])).toBe(false);
+    expect(weightsDifferBetweenSnapshots(undefined, undefined)).toBe(false);
+  });
+
+  it("exercises without ids are compared positionally (no collapse)", () => {
+    const before = [ex("", [10]), ex("", [20])];
+    const after = [ex("", [10]), ex("", [99])];
+    expect(weightsDifferBetweenSnapshots(before, after)).toBe(true);
+  });
+
+  it("non-finite weight entries are normalized to 0 (no spurious diff)", () => {
+    const before = [{ exerciseId: "a", weightBySetKg: [Number.NaN] }];
+    const after = [{ exerciseId: "a", weightBySetKg: [0] }];
+    expect(weightsDifferBetweenSnapshots(before, after)).toBe(false);
+  });
+});
+
+describe("exercisesOf", () => {
+  it("extracts the exercises array from a snapshot", () => {
+    const snapshot = { name: "X", exercises: [ex("a", [10])] };
+    expect(exercisesOf(snapshot)).toHaveLength(1);
+  });
+
+  it("returns [] for malformed / missing snapshots", () => {
+    expect(exercisesOf(null)).toEqual([]);
+    expect(exercisesOf(undefined)).toEqual([]);
+    expect(exercisesOf({})).toEqual([]);
+    expect(exercisesOf({ exercises: "nope" })).toEqual([]);
+  });
+});

--- a/backoffice/src/lib/gc-fitness/__tests__/weight-diff.test.ts
+++ b/backoffice/src/lib/gc-fitness/__tests__/weight-diff.test.ts
@@ -6,6 +6,7 @@
 
 import {
   weightsDifferBetweenSnapshots,
+  changedWeightExerciseIds,
   exercisesOf,
   type WeightComparableExercise,
 } from "../weight-diff";
@@ -103,6 +104,101 @@ describe("weightsDifferBetweenSnapshots", () => {
     const before = [{ exerciseId: "a", weightBySetKg: [Number.NaN] }];
     const after = [{ exerciseId: "a", weightBySetKg: [0] }];
     expect(weightsDifferBetweenSnapshots(before, after)).toBe(false);
+  });
+});
+
+describe("changedWeightExerciseIds", () => {
+  // Mirrors the boolean helper's cases, asserting WHICH exerciseIds changed.
+  it("notes-only change → []", () => {
+    const before = [ex("a", [20, 20], { notes: "old" })];
+    const after = [ex("a", [20, 20], { notes: "totally different note" })];
+    expect(changedWeightExerciseIds(before, after)).toEqual([]);
+  });
+
+  it("identical weights with reps/rest changes → []", () => {
+    const before = [ex("a", [40, 40], { reps: 8, rest_seconds: 90 })];
+    const after = [ex("a", [40, 40], { reps: 12, rest_seconds: 120 })];
+    expect(changedWeightExerciseIds(before, after)).toEqual([]);
+  });
+
+  it("changed weight value → [the changed id]", () => {
+    const before = [ex("a", [20, 20])];
+    const after = [ex("a", [20, 25])];
+    expect(changedWeightExerciseIds(before, after)).toEqual(["a"]);
+  });
+
+  it("added a set (extra weight entry) → [id]", () => {
+    const before = [ex("a", [20, 20])];
+    const after = [ex("a", [20, 20, 20])];
+    expect(changedWeightExerciseIds(before, after)).toEqual(["a"]);
+  });
+
+  it("removed a set (fewer weight entries) → [id]", () => {
+    const before = [ex("a", [20, 20, 20])];
+    const after = [ex("a", [20, 20])];
+    expect(changedWeightExerciseIds(before, after)).toEqual(["a"]);
+  });
+
+  it("added a NEW weighted exercise → [the new id only]", () => {
+    const before = [ex("a", [20])];
+    const after = [ex("a", [20]), ex("b", [30])];
+    expect(changedWeightExerciseIds(before, after)).toEqual(["b"]);
+  });
+
+  it("added a new BODYWEIGHT exercise (no/empty weights) → []", () => {
+    const before = [ex("a", [20])];
+    const after = [ex("a", [20]), ex("b", [])];
+    expect(changedWeightExerciseIds(before, after)).toEqual([]);
+  });
+
+  it("removed a weighted exercise → [the removed id]", () => {
+    const before = [ex("a", [20]), ex("b", [30])];
+    const after = [ex("a", [20])];
+    expect(changedWeightExerciseIds(before, after)).toEqual(["b"]);
+  });
+
+  it("reordering exercises with identical weights → [] (matched by id)", () => {
+    const before = [ex("a", [20]), ex("b", [30])];
+    const after = [ex("b", [30]), ex("a", [20])];
+    expect(changedWeightExerciseIds(before, after)).toEqual([]);
+  });
+
+  it("missing weightBySetKg ↔ empty array are equivalent → []", () => {
+    const before = [ex("a", undefined)];
+    const after = [ex("a", [])];
+    expect(changedWeightExerciseIds(before, after)).toEqual([]);
+  });
+
+  it("missing weightBySetKg → non-empty weights → [id]", () => {
+    const before = [ex("a", undefined)];
+    const after = [ex("a", [20])];
+    expect(changedWeightExerciseIds(before, after)).toEqual(["a"]);
+  });
+
+  it("both empty exercise lists → []", () => {
+    expect(changedWeightExerciseIds([], [])).toEqual([]);
+    expect(changedWeightExerciseIds(undefined, undefined)).toEqual([]);
+  });
+
+  it("id-less exercises change positionally but yield NO stampable ids", () => {
+    // weightsDifferBetweenSnapshots returns true here, but a positional
+    // __idx_ placeholder cannot carry a per-exercise stamp, so we return [].
+    const before = [ex("", [10]), ex("", [20])];
+    const after = [ex("", [10]), ex("", [99])];
+    expect(weightsDifferBetweenSnapshots(before, after)).toBe(true);
+    expect(changedWeightExerciseIds(before, after)).toEqual([]);
+  });
+
+  it("non-finite weight entries are normalized to 0 (no spurious id)", () => {
+    const before = [{ exerciseId: "a", weightBySetKg: [Number.NaN] }];
+    const after = [{ exerciseId: "a", weightBySetKg: [0] }];
+    expect(changedWeightExerciseIds(before, after)).toEqual([]);
+  });
+
+  it("multiple changed exercises → all their ids (order-insensitive)", () => {
+    const before = [ex("a", [20]), ex("b", [30]), ex("c", [40])];
+    const after = [ex("a", [25]), ex("b", [30]), ex("c", [45])];
+    expect(changedWeightExerciseIds(before, after).sort()).toEqual(["a", "c"]);
   });
 });
 

--- a/backoffice/src/lib/gc-fitness/__tests__/weight-prefill.test.ts
+++ b/backoffice/src/lib/gc-fitness/__tests__/weight-prefill.test.ts
@@ -5,6 +5,7 @@
 
 import {
   coachUpdatedSinceLastLog,
+  isCoachUpdate,
   resolveSetPrefill,
   type ResolveSetPrefillInput,
 } from "../weight-prefill";
@@ -184,5 +185,73 @@ describe("resolveSetPrefill — edge cases", () => {
     expect(coachUpdatedSinceLastLog(t0, t1)).toBe(false);
     expect(coachUpdatedSinceLastLog(t1, null)).toBe(false);
     expect(coachUpdatedSinceLastLog(null, t1)).toBe(false);
+  });
+
+  it("isCoachUpdate predicate", () => {
+    expect(isCoachUpdate(t1, t0, 45)).toBe(true);
+    expect(isCoachUpdate(t1, t0, null)).toBe(false);
+    expect(isCoachUpdate(t0, t1, 45)).toBe(false);
+    expect(isCoachUpdate(t1, null, 45)).toBe(false);
+  });
+});
+
+describe("resolveSetPrefill — use-my-previous override", () => {
+  it("override keeps previous on a coach-updated set; alert still fires", () => {
+    const r = resolveSetPrefill(
+      input({
+        templateWeightKg: 45,
+        templateReps: 8,
+        previous: { weightKg: 50, reps: 12 },
+        prescriptionUpdatedAt: t1,
+        lastLoggedAt: t0,
+        preferPreviousWhenCoachUpdated: true,
+      }),
+    );
+    expect(r.origin).toBe("previous");
+    expect(r.weightKg).toBe(50);
+    expect(isCoachUpdate(t1, t0, 45)).toBe(true);
+  });
+
+  it("default (no override) keeps the coach update", () => {
+    const r = resolveSetPrefill(
+      input({
+        templateWeightKg: 45,
+        templateReps: 8,
+        previous: { weightKg: 50, reps: 12 },
+        prescriptionUpdatedAt: t1,
+        lastLoggedAt: t0,
+        preferPreviousWhenCoachUpdated: false,
+      }),
+    );
+    expect(r.origin).toBe("routineUpdated");
+    expect(r.weightKg).toBe(45);
+  });
+
+  it("override is a no-op when the set isn't a coach update", () => {
+    const r = resolveSetPrefill(
+      input({
+        templateWeightKg: 45,
+        previous: { weightKg: 50, reps: 12 },
+        prescriptionUpdatedAt: t0,
+        lastLoggedAt: t1,
+        preferPreviousWhenCoachUpdated: true,
+      }),
+    );
+    expect(r.origin).toBe("previous");
+    expect(r.weightKg).toBe(50);
+  });
+
+  it("override falls to routine when there is no prior value for the set", () => {
+    const r = resolveSetPrefill(
+      input({
+        templateWeightKg: 45,
+        previous: null,
+        prescriptionUpdatedAt: t1,
+        lastLoggedAt: t0,
+        preferPreviousWhenCoachUpdated: true,
+      }),
+    );
+    expect(r.origin).toBe("routineUpdated");
+    expect(r.weightKg).toBe(45);
   });
 });

--- a/backoffice/src/lib/gc-fitness/__tests__/weight-prefill.test.ts
+++ b/backoffice/src/lib/gc-fitness/__tests__/weight-prefill.test.ts
@@ -1,0 +1,188 @@
+// weight-prefill.test.ts
+// Locks the "most recent intent wins" rule that replaced the per-user
+// WorkoutPrefillSource setting. Mirrors the Swift twin's test cases
+// (WeightPrefillResolverTests.swift) one-for-one.
+
+import {
+  coachUpdatedSinceLastLog,
+  resolveSetPrefill,
+  type ResolveSetPrefillInput,
+} from "../weight-prefill";
+
+const t0 = new Date(1_000_000 * 1000); // "old"
+const t1 = new Date(2_000_000 * 1000); // "newer"
+
+/** Base input — every test overrides only the fields it cares about. */
+function input(overrides: Partial<ResolveSetPrefillInput>): ResolveSetPrefillInput {
+  return {
+    templateWeightKg: 40,
+    templateReps: 10,
+    templateDurationSeconds: null,
+    exerciseDefaultReps: 8,
+    exerciseDefaultDurationSeconds: null,
+    previous: null,
+    prescriptionUpdatedAt: t0,
+    lastLoggedAt: null,
+    ...overrides,
+  };
+}
+
+describe("resolveSetPrefill — the four user scenarios", () => {
+  // Scenario 1: first time doing the exercise → routine, no notice.
+  it("first time shows the routine", () => {
+    const r = resolveSetPrefill(
+      input({ templateWeightKg: 40, templateReps: 10, lastLoggedAt: null }),
+    );
+    expect(r.weightKg).toBe(40);
+    expect(r.reps).toBe(10);
+    expect(r.origin).toBe("routine");
+  });
+
+  // Scenario 2: logged before, coach hasn't changed since → remember user's value.
+  it("after logging shows previous", () => {
+    const r = resolveSetPrefill(
+      input({
+        templateWeightKg: 40,
+        templateReps: 10,
+        previous: { weightKg: 50, reps: 12 },
+        prescriptionUpdatedAt: t0, // prescription is OLDER than the log
+        lastLoggedAt: t1,
+      }),
+    );
+    expect(r.weightKg).toBe(50);
+    expect(r.reps).toBe(12);
+    expect(r.origin).toBe("previous");
+  });
+
+  // Scenario 3: coach changed the plan AFTER the last log → routine once + notice.
+  it("coach update overrides previous once", () => {
+    const r = resolveSetPrefill(
+      input({
+        templateWeightKg: 45,
+        templateReps: 8,
+        previous: { weightKg: 50, reps: 12 },
+        prescriptionUpdatedAt: t1, // prescription is NEWER than the log
+        lastLoggedAt: t0,
+      }),
+    );
+    expect(r.weightKg).toBe(45);
+    expect(r.reps).toBe(8);
+    expect(r.origin).toBe("routineUpdated");
+  });
+
+  // Scenario 4: after the coach update, the user logs again → back to remembering.
+  it("after relogging falls back to previous", () => {
+    const r = resolveSetPrefill(
+      input({
+        templateWeightKg: 45,
+        templateReps: 8,
+        previous: { weightKg: 45, reps: 8 },
+        prescriptionUpdatedAt: t0,
+        lastLoggedAt: t1,
+      }),
+    );
+    expect(r.weightKg).toBe(45);
+    expect(r.origin).toBe("previous");
+  });
+});
+
+describe("resolveSetPrefill — edge cases", () => {
+  // Equal timestamps are NOT an update (strict `>`): keep remembering.
+  it("equal timestamps keep previous", () => {
+    const r = resolveSetPrefill(
+      input({
+        templateWeightKg: 45,
+        templateReps: 8,
+        previous: { weightKg: 50, reps: 12 },
+        prescriptionUpdatedAt: t1,
+        lastLoggedAt: t1,
+      }),
+    );
+    expect(r.origin).toBe("previous");
+    expect(r.weightKg).toBe(50);
+  });
+
+  // Legacy assignment with no prescription timestamp → keep remembering, no nag.
+  it("null prescription keeps previous", () => {
+    const r = resolveSetPrefill(
+      input({
+        templateWeightKg: 45,
+        templateReps: 8,
+        previous: { weightKg: 50, reps: 12 },
+        prescriptionUpdatedAt: null,
+        lastLoggedAt: t1,
+      }),
+    );
+    expect(r.origin).toBe("previous");
+  });
+
+  // Coach update but routine has no weight prescribed → cannot override; keep previous.
+  it("coach update without template weight keeps previous", () => {
+    const r = resolveSetPrefill(
+      input({
+        templateWeightKg: null,
+        templateReps: 8,
+        previous: { weightKg: 50, reps: 12 },
+        prescriptionUpdatedAt: t1,
+        lastLoggedAt: t0,
+      }),
+    );
+    expect(r.origin).toBe("previous");
+    expect(r.weightKg).toBe(50);
+  });
+
+  // Exercise logged before but not at this (new) set index → routine, no notice.
+  it("added set index falls to routine", () => {
+    const r = resolveSetPrefill(
+      input({
+        templateWeightKg: 40,
+        templateReps: 10,
+        previous: null, // no history for this set index
+        prescriptionUpdatedAt: t0,
+        lastLoggedAt: t1, // but the exercise WAS logged
+      }),
+    );
+    expect(r.origin).toBe("routine");
+    expect(r.weightKg).toBe(40);
+  });
+
+  // Reps fall back to the exercise-level default when no per-set reps prescribed.
+  it("reps fall back to the exercise default", () => {
+    const r = resolveSetPrefill(
+      input({
+        templateWeightKg: 40,
+        templateReps: null,
+        exerciseDefaultReps: 12,
+        previous: null,
+        prescriptionUpdatedAt: t0,
+        lastLoggedAt: null,
+      }),
+    );
+    expect(r.reps).toBe(12);
+  });
+
+  // Time-based set carries duration through on the previous branch.
+  it("duration carries through on previous", () => {
+    const r = resolveSetPrefill(
+      input({
+        templateWeightKg: 0,
+        templateReps: null,
+        templateDurationSeconds: 60,
+        exerciseDefaultReps: 0,
+        exerciseDefaultDurationSeconds: 60,
+        previous: { weightKg: 0, reps: 0, durationSeconds: 47 },
+        prescriptionUpdatedAt: t0,
+        lastLoggedAt: t1,
+      }),
+    );
+    expect(r.origin).toBe("previous");
+    expect(r.durationSeconds).toBe(47);
+  });
+
+  it("coachUpdatedSinceLastLog helper", () => {
+    expect(coachUpdatedSinceLastLog(t1, t0)).toBe(true);
+    expect(coachUpdatedSinceLastLog(t0, t1)).toBe(false);
+    expect(coachUpdatedSinceLastLog(t1, null)).toBe(false);
+    expect(coachUpdatedSinceLastLog(null, t1)).toBe(false);
+  });
+});

--- a/backoffice/src/lib/gc-fitness/__tests__/workout-assignment-actions.prescription-anchor.test.ts
+++ b/backoffice/src/lib/gc-fitness/__tests__/workout-assignment-actions.prescription-anchor.test.ts
@@ -1,15 +1,22 @@
 // __tests__/workout-assignment-actions.prescription-anchor.test.ts
 //
-// Behavior tests for the REFINED `prescriptionUpdatedAt` bump rules
-// (feat/simplify-weight-prefill):
+// Behavior tests for the PER-EXERCISE `prescriptionUpdatedAtByExerciseId` stamp
+// rules (feat/simplify-weight-prefill):
 //
-//   1. editAssignmentExercises bumps the freshness anchor ONLY when the WEIGHTS
-//      changed vs the assignment's current snapshot — notes-only edits must NOT
-//      bump (each client keeps their own weights).
+//   1. editAssignmentExercises stamps the per-exercise anchor ONLY for the
+//      exercises whose WEIGHTS changed vs the assignment's current snapshot —
+//      notes-only edits must stamp nothing (each client keeps their own
+//      weights). The doc-level `prescriptionUpdatedAt` is NO LONGER bumped on
+//      edits; the per-exercise stamp is written via a dotted field-path key
+//      `prescriptionUpdatedAtByExerciseId.<exId>`.
 //   2. propagateTemplateToFutureAssignments takes a `pushWeights` option:
-//        - false (default): preserve each client's weights, NEVER bump.
-//        - true: replace weights from the template, bump ONLY where a weight
-//          genuinely changed.
+//        - false (default): preserve each client's weights, stamp NOTHING.
+//        - true: replace weights from the template, stamp ONLY the exercises
+//          whose weight genuinely changed.
+
+// The dotted per-exercise field-path key for exercise "ex-1" (the only exercise
+// in the test snapshot).
+const STAMP_KEY = "prescriptionUpdatedAtByExerciseId.ex-1";
 //
 // Mirrors the Admin-SDK mock harness from workout-assignment-actions.test.ts.
 
@@ -162,8 +169,8 @@ beforeEach(() => {
 // editAssignmentExercises — bump only on weight change
 // ─────────────────────────────────────────────────────────────────────────────
 
-describe("editAssignmentExercises — prescription anchor bump decision", () => {
-  it("notes-only edit (same weights) → does NOT bump prescriptionUpdatedAt", async () => {
+describe("editAssignmentExercises — per-exercise prescription stamp decision", () => {
+  it("notes-only edit (same weights) → stamps nothing", async () => {
     mockGet.mockResolvedValue(
       assignmentSnap({ templateSnapshot: snapshot([20, 20], "old note") }),
     );
@@ -184,12 +191,16 @@ describe("editAssignmentExercises — prescription anchor bump decision", () => 
     expect(mockBatchUpdate).toHaveBeenCalledTimes(1);
     const patch = mockBatchUpdate.mock.calls[0][1];
     expect(patch.updatedAt).toBe("SERVER_TIMESTAMP_SENTINEL");
+    // Doc-level anchor is NEVER bumped on edits anymore, and no per-exercise
+    // stamp is written when nothing weight-bearing changed.
     expect(patch).not.toHaveProperty("prescriptionUpdatedAt");
+    expect(patch).not.toHaveProperty(STAMP_KEY);
+    expect(patch).not.toHaveProperty("prescriptionUpdatedAtByExerciseId");
     // The note still gets written.
     expect(patch.templateSnapshot.exercises[0].notes).toBe("a brand new note");
   });
 
-  it("weight change → DOES bump prescriptionUpdatedAt", async () => {
+  it("weight change → stamps the changed exercise's per-exercise anchor (NOT doc-level)", async () => {
     mockGet.mockResolvedValue(
       assignmentSnap({ templateSnapshot: snapshot([20, 20]) }),
     );
@@ -208,10 +219,12 @@ describe("editAssignmentExercises — prescription anchor bump decision", () => 
     });
 
     const patch = mockBatchUpdate.mock.calls[0][1];
-    expect(patch.prescriptionUpdatedAt).toBe("SERVER_TIMESTAMP_SENTINEL");
+    expect(patch[STAMP_KEY]).toBe("SERVER_TIMESTAMP_SENTINEL");
+    // Doc-level anchor stays the create baseline — not bumped on edits.
+    expect(patch).not.toHaveProperty("prescriptionUpdatedAt");
   });
 
-  it("added a set → DOES bump (more weight entries)", async () => {
+  it("added a set → stamps the per-exercise anchor (more weight entries)", async () => {
     mockGet.mockResolvedValue(
       assignmentSnap({ templateSnapshot: snapshot([20, 20]) }),
     );
@@ -230,10 +243,11 @@ describe("editAssignmentExercises — prescription anchor bump decision", () => 
     });
 
     const patch = mockBatchUpdate.mock.calls[0][1];
-    expect(patch.prescriptionUpdatedAt).toBe("SERVER_TIMESTAMP_SENTINEL");
+    expect(patch[STAMP_KEY]).toBe("SERVER_TIMESTAMP_SENTINEL");
+    expect(patch).not.toHaveProperty("prescriptionUpdatedAt");
   });
 
-  it("reps/rest-only edit (same weights) → does NOT bump", async () => {
+  it("reps/rest-only edit (same weights) → stamps nothing", async () => {
     mockGet.mockResolvedValue(
       assignmentSnap({ templateSnapshot: snapshot([40, 40]) }),
     );
@@ -253,6 +267,8 @@ describe("editAssignmentExercises — prescription anchor bump decision", () => 
 
     const patch = mockBatchUpdate.mock.calls[0][1];
     expect(patch).not.toHaveProperty("prescriptionUpdatedAt");
+    expect(patch).not.toHaveProperty(STAMP_KEY);
+    expect(patch).not.toHaveProperty("prescriptionUpdatedAtByExerciseId");
   });
 });
 
@@ -308,12 +324,14 @@ describe("propagateTemplateToFutureAssignments — pushWeights option", () => {
     const patch = mockBatchUpdate.mock.calls[0][1];
     // Client's own weights preserved (NOT replaced with the template's 50s).
     expect(patch.templateSnapshot.exercises[0].weightBySetKg).toEqual([30, 30]);
-    // Anchor untouched.
+    // No anchor touched (neither doc-level nor per-exercise).
     expect(patch).not.toHaveProperty("prescriptionUpdatedAt");
+    expect(patch).not.toHaveProperty(STAMP_KEY);
+    expect(patch).not.toHaveProperty("prescriptionUpdatedAtByExerciseId");
     expect(patch.updatedAt).toBe("SERVER_TIMESTAMP_SENTINEL");
   });
 
-  it("pushWeights:false explicit → same as default (preserve + no bump)", async () => {
+  it("pushWeights:false explicit → same as default (preserve + no stamp)", async () => {
     setupTemplateAndTarget({
       templateWeights: [50, 50],
       assignmentWeights: [30, 30],
@@ -326,9 +344,10 @@ describe("propagateTemplateToFutureAssignments — pushWeights option", () => {
     const patch = mockBatchUpdate.mock.calls[0][1];
     expect(patch.templateSnapshot.exercises[0].weightBySetKg).toEqual([30, 30]);
     expect(patch).not.toHaveProperty("prescriptionUpdatedAt");
+    expect(patch).not.toHaveProperty(STAMP_KEY);
   });
 
-  it("pushWeights:true with a genuine weight change → replaces weights + bumps", async () => {
+  it("pushWeights:true with a genuine weight change → replaces weights + stamps per-exercise", async () => {
     setupTemplateAndTarget({
       templateWeights: [50, 50],
       assignmentWeights: [30, 30],
@@ -341,11 +360,13 @@ describe("propagateTemplateToFutureAssignments — pushWeights option", () => {
     const patch = mockBatchUpdate.mock.calls[0][1];
     // Template weights pushed through.
     expect(patch.templateSnapshot.exercises[0].weightBySetKg).toEqual([50, 50]);
-    // Weight genuinely changed (30→50) → anchor bumped.
-    expect(patch.prescriptionUpdatedAt).toBe("SERVER_TIMESTAMP_SENTINEL");
+    // Weight genuinely changed (30→50) → per-exercise anchor stamped, doc-level
+    // anchor left as the create baseline.
+    expect(patch[STAMP_KEY]).toBe("SERVER_TIMESTAMP_SENTINEL");
+    expect(patch).not.toHaveProperty("prescriptionUpdatedAt");
   });
 
-  it("pushWeights:true but weights already identical → replaces but does NOT bump", async () => {
+  it("pushWeights:true but weights already identical → replaces but stamps nothing", async () => {
     setupTemplateAndTarget({
       templateWeights: [50, 50],
       assignmentWeights: [50, 50], // already matches the template
@@ -358,8 +379,10 @@ describe("propagateTemplateToFutureAssignments — pushWeights option", () => {
 
     const patch = mockBatchUpdate.mock.calls[0][1];
     expect(patch.templateSnapshot.exercises[0].weightBySetKg).toEqual([50, 50]);
-    // No weight delta → no spurious alert.
+    // No weight delta → no spurious alert (no doc-level NOR per-exercise stamp).
     expect(patch).not.toHaveProperty("prescriptionUpdatedAt");
+    expect(patch).not.toHaveProperty(STAMP_KEY);
+    expect(patch).not.toHaveProperty("prescriptionUpdatedAtByExerciseId");
   });
 
   it("default → structure/notes still flow through even though weights are preserved", async () => {

--- a/backoffice/src/lib/gc-fitness/__tests__/workout-assignment-actions.prescription-anchor.test.ts
+++ b/backoffice/src/lib/gc-fitness/__tests__/workout-assignment-actions.prescription-anchor.test.ts
@@ -1,0 +1,381 @@
+// __tests__/workout-assignment-actions.prescription-anchor.test.ts
+//
+// Behavior tests for the REFINED `prescriptionUpdatedAt` bump rules
+// (feat/simplify-weight-prefill):
+//
+//   1. editAssignmentExercises bumps the freshness anchor ONLY when the WEIGHTS
+//      changed vs the assignment's current snapshot — notes-only edits must NOT
+//      bump (each client keeps their own weights).
+//   2. propagateTemplateToFutureAssignments takes a `pushWeights` option:
+//        - false (default): preserve each client's weights, NEVER bump.
+//        - true: replace weights from the template, bump ONLY where a weight
+//          genuinely changed.
+//
+// Mirrors the Admin-SDK mock harness from workout-assignment-actions.test.ts.
+
+jest.mock("next/headers", () => ({
+  cookies: jest.fn().mockResolvedValue({}),
+}));
+jest.mock("next-firebase-auth-edge", () => ({
+  getTokens: jest.fn(),
+}));
+// Server-side timezone read hits cookies() — stub it to a fixed zone so the
+// "future / scheduled" filters use a deterministic "today".
+jest.mock("../trainer-timezone", () => ({
+  getTrainerTimezone: jest.fn().mockResolvedValue("UTC"),
+}));
+// Coach-activity event logging is a best-effort side channel; not under test.
+jest.mock("../coach-activity-log", () => ({
+  recordCoachActivityEvent: jest.fn().mockResolvedValue(undefined),
+  markCoachActivityDeleted: jest.fn().mockResolvedValue(undefined),
+  singleAssignmentEvent: jest.fn(() => ({})),
+  seriesAssignmentEvent: jest.fn(() => ({})),
+}));
+
+const mockUpdate = jest.fn();
+const mockGet = jest.fn();
+const mockDoc = jest.fn((id?: string) => ({
+  set: jest.fn(),
+  update: mockUpdate,
+  delete: jest.fn(),
+  get: mockGet,
+  id: id ?? "MOCK_DOC_ID",
+}));
+
+const mockGetAll = jest.fn((...refs: Array<{ id?: string }>) =>
+  Promise.resolve(
+    refs.map((ref) => {
+      const id = ref?.id ?? "ex-1";
+      return { id, exists: false, data: () => ({ name: { en: id, es: "" } }) };
+    }),
+  ),
+);
+
+const mockWhere = jest.fn();
+const mockOrderBy = jest.fn();
+const mockQueryGet = jest.fn();
+const mockCollection = jest.fn(() => ({
+  doc: mockDoc,
+  where: mockWhere,
+  orderBy: mockOrderBy,
+  get: mockQueryGet,
+}));
+
+const mockBatchSet = jest.fn();
+const mockBatchUpdate = jest.fn();
+const mockBatchCommit = jest.fn();
+const mockBatch = jest.fn(() => ({
+  set: mockBatchSet,
+  update: mockBatchUpdate,
+  commit: mockBatchCommit,
+}));
+
+jest.mock("@/lib/firebase/gc-fitness-admin", () => ({
+  gcFitnessFirestore: jest.fn(() => ({
+    collection: mockCollection,
+    batch: mockBatch,
+    getAll: mockGetAll,
+  })),
+}));
+
+jest.mock("firebase-admin/firestore", () => ({
+  FieldValue: {
+    serverTimestamp: jest.fn(() => "SERVER_TIMESTAMP_SENTINEL"),
+  },
+}));
+
+import {
+  editAssignmentExercises,
+  propagateTemplateToFutureAssignments,
+} from "../workout-assignment-actions";
+import { getTokens } from "next-firebase-auth-edge";
+
+const mockedGetTokens = getTokens as jest.MockedFunction<typeof getTokens>;
+
+const ALLOWED_EMAIL = "trainer@example.com";
+const ALLOWED_UID = "trainer-uid-1";
+
+function fakeTokens() {
+  return {
+    token: "fake-token",
+    decodedToken: { uid: ALLOWED_UID, email: ALLOWED_EMAIL, role: "trainer" },
+  } as unknown as Awaited<ReturnType<typeof getTokens>>;
+}
+
+// A snapshot with one weighted exercise. The per-exercise `name` mirrors the
+// getAll-fallback so denormalization keeps the shape stable.
+function snapshot(weightBySetKg: number[], notes: string | null = null) {
+  return {
+    trainerId: ALLOWED_UID,
+    name: { en: "Push Day", es: "Día de Empuje" },
+    exercises: [
+      {
+        exerciseId: "ex-1",
+        sets: weightBySetKg.length || 2,
+        reps: 10,
+        repsBySet: weightBySetKg.length
+          ? weightBySetKg.map(() => 10)
+          : [10, 10],
+        weightBySetKg,
+        rest_seconds: 90,
+        transition_rest_seconds: 60,
+        notes,
+        order: 0,
+        name: { en: "ex-1", es: "" },
+      },
+    ],
+    version: 1,
+  };
+}
+
+function assignmentSnap(data: Record<string, unknown>) {
+  return { exists: true, data: () => ({ trainerId: ALLOWED_UID, ...data }) };
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  process.env.GC_FITNESS_TEAM_ALLOWLIST = ALLOWED_EMAIL;
+  process.env.NEXT_PUBLIC_GC_FITNESS_FIREBASE_API_KEY = "fake-api-key";
+  process.env.GC_FITNESS_COOKIE_SIGNATURE_KEY = "fake-cookie-sig";
+  process.env.NEXT_PUBLIC_GC_FITNESS_FIREBASE_PROJECT_ID = "gcfitness-3476b";
+  process.env.GC_FITNESS_FIREBASE_ADMIN_CLIENT_EMAIL =
+    "admin@gcfitness-3476b.iam.gserviceaccount.com";
+  process.env.GC_FITNESS_FIREBASE_ADMIN_PRIVATE_KEY = Buffer.from(
+    "fake-private-key",
+  ).toString("base64");
+
+  mockWhere.mockImplementation(() => ({
+    where: mockWhere,
+    orderBy: mockOrderBy,
+    get: mockQueryGet,
+  }));
+  mockOrderBy.mockImplementation(() => ({
+    where: mockWhere,
+    orderBy: mockOrderBy,
+    get: mockQueryGet,
+  }));
+  mockedGetTokens.mockResolvedValue(fakeTokens());
+  mockBatchCommit.mockResolvedValue(undefined);
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// editAssignmentExercises — bump only on weight change
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("editAssignmentExercises — prescription anchor bump decision", () => {
+  it("notes-only edit (same weights) → does NOT bump prescriptionUpdatedAt", async () => {
+    mockGet.mockResolvedValue(
+      assignmentSnap({ templateSnapshot: snapshot([20, 20], "old note") }),
+    );
+
+    await editAssignmentExercises("asg-1", {
+      scope: "one",
+      exercises: [
+        {
+          index: 0,
+          repsBySet: [10, 10],
+          weightBySetKg: [20, 20], // unchanged
+          rest_seconds: 90,
+          notes: "a brand new note", // only the note changed
+        },
+      ],
+    });
+
+    expect(mockBatchUpdate).toHaveBeenCalledTimes(1);
+    const patch = mockBatchUpdate.mock.calls[0][1];
+    expect(patch.updatedAt).toBe("SERVER_TIMESTAMP_SENTINEL");
+    expect(patch).not.toHaveProperty("prescriptionUpdatedAt");
+    // The note still gets written.
+    expect(patch.templateSnapshot.exercises[0].notes).toBe("a brand new note");
+  });
+
+  it("weight change → DOES bump prescriptionUpdatedAt", async () => {
+    mockGet.mockResolvedValue(
+      assignmentSnap({ templateSnapshot: snapshot([20, 20]) }),
+    );
+
+    await editAssignmentExercises("asg-1", {
+      scope: "one",
+      exercises: [
+        {
+          index: 0,
+          repsBySet: [10, 10],
+          weightBySetKg: [20, 25], // second set heavier
+          rest_seconds: 90,
+          notes: "",
+        },
+      ],
+    });
+
+    const patch = mockBatchUpdate.mock.calls[0][1];
+    expect(patch.prescriptionUpdatedAt).toBe("SERVER_TIMESTAMP_SENTINEL");
+  });
+
+  it("added a set → DOES bump (more weight entries)", async () => {
+    mockGet.mockResolvedValue(
+      assignmentSnap({ templateSnapshot: snapshot([20, 20]) }),
+    );
+
+    await editAssignmentExercises("asg-1", {
+      scope: "one",
+      exercises: [
+        {
+          index: 0,
+          repsBySet: [10, 10, 10],
+          weightBySetKg: [20, 20, 20], // a third set added
+          rest_seconds: 90,
+          notes: "",
+        },
+      ],
+    });
+
+    const patch = mockBatchUpdate.mock.calls[0][1];
+    expect(patch.prescriptionUpdatedAt).toBe("SERVER_TIMESTAMP_SENTINEL");
+  });
+
+  it("reps/rest-only edit (same weights) → does NOT bump", async () => {
+    mockGet.mockResolvedValue(
+      assignmentSnap({ templateSnapshot: snapshot([40, 40]) }),
+    );
+
+    await editAssignmentExercises("asg-1", {
+      scope: "one",
+      exercises: [
+        {
+          index: 0,
+          repsBySet: [12, 12], // reps changed
+          weightBySetKg: [40, 40], // weights unchanged
+          rest_seconds: 120, // rest changed
+          notes: "",
+        },
+      ],
+    });
+
+    const patch = mockBatchUpdate.mock.calls[0][1];
+    expect(patch).not.toHaveProperty("prescriptionUpdatedAt");
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// propagateTemplateToFutureAssignments — pushWeights option
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("propagateTemplateToFutureAssignments — pushWeights option", () => {
+  // Template now prescribes [50, 50]; the existing assignment has the client's
+  // own weights [30, 30] under the same exerciseId.
+  const FUTURE = "2999-01-01"; // always after "today"
+
+  function setupTemplateAndTarget(opts: {
+    templateWeights: number[];
+    assignmentWeights: number[];
+    templateNote?: string | null;
+    assignmentNote?: string | null;
+  }) {
+    // First db.get() in the action reads the TEMPLATE doc.
+    mockGet.mockResolvedValue({
+      exists: true,
+      data: () =>
+        snapshot(opts.templateWeights, opts.templateNote ?? null),
+    });
+    // The query for future assignments returns ONE matching target.
+    mockQueryGet.mockResolvedValue({
+      docs: [
+        {
+          ref: { id: "asg-future-1" },
+          data: () => ({
+            trainerId: ALLOWED_UID,
+            scheduledFor: FUTURE,
+            status: "scheduled",
+            templateSnapshot: snapshot(
+              opts.assignmentWeights,
+              opts.assignmentNote ?? null,
+            ),
+          }),
+        },
+      ],
+    });
+  }
+
+  it("default (pushWeights omitted) → preserves client weights + does NOT bump", async () => {
+    setupTemplateAndTarget({
+      templateWeights: [50, 50],
+      assignmentWeights: [30, 30],
+    });
+
+    const result = await propagateTemplateToFutureAssignments("tpl-1");
+
+    expect(result.updatedCount).toBe(1);
+    const patch = mockBatchUpdate.mock.calls[0][1];
+    // Client's own weights preserved (NOT replaced with the template's 50s).
+    expect(patch.templateSnapshot.exercises[0].weightBySetKg).toEqual([30, 30]);
+    // Anchor untouched.
+    expect(patch).not.toHaveProperty("prescriptionUpdatedAt");
+    expect(patch.updatedAt).toBe("SERVER_TIMESTAMP_SENTINEL");
+  });
+
+  it("pushWeights:false explicit → same as default (preserve + no bump)", async () => {
+    setupTemplateAndTarget({
+      templateWeights: [50, 50],
+      assignmentWeights: [30, 30],
+    });
+
+    await propagateTemplateToFutureAssignments("tpl-1", {
+      pushWeights: false,
+    });
+
+    const patch = mockBatchUpdate.mock.calls[0][1];
+    expect(patch.templateSnapshot.exercises[0].weightBySetKg).toEqual([30, 30]);
+    expect(patch).not.toHaveProperty("prescriptionUpdatedAt");
+  });
+
+  it("pushWeights:true with a genuine weight change → replaces weights + bumps", async () => {
+    setupTemplateAndTarget({
+      templateWeights: [50, 50],
+      assignmentWeights: [30, 30],
+    });
+
+    await propagateTemplateToFutureAssignments("tpl-1", {
+      pushWeights: true,
+    });
+
+    const patch = mockBatchUpdate.mock.calls[0][1];
+    // Template weights pushed through.
+    expect(patch.templateSnapshot.exercises[0].weightBySetKg).toEqual([50, 50]);
+    // Weight genuinely changed (30→50) → anchor bumped.
+    expect(patch.prescriptionUpdatedAt).toBe("SERVER_TIMESTAMP_SENTINEL");
+  });
+
+  it("pushWeights:true but weights already identical → replaces but does NOT bump", async () => {
+    setupTemplateAndTarget({
+      templateWeights: [50, 50],
+      assignmentWeights: [50, 50], // already matches the template
+      templateNote: "form cue",
+    });
+
+    await propagateTemplateToFutureAssignments("tpl-1", {
+      pushWeights: true,
+    });
+
+    const patch = mockBatchUpdate.mock.calls[0][1];
+    expect(patch.templateSnapshot.exercises[0].weightBySetKg).toEqual([50, 50]);
+    // No weight delta → no spurious alert.
+    expect(patch).not.toHaveProperty("prescriptionUpdatedAt");
+  });
+
+  it("default → structure/notes still flow through even though weights are preserved", async () => {
+    setupTemplateAndTarget({
+      templateWeights: [50, 50],
+      assignmentWeights: [30, 30],
+      templateNote: "new coach cue",
+      assignmentNote: null,
+    });
+
+    await propagateTemplateToFutureAssignments("tpl-1");
+
+    const patch = mockBatchUpdate.mock.calls[0][1];
+    // Note from the template propagated.
+    expect(patch.templateSnapshot.exercises[0].notes).toBe("new coach cue");
+    // But weight stays the client's.
+    expect(patch.templateSnapshot.exercises[0].weightBySetKg).toEqual([30, 30]);
+  });
+});

--- a/backoffice/src/lib/gc-fitness/live-workout-actions.ts
+++ b/backoffice/src/lib/gc-fitness/live-workout-actions.ts
@@ -279,7 +279,27 @@ async function buildActiveSession(
     // existed (coachUpdatedSinceLastLog then keeps remembering, no false nag).
     prescriptionUpdatedAt:
       toIso(assignment.prescriptionUpdatedAt) ?? toIso(assignment.createdAt),
+    // Per-exercise overrides (exerciseId → ISO). Each entry, when newer than
+    // the doc-level anchor, makes ONLY that exercise show the routine once.
+    prescriptionUpdatedAtByExerciseId: prescriptionMapToIso(
+      assignment.prescriptionUpdatedAtByExerciseId,
+    ),
   };
+}
+
+/** Coerce a Firestore `prescriptionUpdatedAtByExerciseId` map (exerciseId →
+ *  Timestamp) into `exerciseId → ISO-8601`. Non-map / unparseable entries are
+ *  dropped so the resolver cleanly falls back to the doc-level anchor. */
+function prescriptionMapToIso(value: unknown): Record<string, string> {
+  if (!value || typeof value !== "object") return {};
+  const out: Record<string, string> = {};
+  for (const [exerciseId, ts] of Object.entries(
+    value as Record<string, unknown>,
+  )) {
+    const iso = toIso(ts);
+    if (iso) out[exerciseId] = iso;
+  }
+  return out;
 }
 
 function workoutNameToString(value: LocalizedString): string {

--- a/backoffice/src/lib/gc-fitness/live-workout-actions.ts
+++ b/backoffice/src/lib/gc-fitness/live-workout-actions.ts
@@ -274,6 +274,11 @@ async function buildActiveSession(
         : null,
     scheduledFor: String(assignment.scheduledFor ?? ""),
     seriesId: typeof assignment.seriesId === "string" ? assignment.seriesId : null,
+    // Prescription freshness anchor for the weight-prefill rule. Fall back to
+    // createdAt for legacy assignments written before prescriptionUpdatedAt
+    // existed (coachUpdatedSinceLastLog then keeps remembering, no false nag).
+    prescriptionUpdatedAt:
+      toIso(assignment.prescriptionUpdatedAt) ?? toIso(assignment.createdAt),
   };
 }
 
@@ -710,6 +715,10 @@ async function propagateToFutureRecurrence(opts: {
     batch.update(doc.ref, {
       templateSnapshot: { ...existingSnapshot, exercises: enriched },
       updatedAt: FieldValue.serverTimestamp(),
+      // Future occurrences just had their prescription rewritten to match the
+      // performed structure — bump the weight-prefill freshness anchor so the
+      // apps treat it as a fresh coach plan (see weight-prefill.ts).
+      prescriptionUpdatedAt: FieldValue.serverTimestamp(),
     });
     count += 1;
     if (count >= MAX_FUTURE_PROPAGATION) break;
@@ -829,6 +838,11 @@ export async function getPreviousSessionForClient(
     const sets = Array.isArray(data.sets)
       ? (data.sets as Array<Record<string, unknown>>)
       : [];
+    // `lastLoggedAt` for the weight-prefill rule: completion instant of THIS
+    // log. Logs are ordered by startedAt DESC, so the first log we see for an
+    // exercise is its most recent — its completion time is the exercise's
+    // lastLoggedAt. Fall back to startedAt when completed_at is absent.
+    const logCompletedAt = toIso(data.completed_at) ?? toIso(data.startedAt);
     // Logs are newest-first; first time we see an exercise wins. Within a log
     // keep the heaviest working set as the representative "last time".
     for (const raw of sets) {
@@ -849,6 +863,7 @@ export async function getPreviousSessionForClient(
           typeof best.duration_seconds === "number"
             ? best.duration_seconds
             : null,
+        lastLoggedAt: logCompletedAt,
       };
     }
   }

--- a/backoffice/src/lib/gc-fitness/live-workout-types.ts
+++ b/backoffice/src/lib/gc-fitness/live-workout-types.ts
@@ -100,6 +100,13 @@ export interface ActiveSession {
   scheduledFor: string;
   /** Shared id across a recurring series (drives the finalize "future" option). */
   seriesId?: string | null;
+  /**
+   * ISO-8601 of when the coach last set/changed this assignment's prescription
+   * (`prescriptionUpdatedAt ?? createdAt`). Feeds the shared weight-prefill
+   * rule so a coach plan change shows the routine once before reverting to the
+   * client's remembered weights. Null only on the rare doc with neither stamp.
+   */
+  prescriptionUpdatedAt?: string | null;
 }
 
 /** Compact summary for notifications/sidebar surfaces. */
@@ -123,6 +130,13 @@ export interface PreviousSetSummary {
   weightKg: number;
   reps: number;
   durationSeconds?: number | null;
+  /**
+   * ISO-8601 `completedAt` of the client's most recent COMPLETED log of this
+   * exercise — the `lastLoggedAt` input to the shared weight-prefill rule
+   * (resolveSetPrefill / WeightPrefillResolver). Null/absent when the exercise
+   * was never logged. Additive: existing "ANTERIOR" column consumers ignore it.
+   */
+  lastLoggedAt?: string | null;
 }
 
 /** exerciseId → most-recent completed performance. */

--- a/backoffice/src/lib/gc-fitness/live-workout-types.ts
+++ b/backoffice/src/lib/gc-fitness/live-workout-types.ts
@@ -107,6 +107,16 @@ export interface ActiveSession {
    * client's remembered weights. Null only on the rare doc with neither stamp.
    */
   prescriptionUpdatedAt?: string | null;
+  /**
+   * Per-exercise weight-prefill freshness anchor: `exerciseId → ISO-8601`. The
+   * coach stamps an entry here only for an exercise whose weights genuinely
+   * changed, so a plan edit pushes the routine for THAT exercise once while the
+   * client keeps their own weights on every untouched exercise. The resolver
+   * uses, per exercise, `prescriptionUpdatedAtByExerciseId[exerciseId] ??
+   * prescriptionUpdatedAt ?? createdAt`. Empty/absent on docs written before
+   * this field existed (then the doc-level anchor is the only signal).
+   */
+  prescriptionUpdatedAtByExerciseId?: Record<string, string>;
 }
 
 /** Compact summary for notifications/sidebar surfaces. */

--- a/backoffice/src/lib/gc-fitness/schedule-month-actions.ts
+++ b/backoffice/src/lib/gc-fitness/schedule-month-actions.ts
@@ -245,6 +245,17 @@ export interface AssignmentDetail {
   seriesId: string | null;
   recurrence: Record<string, unknown> | null;
   exercises: AssignmentExercise[];
+  /**
+   * The client's MOST RECENT completed set values, per exerciseId — used by the
+   * edit dialog to show the coach a "Último: 50kg × 10" hint next to each set
+   * row. Per exercise, the array is the non-warmup sets of the latest completed
+   * `workout_logs` doc that logged that exercise, sorted by setIndex. Absent
+   * when the client has no logged history for the exercise.
+   */
+  lastLoggedSetsByExerciseId?: Record<
+    string,
+    Array<{ weightKg: number; reps: number }>
+  >;
 }
 
 export async function getAssignmentDetail(id: string): Promise<AssignmentDetail> {
@@ -299,6 +310,13 @@ export async function getAssignmentDetail(id: string): Promise<AssignmentDetail>
   const templateTag =
     typeof snapshot.tag === "string" ? snapshot.tag : null;
   const exercises = Array.isArray(snapshot.exercises) ? snapshot.exercises : [];
+
+  // Q2 — the client's most recent logged set values per exercise, so the edit
+  // dialog can hint "Último: 50kg × 10" beside each set. The trainer reads
+  // their own client's logs (same access the live session uses).
+  const lastLoggedSetsByExerciseId = clientId
+    ? await fetchLastLoggedSetsByExercise(db, trainer.uid, clientId)
+    : {};
 
   return {
     id: snap.id,
@@ -380,7 +398,80 @@ export async function getAssignmentDetail(id: string): Promise<AssignmentDetail>
             : null,
       };
     }),
+    lastLoggedSetsByExerciseId,
   };
+}
+
+/**
+ * Build `exerciseId → [{ weightKg, reps }]` from the client's MOST RECENT
+ * completed `workout_logs`. For each exercise the first (newest) log we see
+ * that logged it wins; within that log we keep the non-warmup sets sorted by
+ * `set_index`. Ordered by `startedAt DESC` to reuse the existing
+ * `(clientId, status, startedAt DESC)` composite index (no new index). Trainer
+ * ownership is filtered in memory (trainer-of-record is denormalized on logs).
+ */
+async function fetchLastLoggedSetsByExercise(
+  db: FirebaseFirestore.Firestore,
+  trainerUid: string,
+  clientId: string,
+): Promise<Record<string, Array<{ weightKg: number; reps: number }>>> {
+  const HISTORY_LIMIT = 20;
+  const out: Record<string, Array<{ weightKg: number; reps: number }>> = {};
+  try {
+    const snap = await db
+      .collection(LOGS)
+      .where("clientId", "==", clientId)
+      .where("status", "==", "completed")
+      .orderBy("startedAt", "desc")
+      .limit(HISTORY_LIMIT)
+      .get();
+    for (const doc of snap.docs) {
+      const data = doc.data() as Record<string, unknown>;
+      if (data.trainerId !== trainerUid) continue;
+      const sets = Array.isArray(data.sets)
+        ? (data.sets as Array<Record<string, unknown>>)
+        : [];
+      // Group this log's working sets by exerciseId. Logs are newest-first, so
+      // the FIRST log that has an exercise wins (skip if already populated).
+      const byExercise = new Map<
+        string,
+        Array<{ setIndex: number; weightKg: number; reps: number }>
+      >();
+      for (const raw of sets) {
+        if (raw.is_warmup === true) continue;
+        const exerciseId =
+          typeof raw.exerciseId === "string" ? raw.exerciseId : "";
+        if (!exerciseId) continue;
+        const setIndex =
+          typeof raw.set_index === "number" && Number.isFinite(raw.set_index)
+            ? raw.set_index
+            : 0;
+        const weightKg =
+          typeof raw.weight_kg === "number" && Number.isFinite(raw.weight_kg)
+            ? raw.weight_kg
+            : 0;
+        const reps =
+          typeof raw.reps === "number" && Number.isFinite(raw.reps)
+            ? raw.reps
+            : 0;
+        (byExercise.get(exerciseId) ?? byExercise.set(exerciseId, []).get(exerciseId))!.push(
+          { setIndex, weightKg, reps },
+        );
+      }
+      for (const [exerciseId, rows] of byExercise.entries()) {
+        if (out[exerciseId]) continue; // an earlier (newer) log already set it
+        rows.sort((a, b) => a.setIndex - b.setIndex);
+        out[exerciseId] = rows.map((r) => ({
+          weightKg: r.weightKg,
+          reps: r.reps,
+        }));
+      }
+    }
+  } catch {
+    // Missing index / rule error — degrade to no history (the hint just won't
+    // render). Never block the dialog from loading the prescription itself.
+  }
+  return out;
 }
 
 export async function listMonthForClients(input: {

--- a/backoffice/src/lib/gc-fitness/weight-diff.ts
+++ b/backoffice/src/lib/gc-fitness/weight-diff.ts
@@ -93,6 +93,44 @@ export function weightsDifferBetweenSnapshots(
   return false;
 }
 
+/**
+ * The exerciseIds whose `weightBySetKg` differs between two snapshots' exercise
+ * lists, matched by `exerciseId` — the PER-EXERCISE granular twin of
+ * `weightsDifferBetweenSnapshots`. An id is returned when:
+ *   - it appears in both lists with a different `weightBySetKg` (changed value
+ *     OR a set added/removed), OR
+ *   - it carried weight in one list and is gone (or weight-stripped) in the
+ *     other — i.e. an added/removed WEIGHTED exercise.
+ * A new/removed BODYWEIGHT exercise (no/empty weights) is NOT returned (nothing
+ * weight-bearing changed). Reorders with identical weights → []. Notes/reps/rest
+ * changes → []. The result preserves no particular order and contains no
+ * duplicates.
+ *
+ * Used by callers that stamp `prescriptionUpdatedAtByExerciseId.<exId>` so ONLY
+ * the exercises whose weights genuinely changed get pushed to the client.
+ * Positional `__idx_<n>` keys (from weightsById) are intentionally excluded —
+ * a per-exercise stamp is only meaningful for a real exerciseId.
+ */
+export function changedWeightExerciseIds(
+  oldExercises: ReadonlyArray<WeightComparableExercise> | undefined,
+  newExercises: ReadonlyArray<WeightComparableExercise> | undefined,
+): string[] {
+  const oldMap = weightsById(oldExercises);
+  const newMap = weightsById(newExercises);
+
+  const out: string[] = [];
+  const allIds = new Set<string>([...oldMap.keys(), ...newMap.keys()]);
+  for (const id of allIds) {
+    // Only a real exerciseId can carry a per-exercise stamp; skip positional
+    // placeholders for id-less exercises.
+    if (id.startsWith("__idx_")) continue;
+    const oldW = oldMap.get(id) ?? [];
+    const newW = newMap.get(id) ?? [];
+    if (!weightArraysEqual(oldW, newW)) out.push(id);
+  }
+  return out;
+}
+
 /** Extract the `exercises` array from a loosely-typed snapshot value. */
 export function exercisesOf(
   snapshot: unknown,

--- a/backoffice/src/lib/gc-fitness/weight-diff.ts
+++ b/backoffice/src/lib/gc-fitness/weight-diff.ts
@@ -1,0 +1,108 @@
+// weight-diff.ts
+// Pure helpers for deciding WHEN a prescription write should bump the
+// `prescriptionUpdatedAt` "weight-prefill freshness anchor" on a
+// workout_assignments doc.
+//
+// Context: `prescriptionUpdatedAt` is the anchor the shared weight-prefill
+// resolver (weight-prefill.ts / WeightPrefillResolver.swift) compares against a
+// client's last log. Bumping it makes the client apps surface the coach's
+// routine weights ONCE (with a "coach updated" alert) before reverting to the
+// client's own remembered weights. We therefore want to bump it ONLY when the
+// WEIGHTS genuinely changed — bumping on a notes-only edit would spuriously
+// nag every client and reset weights they'd set for themselves.
+//
+// PURITY: no Firestore types. Plain snapshot-shaped objects in, booleans out —
+// trivially unit-testable. Used by editAssignmentExercises (per-client edit)
+// and propagateTemplateToFutureAssignments (template → future occurrences).
+
+/** The minimal exercise shape we care about for the weight comparison. The
+ *  real snapshots carry many more fields (reps, rest, notes, name, …) — those
+ *  are intentionally ignored here. We match exercises by `exerciseId` so a
+ *  reorder of identical weights is NOT treated as a change. */
+export interface WeightComparableExercise {
+  exerciseId?: unknown;
+  weightBySetKg?: unknown;
+}
+
+/** Coerce an unknown `weightBySetKg` into a normalized `number[]`. Non-arrays
+ *  become `[]`; non-finite entries become `0` so a malformed value can't make
+ *  two otherwise-equal snapshots compare unequal. */
+function normalizeWeights(value: unknown): number[] {
+  if (!Array.isArray(value)) return [];
+  return value.map((v) =>
+    typeof v === "number" && Number.isFinite(v) ? v : 0,
+  );
+}
+
+/** Per-set array equality. Different lengths (a set added/removed) → not equal,
+ *  which is the whole point: adding or removing a set IS a weight change. */
+function weightArraysEqual(a: number[], b: number[]): boolean {
+  if (a.length !== b.length) return false;
+  for (let i = 0; i < a.length; i += 1) {
+    if (a[i] !== b[i]) return false;
+  }
+  return true;
+}
+
+/** Build an exerciseId → weightBySetKg map. Exercises with no usable
+ *  `exerciseId` are keyed positionally (`__idx_<n>`) so they still participate
+ *  in the diff rather than silently collapsing onto each other. */
+function weightsById(
+  exercises: ReadonlyArray<WeightComparableExercise> | undefined,
+): Map<string, number[]> {
+  const map = new Map<string, number[]>();
+  if (!Array.isArray(exercises)) return map;
+  exercises.forEach((ex, i) => {
+    const id =
+      typeof ex?.exerciseId === "string" && ex.exerciseId.length > 0
+        ? ex.exerciseId
+        : `__idx_${i}`;
+    // First occurrence wins (matches the note-merge convention elsewhere).
+    if (!map.has(id)) map.set(id, normalizeWeights(ex?.weightBySetKg));
+  });
+  return map;
+}
+
+/**
+ * True when the per-exercise weights differ between two snapshots' exercise
+ * lists, matched by `exerciseId`. Returns true when:
+ *   - any matched exercise has a different `weightBySetKg` (changed value OR a
+ *     set added/removed), OR
+ *   - an exercise present in `oldExercises` is gone in `newExercises` (or vice
+ *     versa) AND it carried any weight — i.e. the set of weighted exercises
+ *     changed.
+ * Returns false when only non-weight fields (notes, reps, rest, order, …)
+ * differ — those must NOT bump the freshness anchor.
+ *
+ * Note-only / reorder edits → false. Weight edits, added sets, removed sets,
+ * and added/removed weighted exercises → true.
+ */
+export function weightsDifferBetweenSnapshots(
+  oldExercises: ReadonlyArray<WeightComparableExercise> | undefined,
+  newExercises: ReadonlyArray<WeightComparableExercise> | undefined,
+): boolean {
+  const oldMap = weightsById(oldExercises);
+  const newMap = weightsById(newExercises);
+
+  const allIds = new Set<string>([...oldMap.keys(), ...newMap.keys()]);
+  for (const id of allIds) {
+    const oldW = oldMap.get(id) ?? [];
+    const newW = newMap.get(id) ?? [];
+    if (!weightArraysEqual(oldW, newW)) return true;
+  }
+  return false;
+}
+
+/** Extract the `exercises` array from a loosely-typed snapshot value. */
+export function exercisesOf(
+  snapshot: unknown,
+): WeightComparableExercise[] {
+  if (
+    snapshot &&
+    typeof snapshot === "object" &&
+    Array.isArray((snapshot as { exercises?: unknown }).exercises)
+  ) {
+    return (snapshot as { exercises: WeightComparableExercise[] }).exercises;
+  }
+  return [];
+}

--- a/backoffice/src/lib/gc-fitness/weight-prefill.ts
+++ b/backoffice/src/lib/gc-fitness/weight-prefill.ts
@@ -1,0 +1,153 @@
+// weight-prefill.ts
+// Single source of truth for "what KG/REPS do we pre-fill into a workout set?"
+//
+// TypeScript twin of the Swift `WeightPrefillResolver` at:
+//   gc-fitness/iOS/Packages/GCFitnessCore/Sources/GCFitnessCore/WeightPrefillResolver.swift
+// Keep the two in lockstep — same branch order, same edge cases. Any change
+// here MUST update the Swift twin (and both test suites) in the same PR.
+//
+// THE RULE — "most recent intent wins":
+//   1. Never logged this exercise              → show the ROUTINE.
+//   2. Coach changed the plan after your last  → show the ROUTINE once,
+//      log (`prescriptionUpdatedAt` is newer)     with a "coach updated" notice.
+//   3. Otherwise                               → show YOUR last logged value.
+// After case 2, logging once makes your value the most-recent intent again,
+// so the next session falls back to case 3. No setting, no per-session choice.
+//
+// Rationale: first time → routine; after logging → your last value; coach
+// changes the plan → routine once (origin "routineUpdated" drives a "coach
+// updated" notice on the apps), then back to remembering. We compare against a
+// dedicated `prescriptionUpdatedAt` (not `updatedAt`) because `updatedAt` also
+// bumps on reschedule / status changes, which would spuriously trigger the
+// "coach updated" notice.
+//
+// GRANULARITY — per-workout (doc level): there is ONE `prescriptionUpdatedAt`
+// per `workout_assignments/{id}`. If the coach touches any prescription on the
+// assignment, the WHOLE workout shows the routine again the next session. We do
+// NOT track which individual exercise changed. `lastLoggedAt` is naturally
+// per-exercise (when you last logged THAT exercise), so the comparison is
+// evaluated per exercise against the one shared prescription timestamp.
+//
+// PURITY: no Firestore types. Plain numbers / Dates in, ResolvedPrefill out —
+// trivially unit-testable and identical across surfaces.
+
+/** A single set's previously-logged values (the user's history channel — NOT
+ *  the set just logged in the current workout). */
+export interface PreviousSetValue {
+  weightKg: number;
+  reps: number;
+  durationSeconds?: number | null;
+}
+
+/** Which intent the resolver chose for a set. Drives the "coach updated"
+ *  notice (only `routineUpdated` surfaces it). */
+export type WeightPrefillOrigin = "routine" | "routineUpdated" | "previous";
+
+/** Resolved pre-fill for one set. */
+export interface ResolvedPrefill {
+  weightKg: number;
+  reps: number;
+  durationSeconds: number | null;
+  origin: WeightPrefillOrigin;
+}
+
+export interface ResolveSetPrefillInput {
+  /** Per-set routine weight (null if the coach prescribed none). */
+  templateWeightKg: number | null;
+  /** Per-set routine reps (null → falls back to `exerciseDefaultReps`). */
+  templateReps: number | null;
+  /** Per-set routine duration for time-based sets. */
+  templateDurationSeconds?: number | null;
+  /** Exercise-level reps fallback. */
+  exerciseDefaultReps: number;
+  /** Exercise-level duration fallback. */
+  exerciseDefaultDurationSeconds?: number | null;
+  /** The user's last logged value for THIS set index (null if none). */
+  previous: PreviousSetValue | null;
+  /** When the coach last set/changed this assignment's prescription. Callers
+   *  should pass `prescriptionUpdatedAt ?? createdAt`. */
+  prescriptionUpdatedAt: Date | null;
+  /** `completedAt` of the most recent completed log of THIS exercise (null if
+   *  the exercise was never logged). */
+  lastLoggedAt: Date | null;
+}
+
+/**
+ * True when the coach's prescription for this assignment is strictly newer
+ * than the user's most recent completed log of the exercise — i.e. the routine
+ * should override the remembered value once.
+ *
+ * - Never logged the exercise (`lastLoggedAt == null`) → `false`: that's the
+ *   first-time-routine case, not an "update".
+ * - Unknown prescription freshness (`prescriptionUpdatedAt == null`, e.g. a
+ *   legacy assignment with no timestamp) → `false`: prefer to keep remembering
+ *   the user's weights rather than nag spuriously. Callers should pass
+ *   `prescriptionUpdatedAt ?? createdAt`.
+ */
+export function coachUpdatedSinceLastLog(
+  prescriptionUpdatedAt: Date | null,
+  lastLoggedAt: Date | null,
+): boolean {
+  if (lastLoggedAt === null) return false;
+  if (prescriptionUpdatedAt === null) return false;
+  // strict `>` — equal timestamps are NOT an update (keep remembering).
+  return prescriptionUpdatedAt.getTime() > lastLoggedAt.getTime();
+}
+
+/** Resolve the seed value for ONE set. See the file header for the rule. */
+export function resolveSetPrefill(input: ResolveSetPrefillInput): ResolvedPrefill {
+  const {
+    templateWeightKg,
+    templateReps,
+    templateDurationSeconds = null,
+    exerciseDefaultReps,
+    exerciseDefaultDurationSeconds = null,
+    previous,
+    prescriptionUpdatedAt,
+    lastLoggedAt,
+  } = input;
+
+  const resolvedReps = templateReps ?? exerciseDefaultReps;
+  const resolvedDuration = templateDurationSeconds ?? exerciseDefaultDurationSeconds;
+
+  const routine = (origin: WeightPrefillOrigin): ResolvedPrefill => ({
+    weightKg: templateWeightKg ?? 0,
+    reps: resolvedReps,
+    durationSeconds: resolvedDuration,
+    origin,
+  });
+
+  // Case 1 — never logged this exercise → the coach's routine.
+  if (lastLoggedAt === null) {
+    return routine("routine");
+  }
+
+  // Case 2 — coach changed the plan after the last log → routine once, with
+  // notice. Only override when the routine actually prescribes a weight;
+  // otherwise there is nothing meaningful to override with.
+  if (
+    coachUpdatedSinceLastLog(prescriptionUpdatedAt, lastLoggedAt) &&
+    templateWeightKg !== null
+  ) {
+    return {
+      weightKg: templateWeightKg,
+      reps: resolvedReps,
+      durationSeconds: resolvedDuration,
+      origin: "routineUpdated",
+    };
+  }
+
+  // Case 3 — remember the user's last logged value for this set.
+  if (previous !== null) {
+    return {
+      weightKg: previous.weightKg,
+      reps: previous.reps,
+      durationSeconds: previous.durationSeconds ?? null,
+      origin: "previous",
+    };
+  }
+
+  // Exercise was logged before, but not at this set index (e.g. the coach added
+  // a set). Seed the new row from the routine, no "updated" notice.
+  return routine("routine");
+}

--- a/backoffice/src/lib/gc-fitness/weight-prefill.ts
+++ b/backoffice/src/lib/gc-fitness/weight-prefill.ts
@@ -70,6 +70,11 @@ export interface ResolveSetPrefillInput {
   /** `completedAt` of the most recent completed log of THIS exercise (null if
    *  the exercise was never logged). */
   lastLoggedAt: Date | null;
+  /** Client's per-session escape hatch ("use my previous weights"). When true
+   *  and the set would otherwise be a coach update, the client's remembered
+   *  value wins instead (origin "previous"). The alert still shows (driven by
+   *  `isCoachUpdate`); this only changes the seeded values. Synced phone↔watch. */
+  preferPreviousWhenCoachUpdated?: boolean;
 }
 
 /**
@@ -94,6 +99,23 @@ export function coachUpdatedSinceLastLog(
   return prescriptionUpdatedAt.getTime() > lastLoggedAt.getTime();
 }
 
+/**
+ * Workout-/exercise-level signal: the coach changed this assignment's weight
+ * prescription after the client's last log AND a routine weight is actually
+ * prescribed. Drives the "your coach updated this workout" alert — independent
+ * of whether the client then keeps their own weights.
+ */
+export function isCoachUpdate(
+  prescriptionUpdatedAt: Date | null,
+  lastLoggedAt: Date | null,
+  templateWeightKg: number | null,
+): boolean {
+  return (
+    coachUpdatedSinceLastLog(prescriptionUpdatedAt, lastLoggedAt) &&
+    templateWeightKg !== null
+  );
+}
+
 /** Resolve the seed value for ONE set. See the file header for the rule. */
 export function resolveSetPrefill(input: ResolveSetPrefillInput): ResolvedPrefill {
   const {
@@ -105,6 +127,7 @@ export function resolveSetPrefill(input: ResolveSetPrefillInput): ResolvedPrefil
     previous,
     prescriptionUpdatedAt,
     lastLoggedAt,
+    preferPreviousWhenCoachUpdated = false,
   } = input;
 
   const resolvedReps = templateReps ?? exerciseDefaultReps;
@@ -116,6 +139,16 @@ export function resolveSetPrefill(input: ResolveSetPrefillInput): ResolvedPrefil
     durationSeconds: resolvedDuration,
     origin,
   });
+
+  const previousPrefill = (): ResolvedPrefill | null =>
+    previous === null
+      ? null
+      : {
+          weightKg: previous.weightKg,
+          reps: previous.reps,
+          durationSeconds: previous.durationSeconds ?? null,
+          origin: "previous",
+        };
 
   // Case 1 — never logged this exercise → the coach's routine.
   if (lastLoggedAt === null) {
@@ -129,6 +162,12 @@ export function resolveSetPrefill(input: ResolveSetPrefillInput): ResolvedPrefil
     coachUpdatedSinceLastLog(prescriptionUpdatedAt, lastLoggedAt) &&
     templateWeightKg !== null
   ) {
+    // Client tapped "use my previous weights" — keep their remembered value for
+    // this set (if any) even though the coach changed the plan.
+    if (preferPreviousWhenCoachUpdated) {
+      const prev = previousPrefill();
+      if (prev !== null) return prev;
+    }
     return {
       weightKg: templateWeightKg,
       reps: resolvedReps,
@@ -138,13 +177,9 @@ export function resolveSetPrefill(input: ResolveSetPrefillInput): ResolvedPrefil
   }
 
   // Case 3 — remember the user's last logged value for this set.
-  if (previous !== null) {
-    return {
-      weightKg: previous.weightKg,
-      reps: previous.reps,
-      durationSeconds: previous.durationSeconds ?? null,
-      origin: "previous",
-    };
+  const prev = previousPrefill();
+  if (prev !== null) {
+    return prev;
   }
 
   // Exercise was logged before, but not at this set index (e.g. the coach added

--- a/backoffice/src/lib/gc-fitness/workout-assignment-actions.ts
+++ b/backoffice/src/lib/gc-fitness/workout-assignment-actions.ts
@@ -42,6 +42,10 @@ import {
 } from "./workout-assignment-schema";
 import { getCurrentTrainer } from "./auth-helpers";
 import {
+  weightsDifferBetweenSnapshots,
+  exercisesOf,
+} from "./weight-diff";
+import {
   recordCoachActivityEvent,
   markCoachActivityDeleted,
   singleAssignmentEvent,
@@ -1274,12 +1278,21 @@ export async function listFutureAssignmentsForTemplate(
  * are left untouched — they remain a frozen record of what the client was
  * actually asked to do.
  *
- * Per-assignment prescription overrides (reps/kg/sets/rest) are intentionally
- * replaced with the new template values — that's the whole point of "update
- * all occurrences". The ONE thing we preserve is the per-client per-exercise
- * NOTE the trainer wrote for that student: that note is personal annotation,
- * not template content, and silently wiping it on a template edit was a bug.
- * Merge rule (per exercise, matched by exerciseId then index):
+ * Notes/structure (reps/sets/rest/order/etc.) always flow through from the
+ * template. WEIGHTS are governed by the `pushWeights` option:
+ *   - pushWeights === false (DEFAULT): each assignment KEEPS its existing
+ *     per-exercise `weightBySetKg` (matched by exerciseId); new exercises with
+ *     no prior match take the template's weights. The `prescriptionUpdatedAt`
+ *     freshness anchor is NOT bumped — clients keep their own weights, no
+ *     "coach updated" alert.
+ *   - pushWeights === true: weights are replaced from the template too, and the
+ *     anchor is bumped — BUT only for assignments where a weight genuinely
+ *     changed vs the prior snapshot (avoid spuriously alerting clients whose
+ *     weights already match).
+ *
+ * The per-client per-exercise NOTE the trainer wrote for that student is always
+ * preserved (personal annotation, not template content). Merge rule (per
+ * exercise, matched by exerciseId then index):
  *   - client note only           → keep it
  *   - new template note only      → use it
  *   - both                        → "<client note> * <template note>"
@@ -1299,7 +1312,14 @@ function mergeExerciseNote(
 }
 export async function propagateTemplateToFutureAssignments(
   templateId: string,
+  options?: { pushWeights?: boolean },
 ): Promise<{ updatedCount: number }> {
+  // pushWeights defaults to FALSE: notes/structure/reps/rest flow through, but
+  // each client KEEPS their own per-exercise weights and the freshness anchor
+  // is left alone. Opting in (true) replaces weights from the template AND
+  // bumps the anchor — but only for assignments whose weights genuinely
+  // changed, so identical-weight clients aren't spuriously alerted.
+  const pushWeights = options?.pushWeights === true;
   const trainer = await getCurrentTrainer();
 
   const db = gcFitnessFirestore();
@@ -1346,24 +1366,46 @@ export async function propagateTemplateToFutureAssignments(
         : [];
     // exerciseId → first existing note, for reordered/added template exercises.
     const noteById = new Map<string, unknown>();
+    // exerciseId → first existing weightBySetKg, so we can PRESERVE each
+    // client's own weights when pushWeights is off (the default).
+    const weightById = new Map<string, unknown>();
     for (const ex of existingExercises) {
       const id = typeof ex.exerciseId === "string" ? ex.exerciseId : "";
       if (id && !noteById.has(id)) noteById.set(id, ex.notes);
+      if (id && !weightById.has(id)) weightById.set(id, ex.weightBySetKg);
     }
     const exercises = freshExercises.map((fresh, i) => {
       const byIndex = existingExercises[i];
-      const clientNote =
-        byIndex && byIndex.exerciseId === fresh.exerciseId
-          ? byIndex.notes
-          : noteById.get(
-              typeof fresh.exerciseId === "string" ? fresh.exerciseId : "",
-            );
+      const matchesById = byIndex && byIndex.exerciseId === fresh.exerciseId;
+      const freshId =
+        typeof fresh.exerciseId === "string" ? fresh.exerciseId : "";
+      const clientNote = matchesById
+        ? byIndex.notes
+        : noteById.get(freshId);
       const merged = mergeExerciseNote(clientNote, fresh.notes);
       const next = { ...fresh };
       if (merged !== undefined) {
         next.notes = merged;
       } else {
         delete next.notes;
+      }
+      // pushWeights OFF (default): keep the client's own weights for any
+      // exercise that already existed on this assignment (matched by
+      // exerciseId). New exercises with no prior match fall through to the
+      // template's weights (already in `fresh`). pushWeights ON: leave the
+      // template's weights in place (replace the client's).
+      if (!pushWeights) {
+        const matched = matchesById || weightById.has(freshId);
+        if (matched) {
+          const priorWeight = matchesById
+            ? byIndex.weightBySetKg
+            : weightById.get(freshId);
+          if (priorWeight !== undefined) {
+            next.weightBySetKg = priorWeight;
+          } else {
+            delete next.weightBySetKg;
+          }
+        }
       }
       return next;
     });
@@ -1379,13 +1421,25 @@ export async function propagateTemplateToFutureAssignments(
     for (const doc of targets.slice(i, i + CHUNK)) {
       const existing = (doc.data() as { templateSnapshot?: unknown })
         .templateSnapshot;
+      const nextSnapshot = snapshotForAssignment(existing);
+      // Bump the freshness anchor ONLY when the coach opted to push weights AND
+      // this assignment's weights genuinely changed vs its prior snapshot. With
+      // pushWeights off the client keeps their own weights, so the anchor is
+      // left untouched and nothing surfaces a "coach updated" alert. With it on,
+      // we still skip the bump for assignments whose weights happen to be
+      // identical to the template's — no point nagging an unchanged client.
+      const bump =
+        pushWeights &&
+        weightsDifferBetweenSnapshots(
+          exercisesOf(existing),
+          exercisesOf(nextSnapshot),
+        );
       batch.update(doc.ref, {
-        templateSnapshot: snapshotForAssignment(existing),
+        templateSnapshot: nextSnapshot,
         updatedAt: FieldValue.serverTimestamp(),
-        // The prescription was just rewritten from the edited template — bump
-        // the freshness anchor so the apps show the new plan once (origin
-        // "routineUpdated") before falling back to the client's own weights.
-        prescriptionUpdatedAt: FieldValue.serverTimestamp(),
+        ...(bump
+          ? { prescriptionUpdatedAt: FieldValue.serverTimestamp() }
+          : {}),
       });
     }
     await batch.commit();
@@ -1508,13 +1562,22 @@ export async function editAssignmentExercises(
 
   const batch = db.batch();
   for (const tgt of targets) {
+    const nextSnapshot = applyEdits(tgt.snapshot);
+    // Bump the weight-prefill freshness anchor ONLY when the WEIGHTS actually
+    // changed vs the current snapshot. Each client can hold their own weights,
+    // so a notes-only (or reps/rest-only) edit must NOT reset them — bumping
+    // would make the apps surface the routine weights once and nag the client
+    // spuriously. Editing a client's weights specifically SHOULD push (bump).
+    const weightsChanged = weightsDifferBetweenSnapshots(
+      exercisesOf(tgt.snapshot),
+      exercisesOf(nextSnapshot),
+    );
     batch.update(tgt.ref, {
-      templateSnapshot: applyEdits(tgt.snapshot),
+      templateSnapshot: nextSnapshot,
       updatedAt: FieldValue.serverTimestamp(),
-      // The coach just rewrote this assignment's per-exercise prescription —
-      // bump the freshness anchor so the apps surface the new plan once before
-      // reverting to the client's remembered weights (weight-prefill rule).
-      prescriptionUpdatedAt: FieldValue.serverTimestamp(),
+      ...(weightsChanged
+        ? { prescriptionUpdatedAt: FieldValue.serverTimestamp() }
+        : {}),
     });
   }
   await batch.commit();

--- a/backoffice/src/lib/gc-fitness/workout-assignment-actions.ts
+++ b/backoffice/src/lib/gc-fitness/workout-assignment-actions.ts
@@ -42,7 +42,7 @@ import {
 } from "./workout-assignment-schema";
 import { getCurrentTrainer } from "./auth-helpers";
 import {
-  weightsDifferBetweenSnapshots,
+  changedWeightExerciseIds,
   exercisesOf,
 } from "./weight-diff";
 import {
@@ -290,6 +290,59 @@ function nextCivilForWeekdayOnOrAfter(civilDate: string, weekday: number): strin
   const currentWeekday = dayOfWeekFromCivil(civilDate);
   const delta = (weekday - currentWeekday + 7) % 7;
   return addCivilDays(civilDate, delta);
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Per-exercise weight-prefill freshness anchor (prescriptionUpdatedAtByExerciseId)
+// ─────────────────────────────────────────────────────────────────────────────
+//
+// simplify-weight-prefill: instead of bumping the doc-level
+// `prescriptionUpdatedAt` (which resets the WHOLE workout for the client), we
+// stamp ONLY the exerciseIds whose weights actually changed into the
+// `prescriptionUpdatedAtByExerciseId` map. The resolver reads, per exercise,
+// `prescriptionUpdatedAtByExerciseId[exId] ?? prescriptionUpdatedAt ?? createdAt`.
+//
+// We write each entry via a dotted field-path key (`prescriptionUpdatedAtByExerciseId.<exId>`)
+// so an update touches only that entry, not the whole map. exerciseIds are slugs
+// like "wger-123" (no dots/spaces), but Firestore field paths treat `.` `~` `/`
+// `*` `[` `]` specially, so we GUARD: any id with one of those characters is
+// merged via a read-modify-write of the whole map instead of a dotted path.
+
+/** Firestore field-path-unsafe characters: `.` `~` `/` `*` `[` `]`. */
+const UNSAFE_FIELD_PATH_RE = /[.~/*[\]]/;
+
+/**
+ * Build a Firestore update object that stamps `serverTimestamp()` for each
+ * changed exerciseId into `prescriptionUpdatedAtByExerciseId`. Safe ids use a
+ * dotted field-path key (single-entry merge); any id containing a field-path
+ * special char falls back to merging the whole map (read from `existingMap`).
+ * Returns `{}` when there are no changed ids (caller must not touch the map).
+ */
+function buildPerExerciseStampUpdate(
+  changedIds: string[],
+  existingMap: unknown,
+): Record<string, unknown> {
+  if (changedIds.length === 0) return {};
+  const safe: string[] = [];
+  const unsafe: string[] = [];
+  for (const id of changedIds) {
+    (UNSAFE_FIELD_PATH_RE.test(id) ? unsafe : safe).push(id);
+  }
+  const update: Record<string, unknown> = {};
+  for (const id of safe) {
+    update[`prescriptionUpdatedAtByExerciseId.${id}`] =
+      FieldValue.serverTimestamp();
+  }
+  if (unsafe.length > 0) {
+    // Merge the whole map (preserve existing entries) for the rare unsafe id.
+    const merged: Record<string, unknown> =
+      existingMap && typeof existingMap === "object"
+        ? { ...(existingMap as Record<string, unknown>) }
+        : {};
+    for (const id of unsafe) merged[id] = FieldValue.serverTimestamp();
+    update.prescriptionUpdatedAtByExerciseId = merged;
+  }
+  return update;
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -1419,27 +1472,32 @@ export async function propagateTemplateToFutureAssignments(
   for (let i = 0; i < targets.length; i += CHUNK) {
     const batch = db.batch();
     for (const doc of targets.slice(i, i + CHUNK)) {
-      const existing = (doc.data() as { templateSnapshot?: unknown })
-        .templateSnapshot;
+      const docData = doc.data() as {
+        templateSnapshot?: unknown;
+        prescriptionUpdatedAtByExerciseId?: unknown;
+      };
+      const existing = docData.templateSnapshot;
       const nextSnapshot = snapshotForAssignment(existing);
-      // Bump the freshness anchor ONLY when the coach opted to push weights AND
-      // this assignment's weights genuinely changed vs its prior snapshot. With
-      // pushWeights off the client keeps their own weights, so the anchor is
-      // left untouched and nothing surfaces a "coach updated" alert. With it on,
-      // we still skip the bump for assignments whose weights happen to be
-      // identical to the template's — no point nagging an unchanged client.
-      const bump =
-        pushWeights &&
-        weightsDifferBetweenSnapshots(
-          exercisesOf(existing),
-          exercisesOf(nextSnapshot),
-        );
+      // Stamp the freshness anchor PER EXERCISE — only when the coach opted to
+      // push weights AND only for the exercises whose weights genuinely changed
+      // vs this assignment's prior snapshot. With pushWeights off the client
+      // keeps their own weights, so nothing is stamped and no "coach updated"
+      // alert fires. With it on, an exercise whose weight happens to already
+      // match the template is skipped too — no point nagging on an unchanged
+      // exercise. We no longer bump the doc-level `prescriptionUpdatedAt`.
+      const changedIds = pushWeights
+        ? changedWeightExerciseIds(
+            exercisesOf(existing),
+            exercisesOf(nextSnapshot),
+          )
+        : [];
       batch.update(doc.ref, {
         templateSnapshot: nextSnapshot,
         updatedAt: FieldValue.serverTimestamp(),
-        ...(bump
-          ? { prescriptionUpdatedAt: FieldValue.serverTimestamp() }
-          : {}),
+        ...buildPerExerciseStampUpdate(
+          changedIds,
+          docData.prescriptionUpdatedAtByExerciseId,
+        ),
       });
     }
     await batch.commit();
@@ -1523,6 +1581,7 @@ export async function editAssignmentExercises(
   const targets: Array<{
     ref: FirebaseFirestore.DocumentReference;
     snapshot: unknown;
+    existingMap: unknown;
   }> = [];
   if (input.scope === "series" && typeof data.seriesId === "string" && data.seriesId) {
     const today = civilDateFormat(new Date(), await getTrainerTimezone());
@@ -1536,48 +1595,61 @@ export async function editAssignmentExercises(
         scheduledFor?: string;
         status?: string;
         templateSnapshot?: unknown;
+        prescriptionUpdatedAtByExerciseId?: unknown;
       };
       if (
         typeof dd.scheduledFor === "string" &&
         dd.scheduledFor >= today &&
         (!dd.status || dd.status === "scheduled")
       ) {
-        targets.push({ ref: d.ref, snapshot: dd.templateSnapshot });
+        targets.push({
+          ref: d.ref,
+          snapshot: dd.templateSnapshot,
+          existingMap: dd.prescriptionUpdatedAtByExerciseId,
+        });
       }
     }
     if (targets.length === 0) {
+      const cur = snap.data() as {
+        templateSnapshot?: unknown;
+        prescriptionUpdatedAtByExerciseId?: unknown;
+      };
       targets.push({
         ref,
-        snapshot: (snap.data() as { templateSnapshot?: unknown })
-          .templateSnapshot,
+        snapshot: cur.templateSnapshot,
+        existingMap: cur.prescriptionUpdatedAtByExerciseId,
       });
     }
   } else {
+    const cur = snap.data() as {
+      templateSnapshot?: unknown;
+      prescriptionUpdatedAtByExerciseId?: unknown;
+    };
     targets.push({
       ref,
-      snapshot: (snap.data() as { templateSnapshot?: unknown })
-        .templateSnapshot,
+      snapshot: cur.templateSnapshot,
+      existingMap: cur.prescriptionUpdatedAtByExerciseId,
     });
   }
 
   const batch = db.batch();
   for (const tgt of targets) {
     const nextSnapshot = applyEdits(tgt.snapshot);
-    // Bump the weight-prefill freshness anchor ONLY when the WEIGHTS actually
-    // changed vs the current snapshot. Each client can hold their own weights,
-    // so a notes-only (or reps/rest-only) edit must NOT reset them — bumping
-    // would make the apps surface the routine weights once and nag the client
-    // spuriously. Editing a client's weights specifically SHOULD push (bump).
-    const weightsChanged = weightsDifferBetweenSnapshots(
+    // Stamp the weight-prefill freshness anchor PER EXERCISE — only for the
+    // exercises whose WEIGHTS actually changed vs the current snapshot. Each
+    // client holds their own weights per exercise, so a notes-only (or
+    // reps/rest-only) edit stamps nothing and leaves the rest untouched; the
+    // client keeps their own weights on every exercise the coach didn't change.
+    // We no longer bump the doc-level `prescriptionUpdatedAt` on edits — it
+    // stays as the create baseline + legacy fallback.
+    const changedIds = changedWeightExerciseIds(
       exercisesOf(tgt.snapshot),
       exercisesOf(nextSnapshot),
     );
     batch.update(tgt.ref, {
       templateSnapshot: nextSnapshot,
       updatedAt: FieldValue.serverTimestamp(),
-      ...(weightsChanged
-        ? { prescriptionUpdatedAt: FieldValue.serverTimestamp() }
-        : {}),
+      ...buildPerExerciseStampUpdate(changedIds, tgt.existingMap),
     });
   }
   await batch.commit();

--- a/backoffice/src/lib/gc-fitness/workout-assignment-actions.ts
+++ b/backoffice/src/lib/gc-fitness/workout-assignment-actions.ts
@@ -349,6 +349,10 @@ export async function assignTemplate(
     status: "scheduled" as const,
     createdAt: FieldValue.serverTimestamp(),
     updatedAt: FieldValue.serverTimestamp(),
+    // The coach is establishing the prescription right now — stamp it so the
+    // shared weight-prefill rule can detect future plan changes (see
+    // weight-prefill.ts / WeightPrefillResolver.swift).
+    prescriptionUpdatedAt: FieldValue.serverTimestamp(),
   });
 
   await recordCoachActivityEvent(
@@ -426,6 +430,8 @@ export async function assignTemplateToPending(input: {
     status: "scheduled" as const,
     createdAt: FieldValue.serverTimestamp(),
     updatedAt: FieldValue.serverTimestamp(),
+    // Prescription established now — weight-prefill freshness anchor.
+    prescriptionUpdatedAt: FieldValue.serverTimestamp(),
   });
 
   await recordCoachActivityEvent(
@@ -576,6 +582,8 @@ export async function bulkAssignTemplate(
       status: "scheduled" as const,
       createdAt: FieldValue.serverTimestamp(),
       updatedAt: FieldValue.serverTimestamp(),
+      // Prescription established now — weight-prefill freshness anchor.
+      prescriptionUpdatedAt: FieldValue.serverTimestamp(),
     });
     ids.push(docId);
   }
@@ -728,6 +736,8 @@ export async function assignTemplateRecurring(
       status: "scheduled" as const,
       createdAt: FieldValue.serverTimestamp(),
       updatedAt: FieldValue.serverTimestamp(),
+      // Prescription established now — weight-prefill freshness anchor.
+      prescriptionUpdatedAt: FieldValue.serverTimestamp(),
       recurrence: recurrencePayload,
       seriesId,
     });
@@ -898,6 +908,8 @@ export async function assignTemplateRecurringToPending(input: {
       status: "scheduled" as const,
       createdAt: FieldValue.serverTimestamp(),
       updatedAt: FieldValue.serverTimestamp(),
+      // Prescription established now — weight-prefill freshness anchor.
+      prescriptionUpdatedAt: FieldValue.serverTimestamp(),
       recurrence: recurrencePayload,
       seriesId,
     });
@@ -1370,6 +1382,10 @@ export async function propagateTemplateToFutureAssignments(
       batch.update(doc.ref, {
         templateSnapshot: snapshotForAssignment(existing),
         updatedAt: FieldValue.serverTimestamp(),
+        // The prescription was just rewritten from the edited template — bump
+        // the freshness anchor so the apps show the new plan once (origin
+        // "routineUpdated") before falling back to the client's own weights.
+        prescriptionUpdatedAt: FieldValue.serverTimestamp(),
       });
     }
     await batch.commit();
@@ -1495,6 +1511,10 @@ export async function editAssignmentExercises(
     batch.update(tgt.ref, {
       templateSnapshot: applyEdits(tgt.snapshot),
       updatedAt: FieldValue.serverTimestamp(),
+      // The coach just rewrote this assignment's per-exercise prescription —
+      // bump the freshness anchor so the apps surface the new plan once before
+      // reverting to the client's remembered weights (weight-prefill rule).
+      prescriptionUpdatedAt: FieldValue.serverTimestamp(),
     });
   }
   await batch.commit();

--- a/backoffice/src/lib/gc-fitness/workout-assignment-schema.ts
+++ b/backoffice/src/lib/gc-fitness/workout-assignment-schema.ts
@@ -100,6 +100,24 @@ export const assignTemplateSchema = z.object({
   exerciseOverrides: z.array(assignmentExerciseOverrideSchema).max(50).optional(),
 });
 
+/**
+ * `prescriptionUpdatedAt` — camelCase wire timestamp (like `createdAt` /
+ * `updatedAt`) recording when the coach last SET or REWROTE this assignment's
+ * prescription (templateSnapshot). Drives the shared weight-prefill rule
+ * (`resolveSetPrefill` / Swift `WeightPrefillResolver`): when this is strictly
+ * newer than the client's last log of an exercise, the apps show the routine
+ * once with a "coach updated" notice, then fall back to remembering the
+ * client's own weights.
+ *
+ * It is written by the SERVER (Admin SDK, `FieldValue.serverTimestamp()`) at
+ * every site that establishes or rewrites the prescription — never by client
+ * input — so this schema entry is OPTIONAL and exists only for documentation /
+ * forward-compat on any future shape that round-trips the value. A dedicated
+ * field (NOT `updatedAt`) avoids the false "coach updated" notice that a
+ * reschedule / status flip would otherwise trigger.
+ */
+export const prescriptionUpdatedAtSchema = z.unknown().optional();
+
 export type AssignTemplateInput = z.infer<typeof assignTemplateSchema>;
 
 /**


### PR DESCRIPTION
## What & why

Backoffice half of the cross-surface weight pre-fill simplification. Companion to mdb1/gc-fitness#101 (iOS + watch + Firestore rules), which has the full design and the canonical doc (`docs/WEIGHT_PREFILL.md`).

Replaces the old per-user prefill source with **one automatic rule** — "most recent intent wins": the routine seeds the first session and any session after the coach changes the plan; otherwise the client's last logged value is remembered.

## Changes
- **`weight-prefill.ts`** — pure TS twin of the Swift `WeightPrefillResolver` (same branch order + edge cases) + jest suite mirroring the Swift tests.
- **`prescriptionUpdatedAt`** stamped (`serverTimestamp()`) at every prescription-establishing write: assign (single/bulk/recurring/pending), `propagateTemplateToFutureAssignments`, per-assignment override edit, finalize "session_and_future" snapshot rewrite. Added to the assignment Zod schema (optional).
- **Live coach-run session** (`use-live-session.ts`) seeds via the resolver, fed by the assignment's `prescriptionUpdatedAt` and per-exercise `lastLoggedAt` (surfaced through `live-workout-actions.ts` / `live-workout-types.ts`).
- **Coach-facing explainer** in gc-fitness Settings (en/es).

> ⚠️ Auto-deploys `main` on merge — gate is green below.

## Test gate
- `npx jest`: **393 pass** (incl. new `weight-prefill.test.ts`). Only failure is the pre-existing locale flake `client-activity-time.test.ts` ("Jun 2" vs "2 June", green in CI) — no new failures.
- Firestore rules (in the gc-fitness repo): workout-assignments **36/36**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)