### PR TITLE
feat(gc-fitness/admin): transfer a client to another coach

### DIFF
--- a/backoffice/src/app/gc-fitness/admin/coaches/[uid]/page.tsx
+++ b/backoffice/src/app/gc-fitness/admin/coaches/[uid]/page.tsx
@@ -21,8 +21,10 @@ import {
   deactivateClientForCoach,
   getDeletionTargetInfo,
   getCoachAdminDetail,
+  listCoachesForAdmin,
   previewClientCascade,
   removePendingClientForCoach,
+  transferClientToCoach,
 } from "@/lib/gc-fitness/admin-actions";
 import { AdminSubmitButton } from "../../_components/admin-submit-button";
 
@@ -54,6 +56,10 @@ export default async function CoachAdminDetailPage({
   if (!detail) notFound();
   const actionMessage = op && ok === "1" ? `Action completed: ${op}.` : null;
 
+  // Destination coaches for the transfer control — every coach except this one.
+  const allCoaches = await listCoachesForAdmin();
+  const otherCoaches = allCoaches.filter((coach) => coach.uid !== detail.coach.uid);
+
   let clientPreview: Awaited<ReturnType<typeof previewClientCascade>> | null = null;
   let targetInfo: Awaited<ReturnType<typeof getDeletionTargetInfo>> | null = null;
   if (previewClientUid.length > 0) {
@@ -72,6 +78,16 @@ export default async function CoachAdminDetailPage({
     const clientUid = String(formData.get("clientUid") ?? "");
     await deactivateClientForCoach({ coachUid, clientUid });
     revalidatePath(`/gc-fitness/admin/coaches/${coachUid}`);
+  }
+
+  async function transferClientAction(formData: FormData) {
+    "use server";
+    const coachUid = String(formData.get("coachUid") ?? "");
+    const clientUid = String(formData.get("clientUid") ?? "");
+    const newCoachUid = String(formData.get("newCoachUid") ?? "");
+    await transferClientToCoach({ clientUid, newCoachUid });
+    revalidatePath(`/gc-fitness/admin/coaches/${coachUid}`);
+    redirect(`/gc-fitness/admin/coaches/${coachUid}?op=transfer_client&ok=1`);
   }
 
   async function removePendingAction(formData: FormData) {
@@ -166,7 +182,34 @@ export default async function CoachAdminDetailPage({
                         {client.deleted ? <Badge variant="secondary">deleted</Badge> : <Badge variant="success">active</Badge>}
                       </TableCell>
                       <TableCell className="text-right">
-                        <div className="flex justify-end gap-2">
+                        <div className="flex flex-wrap items-center justify-end gap-2">
+                          {!client.deleted && otherCoaches.length > 0 ? (
+                            <form action={transferClientAction} className="flex items-center gap-1">
+                              <input type="hidden" name="coachUid" value={detail.coach.uid} />
+                              <input type="hidden" name="clientUid" value={client.uid} />
+                              <select
+                                name="newCoachUid"
+                                required
+                                defaultValue=""
+                                aria-label={`Transfer ${client.displayName || client.email} to coach`}
+                                className="h-8 max-w-[12rem] rounded-md border bg-background px-2 text-xs"
+                              >
+                                <option value="" disabled>
+                                  Transfer to…
+                                </option>
+                                {otherCoaches.map((coach) => (
+                                  <option key={coach.uid} value={coach.uid}>
+                                    {coach.displayName || coach.email}
+                                  </option>
+                                ))}
+                              </select>
+                              <AdminSubmitButton
+                                idleLabel="Transfer"
+                                pendingLabel="Transferring..."
+                                className="inline-flex h-8 items-center rounded-md border px-3 text-xs font-medium hover:bg-muted"
+                              />
+                            </form>
+                          ) : null}
                           {!client.deleted ? (
                             <form action={deactivateClientAction}>
                               <input type="hidden" name="coachUid" value={detail.coach.uid} />

--- a/backoffice/src/lib/gc-fitness/admin-actions.ts
+++ b/backoffice/src/lib/gc-fitness/admin-actions.ts
@@ -613,7 +613,7 @@ export async function promoteUserToAdmin(input: unknown): Promise<{ ok: true; ui
 
 async function writeAdminOperationLog(args: {
   actorUid: string;
-  kind: "delete_client_cascade" | "delete_coach_cascade";
+  kind: "delete_client_cascade" | "delete_coach_cascade" | "transfer_client";
   mode: OperationMode;
   targetUid: string;
   status: "success" | "failed";
@@ -990,6 +990,111 @@ export async function deactivateClientForCoach(input: unknown): Promise<{ ok: tr
     summary: { action: "deactivate_client", coachUid: parsed.coachUid },
   });
   return { ok: true };
+}
+
+const transferClientSchema = z.object({
+  clientUid: z.string().trim().min(6).max(128),
+  newCoachUid: z.string().trim().min(6).max(128),
+});
+
+/**
+ * Move a client from their current coach to a different one. Built for the
+ * App Store review fallback: brand-new sign-ups with no mirror are auto-attached
+ * to a default coach (see DEFAULT_FALLBACK_COACH_ID in the functions repo), and
+ * an admin uses this to re-home them onto the correct coach.
+ *
+ * Re-points the canonical client doc (coachId + denormalized coachDisplayName /
+ * coachPhotoURL), moves the 1:1 chat doc to the new coach, and resyncs the
+ * client's `coachId` custom claim (fail-soft — the Firestore doc is the source
+ * of truth; the claim catches up on the client's next token refresh).
+ *
+ * NOTE: historical content authored by the OLD coach (workout_assignments /
+ * habits tagged with the old trainerId) is intentionally left in place — the
+ * client keeps seeing it, the new coach authors fresh content going forward.
+ */
+export async function transferClientToCoach(
+  input: unknown,
+): Promise<{ ok: true; clientUid: string; newCoachUid: string }> {
+  const admin = await getCurrentAdmin();
+  const parsed = transferClientSchema.parse(input);
+  const db = gcFitnessFirestore();
+
+  const clientRef = db.collection(FirestoreCollections.users).doc(parsed.clientUid);
+  const clientSnap = await clientRef.get();
+  if (!clientSnap.exists) {
+    throw new Error("Client not found.");
+  }
+  if (clientSnap.get("role") === "trainer") {
+    throw new Error("That user is a coach, not a client — cannot transfer.");
+  }
+  const currentCoachId = (clientSnap.get("coachId") as string | undefined) ?? null;
+  if (currentCoachId === parsed.newCoachUid) {
+    throw new Error("Client is already linked to this coach.");
+  }
+
+  const newCoachRef = db.collection(FirestoreCollections.users).doc(parsed.newCoachUid);
+  const newCoachSnap = await newCoachRef.get();
+  if (!newCoachSnap.exists) {
+    throw new Error("Destination coach not found.");
+  }
+  if (newCoachSnap.get("role") !== "trainer") {
+    throw new Error("Destination user is not a coach.");
+  }
+
+  const newCoachDisplayName =
+    (newCoachSnap.get("displayName") as string | undefined)?.trim() ||
+    ((newCoachSnap.get("email") as string | undefined) ?? "").split("@")[0] ||
+    "";
+  const newCoachPhotoURL =
+    (newCoachSnap.get("photoURL") as string | undefined) ?? null;
+
+  const chatRef = db.collection(FirestoreCollections.chats).doc(parsed.clientUid);
+  const chatSnap = await chatRef.get();
+
+  const batch = db.batch();
+  batch.update(clientRef, {
+    coachId: parsed.newCoachUid,
+    coachDisplayName: newCoachDisplayName,
+    coachPhotoURL: newCoachPhotoURL,
+    updatedAt: FieldValue.serverTimestamp(),
+  });
+  if (chatSnap.exists) {
+    batch.update(chatRef, {
+      coachId: parsed.newCoachUid,
+      updatedAt: FieldValue.serverTimestamp(),
+    });
+  }
+  await batch.commit();
+
+  // Keep the custom claim in sync (firestore.rules compare
+  // request.auth.token.coachId). Fail-soft — the doc write above already
+  // re-homed the client; the claim resyncs on the client's next token refresh.
+  try {
+    const authUser = await gcFitnessAuth().getUser(parsed.clientUid);
+    const current = (authUser.customClaims ?? {}) as Record<string, unknown>;
+    await gcFitnessAuth().setCustomUserClaims(parsed.clientUid, {
+      ...current,
+      role: "client",
+      coachId: parsed.newCoachUid,
+    });
+  } catch {
+    // fail-soft
+  }
+
+  await writeAdminOperationLog({
+    actorUid: admin.uid,
+    kind: "transfer_client",
+    mode: "execute",
+    targetUid: parsed.clientUid,
+    status: "success",
+    summary: {
+      action: "transfer_client",
+      fromCoachId: currentCoachId,
+      toCoachId: parsed.newCoachUid,
+    },
+  });
+
+  return { ok: true, clientUid: parsed.clientUid, newCoachUid: parsed.newCoachUid };
 }
 
 const removePendingSchema = z.object({


### PR DESCRIPTION
## Why

Pairs with the functions-side **default-coach fallback** (gc-fitness PR — App Store review fix). Brand-new sign-ups with no \`user_mirror\` are now auto-attached to a default coach so reviewers can get into the app. This adds the admin counterpart: a way to **re-home those clients onto the correct coach**.

## What changed

**`transferClientToCoach(input)` server action** (`admin-actions.ts`):
- Validates the client exists and isn't a coach, and the destination is an existing **trainer**; rejects no-op transfers.
- Re-points \`users/{clientId}\`: \`coachId\` + denormalized \`coachDisplayName\` / \`coachPhotoURL\`.
- Moves the 1:1 \`chats/{clientId}\` doc to the new coach (chats are gated by \`coachId\`).
- Resyncs the client's \`coachId\` **custom claim** (fail-soft — Firestore doc is the source of truth; claim catches up on the client's next token refresh).
- Logs a \`transfer_client\` entry to \`admin_operations\`.

**Coach detail page** (`coaches/[uid]`): each active client row gets a **"Transfer to…"** coach picker + submit, in the linked-clients table.

### By design
Historical content authored by the **old** coach (workout_assignments / habits tagged with the old \`trainerId\`) is left in place — the client keeps it, the new coach authors fresh content going forward. Not silently rewriting authorship.

## Notes
- Admin-SDK writes only (bypass Firestore rules) — **no `firestore.rules` change**, so no rules gate triggered.
- \`getCurrentAdmin()\` gates the action (existing pattern).

## Tests
- \`npx tsc --noEmit\` — clean.
- \`npx jest\` — 448 passed; the only failure is the pre-existing \`client-activity-time\` locale flake (green in CI), unrelated to this change.

## Test plan for reviewer
1. Open a coach with at least one client; pick another coach in the row's **Transfer to…** dropdown → **Transfer**.
2. Client disappears from this coach's roster and appears under the destination coach; chat follows.
3. The client's app shows the new coach's name/photo after their next token refresh.