### PR TITLE
feat(gc-fitness/admin): show client assignments + habits in god-mode

### DIFF
--- a/backoffice/src/app/gc-fitness/admin/coaches/[uid]/clients/[clientId]/page.tsx
+++ b/backoffice/src/app/gc-fitness/admin/coaches/[uid]/clients/[clientId]/page.tsx
@@ -17,6 +17,10 @@ import { getCurrentAdmin } from "@/lib/gc-fitness/auth-helpers";
 import { FirestoreCollections } from "@/lib/gc-fitness/collections";
 import { listRecentLogsForClientAsAdmin } from "@/lib/gc-fitness/recent-logs-actions";
 import { listProgressPhotosForClientAsAdmin } from "@/lib/gc-fitness/progress-photo-actions";
+import {
+  listClientAssignmentsForAdmin,
+  listClientHabitsForAdmin,
+} from "@/lib/gc-fitness/admin-actions";
 import { gcFitnessFirestore } from "@/lib/firebase/gc-fitness-admin";
 import { Badge } from "@/components/ui/badge";
 import {
@@ -25,6 +29,14 @@ import {
   CardHeader,
   CardTitle,
 } from "@/components/ui/card";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
 import { PageHeader } from "@/components/gc-fitness/page-header";
 
 import { ClientRecentLogsFeed } from "@/app/gc-fitness/clients/[id]/_components/ClientRecentLogsFeed";
@@ -51,10 +63,14 @@ export default async function AdminCoachClientPage({
 
   let logs: Awaited<ReturnType<typeof listRecentLogsForClientAsAdmin>>;
   let photos: Awaited<ReturnType<typeof listProgressPhotosForClientAsAdmin>>;
+  let assignments: Awaited<ReturnType<typeof listClientAssignmentsForAdmin>>;
+  let habits: Awaited<ReturnType<typeof listClientHabitsForAdmin>>;
   try {
-    [logs, photos] = await Promise.all([
+    [logs, photos, assignments, habits] = await Promise.all([
       listRecentLogsForClientAsAdmin(uid, clientId),
       listProgressPhotosForClientAsAdmin(uid, clientId),
+      listClientAssignmentsForAdmin(uid, clientId),
+      listClientHabitsForAdmin(uid, clientId),
     ]);
   } catch {
     // Client doesn't exist or doesn't belong to this coach.
@@ -115,6 +131,102 @@ export default async function AdminCoachClientPage({
 
       <Card>
         <CardHeader className="pb-3">
+          <CardTitle className="text-xl">Workout assignments</CardTitle>
+        </CardHeader>
+        <CardContent className="p-0">
+          {assignments.length === 0 ? (
+            <p className="px-6 pb-6 text-sm text-muted-foreground">
+              No workout assignments yet.
+            </p>
+          ) : (
+            <div className="overflow-x-auto">
+              <Table>
+                <TableHeader>
+                  <TableRow>
+                    <TableHead>Date</TableHead>
+                    <TableHead>Time</TableHead>
+                    <TableHead>Workout</TableHead>
+                    <TableHead>Status</TableHead>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {assignments.map((a) => (
+                    <TableRow key={a.id}>
+                      <TableCell className="whitespace-nowrap font-mono text-xs">
+                        {a.scheduledFor || "—"}
+                      </TableCell>
+                      <TableCell className="whitespace-nowrap text-xs text-muted-foreground">
+                        {a.scheduledTime ?? "—"}
+                      </TableCell>
+                      <TableCell>{a.title}</TableCell>
+                      <TableCell>
+                        <Badge variant={assignmentStatusVariant(a.status)}>
+                          {a.status}
+                        </Badge>
+                      </TableCell>
+                    </TableRow>
+                  ))}
+                </TableBody>
+              </Table>
+              {assignments.length >= 80 ? (
+                <p className="px-6 py-2 text-xs text-muted-foreground">
+                  Showing the latest 80 assignments.
+                </p>
+              ) : null}
+            </div>
+          )}
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader className="pb-3">
+          <CardTitle className="text-xl">Habits</CardTitle>
+        </CardHeader>
+        <CardContent className="p-0">
+          {habits.length === 0 ? (
+            <p className="px-6 pb-6 text-sm text-muted-foreground">
+              No habits assigned yet.
+            </p>
+          ) : (
+            <div className="overflow-x-auto">
+              <Table>
+                <TableHeader>
+                  <TableRow>
+                    <TableHead>Habit</TableHead>
+                    <TableHead>Cadence</TableHead>
+                    <TableHead>Reminder</TableHead>
+                    <TableHead>Status</TableHead>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {habits.map((h) => (
+                    <TableRow key={h.id}>
+                      <TableCell>{h.name}</TableCell>
+                      <TableCell className="text-xs text-muted-foreground">
+                        {[h.scheduleType, h.cadence].filter(Boolean).join(" · ") ||
+                          "—"}
+                      </TableCell>
+                      <TableCell className="text-xs text-muted-foreground">
+                        {h.reminderEnabled ? "On" : "Off"}
+                      </TableCell>
+                      <TableCell>
+                        {h.deleted ? (
+                          <Badge variant="secondary">deleted</Badge>
+                        ) : (
+                          <Badge variant="success">active</Badge>
+                        )}
+                      </TableCell>
+                    </TableRow>
+                  ))}
+                </TableBody>
+              </Table>
+            </div>
+          )}
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader className="pb-3">
           <CardTitle className="text-xl">Progress photos</CardTitle>
         </CardHeader>
         <CardContent>
@@ -129,4 +241,19 @@ export default async function AdminCoachClientPage({
       </Card>
     </div>
   );
+}
+
+function assignmentStatusVariant(
+  status: string,
+): "default" | "secondary" | "destructive" | "success" {
+  switch (status) {
+    case "completed":
+      return "success";
+    case "missed":
+      return "destructive";
+    case "started":
+      return "default";
+    default:
+      return "secondary";
+  }
 }

--- a/backoffice/src/lib/gc-fitness/admin-actions.ts
+++ b/backoffice/src/lib/gc-fitness/admin-actions.ts
@@ -952,6 +952,117 @@ export async function getDeletionTargetInfo(uid: string): Promise<DeletionTarget
   };
 }
 
+// ─────────────────────────────────────────────────────────────────────────────
+// Admin god-mode (READ-ONLY): a client's workout assignments + habits.
+// Verifies the client belongs to {coachUid} so the URL can't be edited to read
+// a client outside the coach being inspected (same gate as the recent-logs /
+// progress-photo admin readers).
+// ─────────────────────────────────────────────────────────────────────────────
+
+export interface AdminClientAssignmentRow {
+  id: string;
+  title: string;
+  scheduledFor: string;
+  scheduledTime: string | null;
+  status: string;
+}
+
+export interface AdminClientHabitRow {
+  id: string;
+  name: string;
+  cadence: string | null;
+  scheduleType: string | null;
+  reminderEnabled: boolean;
+  deleted: boolean;
+}
+
+async function assertClientBelongsToCoach(
+  db: FirebaseFirestore.Firestore,
+  coachUid: string,
+  clientId: string,
+): Promise<void> {
+  const snap = await db
+    .collection(FirestoreCollections.users)
+    .doc(clientId)
+    .get();
+  if (!snap.exists || snap.get("coachId") !== coachUid) {
+    throw new Error("Not found");
+  }
+}
+
+/** Latest ~80 workout assignments for a client (recurring schedules explode into
+ *  one doc per date, so this is capped — most recent / furthest-future first). */
+export async function listClientAssignmentsForAdmin(
+  coachUid: string,
+  clientId: string,
+): Promise<AdminClientAssignmentRow[]> {
+  await getCurrentAdmin();
+  const db = gcFitnessFirestore();
+  await assertClientBelongsToCoach(db, coachUid, clientId);
+
+  const snap = await db
+    .collection(FirestoreCollections.workoutAssignments)
+    .where("clientId", "==", clientId)
+    .orderBy("scheduledFor", "desc")
+    .limit(80)
+    .get();
+
+  return snap.docs.map((doc) => {
+    const data = doc.data() as Record<string, unknown>;
+    const snapshot = data.templateSnapshot as { title?: unknown } | undefined;
+    const title =
+      typeof snapshot?.title === "string" && snapshot.title.trim().length > 0
+        ? snapshot.title
+        : "—";
+    return {
+      id: doc.id,
+      title,
+      scheduledFor:
+        typeof data.scheduledFor === "string" ? data.scheduledFor : "",
+      scheduledTime:
+        typeof data.scheduledTime === "string" ? data.scheduledTime : null,
+      status: typeof data.status === "string" ? data.status : "scheduled",
+    };
+  });
+}
+
+/** All of a client's habits (active first, soft-deleted shown for context). */
+export async function listClientHabitsForAdmin(
+  coachUid: string,
+  clientId: string,
+): Promise<AdminClientHabitRow[]> {
+  await getCurrentAdmin();
+  const db = gcFitnessFirestore();
+  await assertClientBelongsToCoach(db, coachUid, clientId);
+
+  const snap = await db
+    .collection(FirestoreCollections.habits)
+    .where("clientId", "==", clientId)
+    .limit(100)
+    .get();
+
+  return snap.docs
+    .map((doc) => {
+      const data = doc.data() as Record<string, unknown>;
+      const name = data.name as { en?: unknown; es?: unknown } | undefined;
+      const es = typeof name?.es === "string" ? name.es : "";
+      const en = typeof name?.en === "string" ? name.en : "";
+      return {
+        id: doc.id,
+        name: es || en || "—",
+        cadence:
+          typeof data.scheduleCadence === "string"
+            ? data.scheduleCadence
+            : null,
+        scheduleType:
+          typeof data.scheduleType === "string" ? data.scheduleType : null,
+        reminderEnabled: data.reminderEnabled === true,
+        deleted: data.deleted === true,
+      };
+    })
+    .sort((a, b) => Number(a.deleted) - Number(b.deleted));
+}
+
 const deactivateClientSchema = z.object({
   coachUid: z.string().trim().min(6).max(128),
   clientUid: z.string().trim().min(6).max(128),


### PR DESCRIPTION
## Why
En el admin panel, la ficha read-only de un cliente (`/gc-fitness/admin/coaches/[uid]/clients/[clientId]`) solo mostraba **Recent activity** y **Progress photos**. En god-mode conviene ver también qué tiene asignado.

## What
Dos secciones nuevas read-only:
- **Workout assignments** — últimas 80 (fecha, hora, workout, estado con badge de color: completed/started/scheduled/missed).
- **Habits** — activos primero, los soft-deleted se muestran para contexto (cadencia + recordatorio + estado).

Datos vía dos server actions admin-gated (`listClientAssignmentsForAdmin`, `listClientHabitsForAdmin`) que **verifican que el cliente pertenezca a {coachUid}** — mismo gate que los lectores admin de recent-logs / progress-photos, así la URL no se puede editar para leer clientes de otro coach.

## Notas
- Solo lectura (Admin SDK, sin cambios de `firestore.rules`).
- Las asignaciones recurrentes explotan en un doc por fecha, por eso el cap de 80 (se avisa en la UI cuando se llega al tope).

## Tests
- `tsc --noEmit` limpio.
- `jest` — 450 passing; solo falla el flake pre-existente `client-activity-time` (verde en CI).

## Test plan
Admin Panel → un coach → un cliente → ver **Workout assignments** y **Habits** con sus datos.