### PR TITLE
feat(gc-fitness): admin force-update / min app version panel

### DIFF
--- a/backoffice/src/app/gc-fitness/admin/app-config/app-version-form.tsx
+++ b/backoffice/src/app/gc-fitness/admin/app-config/app-version-form.tsx
@@ -1,0 +1,217 @@
+"use client";
+
+// app-version-form.tsx
+//
+// Admin-only editor for the mobile force-update gate (`/app_config/mobile`).
+// Submits via the `updateAppVersionConfig` Server Action, which owns the
+// authoritative Zod validation + Admin gate. This form mirrors the same schema
+// for early client-side error surfacing (same pattern as quick-replies-form).
+//
+// `minBuild` is THE gate: the apps compare it against their native build
+// (iOS CFBundleVersion / Android versionCode). Bumping it above a shipped
+// build's number blocks that build at launch with a non-dismissable update
+// screen. `0` disables the gate for the platform. `latestVersion` + `storeUrl`
+// are display / deep-link only.
+//
+// English literals (no next-intl): the whole Admin Console is English-only,
+// unlike the trainer Settings surface.
+
+import { useTransition } from "react";
+import { useRouter } from "next/navigation";
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { toast } from "sonner";
+import { z } from "zod";
+
+import {
+  Form,
+  FormControl,
+  FormDescription,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form";
+import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import {
+  updateAppVersionConfig,
+  type AppVersionConfig,
+} from "@/lib/gc-fitness/admin-actions";
+
+const platformSchema = z.object({
+  minBuild: z.coerce
+    .number()
+    .int("Enter a whole number.")
+    .min(0, "Cannot be negative.")
+    .max(2_147_483_647, "Too large."),
+  latestVersion: z
+    .string()
+    .trim()
+    .max(20)
+    .refine((v) => v === "" || /^\d+(\.\d+){0,3}$/.test(v), {
+      message: "Use a dotted version like 1.2.0 (or leave blank).",
+    }),
+  storeUrl: z
+    .string()
+    .trim()
+    .max(300)
+    .refine((v) => v === "" || /^https?:\/\//i.test(v), {
+      message: "Must be an http(s) URL (or leave blank).",
+    }),
+});
+
+const formSchema = z.object({
+  ios: platformSchema,
+  android: platformSchema,
+});
+
+export interface AppVersionFormProps {
+  initialConfig: AppVersionConfig;
+}
+
+const PLATFORMS = [
+  {
+    key: "ios" as const,
+    label: "iOS",
+    buildHint: "Minimum CFBundleVersion (build number). Builds below this are blocked.",
+    storePlaceholder: "https://apps.apple.com/app/id000000000",
+  },
+  {
+    key: "android" as const,
+    label: "Android",
+    buildHint: "Minimum versionCode. Builds below this are blocked. Leave 0 until Android ships.",
+    storePlaceholder: "https://play.google.com/store/apps/details?id=com.goldencrow.fitness",
+  },
+];
+
+export function AppVersionForm({ initialConfig }: AppVersionFormProps) {
+  const router = useRouter();
+  const [pending, startTransition] = useTransition();
+
+  const form = useForm({
+    // Input (number field gives a string) vs output (coerced number) types
+    // differ — same `as any` escape hatch quick-replies-form uses.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    resolver: zodResolver(formSchema as any) as unknown as any,
+    defaultValues: {
+      ios: {
+        minBuild: initialConfig.ios.minBuild,
+        latestVersion: initialConfig.ios.latestVersion,
+        storeUrl: initialConfig.ios.storeUrl,
+      },
+      android: {
+        minBuild: initialConfig.android.minBuild,
+        latestVersion: initialConfig.android.latestVersion,
+        storeUrl: initialConfig.android.storeUrl,
+      },
+    },
+    mode: "onSubmit",
+  });
+
+  const submit = form.handleSubmit((values) => {
+    startTransition(async () => {
+      try {
+        await updateAppVersionConfig(values);
+        toast.success("App version requirements saved.");
+        router.refresh();
+      } catch (err) {
+        console.error("[app-version-form] save failed", err);
+        const message =
+          err instanceof Error ? err.message : "Could not save. Try again.";
+        toast.error(message);
+      }
+    });
+  });
+
+  return (
+    <Form {...form}>
+      <form onSubmit={submit} className="flex flex-col gap-6">
+        {PLATFORMS.map((platform) => (
+          <Card key={platform.key}>
+            <CardHeader>
+              <CardTitle className="text-lg">{platform.label}</CardTitle>
+              <CardDescription>
+                Clients on a build below the minimum see a non-dismissable
+                update screen at launch.
+              </CardDescription>
+            </CardHeader>
+            <CardContent className="grid gap-4 sm:grid-cols-3">
+              <FormField
+                control={form.control}
+                name={`${platform.key}.minBuild` as const}
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Minimum build</FormLabel>
+                    <FormControl>
+                      <Input
+                        type="number"
+                        inputMode="numeric"
+                        min={0}
+                        step={1}
+                        {...field}
+                      />
+                    </FormControl>
+                    <FormDescription>{platform.buildHint}</FormDescription>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+              <FormField
+                control={form.control}
+                name={`${platform.key}.latestVersion` as const}
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Latest version</FormLabel>
+                    <FormControl>
+                      <Input placeholder="1.2.0" {...field} />
+                    </FormControl>
+                    <FormDescription>
+                      Shown in the update message (display-only).
+                    </FormDescription>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+              <FormField
+                control={form.control}
+                name={`${platform.key}.storeUrl` as const}
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Store URL</FormLabel>
+                    <FormControl>
+                      <Input placeholder={platform.storePlaceholder} {...field} />
+                    </FormControl>
+                    <FormDescription>
+                      Opened by the update button.
+                    </FormDescription>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+            </CardContent>
+          </Card>
+        ))}
+
+        <div className="flex items-center justify-end gap-3">
+          {initialConfig.updatedAtISO ? (
+            <span className="text-xs text-muted-foreground">
+              Last updated {new Date(initialConfig.updatedAtISO).toLocaleString()}
+              {initialConfig.updatedBy ? ` by ${initialConfig.updatedBy}` : ""}
+            </span>
+          ) : null}
+          <Button type="submit" disabled={pending}>
+            {pending ? "Saving…" : "Save"}
+          </Button>
+        </div>
+      </form>
+    </Form>
+  );
+}

