### PR TITLE
feat(gc-fitness/reminders): multi-client links + full recurrence

### DIFF
--- a/backoffice/src/app/gc-fitness/checklist/CoachChecklistClient.tsx
+++ b/backoffice/src/app/gc-fitness/checklist/CoachChecklistClient.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { FormEvent, useMemo, useState, useTransition } from "react";
 import {
@@ -9,7 +10,9 @@ import {
   ChevronDown,
   ChevronUp,
   Pencil,
+  Repeat,
   Trash2,
+  User,
 } from "lucide-react";
 import { useLocale, useTranslations } from "next-intl";
 
@@ -28,11 +31,28 @@ import {
 } from "@/lib/gc-fitness/coach-checklist-actions";
 import { cn } from "@/lib/utils";
 
-interface Props {
-  items: CoachChecklistItem[];
+export interface ChecklistClientOption {
+  uid: string;
+  displayName: string;
 }
 
-export function CoachChecklistClient({ items }: Props) {
+interface Props {
+  items: CoachChecklistItem[];
+  clients: ChecklistClientOption[];
+}
+
+// Native-select styling matching the shadcn Input look (the create/edit forms
+// are uncontrolled FormData forms, so we use native <select> not Radix Select).
+const SELECT_CLASS =
+  "flex h-11 w-full rounded-md border border-input bg-transparent px-3 py-1 text-sm shadow-sm focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring";
+
+const RECURRENCE_LABEL: Record<string, string> = {
+  daily: "Diaria",
+  weekly: "Semanal",
+  monthly: "Mensual",
+};
+
+export function CoachChecklistClient({ items, clients }: Props) {
   const t = useTranslations("coachChecklist");
   const locale = useLocale();
   const router = useRouter();
@@ -63,6 +83,8 @@ export function CoachChecklistClient({ items }: Props) {
         notes: String(formData.get("notes") ?? ""),
         dueDate: String(formData.get("dueDate") ?? ""),
         dueTime: String(formData.get("dueTime") ?? ""),
+        clientId: String(formData.get("clientId") ?? ""),
+        recurrence: String(formData.get("recurrence") ?? "none"),
       });
       form.reset();
       router.refresh();
@@ -90,28 +112,60 @@ export function CoachChecklistClient({ items }: Props) {
           <CardTitle className="gc-page-title text-xl">{t("newTitle")}</CardTitle>
         </CardHeader>
         <CardContent>
-          <form className="grid gap-4 xl:grid-cols-[minmax(0,1.2fr)_minmax(0,1fr)_auto]" onSubmit={handleSubmit}>
-            <div className="grid gap-2 xl:col-span-1">
-              <Label htmlFor="checklist-title">{t("titleLabel")}</Label>
-              <Input
-                id="checklist-title"
-                name="title"
-                required
-                maxLength={160}
-                placeholder={t("titlePlaceholder")}
-              />
+          <form className="grid gap-4" onSubmit={handleSubmit}>
+            <div className="grid gap-4 md:grid-cols-2">
+              <div className="grid gap-2">
+                <Label htmlFor="checklist-title">{t("titleLabel")}</Label>
+                <Input
+                  id="checklist-title"
+                  name="title"
+                  required
+                  maxLength={160}
+                  placeholder={t("titlePlaceholder")}
+                />
+              </div>
+              <div className="grid gap-2">
+                <Label htmlFor="checklist-notes">{t("notesLabel")}</Label>
+                <Textarea
+                  id="checklist-notes"
+                  name="notes"
+                  maxLength={500}
+                  placeholder={t("notesPlaceholder")}
+                  className="min-h-11"
+                />
+              </div>
             </div>
-            <div className="grid gap-2">
-              <Label htmlFor="checklist-notes">{t("notesLabel")}</Label>
-              <Textarea
-                id="checklist-notes"
-                name="notes"
-                maxLength={500}
-                placeholder={t("notesPlaceholder")}
-                className="min-h-11 xl:min-h-10"
-              />
-            </div>
-            <div className="grid gap-3 sm:grid-cols-[minmax(0,1fr)_minmax(0,0.8fr)] xl:col-span-1">
+            <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
+              <div className="grid gap-2">
+                <Label htmlFor="checklist-client">Cliente</Label>
+                <select
+                  id="checklist-client"
+                  name="clientId"
+                  defaultValue=""
+                  className={SELECT_CLASS}
+                >
+                  <option value="">Sin cliente</option>
+                  {clients.map((c) => (
+                    <option key={c.uid} value={c.uid}>
+                      {c.displayName}
+                    </option>
+                  ))}
+                </select>
+              </div>
+              <div className="grid gap-2">
+                <Label htmlFor="checklist-recurrence">Recurrencia</Label>
+                <select
+                  id="checklist-recurrence"
+                  name="recurrence"
+                  defaultValue="none"
+                  className={SELECT_CLASS}
+                >
+                  <option value="none">Única</option>
+                  <option value="daily">Diaria</option>
+                  <option value="weekly">Semanal</option>
+                  <option value="monthly">Mensual</option>
+                </select>
+              </div>
               <div className="grid gap-2">
                 <Label htmlFor="checklist-date">{t("dateLabel")}</Label>
                 <Input id="checklist-date" name="dueDate" type="date" className="h-11" />
@@ -124,7 +178,7 @@ export function CoachChecklistClient({ items }: Props) {
             <Button
               type="submit"
               disabled={pending}
-              className="h-11 self-end rounded-full px-6"
+              className="h-11 justify-self-start rounded-full px-6"
             >
               {pending ? t("saving") : t("addCta")}
             </Button>
@@ -225,7 +279,22 @@ export function CoachChecklistClient({ items }: Props) {
                                 {t("overdueBadge")}
                               </span>
                             ) : null}
+                            {item.recurrence !== "none" ? (
+                              <span className="inline-flex items-center gap-1 rounded-full bg-primary/10 px-2 py-0.5 text-[11px] font-semibold text-primary">
+                                <Repeat className="size-3" />
+                                {RECURRENCE_LABEL[item.recurrence] ?? item.recurrence}
+                              </span>
+                            ) : null}
                           </div>
+                          {item.clientId ? (
+                            <Link
+                              href={`/gc-fitness/clients/${item.clientId}`}
+                              className="mt-1 inline-flex w-fit items-center gap-1 text-xs font-medium text-primary hover:underline"
+                            >
+                              <User className="size-3.5" />
+                              {item.clientName ?? "Ver cliente"}
+                            </Link>
+                          ) : null}
                           {item.notes ? (
                             <p className="mt-1 whitespace-pre-wrap text-sm text-muted-foreground">
                               {item.notes}
@@ -246,6 +315,7 @@ export function CoachChecklistClient({ items }: Props) {
                         <div className="flex shrink-0 items-center gap-1">
                           <ChecklistEditDialog
                             item={item}
+                            clients={clients}
                             trigger={
                               <Button
                                 type="button"

--- a/backoffice/src/app/gc-fitness/checklist/CoachChecklistClient.tsx
+++ b/backoffice/src/app/gc-fitness/checklist/CoachChecklistClient.tsx
@@ -78,6 +78,10 @@ export function CoachChecklistClient({ items, clients }: Props) {
   const router = useRouter();
   const [pending, startTransition] = useTransition();
   const [showCompleted, setShowCompleted] = useState(false);
+  // Recurrence validity (weekly/monthly need ≥1 day) gates the submit button.
+  const [recurrenceValid, setRecurrenceValid] = useState(true);
+  // Bumped after a successful create so the recurrence fields remount/reset.
+  const [recurrenceKey, setRecurrenceKey] = useState(0);
   const now = useMemo(() => new Date(), []);
   const activeItems = useMemo(
     () => items.filter((item) => !item.completed),
@@ -116,6 +120,7 @@ export function CoachChecklistClient({ items, clients }: Props) {
           .filter((n) => Number.isInteger(n)),
       });
       form.reset();
+      setRecurrenceKey((k) => k + 1);
       router.refresh();
     });
   }
@@ -190,10 +195,14 @@ export function CoachChecklistClient({ items, clients }: Props) {
                 <Input id="checklist-time" name="dueTime" type="time" className="h-11" />
               </div>
             </div>
-            <ChecklistRecurrenceFields idPrefix="checklist-create" />
+            <ChecklistRecurrenceFields
+              key={recurrenceKey}
+              idPrefix="checklist-create"
+              onValidityChange={setRecurrenceValid}
+            />
             <Button
               type="submit"
-              disabled={pending}
+              disabled={pending || !recurrenceValid}
               className="h-11 justify-self-start rounded-full px-6"
             >
               {pending ? t("saving") : t("addCta")}

--- a/backoffice/src/app/gc-fitness/checklist/CoachChecklistClient.tsx
+++ b/backoffice/src/app/gc-fitness/checklist/CoachChecklistClient.tsx
@@ -18,6 +18,7 @@ import { useLocale, useTranslations } from "next-intl";
 
 import { Button } from "@/components/ui/button";
 import { ChecklistEditDialog } from "@/components/gc-fitness/ChecklistEditDialog";
+import { ChecklistRecurrenceFields } from "@/components/gc-fitness/ChecklistRecurrenceFields";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Checkbox } from "@/components/ui/checkbox";
 import { Input } from "@/components/ui/input";
@@ -52,6 +53,25 @@ const RECURRENCE_LABEL: Record<string, string> = {
   monthly: "Mensual",
 };
 
+// 1=Mon … 7=Sun → short labels for the list pill.
+const WEEKDAY_LETTER = ["", "Lun", "Mar", "Mié", "Jue", "Vie", "Sáb", "Dom"];
+
+function recurrenceSummary(item: CoachChecklistItem): string {
+  const base = RECURRENCE_LABEL[item.recurrence] ?? item.recurrence;
+  if (item.recurrence === "weekly" && item.recurrenceWeekdays.length > 0) {
+    const days = [...item.recurrenceWeekdays]
+      .sort((a, b) => a - b)
+      .map((d) => WEEKDAY_LETTER[d] ?? d)
+      .join(", ");
+    return `${base} · ${days}`;
+  }
+  if (item.recurrence === "monthly" && item.recurrenceMonthDays.length > 0) {
+    const days = [...item.recurrenceMonthDays].sort((a, b) => a - b).join(", ");
+    return `${base} · día ${days}`;
+  }
+  return base;
+}
+
 export function CoachChecklistClient({ items, clients }: Props) {
   const t = useTranslations("coachChecklist");
   const locale = useLocale();
@@ -85,6 +105,15 @@ export function CoachChecklistClient({ items, clients }: Props) {
         dueTime: String(formData.get("dueTime") ?? ""),
         clientId: String(formData.get("clientId") ?? ""),
         recurrence: String(formData.get("recurrence") ?? "none"),
+        recurrenceEndsOn: String(formData.get("recurrenceEndsOn") ?? ""),
+        recurrenceWeekdays: formData
+          .getAll("recurrenceWeekdays")
+          .map((v) => Number(v))
+          .filter((n) => Number.isInteger(n)),
+        recurrenceMonthDays: formData
+          .getAll("recurrenceMonthDays")
+          .map((v) => Number(v))
+          .filter((n) => Number.isInteger(n)),
       });
       form.reset();
       router.refresh();
@@ -135,7 +164,7 @@ export function CoachChecklistClient({ items, clients }: Props) {
                 />
               </div>
             </div>
-            <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
+            <div className="grid gap-3 sm:grid-cols-3">
               <div className="grid gap-2">
                 <Label htmlFor="checklist-client">Cliente</Label>
                 <select
@@ -153,20 +182,6 @@ export function CoachChecklistClient({ items, clients }: Props) {
                 </select>
               </div>
               <div className="grid gap-2">
-                <Label htmlFor="checklist-recurrence">Recurrencia</Label>
-                <select
-                  id="checklist-recurrence"
-                  name="recurrence"
-                  defaultValue="none"
-                  className={SELECT_CLASS}
-                >
-                  <option value="none">Única</option>
-                  <option value="daily">Diaria</option>
-                  <option value="weekly">Semanal</option>
-                  <option value="monthly">Mensual</option>
-                </select>
-              </div>
-              <div className="grid gap-2">
                 <Label htmlFor="checklist-date">{t("dateLabel")}</Label>
                 <Input id="checklist-date" name="dueDate" type="date" className="h-11" />
               </div>
@@ -175,6 +190,7 @@ export function CoachChecklistClient({ items, clients }: Props) {
                 <Input id="checklist-time" name="dueTime" type="time" className="h-11" />
               </div>
             </div>
+            <ChecklistRecurrenceFields idPrefix="checklist-create" />
             <Button
               type="submit"
               disabled={pending}
@@ -282,7 +298,10 @@ export function CoachChecklistClient({ items, clients }: Props) {
                             {item.recurrence !== "none" ? (
                               <span className="inline-flex items-center gap-1 rounded-full bg-primary/10 px-2 py-0.5 text-[11px] font-semibold text-primary">
                                 <Repeat className="size-3" />
-                                {RECURRENCE_LABEL[item.recurrence] ?? item.recurrence}
+                                {recurrenceSummary(item)}
+                                {item.recurrenceEndsOn
+                                  ? ` · hasta ${item.recurrenceEndsOn}`
+                                  : ""}
                               </span>
                             ) : null}
                           </div>

--- a/backoffice/src/app/gc-fitness/checklist/CoachChecklistClient.tsx
+++ b/backoffice/src/app/gc-fitness/checklist/CoachChecklistClient.tsx
@@ -18,6 +18,7 @@ import { useLocale, useTranslations } from "next-intl";
 
 import { Button } from "@/components/ui/button";
 import { ChecklistEditDialog } from "@/components/gc-fitness/ChecklistEditDialog";
+import { ChecklistClientPicker } from "@/components/gc-fitness/ChecklistClientPicker";
 import { ChecklistRecurrenceFields } from "@/components/gc-fitness/ChecklistRecurrenceFields";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Checkbox } from "@/components/ui/checkbox";
@@ -41,11 +42,6 @@ interface Props {
   items: CoachChecklistItem[];
   clients: ChecklistClientOption[];
 }
-
-// Native-select styling matching the shadcn Input look (the create/edit forms
-// are uncontrolled FormData forms, so we use native <select> not Radix Select).
-const SELECT_CLASS =
-  "flex h-11 w-full rounded-md border border-input bg-transparent px-3 py-1 text-sm shadow-sm focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring";
 
 const RECURRENCE_LABEL: Record<string, string> = {
   daily: "Diaria",
@@ -107,7 +103,7 @@ export function CoachChecklistClient({ items, clients }: Props) {
         notes: String(formData.get("notes") ?? ""),
         dueDate: String(formData.get("dueDate") ?? ""),
         dueTime: String(formData.get("dueTime") ?? ""),
-        clientId: String(formData.get("clientId") ?? ""),
+        clientIds: formData.getAll("clientIds").map((v) => String(v)),
         recurrence: String(formData.get("recurrence") ?? "none"),
         recurrenceEndsOn: String(formData.get("recurrenceEndsOn") ?? ""),
         recurrenceWeekdays: formData
@@ -169,23 +165,11 @@ export function CoachChecklistClient({ items, clients }: Props) {
                 />
               </div>
             </div>
-            <div className="grid gap-3 sm:grid-cols-3">
-              <div className="grid gap-2">
-                <Label htmlFor="checklist-client">Cliente</Label>
-                <select
-                  id="checklist-client"
-                  name="clientId"
-                  defaultValue=""
-                  className={SELECT_CLASS}
-                >
-                  <option value="">Sin cliente</option>
-                  {clients.map((c) => (
-                    <option key={c.uid} value={c.uid}>
-                      {c.displayName}
-                    </option>
-                  ))}
-                </select>
-              </div>
+            <div className="grid gap-2">
+              <Label>Clientes</Label>
+              <ChecklistClientPicker clients={clients} />
+            </div>
+            <div className="grid gap-3 sm:max-w-md sm:grid-cols-2">
               <div className="grid gap-2">
                 <Label htmlFor="checklist-date">{t("dateLabel")}</Label>
                 <Input id="checklist-date" name="dueDate" type="date" className="h-11" />
@@ -314,14 +298,19 @@ export function CoachChecklistClient({ items, clients }: Props) {
                               </span>
                             ) : null}
                           </div>
-                          {item.clientId ? (
-                            <Link
-                              href={`/gc-fitness/clients/${item.clientId}`}
-                              className="mt-1 inline-flex w-fit items-center gap-1 text-xs font-medium text-primary hover:underline"
-                            >
-                              <User className="size-3.5" />
-                              {item.clientName ?? "Ver cliente"}
-                            </Link>
+                          {item.clients.length > 0 ? (
+                            <div className="mt-1 flex flex-wrap gap-1.5">
+                              {item.clients.map((c) => (
+                                <Link
+                                  key={c.id}
+                                  href={`/gc-fitness/clients/${c.id}`}
+                                  className="inline-flex items-center gap-1 rounded-full bg-muted px-2 py-0.5 text-xs font-medium text-primary hover:underline"
+                                >
+                                  <User className="size-3" />
+                                  {c.name}
+                                </Link>
+                              ))}
+                            </div>
                           ) : null}
                           {item.notes ? (
                             <p className="mt-1 whitespace-pre-wrap text-sm text-muted-foreground">

--- a/backoffice/src/app/gc-fitness/checklist/page.tsx
+++ b/backoffice/src/app/gc-fitness/checklist/page.tsx
@@ -4,6 +4,7 @@ import { getTranslations } from "next-intl/server";
 import { PageHeader } from "@/components/gc-fitness/page-header";
 import { getCurrentTrainer } from "@/lib/gc-fitness/auth-helpers";
 import { listCoachChecklistItems } from "@/lib/gc-fitness/coach-checklist-actions";
+import { listClients } from "@/lib/gc-fitness/client-roster";
 import { CoachChecklistClient } from "./CoachChecklistClient";
 
 export const dynamic = "force-dynamic";
@@ -19,12 +20,20 @@ export default async function CoachChecklistPage() {
     throw err;
   }
   const t = await getTranslations("coachChecklist");
-  const items = await listCoachChecklistItems();
+  const [items, roster] = await Promise.all([
+    listCoachChecklistItems(),
+    listClients(),
+  ]);
+  // Only real (signed-in) clients can be linked — pending/mirror entries have a
+  // synthetic `mirror:` uid that isn't a valid client route.
+  const clients = roster
+    .filter((c) => !c.pendingProvisioning)
+    .map((c) => ({ uid: c.uid, displayName: c.displayName }));
 
   return (
     <div className="gc-page flex flex-col gap-6">
       <PageHeader title={t("title")} subtitle={t("headerSubtitle")} />
-      <CoachChecklistClient items={items} />
+      <CoachChecklistClient items={items} clients={clients} />
     </div>
   );
 }

--- a/backoffice/src/components/gc-fitness/ChecklistClientPicker.tsx
+++ b/backoffice/src/components/gc-fitness/ChecklistClientPicker.tsx
@@ -1,0 +1,110 @@
+"use client";
+
+// ChecklistClientPicker.tsx
+//
+// Multi-select client picker for a coach reminder. A searchable checkbox list
+// whose selection is mirrored into hidden <input name="clientIds"> elements, so
+// the host's uncontrolled FormData submit reads every selected uid via
+// formData.getAll("clientIds") — even ones filtered out of the visible list.
+
+import { useMemo, useState } from "react";
+import { Check } from "lucide-react";
+
+import { Input } from "@/components/ui/input";
+import { cn } from "@/lib/utils";
+
+export interface ChecklistClientOption {
+  uid: string;
+  displayName: string;
+}
+
+export function ChecklistClientPicker({
+  clients,
+  defaultSelected = [],
+}: {
+  clients: ChecklistClientOption[];
+  defaultSelected?: string[];
+}) {
+  const [selected, setSelected] = useState<Set<string>>(
+    new Set(defaultSelected),
+  );
+  const [search, setSearch] = useState("");
+
+  const filtered = useMemo(() => {
+    const q = search.trim().toLowerCase();
+    if (!q) return clients;
+    return clients.filter((c) => c.displayName.toLowerCase().includes(q));
+  }, [clients, search]);
+
+  function toggle(uid: string) {
+    setSelected((prev) => {
+      const next = new Set(prev);
+      if (next.has(uid)) next.delete(uid);
+      else next.add(uid);
+      return next;
+    });
+  }
+
+  return (
+    <div className="grid gap-2">
+      {/* Carries the selection through the uncontrolled FormData submit,
+          independent of the search filter. */}
+      {[...selected].map((uid) => (
+        <input key={uid} type="hidden" name="clientIds" value={uid} />
+      ))}
+
+      <Input
+        value={search}
+        onChange={(e) => setSearch(e.target.value)}
+        placeholder="Buscar cliente…"
+        className="h-9"
+      />
+      <div className="max-h-44 overflow-y-auto rounded-md border border-input">
+        {clients.length === 0 ? (
+          <p className="px-3 py-2 text-sm text-muted-foreground">
+            No hay clientes.
+          </p>
+        ) : filtered.length === 0 ? (
+          <p className="px-3 py-2 text-sm text-muted-foreground">
+            Sin resultados.
+          </p>
+        ) : (
+          filtered.map((c) => {
+            const checked = selected.has(c.uid);
+            return (
+              <button
+                type="button"
+                key={c.uid}
+                onClick={() => toggle(c.uid)}
+                aria-pressed={checked}
+                className={cn(
+                  "flex w-full items-center gap-2 px-3 py-2 text-left text-sm hover:bg-accent",
+                  checked && "bg-accent/50",
+                )}
+              >
+                <span
+                  className={cn(
+                    "flex size-4 shrink-0 items-center justify-center rounded border",
+                    checked
+                      ? "border-primary bg-primary text-primary-foreground"
+                      : "border-input",
+                  )}
+                >
+                  {checked ? <Check className="size-3" /> : null}
+                </span>
+                <span className="truncate">{c.displayName}</span>
+              </button>
+            );
+          })
+        )}
+      </div>
+      <p className="text-xs text-muted-foreground">
+        {selected.size === 0
+          ? "Sin cliente"
+          : selected.size === 1
+            ? "1 cliente seleccionado"
+            : `${selected.size} clientes seleccionados`}
+      </p>
+    </div>
+  );
+}

--- a/backoffice/src/components/gc-fitness/ChecklistEditDialog.tsx
+++ b/backoffice/src/components/gc-fitness/ChecklistEditDialog.tsx
@@ -17,6 +17,7 @@ import {
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
+import { ChecklistClientPicker } from "@/components/gc-fitness/ChecklistClientPicker";
 import { ChecklistRecurrenceFields } from "@/components/gc-fitness/ChecklistRecurrenceFields";
 import type { CoachChecklistItem } from "@/lib/gc-fitness/coach-checklist-actions";
 import { updateCoachChecklistItem } from "@/lib/gc-fitness/coach-checklist-actions";
@@ -28,9 +29,6 @@ interface Props {
   /** Linkable clients. When empty (e.g. the dashboard widget) the picker is hidden. */
   clients?: Array<{ uid: string; displayName: string }>;
 }
-
-const SELECT_CLASS =
-  "flex h-11 w-full rounded-md border border-input bg-transparent px-3 py-1 text-sm shadow-sm focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring";
 
 // Split a stored ISO `dueAt` into the local date/time strings the
 // <input type="date"|"time"> controls expect. Empty when there's no due date.
@@ -67,7 +65,7 @@ export function ChecklistEditDialog({ item, trigger, clients = [] }: Props) {
         notes: String(formData.get("notes") ?? ""),
         dueDate: String(formData.get("dueDate") ?? ""),
         dueTime: String(formData.get("dueTime") ?? ""),
-        clientId: String(formData.get("clientId") ?? ""),
+        clientIds: formData.getAll("clientIds").map((v) => String(v)),
         recurrence: String(formData.get("recurrence") ?? "none"),
         recurrenceEndsOn: String(formData.get("recurrenceEndsOn") ?? ""),
         recurrenceWeekdays: formData
@@ -120,20 +118,11 @@ export function ChecklistEditDialog({ item, trigger, clients = [] }: Props) {
           </div>
           {clients.length > 0 ? (
             <div className="grid gap-2">
-              <Label htmlFor={`edit-client-${item.id}`}>Cliente</Label>
-              <select
-                id={`edit-client-${item.id}`}
-                name="clientId"
-                defaultValue={item.clientId ?? ""}
-                className={SELECT_CLASS}
-              >
-                <option value="">Sin cliente</option>
-                {clients.map((c) => (
-                  <option key={c.uid} value={c.uid}>
-                    {c.displayName}
-                  </option>
-                ))}
-              </select>
+              <Label>Clientes</Label>
+              <ChecklistClientPicker
+                clients={clients}
+                defaultSelected={item.clients.map((c) => c.id)}
+              />
             </div>
           ) : null}
           <ChecklistRecurrenceFields

--- a/backoffice/src/components/gc-fitness/ChecklistEditDialog.tsx
+++ b/backoffice/src/components/gc-fitness/ChecklistEditDialog.tsx
@@ -24,7 +24,12 @@ interface Props {
   item: CoachChecklistItem;
   /** The element that opens the dialog (e.g. a pencil icon button). */
   trigger: ReactNode;
+  /** Linkable clients. When empty (e.g. the dashboard widget) the picker is hidden. */
+  clients?: Array<{ uid: string; displayName: string }>;
 }
+
+const SELECT_CLASS =
+  "flex h-11 w-full rounded-md border border-input bg-transparent px-3 py-1 text-sm shadow-sm focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring";
 
 // Split a stored ISO `dueAt` into the local date/time strings the
 // <input type="date"|"time"> controls expect. Empty when there's no due date.
@@ -44,7 +49,7 @@ function splitDueAt(iso: string | null): { date: string; time: string } {
  * checklist page and the dashboard "Pendientes" widget. Uncontrolled form
  * whose defaults are reset on every open via a `key` tied to open state.
  */
-export function ChecklistEditDialog({ item, trigger }: Props) {
+export function ChecklistEditDialog({ item, trigger, clients = [] }: Props) {
   const t = useTranslations("coachChecklist");
   const router = useRouter();
   const [open, setOpen] = useState(false);
@@ -60,6 +65,8 @@ export function ChecklistEditDialog({ item, trigger }: Props) {
         notes: String(formData.get("notes") ?? ""),
         dueDate: String(formData.get("dueDate") ?? ""),
         dueTime: String(formData.get("dueTime") ?? ""),
+        clientId: String(formData.get("clientId") ?? ""),
+        recurrence: String(formData.get("recurrence") ?? "none"),
       });
       setOpen(false);
       router.refresh();
@@ -99,6 +106,40 @@ export function ChecklistEditDialog({ item, trigger }: Props) {
               placeholder={t("notesPlaceholder")}
               className="min-h-20"
             />
+          </div>
+          <div className="grid gap-3 sm:grid-cols-2">
+            {clients.length > 0 ? (
+              <div className="grid gap-2">
+                <Label htmlFor={`edit-client-${item.id}`}>Cliente</Label>
+                <select
+                  id={`edit-client-${item.id}`}
+                  name="clientId"
+                  defaultValue={item.clientId ?? ""}
+                  className={SELECT_CLASS}
+                >
+                  <option value="">Sin cliente</option>
+                  {clients.map((c) => (
+                    <option key={c.uid} value={c.uid}>
+                      {c.displayName}
+                    </option>
+                  ))}
+                </select>
+              </div>
+            ) : null}
+            <div className="grid gap-2">
+              <Label htmlFor={`edit-recurrence-${item.id}`}>Recurrencia</Label>
+              <select
+                id={`edit-recurrence-${item.id}`}
+                name="recurrence"
+                defaultValue={item.recurrence ?? "none"}
+                className={SELECT_CLASS}
+              >
+                <option value="none">Única</option>
+                <option value="daily">Diaria</option>
+                <option value="weekly">Semanal</option>
+                <option value="monthly">Mensual</option>
+              </select>
+            </div>
           </div>
           <div className="grid gap-3 sm:grid-cols-2">
             <div className="grid gap-2">

--- a/backoffice/src/components/gc-fitness/ChecklistEditDialog.tsx
+++ b/backoffice/src/components/gc-fitness/ChecklistEditDialog.tsx
@@ -55,6 +55,7 @@ export function ChecklistEditDialog({ item, trigger, clients = [] }: Props) {
   const router = useRouter();
   const [open, setOpen] = useState(false);
   const [pending, startTransition] = useTransition();
+  const [recurrenceValid, setRecurrenceValid] = useState(true);
   const initial = splitDueAt(item.dueAt);
 
   function handleSubmit(event: FormEvent<HTMLFormElement>) {
@@ -137,6 +138,7 @@ export function ChecklistEditDialog({ item, trigger, clients = [] }: Props) {
           ) : null}
           <ChecklistRecurrenceFields
             idPrefix={`edit-${item.id}`}
+            onValidityChange={setRecurrenceValid}
             defaults={{
               recurrence: item.recurrence,
               endsOn: item.recurrenceEndsOn,
@@ -174,7 +176,7 @@ export function ChecklistEditDialog({ item, trigger, clients = [] }: Props) {
             </DialogClose>
             <Button
               type="submit"
-              disabled={pending}
+              disabled={pending || !recurrenceValid}
               className="rounded-full"
             >
               {pending ? t("saving") : t("saveCta")}

--- a/backoffice/src/components/gc-fitness/ChecklistEditDialog.tsx
+++ b/backoffice/src/components/gc-fitness/ChecklistEditDialog.tsx
@@ -17,6 +17,7 @@ import {
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
+import { ChecklistRecurrenceFields } from "@/components/gc-fitness/ChecklistRecurrenceFields";
 import type { CoachChecklistItem } from "@/lib/gc-fitness/coach-checklist-actions";
 import { updateCoachChecklistItem } from "@/lib/gc-fitness/coach-checklist-actions";
 
@@ -67,6 +68,15 @@ export function ChecklistEditDialog({ item, trigger, clients = [] }: Props) {
         dueTime: String(formData.get("dueTime") ?? ""),
         clientId: String(formData.get("clientId") ?? ""),
         recurrence: String(formData.get("recurrence") ?? "none"),
+        recurrenceEndsOn: String(formData.get("recurrenceEndsOn") ?? ""),
+        recurrenceWeekdays: formData
+          .getAll("recurrenceWeekdays")
+          .map((v) => Number(v))
+          .filter((n) => Number.isInteger(n)),
+        recurrenceMonthDays: formData
+          .getAll("recurrenceMonthDays")
+          .map((v) => Number(v))
+          .filter((n) => Number.isInteger(n)),
       });
       setOpen(false);
       router.refresh();
@@ -107,40 +117,33 @@ export function ChecklistEditDialog({ item, trigger, clients = [] }: Props) {
               className="min-h-20"
             />
           </div>
-          <div className="grid gap-3 sm:grid-cols-2">
-            {clients.length > 0 ? (
-              <div className="grid gap-2">
-                <Label htmlFor={`edit-client-${item.id}`}>Cliente</Label>
-                <select
-                  id={`edit-client-${item.id}`}
-                  name="clientId"
-                  defaultValue={item.clientId ?? ""}
-                  className={SELECT_CLASS}
-                >
-                  <option value="">Sin cliente</option>
-                  {clients.map((c) => (
-                    <option key={c.uid} value={c.uid}>
-                      {c.displayName}
-                    </option>
-                  ))}
-                </select>
-              </div>
-            ) : null}
+          {clients.length > 0 ? (
             <div className="grid gap-2">
-              <Label htmlFor={`edit-recurrence-${item.id}`}>Recurrencia</Label>
+              <Label htmlFor={`edit-client-${item.id}`}>Cliente</Label>
               <select
-                id={`edit-recurrence-${item.id}`}
-                name="recurrence"
-                defaultValue={item.recurrence ?? "none"}
+                id={`edit-client-${item.id}`}
+                name="clientId"
+                defaultValue={item.clientId ?? ""}
                 className={SELECT_CLASS}
               >
-                <option value="none">Única</option>
-                <option value="daily">Diaria</option>
-                <option value="weekly">Semanal</option>
-                <option value="monthly">Mensual</option>
+                <option value="">Sin cliente</option>
+                {clients.map((c) => (
+                  <option key={c.uid} value={c.uid}>
+                    {c.displayName}
+                  </option>
+                ))}
               </select>
             </div>
-          </div>
+          ) : null}
+          <ChecklistRecurrenceFields
+            idPrefix={`edit-${item.id}`}
+            defaults={{
+              recurrence: item.recurrence,
+              endsOn: item.recurrenceEndsOn,
+              weekdays: item.recurrenceWeekdays,
+              monthDays: item.recurrenceMonthDays,
+            }}
+          />
           <div className="grid gap-3 sm:grid-cols-2">
             <div className="grid gap-2">
               <Label htmlFor={`edit-date-${item.id}`}>{t("dateLabel")}</Label>

--- a/backoffice/src/components/gc-fitness/ChecklistRecurrenceFields.tsx
+++ b/backoffice/src/components/gc-fitness/ChecklistRecurrenceFields.tsx
@@ -1,0 +1,160 @@
+"use client";
+
+// ChecklistRecurrenceFields.tsx
+//
+// Self-contained recurrence controls for a coach reminder, shared by the create
+// form and the edit dialog. Renders REAL named form inputs so the host's
+// uncontrolled FormData submit picks them up:
+//   - <select name="recurrence">              none | daily | weekly | monthly
+//   - <input name="recurrenceEndsOn" type=date> end date (any recurrence)
+//   - weekday checkboxes name="recurrenceWeekdays" value 1..7 (Mon..Sun) — weekly
+//   - month-day checkboxes name="recurrenceMonthDays" value 1..31 — monthly
+//
+// Only the currently-selected recurrence's sub-fields are mounted, so the host
+// reads exactly the relevant arrays via formData.getAll(...).
+
+import { useState } from "react";
+
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { cn } from "@/lib/utils";
+
+const SELECT_CLASS =
+  "flex h-11 w-full rounded-md border border-input bg-transparent px-3 py-1 text-sm shadow-sm focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring";
+
+// Mon=1 … Sun=7 (matches the habit/workout schedule weekday convention).
+const WEEKDAYS: Array<{ value: number; label: string }> = [
+  { value: 1, label: "Lun" },
+  { value: 2, label: "Mar" },
+  { value: 3, label: "Mié" },
+  { value: 4, label: "Jue" },
+  { value: 5, label: "Vie" },
+  { value: 6, label: "Sáb" },
+  { value: 7, label: "Dom" },
+];
+const MONTH_DAYS = Array.from({ length: 31 }, (_, i) => i + 1);
+
+export interface ChecklistRecurrenceDefaults {
+  recurrence?: "none" | "daily" | "weekly" | "monthly";
+  endsOn?: string | null;
+  weekdays?: number[];
+  monthDays?: number[];
+}
+
+function Chip({
+  name,
+  value,
+  label,
+  defaultChecked,
+}: {
+  name: string;
+  value: number;
+  label: string;
+  defaultChecked: boolean;
+}) {
+  return (
+    <label className="cursor-pointer">
+      <input
+        type="checkbox"
+        name={name}
+        value={value}
+        defaultChecked={defaultChecked}
+        className="peer sr-only"
+      />
+      <span
+        className={cn(
+          "inline-flex h-9 min-w-9 items-center justify-center rounded-md border border-input px-2 text-sm tabular-nums transition-colors",
+          "peer-checked:border-primary peer-checked:bg-primary peer-checked:text-primary-foreground",
+        )}
+      >
+        {label}
+      </span>
+    </label>
+  );
+}
+
+export function ChecklistRecurrenceFields({
+  idPrefix,
+  defaults = {},
+}: {
+  idPrefix: string;
+  defaults?: ChecklistRecurrenceDefaults;
+}) {
+  const [recurrence, setRecurrence] = useState(defaults.recurrence ?? "none");
+  const weekdaySet = new Set(defaults.weekdays ?? []);
+  const monthDaySet = new Set(defaults.monthDays ?? []);
+
+  return (
+    <div className="grid gap-3">
+      <div className="grid gap-2 sm:max-w-xs">
+        <Label htmlFor={`${idPrefix}-recurrence`}>Recurrencia</Label>
+        <select
+          id={`${idPrefix}-recurrence`}
+          name="recurrence"
+          value={recurrence}
+          onChange={(e) =>
+            setRecurrence(e.target.value as ChecklistRecurrenceDefaults["recurrence"] & string)
+          }
+          className={SELECT_CLASS}
+        >
+          <option value="none">Única</option>
+          <option value="daily">Diaria</option>
+          <option value="weekly">Semanal</option>
+          <option value="monthly">Mensual</option>
+        </select>
+      </div>
+
+      {recurrence !== "none" ? (
+        <div className="grid gap-3 rounded-md border border-border/70 bg-muted/30 p-3">
+          <div className="grid gap-2 sm:max-w-xs">
+            <Label htmlFor={`${idPrefix}-ends`}>Fecha de fin (opcional)</Label>
+            <Input
+              id={`${idPrefix}-ends`}
+              name="recurrenceEndsOn"
+              type="date"
+              defaultValue={defaults.endsOn ?? ""}
+              className="h-11"
+            />
+            <p className="text-xs text-muted-foreground">
+              Dejá vacío para que se repita sin fin.
+            </p>
+          </div>
+
+          {recurrence === "weekly" ? (
+            <div className="grid gap-2">
+              <Label>Días de la semana</Label>
+              <div className="flex flex-wrap gap-1.5">
+                {WEEKDAYS.map((d) => (
+                  <Chip
+                    key={d.value}
+                    name="recurrenceWeekdays"
+                    value={d.value}
+                    label={d.label}
+                    defaultChecked={weekdaySet.has(d.value)}
+                  />
+                ))}
+              </div>
+            </div>
+          ) : null}
+
+          {recurrence === "monthly" ? (
+            <div className="grid gap-2">
+              <Label>Días del mes</Label>
+              <div className="flex flex-wrap gap-1.5">
+                {MONTH_DAYS.map((d) => (
+                  <Chip
+                    key={d}
+                    name="recurrenceMonthDays"
+                    value={d}
+                    label={String(d)}
+                    defaultChecked={monthDaySet.has(d)}
+                  />
+                ))}
+              </div>
+            </div>
+          ) : null}
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/backoffice/src/components/gc-fitness/ChecklistRecurrenceFields.tsx
+++ b/backoffice/src/components/gc-fitness/ChecklistRecurrenceFields.tsx
@@ -10,10 +10,13 @@
 //   - weekday checkboxes name="recurrenceWeekdays" value 1..7 (Mon..Sun) — weekly
 //   - month-day checkboxes name="recurrenceMonthDays" value 1..31 — monthly
 //
-// Only the currently-selected recurrence's sub-fields are mounted, so the host
-// reads exactly the relevant arrays via formData.getAll(...).
+// The day chips are CONTROLLED so we can (a) auto-select today's weekday/day when
+// the trainer switches to weekly/monthly with nothing selected, and (b) report
+// validity to the host (a weekly/monthly reminder needs ≥1 day) so it can
+// disable the submit button. Only the active recurrence's sub-fields are
+// mounted, so the host reads exactly the relevant arrays via formData.getAll().
 
-import { useState } from "react";
+import { useEffect, useState } from "react";
 
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -34,23 +37,32 @@ const WEEKDAYS: Array<{ value: number; label: string }> = [
 ];
 const MONTH_DAYS = Array.from({ length: 31 }, (_, i) => i + 1);
 
+type Recurrence = "none" | "daily" | "weekly" | "monthly";
+
 export interface ChecklistRecurrenceDefaults {
-  recurrence?: "none" | "daily" | "weekly" | "monthly";
+  recurrence?: Recurrence;
   endsOn?: string | null;
   weekdays?: number[];
   monthDays?: number[];
 }
 
-function Chip({
+function isoWeekdayToday(): number {
+  const g = new Date().getDay(); // 0=Sun … 6=Sat
+  return g === 0 ? 7 : g; // → 1=Mon … 7=Sun
+}
+
+function ToggleChip({
   name,
   value,
   label,
-  defaultChecked,
+  checked,
+  onToggle,
 }: {
   name: string;
   value: number;
   label: string;
-  defaultChecked: boolean;
+  checked: boolean;
+  onToggle: () => void;
 }) {
   return (
     <label className="cursor-pointer">
@@ -58,7 +70,8 @@ function Chip({
         type="checkbox"
         name={name}
         value={value}
-        defaultChecked={defaultChecked}
+        checked={checked}
+        onChange={onToggle}
         className="peer sr-only"
       />
       <span
@@ -76,13 +89,53 @@ function Chip({
 export function ChecklistRecurrenceFields({
   idPrefix,
   defaults = {},
+  onValidityChange,
 }: {
   idPrefix: string;
   defaults?: ChecklistRecurrenceDefaults;
+  /** Reports whether the current recurrence selection is complete (weekly /
+   *  monthly need ≥1 day). The host disables submit when false. */
+  onValidityChange?: (valid: boolean) => void;
 }) {
-  const [recurrence, setRecurrence] = useState(defaults.recurrence ?? "none");
-  const weekdaySet = new Set(defaults.weekdays ?? []);
-  const monthDaySet = new Set(defaults.monthDays ?? []);
+  const [recurrence, setRecurrence] = useState<Recurrence>(
+    defaults.recurrence ?? "none",
+  );
+  const [weekdays, setWeekdays] = useState<Set<number>>(
+    new Set(defaults.weekdays ?? []),
+  );
+  const [monthDays, setMonthDays] = useState<Set<number>>(
+    new Set(defaults.monthDays ?? []),
+  );
+
+  const valid =
+    recurrence === "weekly"
+      ? weekdays.size > 0
+      : recurrence === "monthly"
+        ? monthDays.size > 0
+        : true;
+
+  useEffect(() => {
+    onValidityChange?.(valid);
+  }, [valid, onValidityChange]);
+
+  function changeRecurrence(next: Recurrence) {
+    setRecurrence(next);
+    // Auto-select today's weekday / day-of-month when there's nothing chosen yet
+    // so the reminder is immediately submittable (and the button stays enabled).
+    if (next === "weekly" && weekdays.size === 0) {
+      setWeekdays(new Set([isoWeekdayToday()]));
+    }
+    if (next === "monthly" && monthDays.size === 0) {
+      setMonthDays(new Set([new Date().getDate()]));
+    }
+  }
+
+  function toggle(set: Set<number>, value: number): Set<number> {
+    const next = new Set(set);
+    if (next.has(value)) next.delete(value);
+    else next.add(value);
+    return next;
+  }
 
   return (
     <div className="grid gap-3">
@@ -92,9 +145,7 @@ export function ChecklistRecurrenceFields({
           id={`${idPrefix}-recurrence`}
           name="recurrence"
           value={recurrence}
-          onChange={(e) =>
-            setRecurrence(e.target.value as ChecklistRecurrenceDefaults["recurrence"] & string)
-          }
+          onChange={(e) => changeRecurrence(e.target.value as Recurrence)}
           className={SELECT_CLASS}
         >
           <option value="none">Única</option>
@@ -125,15 +176,21 @@ export function ChecklistRecurrenceFields({
               <Label>Días de la semana</Label>
               <div className="flex flex-wrap gap-1.5">
                 {WEEKDAYS.map((d) => (
-                  <Chip
+                  <ToggleChip
                     key={d.value}
                     name="recurrenceWeekdays"
                     value={d.value}
                     label={d.label}
-                    defaultChecked={weekdaySet.has(d.value)}
+                    checked={weekdays.has(d.value)}
+                    onToggle={() => setWeekdays((s) => toggle(s, d.value))}
                   />
                 ))}
               </div>
+              {!valid ? (
+                <p className="text-xs text-destructive">
+                  Elegí al menos un día.
+                </p>
+              ) : null}
             </div>
           ) : null}
 
@@ -142,15 +199,21 @@ export function ChecklistRecurrenceFields({
               <Label>Días del mes</Label>
               <div className="flex flex-wrap gap-1.5">
                 {MONTH_DAYS.map((d) => (
-                  <Chip
+                  <ToggleChip
                     key={d}
                     name="recurrenceMonthDays"
                     value={d}
                     label={String(d)}
-                    defaultChecked={monthDaySet.has(d)}
+                    checked={monthDays.has(d)}
+                    onToggle={() => setMonthDays((s) => toggle(s, d))}
                   />
                 ))}
               </div>
+              {!valid ? (
+                <p className="text-xs text-destructive">
+                  Elegí al menos un día.
+                </p>
+              ) : null}
             </div>
           ) : null}
         </div>

--- a/backoffice/src/lib/gc-fitness/coach-checklist-actions.ts
+++ b/backoffice/src/lib/gc-fitness/coach-checklist-actions.ts
@@ -29,6 +29,12 @@ export interface CoachChecklistItem {
   /** Resolved display name for `clientId` (null if unknown / no client). */
   clientName: string | null;
   recurrence: ChecklistRecurrence;
+  /** Recurrence end date (YYYY-MM-DD) or null for "no end". */
+  recurrenceEndsOn: string | null;
+  /** Selected weekdays (1=Mon … 7=Sun) for weekly recurrence. */
+  recurrenceWeekdays: number[];
+  /** Selected days of month (1..31) for monthly recurrence. */
+  recurrenceMonthDays: number[];
 }
 
 const createChecklistItemSchema = z.object({
@@ -38,6 +44,9 @@ const createChecklistItemSchema = z.object({
   dueTime: z.string().trim().optional(),
   clientId: z.string().trim().max(128).optional(),
   recurrence: z.enum(["none", "daily", "weekly", "monthly"]).optional(),
+  recurrenceEndsOn: z.string().trim().optional(),
+  recurrenceWeekdays: z.array(z.number().int().min(1).max(7)).max(7).optional(),
+  recurrenceMonthDays: z.array(z.number().int().min(1).max(31)).max(31).optional(),
 });
 
 function normalizeRecurrence(value: unknown): ChecklistRecurrence {
@@ -46,19 +55,79 @@ function normalizeRecurrence(value: unknown): ChecklistRecurrence {
     : "none";
 }
 
-/** Roll a due date forward by one recurrence step. Null for "none"/invalid. */
+function isoWeekday(d: Date): number {
+  const g = d.getDay(); // 0=Sun … 6=Sat
+  return g === 0 ? 7 : g; // → 1=Mon … 7=Sun
+}
+
+function sanitizeIntArray(value: unknown, min: number, max: number): number[] {
+  if (!Array.isArray(value)) return [];
+  return value
+    .map((v) => Number(v))
+    .filter((n) => Number.isInteger(n) && n >= min && n <= max);
+}
+
+/**
+ * Roll a due date forward to the NEXT occurrence, preserving the time of day.
+ * - daily: +1 day
+ * - weekly: next day whose ISO weekday is in `weekdays` (fallback +7)
+ * - monthly: next date whose day-of-month is in `monthDays` (fallback +1 month)
+ * Returns null for "none"/invalid.
+ */
 function advanceDueDate(
   iso: string,
   recurrence: ChecklistRecurrence,
+  weekdays: number[] = [],
+  monthDays: number[] = [],
 ): Date | null {
+  const current = new Date(iso);
+  if (Number.isNaN(current.getTime())) return null;
+
+  if (recurrence === "daily") {
+    const next = new Date(current);
+    next.setDate(next.getDate() + 1);
+    return next;
+  }
+  if (recurrence === "weekly") {
+    const set = weekdays.length > 0 ? new Set(weekdays) : null;
+    for (let i = 1; i <= 7; i += 1) {
+      const cand = new Date(current);
+      cand.setDate(cand.getDate() + i);
+      if (!set || set.has(isoWeekday(cand))) return cand;
+    }
+    const fallback = new Date(current);
+    fallback.setDate(fallback.getDate() + 7);
+    return fallback;
+  }
+  if (recurrence === "monthly") {
+    const set = monthDays.length > 0 ? new Set(monthDays) : null;
+    for (let i = 1; i <= 62; i += 1) {
+      const cand = new Date(current);
+      cand.setDate(cand.getDate() + i);
+      if (!set || set.has(cand.getDate())) return cand;
+    }
+    const fallback = new Date(current);
+    fallback.setMonth(fallback.getMonth() + 1);
+    return fallback;
+  }
+  return null;
+}
+
+/** Parse a "YYYY-MM-DD" end date into an end-of-day Date, or null. */
+function parseRecurrenceEnd(endsOn?: string): Date | null {
+  if (!endsOn || !/^\d{4}-\d{2}-\d{2}$/.test(endsOn)) return null;
+  const d = new Date(`${endsOn}T23:59:59`);
+  return Number.isNaN(d.getTime()) ? null : d;
+}
+
+/** Render a stored Timestamp/Date back to a civil "YYYY-MM-DD" string. */
+function toCivilDate(value: unknown): string | null {
+  const iso = toIso(value);
+  if (!iso) return null;
   const d = new Date(iso);
   if (Number.isNaN(d.getTime())) return null;
-  const next = new Date(d);
-  if (recurrence === "daily") next.setDate(next.getDate() + 1);
-  else if (recurrence === "weekly") next.setDate(next.getDate() + 7);
-  else if (recurrence === "monthly") next.setMonth(next.getMonth() + 1);
-  else return null;
-  return next;
+  const pad = (n: number) => String(n).padStart(2, "0");
+  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}`;
 }
 
 const itemIdSchema = z.string().trim().min(1).max(160);
@@ -96,6 +165,9 @@ export async function listCoachChecklistItems(): Promise<CoachChecklistItem[]> {
           : null,
       clientName: null,
       recurrence: normalizeRecurrence(data.recurrence),
+      recurrenceEndsOn: toCivilDate(data.recurrenceEndsAt),
+      recurrenceWeekdays: sanitizeIntArray(data.recurrenceWeekdays, 1, 7),
+      recurrenceMonthDays: sanitizeIntArray(data.recurrenceMonthDays, 1, 31),
     };
   });
 
@@ -169,11 +241,22 @@ export async function createCoachChecklistItem(
   const parsed = createChecklistItemSchema.parse(input);
   const dueAt = parseDueAt(parsed.dueDate, parsed.dueTime);
 
+  const recurrence = parsed.recurrence ?? "none";
+  const recurrenceEndsAt =
+    recurrence !== "none" ? parseRecurrenceEnd(parsed.recurrenceEndsOn) : null;
+
   await checklistCollection(trainer.uid).add({
     title: parsed.title,
     ...(parsed.notes ? { notes: parsed.notes } : {}),
     ...(parsed.clientId ? { clientId: parsed.clientId } : {}),
-    recurrence: parsed.recurrence ?? "none",
+    recurrence,
+    ...(recurrenceEndsAt ? { recurrenceEndsAt } : {}),
+    ...(recurrence === "weekly" && parsed.recurrenceWeekdays?.length
+      ? { recurrenceWeekdays: parsed.recurrenceWeekdays }
+      : {}),
+    ...(recurrence === "monthly" && parsed.recurrenceMonthDays?.length
+      ? { recurrenceMonthDays: parsed.recurrenceMonthDays }
+      : {}),
     dueAt,
     completed: false,
     createdAt: FieldValue.serverTimestamp(),
@@ -196,13 +279,27 @@ export async function updateCoachChecklistItem(
   // Empty notes / cleared date are intentional removals, not "leave as-is":
   // delete the notes field and null out dueAt so the item drops back to the
   // "Sin fecha" group. `completed`/`createdAt` are left untouched.
+  const recurrence = parsed.recurrence ?? "none";
+  const recurrenceEndsAt =
+    recurrence !== "none" ? parseRecurrenceEnd(parsed.recurrenceEndsOn) : null;
+  const weekdays =
+    recurrence === "weekly" ? parsed.recurrenceWeekdays ?? [] : [];
+  const monthDays =
+    recurrence === "monthly" ? parsed.recurrenceMonthDays ?? [] : [];
+
   await checklistCollection(trainer.uid)
     .doc(parsedItemId)
     .update({
       title: parsed.title,
       notes: parsed.notes ? parsed.notes : FieldValue.delete(),
       clientId: parsed.clientId ? parsed.clientId : FieldValue.delete(),
-      recurrence: parsed.recurrence ?? "none",
+      recurrence,
+      // Cleared / inapplicable recurrence sub-fields are removed, not left stale.
+      recurrenceEndsAt: recurrenceEndsAt ?? FieldValue.delete(),
+      recurrenceWeekdays:
+        weekdays.length > 0 ? weekdays : FieldValue.delete(),
+      recurrenceMonthDays:
+        monthDays.length > 0 ? monthDays : FieldValue.delete(),
       dueAt,
       updatedAt: FieldValue.serverTimestamp(),
     });
@@ -227,8 +324,20 @@ export async function setCoachChecklistItemCompleted(
     const recurrence = normalizeRecurrence(data.recurrence);
     const dueIso = toIso(data.dueAt);
     if (recurrence !== "none" && dueIso) {
-      const next = advanceDueDate(dueIso, recurrence);
-      if (next) {
+      const next = advanceDueDate(
+        dueIso,
+        recurrence,
+        sanitizeIntArray(data.recurrenceWeekdays, 1, 7),
+        sanitizeIntArray(data.recurrenceMonthDays, 1, 31),
+      );
+      const endsAtIso = toIso(data.recurrenceEndsAt);
+      const pastEnd =
+        next !== null &&
+        endsAtIso !== null &&
+        next.getTime() > new Date(endsAtIso).getTime();
+      // Roll forward to the next occurrence UNLESS we've passed the end date —
+      // then fall through and mark the reminder completed for good.
+      if (next && !pastEnd) {
         await ref.update({
           dueAt: next,
           completed: false,

--- a/backoffice/src/lib/gc-fitness/coach-checklist-actions.ts
+++ b/backoffice/src/lib/gc-fitness/coach-checklist-actions.ts
@@ -24,10 +24,9 @@ export interface CoachChecklistItem {
   dueAt: string | null;
   completed: boolean;
   createdAt: string | null;
-  /** Optional client this reminder is about (links to /gc-fitness/clients/[id]). */
-  clientId: string | null;
-  /** Resolved display name for `clientId` (null if unknown / no client). */
-  clientName: string | null;
+  /** Clients this reminder is about (each links to /gc-fitness/clients/[id]).
+   *  Empty when the reminder isn't tied to anyone. */
+  clients: Array<{ id: string; name: string }>;
   recurrence: ChecklistRecurrence;
   /** Recurrence end date (YYYY-MM-DD) or null for "no end". */
   recurrenceEndsOn: string | null;
@@ -42,7 +41,7 @@ const createChecklistItemSchema = z.object({
   notes: z.string().trim().max(500).optional(),
   dueDate: z.string().trim().optional(),
   dueTime: z.string().trim().optional(),
-  clientId: z.string().trim().max(128).optional(),
+  clientIds: z.array(z.string().trim().min(1).max(128)).max(50).optional(),
   recurrence: z.enum(["none", "daily", "weekly", "monthly"]).optional(),
   recurrenceEndsOn: z.string().trim().optional(),
   recurrenceWeekdays: z.array(z.number().int().min(1).max(7)).max(7).optional(),
@@ -147,47 +146,60 @@ export async function listCoachChecklistItems(): Promise<CoachChecklistItem[]> {
     .limit(MAX_CHECKLIST_ITEMS)
     .get();
 
-  const rows: CoachChecklistItem[] = snap.docs.map((doc) => {
+  // Each row carries its linked client UIDs; names are resolved below.
+  const rows = snap.docs.map((doc) => {
     const data = doc.data() as Record<string, unknown>;
+    // New docs store `clientIds: string[]`; legacy docs stored a single
+    // `clientId` — read both so old reminders keep their link.
+    const ids = Array.isArray(data.clientIds)
+      ? data.clientIds.filter(
+          (v): v is string => typeof v === "string" && v.length > 0,
+        )
+      : typeof data.clientId === "string" && data.clientId.length > 0
+        ? [data.clientId]
+        : [];
     return {
-      id: doc.id,
-      title: typeof data.title === "string" ? data.title : "Reminder",
-      notes:
-        typeof data.notes === "string" && data.notes.trim().length > 0
-          ? data.notes
-          : null,
-      dueAt: toIso(data.dueAt),
-      completed: data.completed === true,
-      createdAt: toIso(data.createdAt),
-      clientId:
-        typeof data.clientId === "string" && data.clientId.length > 0
-          ? data.clientId
-          : null,
-      clientName: null,
-      recurrence: normalizeRecurrence(data.recurrence),
-      recurrenceEndsOn: toCivilDate(data.recurrenceEndsAt),
-      recurrenceWeekdays: sanitizeIntArray(data.recurrenceWeekdays, 1, 7),
-      recurrenceMonthDays: sanitizeIntArray(data.recurrenceMonthDays, 1, 31),
+      item: {
+        id: doc.id,
+        title: typeof data.title === "string" ? data.title : "Reminder",
+        notes:
+          typeof data.notes === "string" && data.notes.trim().length > 0
+            ? data.notes
+            : null,
+        dueAt: toIso(data.dueAt),
+        completed: data.completed === true,
+        createdAt: toIso(data.createdAt),
+        clients: [] as Array<{ id: string; name: string }>,
+        recurrence: normalizeRecurrence(data.recurrence),
+        recurrenceEndsOn: toCivilDate(data.recurrenceEndsAt),
+        recurrenceWeekdays: sanitizeIntArray(data.recurrenceWeekdays, 1, 7),
+        recurrenceMonthDays: sanitizeIntArray(data.recurrenceMonthDays, 1, 31),
+      } satisfies CoachChecklistItem,
+      clientIds: ids,
     };
   });
 
-  // Resolve display names for the linked clients (one cached roster read).
-  const linkedClientIds = new Set(
-    rows.map((r) => r.clientId).filter((v): v is string => v !== null),
-  );
-  if (linkedClientIds.size > 0) {
+  // Resolve display names for every linked client (one cached roster read).
+  const allClientIds = new Set(rows.flatMap((r) => r.clientIds));
+  let nameByUid = new Map<string, string>();
+  if (allClientIds.size > 0) {
     try {
       const roster = await listClients();
-      const nameByUid = new Map(roster.map((c) => [c.uid, c.displayName]));
-      for (const row of rows) {
-        if (row.clientId) row.clientName = nameByUid.get(row.clientId) ?? null;
-      }
+      nameByUid = new Map(roster.map((c) => [c.uid, c.displayName]));
     } catch {
-      // Best-effort — leave names null if the roster read fails.
+      // Best-effort — fall back to the raw uid if the roster read fails.
     }
   }
+  for (const row of rows) {
+    row.item.clients = row.clientIds.map((id) => ({
+      id,
+      name: nameByUid.get(id) ?? id,
+    }));
+  }
 
-  return rows.sort((a, b) => Number(a.completed) - Number(b.completed));
+  return rows
+    .map((r) => r.item)
+    .sort((a, b) => Number(a.completed) - Number(b.completed));
 }
 
 export type PendingChecklistBucket = "overdue" | "today";
@@ -248,7 +260,9 @@ export async function createCoachChecklistItem(
   await checklistCollection(trainer.uid).add({
     title: parsed.title,
     ...(parsed.notes ? { notes: parsed.notes } : {}),
-    ...(parsed.clientId ? { clientId: parsed.clientId } : {}),
+    ...(parsed.clientIds && parsed.clientIds.length > 0
+      ? { clientIds: parsed.clientIds }
+      : {}),
     recurrence,
     ...(recurrenceEndsAt ? { recurrenceEndsAt } : {}),
     ...(recurrence === "weekly" && parsed.recurrenceWeekdays?.length
@@ -292,7 +306,12 @@ export async function updateCoachChecklistItem(
     .update({
       title: parsed.title,
       notes: parsed.notes ? parsed.notes : FieldValue.delete(),
-      clientId: parsed.clientId ? parsed.clientId : FieldValue.delete(),
+      clientIds:
+        parsed.clientIds && parsed.clientIds.length > 0
+          ? parsed.clientIds
+          : FieldValue.delete(),
+      // Drop the legacy single-client field on any edit.
+      clientId: FieldValue.delete(),
       recurrence,
       // Cleared / inapplicable recurrence sub-fields are removed, not left stale.
       recurrenceEndsAt: recurrenceEndsAt ?? FieldValue.delete(),

--- a/backoffice/src/lib/gc-fitness/coach-checklist-actions.ts
+++ b/backoffice/src/lib/gc-fitness/coach-checklist-actions.ts
@@ -7,11 +7,15 @@ import { z } from "zod";
 import { gcFitnessFirestore } from "@/lib/firebase/gc-fitness-admin";
 import { getCurrentTrainer } from "./auth-helpers";
 import { civilDateFormat, civilDateToday } from "./civil-date";
+import { listClients } from "./client-roster";
 import { FirestoreCollections } from "./collections";
 import { getTrainerTimezone } from "./trainer-timezone";
 
 const CHECKLIST_COLLECTION = "coach_checklist";
 const MAX_CHECKLIST_ITEMS = 50;
+
+/** Reminder recurrence — "none" is a one-off (default). */
+export type ChecklistRecurrence = "none" | "daily" | "weekly" | "monthly";
 
 export interface CoachChecklistItem {
   id: string;
@@ -20,6 +24,11 @@ export interface CoachChecklistItem {
   dueAt: string | null;
   completed: boolean;
   createdAt: string | null;
+  /** Optional client this reminder is about (links to /gc-fitness/clients/[id]). */
+  clientId: string | null;
+  /** Resolved display name for `clientId` (null if unknown / no client). */
+  clientName: string | null;
+  recurrence: ChecklistRecurrence;
 }
 
 const createChecklistItemSchema = z.object({
@@ -27,7 +36,30 @@ const createChecklistItemSchema = z.object({
   notes: z.string().trim().max(500).optional(),
   dueDate: z.string().trim().optional(),
   dueTime: z.string().trim().optional(),
+  clientId: z.string().trim().max(128).optional(),
+  recurrence: z.enum(["none", "daily", "weekly", "monthly"]).optional(),
 });
+
+function normalizeRecurrence(value: unknown): ChecklistRecurrence {
+  return value === "daily" || value === "weekly" || value === "monthly"
+    ? value
+    : "none";
+}
+
+/** Roll a due date forward by one recurrence step. Null for "none"/invalid. */
+function advanceDueDate(
+  iso: string,
+  recurrence: ChecklistRecurrence,
+): Date | null {
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return null;
+  const next = new Date(d);
+  if (recurrence === "daily") next.setDate(next.getDate() + 1);
+  else if (recurrence === "weekly") next.setDate(next.getDate() + 7);
+  else if (recurrence === "monthly") next.setMonth(next.getMonth() + 1);
+  else return null;
+  return next;
+}
 
 const itemIdSchema = z.string().trim().min(1).max(160);
 
@@ -46,22 +78,44 @@ export async function listCoachChecklistItems(): Promise<CoachChecklistItem[]> {
     .limit(MAX_CHECKLIST_ITEMS)
     .get();
 
-  return snap.docs
-    .map((doc) => {
-      const data = doc.data() as Record<string, unknown>;
-      return {
-        id: doc.id,
-        title: typeof data.title === "string" ? data.title : "Reminder",
-        notes:
-          typeof data.notes === "string" && data.notes.trim().length > 0
-            ? data.notes
-            : null,
-        dueAt: toIso(data.dueAt),
-        completed: data.completed === true,
-        createdAt: toIso(data.createdAt),
-      };
-    })
-    .sort((a, b) => Number(a.completed) - Number(b.completed));
+  const rows: CoachChecklistItem[] = snap.docs.map((doc) => {
+    const data = doc.data() as Record<string, unknown>;
+    return {
+      id: doc.id,
+      title: typeof data.title === "string" ? data.title : "Reminder",
+      notes:
+        typeof data.notes === "string" && data.notes.trim().length > 0
+          ? data.notes
+          : null,
+      dueAt: toIso(data.dueAt),
+      completed: data.completed === true,
+      createdAt: toIso(data.createdAt),
+      clientId:
+        typeof data.clientId === "string" && data.clientId.length > 0
+          ? data.clientId
+          : null,
+      clientName: null,
+      recurrence: normalizeRecurrence(data.recurrence),
+    };
+  });
+
+  // Resolve display names for the linked clients (one cached roster read).
+  const linkedClientIds = new Set(
+    rows.map((r) => r.clientId).filter((v): v is string => v !== null),
+  );
+  if (linkedClientIds.size > 0) {
+    try {
+      const roster = await listClients();
+      const nameByUid = new Map(roster.map((c) => [c.uid, c.displayName]));
+      for (const row of rows) {
+        if (row.clientId) row.clientName = nameByUid.get(row.clientId) ?? null;
+      }
+    } catch {
+      // Best-effort — leave names null if the roster read fails.
+    }
+  }
+
+  return rows.sort((a, b) => Number(a.completed) - Number(b.completed));
 }
 
 export type PendingChecklistBucket = "overdue" | "today";
@@ -118,6 +172,8 @@ export async function createCoachChecklistItem(
   await checklistCollection(trainer.uid).add({
     title: parsed.title,
     ...(parsed.notes ? { notes: parsed.notes } : {}),
+    ...(parsed.clientId ? { clientId: parsed.clientId } : {}),
+    recurrence: parsed.recurrence ?? "none",
     dueAt,
     completed: false,
     createdAt: FieldValue.serverTimestamp(),
@@ -145,6 +201,8 @@ export async function updateCoachChecklistItem(
     .update({
       title: parsed.title,
       notes: parsed.notes ? parsed.notes : FieldValue.delete(),
+      clientId: parsed.clientId ? parsed.clientId : FieldValue.delete(),
+      recurrence: parsed.recurrence ?? "none",
       dueAt,
       updatedAt: FieldValue.serverTimestamp(),
     });
@@ -159,8 +217,31 @@ export async function setCoachChecklistItemCompleted(
 ): Promise<{ ok: true }> {
   const trainer = await getCurrentTrainer();
   const parsedItemId = itemIdSchema.parse(itemId);
+  const ref = checklistCollection(trainer.uid).doc(parsedItemId);
 
-  await checklistCollection(trainer.uid).doc(parsedItemId).update({
+  // For a RECURRING reminder, "completing" an occurrence rolls its due date
+  // forward to the next one and keeps it active, instead of marking it done.
+  if (completed) {
+    const snap = await ref.get();
+    const data = (snap.data() ?? {}) as Record<string, unknown>;
+    const recurrence = normalizeRecurrence(data.recurrence);
+    const dueIso = toIso(data.dueAt);
+    if (recurrence !== "none" && dueIso) {
+      const next = advanceDueDate(dueIso, recurrence);
+      if (next) {
+        await ref.update({
+          dueAt: next,
+          completed: false,
+          completedAt: FieldValue.delete(),
+          updatedAt: FieldValue.serverTimestamp(),
+        });
+        revalidateChecklistSurfaces();
+        return { ok: true };
+      }
+    }
+  }
+
+  await ref.update({
     completed,
     completedAt: completed ? FieldValue.serverTimestamp() : FieldValue.delete(),
     updatedAt: FieldValue.serverTimestamp(),


### PR DESCRIPTION
## Qué
Mejoras a los **Reminders** (Notificaciones / `/gc-fitness/checklist`):

### 1. Clientes (multi-select) con link directo
- Un reminder ahora puede vincularse a **varios clientes** (`clientIds[]`).
- Buscador + checkboxes (`ChecklistClientPicker`) en crear y editar.
- En la lista, cada cliente aparece como **chip-link** a `/gc-fitness/clients/[id]`.
- Compat: lee el `clientId` único legacy; al editar migra a la lista.

### 2. Recurrencia: Única (default) / Diaria / Semanal / Mensual
- **Fecha de fin (opcional)** para cualquier recurrencia.
- **Semanal** → selector de días de la semana (Lun…Dom, convención 1=Lun…7=Dom igual que hábitos/workouts).
- **Mensual** → selector de días del mes (1…31).
- Al elegir Semanal/Mensual se **auto-selecciona el día de hoy** si no hay nada elegido; el botón de crear/guardar se **deshabilita** si no hay ningún día (con hint).
- Al **completar** un reminder recurrente, su fecha **avanza a la próxima ocurrencia** y queda activo, en vez de marcarse hecho — salvo que pase la fecha de fin, ahí sí queda completado.
- El pill de la lista muestra el detalle: *"🔁 Semanal · Lun, Jue · hasta 2026-07-05"*.

## Detalles técnicos
- Subcolección coach-only `users/{coach}/coach_checklist`, escrita por **Admin SDK** (server actions) → **sin cambios en `firestore.rules`**.
- Nuevos campos en el doc: `clientIds`, `recurrence`, `recurrenceEndsAt`, `recurrenceWeekdays`, `recurrenceMonthDays`.
- Componentes nuevos: `ChecklistClientPicker`, `ChecklistRecurrenceFields` (compartidos por crear + editar).
- Server: `coach-checklist-actions.ts` — schema/type/create/update + resolución de nombres de cliente + avance-al-completar que respeta días y fecha de fin.

## Tests
- `tsc --noEmit` limpio.
- `jest` 450 passing (solo el flake pre-existente `client-activity-time`, verde en CI).
- Probado en local (`localhost:3001`) end-to-end.

## Test plan
1. Crear reminder con **2–3 clientes** → aparecen los chips, cada uno linkea a su ficha.
2. **Semanal** → viene hoy marcado → elegir Lun+Jue → completar → salta al próximo Lun/Jue.
3. **Mensual** → elegir días → completar → salta al próximo día elegido.
4. **Fecha de fin** cercana → completar hasta pasarla → queda hecho y deja de repetirse.
5. Deseleccionar todos los días en Semanal/Mensual → el botón se deshabilita.