### PR TITLE
feat(gc-fitness/habits): 'Crear nuevo' habit becomes a reusable template

### DIFF
--- a/backoffice/src/components/gc-fitness/schedule/new-habit-dialog.tsx
+++ b/backoffice/src/components/gc-fitness/schedule/new-habit-dialog.tsx
@@ -177,6 +177,13 @@ export function NewHabitDialog({
               <>
                 Cliente: <span className="font-medium">{clientName}</span> ·
                 Empieza el <span className="font-medium">{startsOn}</span>.
+                {tab === "new" ? (
+                  <>
+                    {" "}
+                    Se guarda también como plantilla reutilizable para asignarlo
+                    a otros clientes.
+                  </>
+                ) : null}
               </>
             )}
           </DialogDescription>

--- a/backoffice/src/lib/gc-fitness/__tests__/habit-actions.test.ts
+++ b/backoffice/src/lib/gc-fitness/__tests__/habit-actions.test.ts
@@ -245,6 +245,54 @@ describe("createHabit", () => {
     expect(payload.trainerId).toBe(ALLOWED_UID);
     expect(payload.trainerId).not.toBe("victim-trainer-uid");
   });
+
+  // T04b — reusability: a habit authored from scratch ALSO writes a reusable
+  // trainer template, and the assignment back-links to it via sourceTemplateId.
+  it("T04b — also creates a reusable template and links the assignment to it", async () => {
+    mockedGetTokens.mockResolvedValue(fakeTokens({ role: "trainer" }));
+    mockSet.mockResolvedValue(undefined);
+
+    await createHabit(VALID_BINARY_HABIT_INPUT);
+
+    // The template collection is written to.
+    expect(mockCollection).toHaveBeenCalledWith("habit_templates");
+
+    // The habit (first set) links to the new template.
+    const habitPayload = mockSet.mock.calls[0][0] as Record<string, unknown>;
+    expect(typeof habitPayload.sourceTemplateId).toBe("string");
+    expect(habitPayload.sourceTemplateId as string).toMatch(
+      new RegExp(`^habit-template-${ALLOWED_UID}-`),
+    );
+
+    // The template (second set) is a trainer-scoped, client-less copy.
+    const templatePayload = mockSet.mock.calls[1][0] as Record<string, unknown>;
+    expect(templatePayload.scope).toBe("trainer");
+    expect(templatePayload.trainerId).toBe(ALLOWED_UID);
+    expect(templatePayload.clientId).toBeUndefined();
+    expect(templatePayload.id).toBe(habitPayload.sourceTemplateId);
+  });
+
+  // T04c — a habit assigned FROM an existing template does NOT spawn a
+  // duplicate template; it just reuses the provided sourceTemplateId.
+  it("T04c — does not create a template when sourceTemplateId is provided", async () => {
+    mockedGetTokens.mockResolvedValue(fakeTokens({ role: "trainer" }));
+    mockSet.mockResolvedValue(undefined);
+
+    await createHabit({
+      ...VALID_BINARY_HABIT_INPUT,
+      sourceTemplateId: "habit-template-trainer-A-existing",
+    });
+
+    expect(mockCollection).not.toHaveBeenCalledWith("habit_templates");
+    const habitPayload = mockSet.mock.calls[0][0] as Record<string, unknown>;
+    expect(habitPayload.sourceTemplateId).toBe(
+      "habit-template-trainer-A-existing",
+    );
+    // No trainer-scoped template doc among the writes.
+    for (const call of mockSet.mock.calls) {
+      expect((call[0] as Record<string, unknown>).scope).not.toBe("trainer");
+    }
+  });
 });
 
 describe("updateHabit", () => {

--- a/backoffice/src/lib/gc-fitness/habit-actions.ts
+++ b/backoffice/src/lib/gc-fitness/habit-actions.ts
@@ -511,25 +511,65 @@ export async function createHabit(
   const docId = `hab-${trainer.uid}-${randomUUID()}`;
   const docRef = db.collection(COLLECTION).doc(docId);
 
+  const reminderDayOfMonth =
+    data.reminderDayOfMonth ??
+    (Array.isArray(data.reminderMonthDays) && data.reminderMonthDays.length > 0
+      ? data.reminderMonthDays[0]
+      : undefined);
+  const scheduleDayOfMonth =
+    data.scheduleDayOfMonth ??
+    (Array.isArray(data.scheduleMonthDays) && data.scheduleMonthDays.length > 0
+      ? data.scheduleMonthDays[0]
+      : undefined);
+
+  // Reusability (BO habit "Crear nuevo"): a habit authored from scratch ALSO
+  // gets saved as a reusable trainer template so it shows up under "Asignar
+  // existente" for OTHER clients. A habit assigned FROM an existing template
+  // already carries `sourceTemplateId` and must NOT spawn a duplicate template.
+  const existingSourceTemplateId =
+    typeof data.sourceTemplateId === "string" && data.sourceTemplateId.length > 0
+      ? data.sourceTemplateId
+      : undefined;
+  const newTemplateId = existingSourceTemplateId
+    ? undefined
+    : `habit-template-${trainer.uid}-${randomUUID()}`;
+  const sourceTemplateId = existingSourceTemplateId ?? newTemplateId;
+
   await docRef.set(withoutUndefined({
     ...data,
-    reminderDayOfMonth:
-      data.reminderDayOfMonth ??
-      (Array.isArray(data.reminderMonthDays) && data.reminderMonthDays.length > 0
-        ? data.reminderMonthDays[0]
-        : undefined),
-    scheduleDayOfMonth:
-      data.scheduleDayOfMonth ??
-      (Array.isArray(data.scheduleMonthDays) && data.scheduleMonthDays.length > 0
-        ? data.scheduleMonthDays[0]
-        : undefined),
+    reminderDayOfMonth,
+    scheduleDayOfMonth,
     startsOn: normalizeStartsOn(data.startsOn),
+    sourceTemplateId, // links the assignment to its (existing or new) template
     id: docId,
     trainerId: trainer.uid, // T-06-05-01: ALWAYS from session, NEVER from input.
     deleted: false,
     createdAt: FieldValue.serverTimestamp(),
     updatedAt: FieldValue.serverTimestamp(),
   }));
+
+  // Persist the reusable template (content only — strip per-assignment fields:
+  // clientId, startsOn, and the sourceTemplateId back-link itself).
+  if (newTemplateId) {
+    const templatePayload: Record<string, unknown> = {
+      ...data,
+      reminderDayOfMonth,
+      scheduleDayOfMonth,
+      id: newTemplateId,
+      scope: "trainer",
+      trainerId: trainer.uid,
+      deleted: false,
+      createdAt: FieldValue.serverTimestamp(),
+      updatedAt: FieldValue.serverTimestamp(),
+    };
+    delete templatePayload.clientId;
+    delete templatePayload.startsOn;
+    delete templatePayload.sourceTemplateId;
+    await db
+      .collection(TEMPLATE_COLLECTION)
+      .doc(newTemplateId)
+      .set(withoutUndefined(templatePayload));
+  }
 
   if (typeof data.photoUrl === "string" && data.photoUrl.length > 0) {
     const rehomedPhotoUrl = await rehomeDraftHabitPhotoIfNeeded({
@@ -542,6 +582,16 @@ export async function createHabit(
         photoUrl: rehomedPhotoUrl,
         updatedAt: FieldValue.serverTimestamp(),
       });
+      // Keep the just-created template's photo in sync with the rehomed URL.
+      if (newTemplateId) {
+        await db
+          .collection(TEMPLATE_COLLECTION)
+          .doc(newTemplateId)
+          .update({
+            photoUrl: rehomedPhotoUrl,
+            updatedAt: FieldValue.serverTimestamp(),
+          });
+      }
     }
   }
 


### PR DESCRIPTION
## Bug
Cuando un coach usa **"Crear nuevo"** en el modal de hábito de un cliente, el hábito se guardaba **solo** como asignación per-cliente (`/habits`) y **no** como plantilla. Por eso después no aparecía en **"Asignar existente"** para reutilizarlo con otros clientes.

## Fix
`createHabit` ahora **también** guarda una plantilla reutilizable (`/habit_templates`, `scope: "trainer"`) cuando el hábito **no** viene ya de una plantilla, y enlaza la asignación con `sourceTemplateId` — el mismo patrón que `workout_templates → workout_assignments`.

- Plantilla = copia del contenido (nombre/descr/foto/youtube/recordatorio/cronograma) **sin** `clientId` ni `startsOn`.
- Un hábito asignado **desde** una plantilla existente (ya trae `sourceTemplateId`) **no** genera una plantilla duplicada.
- Bonus: como queda enlazado por `sourceTemplateId`, editar la plantilla cascada a la asignación (comportamiento ya existente de `updateHabitTemplate`).
- Copy del modal: aclara que "Crear nuevo" también guarda una plantilla reutilizable.

## Notas / trade-offs
- Si creás el **mismo** hábito con "Crear nuevo" para varios clientes, se generan varias plantillas iguales (sin dedupe). La idea es crearlo una vez y después usar "Asignar existente". Puedo agregar dedupe por nombre si lo querés.
- La foto de la plantilla referencia la misma URL rehospedada del hábito (los hábitos solo se borran de forma lógica, así que el objeto de Storage persiste).

## Tests
- `tsc --noEmit` limpio.
- `jest habit-actions` 19/19 — incluye **T04b** (dual-write + link) y **T04c** (no duplica cuando viene de plantilla).
- Suite completa: 450 passing; solo falla el flake pre-existente `client-activity-time` (verde en CI).

## Test plan
1. Cliente A → "Crear nuevo" hábito "Beber agua" → guardar.
2. Cliente B → abrir modal → **"Asignar existente"** → "Beber agua" aparece y se puede asignar.