### PR TITLE
fix(gc-fitness/habits): assigning an existing habit no longer duplicates the template

### DIFF
--- a/backoffice/src/app/gc-fitness/habits/_components/HabitForm.tsx
+++ b/backoffice/src/app/gc-fitness/habits/_components/HabitForm.tsx
@@ -98,6 +98,12 @@ export interface HabitFormProps {
    * (e.g. a dialog with its own close affordance).
    */
   hideCancelButton?: boolean;
+  /**
+   * Overrides the submit button label. Used by the "assign existing habit"
+   * flow so the CTA reads "Asignar" instead of the default "Crear" — that
+   * flow reuses this create-mode form but is semantically an assignment.
+   */
+  submitLabel?: string;
 }
 
 const WEEKDAY_KEYS = [
@@ -169,6 +175,7 @@ export function HabitForm({
   onSubmit,
   onAfterSubmit,
   hideCancelButton,
+  submitLabel,
 }: HabitFormProps) {
   const router = useRouter();
   const t = useTranslations("habits.form");
@@ -825,6 +832,8 @@ export function HabitForm({
             <Button type="submit" disabled={pending} className="rounded-full">
               {pending
                 ? t("saving")
+                : submitLabel
+                ? submitLabel
                 : mode === "create"
                 ? t("createCta")
                 : t("saveCta")}

--- a/backoffice/src/components/gc-fitness/schedule/new-habit-dialog.tsx
+++ b/backoffice/src/components/gc-fitness/schedule/new-habit-dialog.tsx
@@ -274,8 +274,15 @@ export function NewHabitDialog({
                   effStartsOn,
                 )}
                 hideCancelButton
+                submitLabel="Asignar"
                 onAfterSubmit={afterSubmit}
-                onSubmit={async (input) => createHabit(input)}
+                // Pass sourceTemplateId EXPLICITLY: HabitForm's payload drops it,
+                // and without it createHabit would treat this as a brand-new
+                // habit and spawn a DUPLICATE library template. With it, the
+                // assignment just links back to the existing template.
+                onSubmit={async (input) =>
+                  createHabit({ ...input, sourceTemplateId: selected.id })
+                }
               />
             </div>
           ) : (


### PR DESCRIPTION
## Bug (regresión de #118)
Al **asignar un hábito existente** a otro cliente:
1. el botón decía **"Crear"** en vez de **"Asignar"**, y
2. se generaba una **plantilla duplicada** en la biblioteca (dos "50-50").

## Causa
La rama "Asignar existente" del modal reusa `HabitForm` (mode="create") → `createHabit`. `templateToDefaults` setea `sourceTemplateId`, **pero `HabitForm` arma su payload campo por campo y lo descarta** (nunca es un campo del form). Sin `sourceTemplateId`, `createHabit` (post-#118) cree que es un hábito nuevo y **crea una segunda plantilla**.

## Fix
- **`new-habit-dialog`** (rama asignar-existente): pasa `sourceTemplateId` **explícito** a `createHabit` → enlaza con la plantilla existente en vez de duplicarla.
- **`HabitForm`**: nuevo prop opcional `submitLabel`; el flujo de asignar lo setea en **"Asignar"** (antes mostraba "Crear").

El contrato "no duplica cuando viene de plantilla" ya está cubierto por el test `habit-actions` **T04c**.

## Limpieza de datos
Las plantillas "50-50" duplicadas que ya se crearon son data — se borra una desde la Biblioteca (este fix evita que vuelva a pasar).

## Tests
- `tsc --noEmit` limpio.
- `jest habit-actions` 19/19; suite completa 450 passing (solo el flake pre-existente `client-activity-time`).

## Test plan
1. Cliente A: crear hábito "X" (queda 1 plantilla).
2. Cliente B → **Asignar existente** → "X": el botón dice **Asignar**, se asigna y **NO** aparece una segunda plantilla en la Biblioteca.