### PR TITLE
chore: Google site verification file for goldencrowvs.com

### DIFF
--- a/pocket-genes/public/google36e5c824fdeb3a14.html
+++ b/pocket-genes/public/google36e5c824fdeb3a14.html
@@ -1,0 +1,1 @@
+google-site-verification: google36e5c824fdeb3a14.html


### PR DESCRIPTION
## Qué

Agrega el archivo de verificación de Google `google36e5c824fdeb3a14.html` para `goldencrowvs.com`, necesario para verificar la propiedad del dominio (Google Search Console / verificación de la organización en Play Console).

## Por qué en `pocket-genes/public/` y no en el root

El sitio de `goldencrowvs.com` se publica con el workflow `.github/workflows/deploy.yml`, que **construye `pocket-genes/` (Astro) y sube únicamente `pocket-genes/dist/`** a GitHub Pages. Un archivo en el root del repo **no** se serviría en `https://goldencrowvs.com/`.

Astro copia `pocket-genes/public/` tal cual a `dist/`, así que el archivo queda servido en la raíz del dominio:
`https://goldencrowvs.com/google36e5c824fdeb3a14.html`

(Ahí también vive el `CNAME` real del sitio.)

## Verificado

- `npm run build` en `pocket-genes` ✓ — el archivo aparece en `dist/google36e5c824fdeb3a14.html`.
- Contenido: `google-site-verification: google36e5c824fdeb3a14.html`.

## Después de mergear

1. Esperar a que el deploy de GitHub Pages termine (push a `main`).
2. Confirmar que carga: `https://goldencrowvs.com/google36e5c824fdeb3a14.html`.
3. Hacer click en **VERIFY** en Google.
4. ⚠️ No borrar el archivo aunque la verificación pase (Google revalida periódicamente).

Relacionado: setup de la cuenta de Play Console (issue gc-fitness#123).