### PR TITLE
feat(gc-fitness/habits): confirm + preview before cascading a template edit to clients

### DIFF
--- a/backoffice/src/app/gc-fitness/habits/_components/HabitTemplateDetailDialog.tsx
+++ b/backoffice/src/app/gc-fitness/habits/_components/HabitTemplateDetailDialog.tsx
@@ -8,7 +8,7 @@
 // or soft-deleted. Global templates are read-only. Recurrence is intentionally
 // absent — it's a per-assignment concern, not a template one.
 
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import { EyeOff, Pencil, Trash2 } from "lucide-react";
 import { toast } from "sonner";
 import { useTranslations } from "next-intl";
@@ -40,8 +40,10 @@ import {
 import {
   hideGlobalHabitTemplate,
   listHabitTemplateAssignments,
+  propagateHabitTemplateContent,
   softDeleteHabitTemplate,
   updateHabitTemplate,
+  type HabitTemplateAssignmentImpact,
   type HabitTemplateRow,
 } from "@/lib/gc-fitness/habit-actions";
 import { recurrenceLabel, ReminderCell, ScopePill } from "./habit-pills";
@@ -82,6 +84,32 @@ export function HabitTemplateDetailDialog({
   const [editing, setEditing] = useState(false);
   // B5 — hide-from-library confirm (global templates only).
   const [confirmHideOpen, setConfirmHideOpen] = useState(false);
+
+  // Post-save cascade: after editing a template, ask whether to push the
+  // content (description / photo / video) to the clients who have it assigned.
+  // Non-null = the propagation confirm dialog is open with this impact list.
+  const [propagateImpact, setPropagateImpact] = useState<
+    HabitTemplateAssignmentImpact[] | null
+  >(null);
+  const [propagating, setPropagating] = useState(false);
+
+  // Group the per-assignment impact list into per-client rows (name + count)
+  // for the propagation confirm dialog.
+  const affectedClients = useMemo(() => {
+    if (!propagateImpact) return [];
+    const byClient = new Map<string, { name: string; count: number }>();
+    for (const imp of propagateImpact) {
+      const key =
+        imp.clientId ?? (imp.pendingEmail ? `pending:${imp.pendingEmail}` : "?");
+      const name = imp.clientId
+        ? clientNames?.get(imp.clientId) ?? imp.clientId
+        : imp.pendingEmail ?? "Cliente pendiente";
+      const existing = byClient.get(key);
+      if (existing) existing.count += 1;
+      else byClient.set(key, { name, count: 1 });
+    }
+    return Array.from(byClient.values());
+  }, [propagateImpact, clientNames]);
 
   // Edit-form drafts (seeded from the template when entering edit mode).
   const [nameEn, setNameEn] = useState("");
@@ -136,14 +164,50 @@ export function HabitTemplateDetailDialog({
         reminderEnabled,
         reminderTime: reminderEnabled ? reminderTime || undefined : undefined,
       });
-      toast.success(tf("savedToast"));
       onChanged();
-      closeDialog();
+
+      // The template is saved. If clients have it assigned, ASK whether to push
+      // the content edit to them (instead of cascading silently).
+      let affected: HabitTemplateAssignmentImpact[] = [];
+      try {
+        affected = await listHabitTemplateAssignments(template.id);
+      } catch (previewErr) {
+        console.error("[habits] template impact preview failed", previewErr);
+      }
+      if (affected.length > 0) {
+        toast.success(tf("savedToast"));
+        setEditing(false);
+        setPropagateImpact(affected); // opens the cascade confirm dialog
+      } else {
+        toast.success(tf("savedToast"));
+        closeDialog();
+      }
     } catch (err) {
       console.error("[habits] update template failed", err);
       toast.error(err instanceof Error ? err.message : tf("saveFailed"));
     } finally {
       setPending(false);
+    }
+  }
+
+  async function handlePropagate() {
+    if (!template) return;
+    setPropagating(true);
+    try {
+      const res = await propagateHabitTemplateContent(template.id);
+      toast.success(
+        res.updated === 1
+          ? "Actualizado en 1 cliente"
+          : `Actualizado en ${res.updated} clientes`,
+      );
+      onChanged();
+      setPropagateImpact(null);
+      closeDialog();
+    } catch (err) {
+      console.error("[habits] propagate template failed", err);
+      toast.error(err instanceof Error ? err.message : "No se pudo actualizar");
+    } finally {
+      setPropagating(false);
     }
   }
 
@@ -478,6 +542,81 @@ export function HabitTemplateDetailDialog({
               disabled={pending}
             >
               {pending ? t("deleting") : t("hideGlobalConfirm")}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+
+      {/* Post-save cascade: push the content edit to the clients who have this
+          template assigned. Opt-in — dismissing keeps the template saved but
+          leaves each client's assignment untouched. */}
+      <AlertDialog
+        open={propagateImpact !== null}
+        onOpenChange={(o) => {
+          if (!o && !propagating) {
+            setPropagateImpact(null);
+            closeDialog();
+          }
+        }}
+      >
+        <AlertDialogContent className="max-h-[calc(100vh-2rem)] overflow-y-auto">
+          <AlertDialogHeader>
+            <AlertDialogTitle>¿Actualizar a los clientes?</AlertDialogTitle>
+            <AlertDialogDescription asChild className="text-left">
+              <div className="space-y-3 text-left text-sm text-muted-foreground">
+                <p>
+                  Guardaste la plantilla.{" "}
+                  <strong className="text-foreground">
+                    {affectedClients.length}
+                  </strong>{" "}
+                  {affectedClients.length === 1
+                    ? "cliente la tiene asignada"
+                    : "clientes la tienen asignada"}
+                  . ¿Querés actualizarles la{" "}
+                  <strong className="text-foreground">
+                    descripción, foto y video
+                  </strong>
+                  ?
+                </p>
+                {affectedClients.length > 0 ? (
+                  <ul className="max-h-48 list-disc space-y-1 overflow-y-auto rounded-md border border-border/70 bg-background/40 px-4 py-2 text-xs text-foreground">
+                    {affectedClients.map((c) => (
+                      <li key={c.name} className="break-words">
+                        {c.name}
+                        {c.count > 1 ? ` (${c.count})` : ""}
+                      </li>
+                    ))}
+                  </ul>
+                ) : null}
+                <p className="text-xs">
+                  No se tocan el nombre, la recurrencia ni el recordatorio de
+                  cada cliente.
+                </p>
+              </div>
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter className="flex-col-reverse gap-2 sm:flex-row">
+            <AlertDialogCancel
+              onClick={() => {
+                setPropagateImpact(null);
+                closeDialog();
+              }}
+              disabled={propagating}
+            >
+              No actualizar
+            </AlertDialogCancel>
+            <AlertDialogAction
+              onClick={(e) => {
+                e.preventDefault();
+                void handlePropagate();
+              }}
+              disabled={propagating}
+            >
+              {propagating
+                ? "Actualizando…"
+                : `Actualizar a ${affectedClients.length} ${
+                    affectedClients.length === 1 ? "cliente" : "clientes"
+                  }`}
             </AlertDialogAction>
           </AlertDialogFooter>
         </AlertDialogContent>

--- a/backoffice/src/lib/gc-fitness/habit-actions.ts
+++ b/backoffice/src/lib/gc-fitness/habit-actions.ts
@@ -1438,46 +1438,85 @@ export async function updateHabitTemplate(
     }),
   );
 
-  // Cascade the CONTENT fields (description / photo / video) onto every live
-  // assignment created from this template (linked via `sourceTemplateId`). The
-  // iOS app reads the per-client assignment doc, not the template — without
-  // this, a library edit would never reach the client. We intentionally do NOT
-  // cascade name / schedule / reminder: those are commonly customised per
-  // assignment, whereas the description/photo/video are intrinsic "what is this
-  // habit" context the trainer expects to edit once.
-  //
-  // LIMITATION: only assignments carrying `sourceTemplateId` are reached.
-  // Assignments created before this link existed (or by any unlinked path) are
-  // NOT updated — edit those directly from the Assignments tab.
-  const contentPatch = withoutUndefined({
-    description: parsed.description,
-    photoUrl: parsed.photoUrl,
-    youtubeUrl: parsed.youtubeUrl,
-  });
-  if (Object.keys(contentPatch).length > 0) {
-    // Single-field equality query — no composite index required.
-    const linked = await db
-      .collection(COLLECTION)
-      .where("sourceTemplateId", "==", id)
-      .get();
-    const mine = linked.docs.filter((d) => {
-      const data = d.data() as { trainerId?: string; deleted?: boolean };
-      return data.trainerId === trainer.uid && data.deleted !== true;
-    });
-    // Firestore batches cap at 500 writes; chunk defensively.
-    for (let i = 0; i < mine.length; i += 450) {
-      const batch = db.batch();
-      for (const d of mine.slice(i, i + 450)) {
-        batch.update(d.ref, {
-          ...contentPatch,
-          updatedAt: FieldValue.serverTimestamp(),
-        });
-      }
-      await batch.commit();
-    }
+  // NOTE: cascading the content fields (description / photo / video) onto the
+  // linked client assignments is now an EXPLICIT, opt-in step — the UI shows
+  // which clients would be affected and asks before pushing. See
+  // `propagateHabitTemplateContent` (called from the template edit dialog after
+  // the trainer confirms). Editing the template alone no longer silently
+  // rewrites every client's assignment.
+  return { ok: true };
+}
+
+/**
+ * Opt-in cascade: push the template's CURRENT content fields (description /
+ * photo / video) onto every live per-client assignment linked via
+ * `sourceTemplateId`. The iOS app reads the per-client assignment doc (not the
+ * template), so this is how a library edit reaches clients. Name / schedule /
+ * reminder are deliberately NOT cascaded — those are commonly customised per
+ * assignment.
+ *
+ * LIMITATION: only assignments carrying `sourceTemplateId` are reached.
+ */
+export async function propagateHabitTemplateContent(
+  templateId: string,
+): Promise<{ updated: number }> {
+  const trainer = await getCurrentTrainer();
+  if (typeof templateId !== "string" || templateId.trim().length === 0) {
+    return { updated: 0 };
   }
 
-  return { ok: true };
+  const db = gcFitnessFirestore();
+  const tplSnap = await db.collection(TEMPLATE_COLLECTION).doc(templateId).get();
+  if (!tplSnap.exists) throw new Error("Not found");
+  const tpl = tplSnap.data() as {
+    scope?: string;
+    trainerId?: string;
+    description?: unknown;
+    photoUrl?: unknown;
+    youtubeUrl?: unknown;
+  };
+  if (tpl.scope === "global") throw new Error("Global templates can't be edited.");
+  if (tpl.trainerId !== trainer.uid) throw new Error("Not your template.");
+
+  // Push only fields that are set on the template (matches the prior cascade —
+  // clearing a field on the template does not clear it on assignments).
+  const contentPatch = withoutUndefined({
+    description: tpl.description,
+    photoUrl:
+      typeof tpl.photoUrl === "string" && tpl.photoUrl.length > 0
+        ? tpl.photoUrl
+        : undefined,
+    youtubeUrl:
+      typeof tpl.youtubeUrl === "string" && tpl.youtubeUrl.length > 0
+        ? tpl.youtubeUrl
+        : undefined,
+  });
+  if (Object.keys(contentPatch).length === 0) return { updated: 0 };
+
+  // Single-field equality query — no composite index required.
+  const linked = await db
+    .collection(COLLECTION)
+    .where("sourceTemplateId", "==", templateId)
+    .get();
+  const mine = linked.docs.filter((d) => {
+    const data = d.data() as { trainerId?: string; deleted?: boolean };
+    return data.trainerId === trainer.uid && data.deleted !== true;
+  });
+
+  let updated = 0;
+  // Firestore batches cap at 500 writes; chunk defensively.
+  for (let i = 0; i < mine.length; i += 450) {
+    const batch = db.batch();
+    for (const d of mine.slice(i, i + 450)) {
+      batch.update(d.ref, {
+        ...contentPatch,
+        updatedAt: FieldValue.serverTimestamp(),
+      });
+      updated += 1;
+    }
+    await batch.commit();
+  }
+  return { updated };
 }
 
 export async function assignHabitTemplate(input: unknown): Promise<{


### PR DESCRIPTION
## Qué (Parte B del reporte)
Al **editar un template de hábito**, antes se cascadeaba **en silencio** el contenido (descripción/foto/video) a todos los clientes que lo tenían asignado — sin preguntar ni mostrar a quiénes. Ahora es **opt-in con preview**, igual que los workouts.

## Cambios
**Server (`habit-actions.ts`)**
- `updateHabitTemplate` ahora **solo guarda el template** (saqué la cascada automática).
- Nueva action `propagateHabitTemplateContent(templateId)`: empuja el contenido del template a las asignaciones vivas linkeadas por `sourceTemplateId`. Se llama **solo al confirmar**.

**UI (`HabitTemplateDetailDialog`)**
- Después de guardar, busca los clientes con ese template (`listHabitTemplateAssignments` + `clientNames`).
- Si hay alguno → abre un **diálogo de confirmación** que **lista los clientes** y pregunta si actualizar.
  - **"Actualizar a N clientes"** → cascada.
  - **"No actualizar"** → el template queda guardado, las asignaciones intactas.
- Nombre / recurrencia / recordatorio siguen siendo per-cliente y **nunca** se cascadean.

> Pareja con #122 (foto + editar en el modal del cliente).

## Tests
- `tsc --noEmit` limpio. (Ningún test lockeaba la cascada silenciosa anterior.)
- `jest` 450 passing (solo el flake pre-existente `client-activity-time`).

## Test plan
1. Biblioteca → editar un template que **tenga clientes** → guardar → aparece el diálogo con la lista de clientes.
2. "Actualizar a N" → toast "Actualizado en N clientes" y el iOS de esos clientes ve la nueva descripción/foto/video.
3. "No actualizar" → el template queda editado pero las asignaciones no cambian.
4. Editar un template **sin** clientes → guarda y cierra sin preguntar (como antes).