### PR TITLE
fix(gc-fitness): mobile coach sign-in loses session

### DIFF
--- a/backoffice/src/app/gc-fitness/login/page.tsx
+++ b/backoffice/src/app/gc-fitness/login/page.tsx
@@ -59,6 +59,12 @@ export default function GCFitnessLoginPage() {
     window.location.href = "/gc-fitness/dashboard";
   }
 
+  // Resume a redirect-based sign-in if we got here via signInWithRedirect.
+  // Redirect is now ONLY the popup-blocked fallback (see handleGoogleSignIn) —
+  // on mobile the primary path is signInWithPopup, because getRedirectResult
+  // returns null when the browser blocks third-party storage for the
+  // cross-origin authDomain (gcfitness-3476b.firebaseapp.com), which silently
+  // dropped the session and bounced trainers back to /login.
   useEffect(() => {
     let cancelled = false;
     async function resumeRedirectSignIn() {
@@ -76,11 +82,6 @@ export default function GCFitnessLoginPage() {
     };
   }, [t]);
 
-  function shouldPreferRedirectFlow() {
-    const ua = navigator.userAgent.toLowerCase();
-    return /iphone|ipad|ipod|android/.test(ua);
-  }
-
   async function readError(res: Response): Promise<string> {
     try {
       const data = (await res.json()) as { error?: string };
@@ -97,10 +98,11 @@ export default function GCFitnessLoginPage() {
     try {
       const provider = new GoogleAuthProvider();
       const auth = getGCFitnessAuth();
-      if (shouldPreferRedirectFlow()) {
-        await signInWithRedirect(auth, provider);
-        return;
-      }
+      // Popup on every platform (desktop AND mobile). signInWithPopup returns
+      // the credential via postMessage and does not rely on the third-party
+      // storage round-trip that signInWithRedirect needs — which mobile Safari
+      // and Chrome block for the cross-origin firebaseapp.com authDomain,
+      // breaking getRedirectResult and the whole mobile sign-in.
       const result = await signInWithPopup(auth, provider);
       await completeBackofficeSession(result);
     } catch (err) {


### PR DESCRIPTION
## Problem

On **mobile** browsers, completing Google Sign-In on the Coach Portal returns to `/gc-fitness/login` with **no active session**. Desktop works fine.

## Root cause

The login page used `signInWithRedirect` on mobile and resumed via `getRedirectResult()`. The Firebase auth handler lives on the cross-origin `gcfitness-3476b.firebaseapp.com` `authDomain`. Mobile Safari/Chrome block the third-party storage that `getRedirectResult` relies on, so it resolves to `null` → the `POST /api/gc-fitness/login` token exchange never fires → no `GcFitnessAuthToken` cookie is minted → the proxy bounces back to `/login`.

Desktop tolerates the cross-origin authDomain because `signInWithPopup` doesn't need that third-party-storage round-trip.

## Fix

Use `signInWithPopup` on **every** platform (it returns the credential via `postMessage`). Redirect stays only as the `popup-blocked` fallback, and the `getRedirectResult` resume handler is kept for that case. Desktop behavior is unchanged.

This avoids touching shared `next.config`/`proxy.ts` and needs no Firebase *Authorized domains* changes. (The bulletproof alternative — reverse-proxying the firebaseapp.com auth handler onto the app's own origin + switching `authDomain` — was considered but is heavier and requires registering every prod/preview domain in Firebase.)

## Testing

- `npx jest` — 450 passing; only failure is the pre-existing `client-activity-time` locale flake (green in CI, unrelated).
- `tsc --noEmit` — no errors on the login page.
- Manual mobile verification recommended after deploy (cannot drive a real mobile browser from CI).