### PR TITLE
fix(gc-fitness chat): load older messages on scroll up

### DIFF
--- a/backoffice/src/app/gc-fitness/chat/_components/ChatConversation.tsx
+++ b/backoffice/src/app/gc-fitness/chat/_components/ChatConversation.tsx
@@ -98,10 +98,19 @@ export function ChatConversation({
     fetchNextPage,
     isFetchingNextPage,
   } = useChatMessages(chatId);
-  const messages = useMemo(
-    () => (data?.pages ?? []).flatMap((page) => page),
-    [data],
-  );
+  const messages = useMemo(() => {
+    // useInfiniteQuery APPENDS each older page, so the flattened array is
+    // [newest-page, older-page, …]. Sort ascending by createdAt so prepended
+    // older messages render above the newer ones (oldest at top, newest at
+    // bottom); pending sends (no createdAt) sort to the very bottom.
+    const flat = (data?.pages ?? []).flatMap((page) => page);
+    return [...flat].sort((a, b) => {
+      const ta = a.createdAt ? new Date(a.createdAt).getTime() : Number.POSITIVE_INFINITY;
+      const tb = b.createdAt ? new Date(b.createdAt).getTime() : Number.POSITIVE_INFINITY;
+      return ta - tb;
+    });
+  }, [data]);
+  const newestMessageId = messages.length ? messages[messages.length - 1].id : null;
   const queryClient = useQueryClient();
 
   const partnerEntry = useMemo(
@@ -227,11 +236,22 @@ export function ChatConversation({
     nearBottomRef.current = true;
   }, []);
 
-  // Initial enter / new-message scroll stays instant ("auto") — the user
-  // expects the thread to LAND at the bottom, not glide into place.
+  // Scroll to the bottom on conversation switch, or when a genuinely NEW message
+  // arrives at the tail while the user is near the bottom. Keyed on the newest
+  // message id (NOT messages.length) so a "load older" prepend — which also grows
+  // the length — does not yank the user back down (that bug made scroll-up paging
+  // look broken: older messages loaded but the view snapped straight to bottom).
+  const prevChatIdRef = useRef<string | null>(null);
+  const prevNewestIdRef = useRef<string | null>(null);
   useEffect(() => {
-    requestAnimationFrame(() => scrollToBottom("auto"));
-  }, [chatId, messages.length, scrollToBottom]);
+    const chatChanged = prevChatIdRef.current !== chatId;
+    const newestChanged = prevNewestIdRef.current !== newestMessageId;
+    prevChatIdRef.current = chatId;
+    prevNewestIdRef.current = newestMessageId;
+    if (chatChanged || (newestChanged && nearBottomRef.current)) {
+      requestAnimationFrame(() => scrollToBottom("auto"));
+    }
+  }, [chatId, newestMessageId, scrollToBottom]);
 
   useEffect(() => {
     const node = scrollContainerRef.current;


### PR DESCRIPTION
## Problem

In the GC Fitness backoffice chat, scrolling up did not reveal older messages.

The infinite-query plumbing was actually already there (`useChatMessages` + `onScrollTopFetchOlder` + a `previousScrollHeightRef` viewport-preserver), but **two bugs** made paging look broken:

1. **Yanked back to bottom.** The scroll-to-bottom effect was keyed on `messages.length`. A "load older" prepend grows the length too, so every page fetch instantly snapped the view back to the bottom — the older messages *did* load, you just never saw them.
2. **Wrong order.** `useInfiniteQuery` **appends** each older page, so the flattened array was `[newest-page, older-page, …]` and `groupByCivilDate` doesn't sort — older pages would render *below* the newer ones.

## Fix

- Scroll-to-bottom now keys on the **newest message id** (not length): scroll only on conversation switch or a genuinely new tail message while near the bottom — never on prepend.
- `messages` is **sorted ascending by `createdAt`** (pending sends last) so prepended history lands above the newer messages.

The existing `previousScrollHeightRef` anchor-preservation now works since the yank is gone.

## Verification

`npx tsc --noEmit` clean; `npx jest` green except the known non-en-US locale flake (`client-activity-time`, green in CI). ⚠️ **Not live-verified** — running the backoffice needs the dev server + Firebase auth; please give scroll-up a quick check after deploy/preview.

> The repo auto-deploys `main`, so this is a branch + PR (not a direct push).