--- a/backoffice/src/app/gc-fitness/admin/app-config/page.tsx
+++ b/backoffice/src/app/gc-fitness/admin/app-config/page.tsx
@@ -1,0 +1,61 @@
+import Link from "next/link";
+import { redirect } from "next/navigation";
+import { ArrowLeft } from "lucide-react";
+
+import {
+  getAppVersionConfig,
+  type AppVersionConfig,
+} from "@/lib/gc-fitness/admin-actions";
+import { getCurrentAdmin } from "@/lib/gc-fitness/auth-helpers";
+import { PageHeader } from "@/components/gc-fitness/page-header";
+import { AppVersionForm } from "./app-version-form";
+
+export const dynamic = "force-dynamic";
+
+const EMPTY_CONFIG: AppVersionConfig = {
+  ios: { minBuild: 0, latestVersion: "", storeUrl: "" },
+  android: { minBuild: 0, latestVersion: "", storeUrl: "" },
+  updatedAtISO: null,
+  updatedBy: null,
+};
+
+export default async function AppConfigPage() {
+  try {
+    await getCurrentAdmin();
+  } catch (err) {
+    const message = err instanceof Error ? err.message : "Forbidden";
+    if (message === "Forbidden") {
+      redirect("/gc-fitness/forbidden");
+    }
+    throw err;
+  }
+
+  // The Admin gate above already ran; if the read itself fails (e.g. the doc
+  // has never been written) fall back to zeroed defaults so the form still
+  // renders — the gate is simply "off" (minBuild 0) until first save.
+  let config: AppVersionConfig;
+  try {
+    config = await getAppVersionConfig();
+  } catch {
+    config = EMPTY_CONFIG;
+  }
+
+  return (
+    <div className="gc-page flex flex-col gap-6">
+      <PageHeader
+        title="App Version"
+        subtitle="Set the minimum supported app build per platform. Clients on an older build are forced to update before they can use the app."
+      />
+
+      <Link
+        href="/gc-fitness/admin"
+        className="inline-flex w-fit items-center gap-1 text-sm text-muted-foreground hover:text-foreground"
+      >
+        <ArrowLeft className="size-4" />
+        Back to Admin Console
+      </Link>
+
+      <AppVersionForm initialConfig={config} />
+    </div>
+  );
+}

