### PR TITLE
feat(gc-fitness/clients): flag NEW auto-assigned clients + notification

### DIFF
--- a/backoffice/src/app/gc-fitness/clients/_components/RosterTable.tsx
+++ b/backoffice/src/app/gc-fitness/clients/_components/RosterTable.tsx
@@ -227,6 +227,14 @@ export function RosterTable({
                         {row.email}
                       </p>
                       <div className="mt-1.5 flex flex-wrap items-center gap-1.5">
+                        {row.autoAssignedCoach ? (
+                          <Badge
+                            variant="default"
+                            title="Se registró sin pre-asignación y quedó asignado a vos. Revisalo o transferilo desde el panel de admin."
+                          >
+                            NEW
+                          </Badge>
+                        ) : null}
                         {row.pendingProvisioning ? (
                           <Badge variant="secondary">
                             {tCommon("pendingSignIn")}

--- a/backoffice/src/app/gc-fitness/clients/page.tsx
+++ b/backoffice/src/app/gc-fitness/clients/page.tsx
@@ -9,6 +9,7 @@
 // breakdown uses ICU pluralization on `subtitleOne`/`subtitleOther`.
 
 import { redirect } from "next/navigation";
+import { Bell } from "lucide-react";
 import { getTranslations } from "next-intl/server";
 
 import {
@@ -54,9 +55,32 @@ export default async function ClientsPage({
 
   const subtitle = `${activeText}${pendingSuffix}${t("subtitleSortNote")}`;
 
+  // New clients that signed up WITHOUT a coach pre-assignment (no user_mirror)
+  // and were auto-attached to this coach by the sign-up fallback. Surface them
+  // as a notification so they get triaged (kept or transferred via admin).
+  const newAutoAssigned = rows.filter((row) => row.autoAssignedCoach);
+
   return (
     <div className="gc-page flex flex-col gap-6">
       <AddClientPanel title={t("title")} subtitle={subtitle} />
+      {newAutoAssigned.length > 0 ? (
+        <div className="flex items-start gap-3 rounded-2xl border border-primary/40 bg-primary/10 px-4 py-3 text-sm">
+          <Bell className="mt-0.5 size-4 shrink-0 text-primary" aria-hidden />
+          <div className="flex flex-col gap-0.5">
+            <p className="font-medium text-foreground">
+              {newAutoAssigned.length === 1
+                ? "1 cliente nuevo se registró sin coach y quedó asignado a vos"
+                : `${newAutoAssigned.length} clientes nuevos se registraron sin coach y quedaron asignados a vos`}
+            </p>
+            <p className="text-muted-foreground">
+              Están marcados con{" "}
+              <span className="font-semibold text-foreground">NEW</span> abajo.
+              Revisalos y, si corresponden a otro coach, transferilos desde el
+              panel de admin.
+            </p>
+          </div>
+        </div>
+      ) : null}
       <RosterQueryProvider>
         <RosterTable
           rows={rows}

--- a/backoffice/src/lib/gc-fitness/admin-actions.ts
+++ b/backoffice/src/lib/gc-fitness/admin-actions.ts
@@ -1056,6 +1056,9 @@ export async function transferClientToCoach(
     coachId: parsed.newCoachUid,
     coachDisplayName: newCoachDisplayName,
     coachPhotoURL: newCoachPhotoURL,
+    // Transferring counts as triage — drop the "NEW" auto-assigned flag so the
+    // destination coach's roster doesn't keep flagging it.
+    autoAssignedCoach: FieldValue.delete(),
     updatedAt: FieldValue.serverTimestamp(),
   });
   if (chatSnap.exists) {

--- a/backoffice/src/lib/gc-fitness/client-roster.ts
+++ b/backoffice/src/lib/gc-fitness/client-roster.ts
@@ -65,6 +65,10 @@ export interface ClientRosterEntry {
   timezone: string | null;
   photoURL: string | null;
   pendingProvisioning: boolean;
+  /** True when this client signed up WITHOUT a trainer-authored user_mirror and
+   *  was auto-attached to the default coach (functions DEFAULT_FALLBACK_COACH_ID).
+   *  Drives the "NEW" roster badge + the new-clients notification. */
+  autoAssignedCoach: boolean;
 }
 
 /**
@@ -90,6 +94,9 @@ export interface ClientRosterRow {
   timezone: string | null;
   source: "active" | "pending";
   pendingProvisioning: boolean;
+  /** True when this client was auto-attached to the default coach at sign-up
+   *  (no user_mirror). Drives the "NEW" roster badge + new-clients notification. */
+  autoAssignedCoach: boolean;
   /** ISO-8601 of the most recent activity across workout/habit/chat — or null if no activity. */
   lastActivityAt: string | null;
   /** Compliance ratio in [0, 1] averaged across this client's habits over the last 7 days. */
@@ -163,6 +170,7 @@ async function _fetchClientsForTrainer(
       displayName?: string;
       timezone?: string;
       photoURL?: string;
+      autoAssignedCoach?: boolean;
     };
     return {
       uid: d.id,
@@ -171,6 +179,7 @@ async function _fetchClientsForTrainer(
       timezone: typeof data.timezone === "string" ? data.timezone : null,
       photoURL: typeof data.photoURL === "string" ? data.photoURL : null,
       pendingProvisioning: false,
+      autoAssignedCoach: data.autoAssignedCoach === true,
     };
   });
 
@@ -197,6 +206,7 @@ async function _fetchClientsForTrainer(
         timezone: null,
         photoURL: null,
         pendingProvisioning: true,
+        autoAssignedCoach: false,
       });
       return rows;
     }, []);
@@ -335,6 +345,7 @@ export async function listClientsForRoster(): Promise<ClientRosterRow[]> {
         timezone: null,
         photoURL: null,
         pendingProvisioning: true,
+        autoAssignedCoach: false,
       });
       return rows;
     }, []);
@@ -770,6 +781,7 @@ export async function listClientsForRoster(): Promise<ClientRosterRow[]> {
         timezone: c.timezone,
         source: isPending ? "pending" : "active",
         pendingProvisioning: isPending,
+        autoAssignedCoach: isPending ? false : c.autoAssignedCoach,
         lastActivityAt: lastActivity?.toISOString() ?? null,
         thisWeekComplianceRatio,
         unreadChatCount,

--- a/backoffice/src/lib/gc-fitness/recent-logs-actions.ts
+++ b/backoffice/src/lib/gc-fitness/recent-logs-actions.ts
@@ -1209,6 +1209,7 @@ async function loadClientRosterEntry(
       timezone: typeof data.timezone === "string" ? data.timezone : null,
       photoURL: typeof data.photoURL === "string" ? data.photoURL : null,
       pendingProvisioning: false,
+      autoAssignedCoach: data.autoAssignedCoach === true,
     },
     coachId,
   };


### PR DESCRIPTION
## Why
Pairs with the gc-fitness `autoAssignedCoach` flag. Clients who signed up **without a coach pre-assignment** (no `user_mirror`) are auto-attached to the coach by the sign-up fallback — this makes them visible and triage-able in the roster.

## What
- **`/gc-fitness/clients` notification banner** 🔔 — counts the new auto-assigned clients ("N clientes nuevos se registraron sin coach y quedaron asignados a vos").
- **"NEW" badge** on each auto-assigned client card in the roster.
- `client-roster`: threads `autoAssignedCoach` through `ClientRosterEntry` / `ClientRosterRow` (active clients read it from their `/users` doc; pending/mirror clients are always `false`).
- **`transferClientToCoach`**: clears `autoAssignedCoach` on transfer — moving a client counts as triage, so it stops being flagged.

## Notes
- Auto-deploys to prod on merge (backoffice ships `main`).
- The flag only appears once the **functions** side is deployed and a fallback sign-up happens.
- A kept (not-transferred) client stays flagged NEW — that's intended; transfer is the clear action. Tell me if you want an explicit "mark reviewed" dismiss too.

## Tests
- `tsc --noEmit` clean.
- `jest` — 448 passed; only the pre-existing `client-activity-time` locale flake fails (green in CI).