--- a/backoffice/src/app/gc-fitness/admin/page.tsx
+++ b/backoffice/src/app/gc-fitness/admin/page.tsx
@@ -112,6 +112,21 @@ export default async function AdminPage({
         </div>
       ) : null}
 
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-xl">App version (force update)</CardTitle>
+          <CardDescription>
+            Set the minimum supported app build per platform. Clients on an
+            older build are forced to update before they can use the app.
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <Button asChild>
+            <Link href="/gc-fitness/admin/app-config">Manage app version</Link>
+          </Button>
+        </CardContent>
+      </Card>
+
       <section className="grid gap-4 lg:grid-cols-2">
         <Card>
           <CardHeader>

--- a/backoffice/src/lib/gc-fitness/__tests__/admin-actions.app-config.test.ts
+++ b/backoffice/src/lib/gc-fitness/__tests__/admin-actions.app-config.test.ts
@@ -1,0 +1,164 @@
+// __tests__/admin-actions.app-config.test.ts
+//
+// Auth-gate + validation + write-shape tests for the app-version (force-update)
+// Server Actions in `admin-actions.ts`:
+//   - getAppVersionConfig  — admin-gated read, zeroed defaults when absent.
+//   - updateAppVersionConfig — admin-gated, Zod-validated write to
+//     /app_config/mobile with the acting admin recorded for audit.
+//
+// All Firebase Admin + auth surfaces are mocked — no live Firestore.
+
+jest.mock("@/lib/gc-fitness/auth-helpers", () => ({
+  getCurrentAdmin: jest.fn(),
+}));
+
+const mockSet = jest.fn();
+const mockGet = jest.fn();
+const mockDoc = jest.fn(() => ({ set: mockSet, get: mockGet }));
+const mockCollection = jest.fn(() => ({ doc: mockDoc }));
+
+jest.mock("@/lib/firebase/gc-fitness-admin", () => ({
+  gcFitnessFirestore: jest.fn(() => ({ collection: mockCollection })),
+  gcFitnessAuth: jest.fn(),
+}));
+
+jest.mock("firebase-admin/firestore", () => ({
+  FieldValue: {
+    serverTimestamp: jest.fn(() => "SERVER_TIMESTAMP_SENTINEL"),
+    increment: jest.fn((n: number) => ({ __increment: n })),
+  },
+}));
+
+import {
+  getAppVersionConfig,
+  updateAppVersionConfig,
+} from "@/lib/gc-fitness/admin-actions";
+import { getCurrentAdmin } from "@/lib/gc-fitness/auth-helpers";
+
+const mockedGetCurrentAdmin = getCurrentAdmin as jest.MockedFunction<
+  typeof getCurrentAdmin
+>;
+
+const ADMIN = {
+  uid: "admin-1",
+  email: "admin@example.com",
+  role: "admin" as const,
+  isTrainer: false,
+  roles: ["admin"],
+};
+
+const validInput = () => ({
+  ios: { minBuild: 42, latestVersion: "1.2.0", storeUrl: "https://apps.apple.com/app/id1" },
+  android: { minBuild: 0, latestVersion: "", storeUrl: "" },
+});
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockedGetCurrentAdmin.mockResolvedValue(ADMIN);
+  mockSet.mockResolvedValue(undefined);
+});
+
+describe("updateAppVersionConfig", () => {
+  it("rejects when the caller is not an admin (Forbidden)", async () => {
+    mockedGetCurrentAdmin.mockRejectedValueOnce(new Error("Forbidden"));
+    await expect(updateAppVersionConfig(validInput())).rejects.toThrow(
+      "Forbidden",
+    );
+    expect(mockSet).not.toHaveBeenCalled();
+  });
+
+  it("rejects a negative minBuild before any write", async () => {
+    const bad = validInput();
+    bad.ios.minBuild = -1;
+    await expect(updateAppVersionConfig(bad)).rejects.toThrow();
+    expect(mockSet).not.toHaveBeenCalled();
+  });
+
+  it("rejects a malformed latestVersion before any write", async () => {
+    const bad = validInput();
+    bad.ios.latestVersion = "not-a-version";
+    await expect(updateAppVersionConfig(bad)).rejects.toThrow();
+    expect(mockSet).not.toHaveBeenCalled();
+  });
+
+  it("rejects a non-http storeUrl before any write", async () => {
+    const bad = validInput();
+    bad.ios.storeUrl = "javascript:alert(1)";
+    await expect(updateAppVersionConfig(bad)).rejects.toThrow();
+    expect(mockSet).not.toHaveBeenCalled();
+  });
+
+  it("writes /app_config/mobile with the validated shape + acting admin", async () => {
+    await updateAppVersionConfig(validInput());
+
+    expect(mockCollection).toHaveBeenCalledWith("app_config");
+    expect(mockDoc).toHaveBeenCalledWith("mobile");
+    expect(mockSet).toHaveBeenCalledTimes(1);
+
+    const [payload, options] = mockSet.mock.calls[0];
+    expect(options).toEqual({ merge: true });
+    expect(payload.ios).toEqual({
+      minBuild: 42,
+      latestVersion: "1.2.0",
+      storeUrl: "https://apps.apple.com/app/id1",
+    });
+    expect(payload.android).toEqual({
+      minBuild: 0,
+      latestVersion: "",
+      storeUrl: "",
+    });
+    expect(payload.updatedBy).toBe("admin@example.com");
+    expect(payload.updatedAt).toBe("SERVER_TIMESTAMP_SENTINEL");
+  });
+
+  it("coerces a numeric-string minBuild to a number", async () => {
+    const input = validInput();
+    // Simulate a form-posted string (Input type=number serializes to string).
+    (input.ios as unknown as { minBuild: string }).minBuild = "57";
+    await updateAppVersionConfig(input);
+    const [payload] = mockSet.mock.calls[0];
+    expect(payload.ios.minBuild).toBe(57);
+  });
+});
+
+describe("getAppVersionConfig", () => {
+  it("rejects when the caller is not an admin (Forbidden)", async () => {
+    mockedGetCurrentAdmin.mockRejectedValueOnce(new Error("Forbidden"));
+    await expect(getAppVersionConfig()).rejects.toThrow("Forbidden");
+  });
+
+  it("returns zeroed defaults when the doc does not exist", async () => {
+    mockGet.mockResolvedValueOnce({ exists: false, get: () => undefined });
+    const config = await getAppVersionConfig();
+    expect(config).toEqual({
+      ios: { minBuild: 0, latestVersion: "", storeUrl: "" },
+      android: { minBuild: 0, latestVersion: "", storeUrl: "" },
+      updatedAtISO: null,
+      updatedBy: null,
+    });
+  });
+
+  it("maps stored platform fields + audit metadata", async () => {
+    const updatedAtDate = new Date("2026-06-05T12:00:00.000Z");
+    const stored: Record<string, unknown> = {
+      ios: { minBuild: 42, latestVersion: "1.2.0", storeUrl: "https://apps.apple.com/app/id1" },
+      android: { minBuild: 3, latestVersion: "0.9.0", storeUrl: "https://play.google.com/x" },
+      updatedAt: { toDate: () => updatedAtDate },
+      updatedBy: "admin@example.com",
+    };
+    mockGet.mockResolvedValueOnce({
+      exists: true,
+      get: (key: string) => stored[key],
+    });
+
+    const config = await getAppVersionConfig();
+    expect(config.ios).toEqual({
+      minBuild: 42,
+      latestVersion: "1.2.0",
+      storeUrl: "https://apps.apple.com/app/id1",
+    });
+    expect(config.android.minBuild).toBe(3);
+    expect(config.updatedAtISO).toBe(updatedAtDate.toISOString());
+    expect(config.updatedBy).toBe("admin@example.com");
+  });
+});

--- a/backoffice/src/lib/gc-fitness/__tests__/collections.test.ts
+++ b/backoffice/src/lib/gc-fitness/__tests__/collections.test.ts
@@ -50,6 +50,10 @@ describe("FirestoreCollections — literal-string contract with Swift twin", () 
     );
   });
 
+  it("appConfig is 'app_config' (force-update gate — same-commit invariant w/ Collections.swift)", () => {
+    expect(FirestoreCollections.appConfig).toBe("app_config");
+  });
+
   it("every value is lowercase snake_case", () => {
     for (const [key, value] of Object.entries(FirestoreCollections)) {
       expect(value).toBe(value.toLowerCase());

--- a/backoffice/src/lib/gc-fitness/admin-actions.ts
+++ b/backoffice/src/lib/gc-fitness/admin-actions.ts
@@ -1018,3 +1018,153 @@ export async function removePendingClientForCoach(input: unknown): Promise<{ ok:
   });
   return { ok: true };
 }
+
+// ─────────────────────────────────────────────────────────────────────────────
+// App version config (force-update gate)
+//
+// Single doc `/app_config/mobile` holding the per-platform minimum supported
+// native build + store URLs that the iOS/Android apps read at launch to force
+// out-of-date clients to update. This backoffice is the SOLE writer (the
+// firestore.rules `/app_config/{docId}` block denies every client-SDK write);
+// these Admin-SDK writes bypass the rules. Read is public on the doc so the
+// app gate works pre-sign-in.
+//
+// `minBuild` is the gate the app actually compares against (native
+// CFBundleVersion / versionCode — a monotonic integer, unambiguous). The
+// `latestVersion` marketing string is display-only (shown in the "please
+// update" copy). The Swift consumer is `AppConfig` / `ForceUpdatePolicy` in
+// GCFitnessCore.
+// ─────────────────────────────────────────────────────────────────────────────
+
+export interface AppVersionPlatformConfig {
+  /** Minimum acceptable native build. `0` disables the gate for the platform. */
+  minBuild: number;
+  /** Marketing version of the minimum release (display-only), e.g. "1.2.0". */
+  latestVersion: string;
+  /** Store listing URL the app's update button opens. */
+  storeUrl: string;
+}
+
+export interface AppVersionConfig {
+  ios: AppVersionPlatformConfig;
+  android: AppVersionPlatformConfig;
+  updatedAtISO: string | null;
+  updatedBy: string | null;
+}
+
+const APP_CONFIG_DOC_ID = "mobile";
+
+const EMPTY_PLATFORM_CONFIG: AppVersionPlatformConfig = {
+  minBuild: 0,
+  latestVersion: "",
+  storeUrl: "",
+};
+
+// storeUrl: empty (gate not yet published) OR an http(s) URL. latestVersion:
+// empty OR a dotted version (1, 1.2, 1.2.0). minBuild: non-negative int.
+const platformConfigSchema = z.object({
+  minBuild: z.coerce.number().int().min(0).max(2_147_483_647),
+  latestVersion: z
+    .string()
+    .trim()
+    .max(20)
+    .refine((v) => v === "" || /^\d+(\.\d+){0,3}$/.test(v), {
+      message: "Use a dotted version like 1.2.0 (or leave blank).",
+    }),
+  storeUrl: z
+    .string()
+    .trim()
+    .max(300)
+    .refine((v) => v === "" || /^https?:\/\//i.test(v), {
+      message: "Must be an http(s) URL (or leave blank).",
+    }),
+});
+
+const updateAppVersionConfigSchema = z.object({
+  ios: platformConfigSchema,
+  android: platformConfigSchema,
+});
+
+export type UpdateAppVersionConfigInput = z.input<
+  typeof updateAppVersionConfigSchema
+>;
+
+function coercePlatform(raw: unknown): AppVersionPlatformConfig {
+  const obj = (raw ?? {}) as Record<string, unknown>;
+  const minBuildRaw = obj.minBuild;
+  const minBuild =
+    typeof minBuildRaw === "number" && Number.isFinite(minBuildRaw)
+      ? Math.max(0, Math.trunc(minBuildRaw))
+      : 0;
+  return {
+    minBuild,
+    latestVersion: typeof obj.latestVersion === "string" ? obj.latestVersion : "",
+    storeUrl: typeof obj.storeUrl === "string" ? obj.storeUrl : "",
+  };
+}
+
+/**
+ * Reads the current `/app_config/mobile` document. Admin-gated. Returns
+ * zeroed defaults when the doc has never been written so the form renders a
+ * disabled gate (minBuild 0) instead of throwing.
+ */
+export async function getAppVersionConfig(): Promise<AppVersionConfig> {
+  await getCurrentAdmin();
+  const db = gcFitnessFirestore();
+  const snap = await db
+    .collection(FirestoreCollections.appConfig)
+    .doc(APP_CONFIG_DOC_ID)
+    .get();
+
+  if (!snap.exists) {
+    return {
+      ios: { ...EMPTY_PLATFORM_CONFIG },
+      android: { ...EMPTY_PLATFORM_CONFIG },
+      updatedAtISO: null,
+      updatedBy: null,
+    };
+  }
+
+  const updatedAt = snap.get("updatedAt");
+  const updatedAtISO =
+    updatedAt && typeof updatedAt.toDate === "function"
+      ? updatedAt.toDate().toISOString()
+      : null;
+  const updatedBy = snap.get("updatedBy");
+
+  return {
+    ios: coercePlatform(snap.get("ios")),
+    android: coercePlatform(snap.get("android")),
+    updatedAtISO,
+    updatedBy: typeof updatedBy === "string" ? updatedBy : null,
+  };
+}
+
+/**
+ * Writes the `/app_config/mobile` document. Admin-gated + Zod-validated BEFORE
+ * any write (defense in depth — the rules already deny client writes, but the
+ * Admin SDK bypasses them, so validation here is the real guard). Records the
+ * acting admin email + server timestamp for the audit trail.
+ */
+export async function updateAppVersionConfig(
+  input: unknown,
+): Promise<{ ok: true }> {
+  const admin = await getCurrentAdmin();
+  const parsed = updateAppVersionConfigSchema.parse(input);
+
+  const db = gcFitnessFirestore();
+  await db
+    .collection(FirestoreCollections.appConfig)
+    .doc(APP_CONFIG_DOC_ID)
+    .set(
+      {
+        ios: parsed.ios,
+        android: parsed.android,
+        updatedAt: FieldValue.serverTimestamp(),
+        updatedBy: admin.email,
+      },
+      { merge: true },
+    );
+
+  return { ok: true };
+}

--- a/backoffice/src/lib/gc-fitness/collections.ts
+++ b/backoffice/src/lib/gc-fitness/collections.ts
@@ -151,6 +151,16 @@ export const FirestoreCollections = {
    * this TS twin in P11 long after Collections.swift).
    */
   clientExerciseNotes: "client_exercise_notes",
+
+  /**
+   * Global, single-document mobile app configuration (`/app_config/mobile`).
+   * Holds the per-platform minimum supported build + store URLs that drive the
+   * iOS/Android force-update gate. Written EXCLUSIVELY by this backoffice via
+   * the Admin SDK (firestore.rules denies every client-SDK write); read
+   * publicly by the apps so the gate works before sign-in. Swift twin:
+   * `FirestoreCollections.appConfig` (same-commit invariant, Pitfall 7).
+   */
+  appConfig: "app_config",
 } as const;
 
 /**


### PR DESCRIPTION
## What

The **write side** of the iOS force-update gate: an admin-only Admin Console page to set the minimum supported app build per platform (iOS + future Android), stored in the `app_config/mobile` Firestore doc that the apps read at launch.

Paired iOS PR (the read/gate side): `mdb1/gc-fitness` → `feat/force-update-min-version`.

## How

- **collections:** `appConfig: "app_config"` constant + lock test (same-commit Swift twin invariant, Pitfall 7).
- **admin-actions:** `getAppVersionConfig` / `updateAppVersionConfig` server actions — **admin-gated** (`getCurrentAdmin`) + **Zod-validated before any write** (`minBuild` non-negative int, dotted `latestVersion`, http(s) `storeUrl`). Records acting admin email + `serverTimestamp` for audit. The Admin SDK bypasses rules, so this validation is the real guard.
- **page:** `/gc-fitness/admin/app-config` (force-dynamic, admin-gated, redirects to `/gc-fitness/forbidden`) + RHF/zod form (iOS + Android cards), linked from a new card on the Admin Console.
- `minBuild` is the gate the apps compare against (native build / versionCode); `latestVersion` + `storeUrl` are display / deep-link only.

## Test status

- ✅ `npx jest collections.test admin-actions.app-config` — 20/20 green (lock test + 13 new action tests: auth gate, validation rejects, write shape, numeric-string coercion, read defaults + mapping)
- ✅ `tsc --noEmit` — 0 errors project-wide
- ✅ Full `npx jest` — 448 pass; only failure is the **documented `client-activity-time` locale flake** ("Jun 2" vs "2 June", green in CI), unrelated to this change.

> ⚠️ `main` auto-deploys to production on merge — backoffice Jest is green (modulo the known locale flake), so this is release-safe.