### PR TITLE
Add new client badges to GC Fitness nav

### DIFF
--- a/backoffice/src/components/gc-fitness/gc-fitness-shell.tsx
+++ b/backoffice/src/components/gc-fitness/gc-fitness-shell.tsx
@@ -37,6 +37,7 @@ import {
 import { CoachCard } from "@/components/gc-fitness/coach-card";
 import { useTrainerChats } from "@/lib/gc-fitness/chat-listener";
 import { useActiveWorkoutSummaries } from "@/lib/gc-fitness/live-workout-listener";
+import { useNewClientActivationBadges } from "@/lib/gc-fitness/new-client-activation-listener";
 import { Badge } from "@/components/ui/badge";
 
 const HIDDEN_SHELL_PATHS = new Set([
@@ -119,12 +120,22 @@ export function GCFitnessShell({
   const activeWorkoutQuery = useActiveWorkoutSummaries(
     !shellHidden && !!trainerUid,
   );
+  const newClientBadges = useNewClientActivationBadges({
+    enabled: !shellHidden && !!trainerUid,
+    pathname,
+    trainerUid,
+  });
   const inLiveWorkout =
     pathname.includes("/sessions/") && pathname.endsWith("/run");
   const unreadChatTotal = (chatsQuery.data ?? []).reduce((sum, chat) => {
     if (!trainerUid) return sum;
     return sum + Math.max(0, chat.unreadCount?.[trainerUid] ?? 0);
   }, 0);
+  const navBadges: Record<string, number> = {
+    "/gc-fitness/chat": unreadChatTotal,
+    "/gc-fitness/notifications": newClientBadges.notifications,
+    "/gc-fitness/clients": newClientBadges.clients,
+  };
 
   if (shellHidden) {
     return children;
@@ -227,12 +238,7 @@ export function GCFitnessShell({
                           label={tNav(item.labelKey)}
                           isActive={isItemActive(item)}
                           icon={<item.icon className="h-4 w-4" />}
-                          badge={
-                            item.href === "/gc-fitness/chat" &&
-                            unreadChatTotal > 0
-                              ? unreadChatTotal
-                              : null
-                          }
+                          badge={navBadges[item.href] > 0 ? navBadges[item.href] : null}
                         />
                       </SidebarMenuItem>
                     ))}

--- a/backoffice/src/components/gc-fitness/schedule/assign-template-modal.tsx
+++ b/backoffice/src/components/gc-fitness/schedule/assign-template-modal.tsx
@@ -951,7 +951,7 @@ export function AssignTemplateModal({
                         </span>
                       ) : null}
                     </div>
-                    <div className="grid min-w-0 grid-cols-1 gap-2 sm:w-[18rem] sm:grid-cols-2">
+                    <div className="min-w-0 sm:w-[16rem]">
                       <label className="min-w-0 text-[11px] font-medium text-muted-foreground">
                         <span className="block truncate">{t("exerciseOverridesRest")}</span>
                         <input
@@ -975,31 +975,31 @@ export function AssignTemplateModal({
                           {restMinutesHint(draft.rest_seconds)}
                         </span>
                       </label>
-                      <label className="min-w-0 rounded-md border border-amber-400/50 bg-amber-50/60 p-2 text-[11px] font-medium text-amber-800 shadow-sm dark:border-amber-300/35 dark:bg-amber-950/20 dark:text-amber-200">
-                        <span className="block truncate">{t("exerciseOverridesTransitionRest")}</span>
-                        <input
-                          type="text"
-                          inputMode="numeric"
-                          pattern="[0-9]*"
-                          value={draft.transition_rest_seconds}
-                          onChange={(event) => {
-                            const value = event.target.value;
-                            setOverrideDrafts((prev) => ({
-                              ...prev,
-                              [exercise.index]: {
-                                ...prev[exercise.index],
-                                transition_rest_seconds: value,
-                              },
-                            }));
-                          }}
-                          className="mt-1 h-8 w-full rounded-md border border-amber-300/70 bg-background px-2 text-sm text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-400/50 dark:border-amber-300/40"
-                        />
-                        <span className="mt-0.5 block h-3 text-[10px] font-normal text-amber-700/80 dark:text-amber-200/80">
-                          {restMinutesHint(draft.transition_rest_seconds)}
-                        </span>
-                      </label>
                     </div>
                   </div>
+                  <label className="mt-3 block rounded-md border border-amber-400/50 bg-amber-50/60 p-3 text-[11px] font-medium text-amber-800 shadow-sm dark:border-amber-300/35 dark:bg-amber-950/20 dark:text-amber-200">
+                    <span className="block">{t("exerciseOverridesTransitionRest")}</span>
+                    <input
+                      type="text"
+                      inputMode="numeric"
+                      pattern="[0-9]*"
+                      value={draft.transition_rest_seconds}
+                      onChange={(event) => {
+                        const value = event.target.value;
+                        setOverrideDrafts((prev) => ({
+                          ...prev,
+                          [exercise.index]: {
+                            ...prev[exercise.index],
+                            transition_rest_seconds: value,
+                          },
+                        }));
+                      }}
+                      className="mt-1 h-9 w-full rounded-md border border-amber-300/70 bg-background px-2 text-sm text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-400/50 dark:border-amber-300/40"
+                    />
+                    <span className="mt-1 block text-[10px] font-normal text-amber-700/80 dark:text-amber-200/80">
+                      {restMinutesHint(draft.transition_rest_seconds)}
+                    </span>
+                  </label>
                   {/* Per-set table — one row per prescribed set. Mirrors the
                       authoring form so the trainer assigns by editing the
                       exact (reps × kg) prescription set-by-set rather than

--- a/backoffice/src/components/gc-fitness/schedule/assign-template-modal.tsx
+++ b/backoffice/src/components/gc-fitness/schedule/assign-template-modal.tsx
@@ -977,29 +977,6 @@ export function AssignTemplateModal({
                       </label>
                     </div>
                   </div>
-                  <label className="mt-3 block rounded-md border border-amber-400/50 bg-amber-50/60 p-3 text-[11px] font-medium text-amber-800 shadow-sm dark:border-amber-300/35 dark:bg-amber-950/20 dark:text-amber-200">
-                    <span className="block">{t("exerciseOverridesTransitionRest")}</span>
-                    <input
-                      type="text"
-                      inputMode="numeric"
-                      pattern="[0-9]*"
-                      value={draft.transition_rest_seconds}
-                      onChange={(event) => {
-                        const value = event.target.value;
-                        setOverrideDrafts((prev) => ({
-                          ...prev,
-                          [exercise.index]: {
-                            ...prev[exercise.index],
-                            transition_rest_seconds: value,
-                          },
-                        }));
-                      }}
-                      className="mt-1 h-9 w-full rounded-md border border-amber-300/70 bg-background px-2 text-sm text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-400/50 dark:border-amber-300/40"
-                    />
-                    <span className="mt-1 block text-[10px] font-normal text-amber-700/80 dark:text-amber-200/80">
-                      {restMinutesHint(draft.transition_rest_seconds)}
-                    </span>
-                  </label>
                   {/* Per-set table — one row per prescribed set. Mirrors the
                       authoring form so the trainer assigns by editing the
                       exact (reps × kg) prescription set-by-set rather than
@@ -1180,6 +1157,31 @@ export function AssignTemplateModal({
                     placeholder={t("exerciseOverridesNotesPlaceholder")}
                     className="mt-2 min-h-16 w-full rounded-md border bg-background px-2 py-2 text-sm"
                   />
+                  {/* Transition rest sits below the coach notes — the client
+                      sees it after finishing this exercise. */}
+                  <label className="mt-3 block rounded-md border border-amber-400/50 bg-amber-50/60 p-3 text-[11px] font-medium text-amber-800 shadow-sm dark:border-amber-300/35 dark:bg-amber-950/20 dark:text-amber-200">
+                    <span className="block">{t("exerciseOverridesTransitionRest")}</span>
+                    <input
+                      type="text"
+                      inputMode="numeric"
+                      pattern="[0-9]*"
+                      value={draft.transition_rest_seconds}
+                      onChange={(event) => {
+                        const value = event.target.value;
+                        setOverrideDrafts((prev) => ({
+                          ...prev,
+                          [exercise.index]: {
+                            ...prev[exercise.index],
+                            transition_rest_seconds: value,
+                          },
+                        }));
+                      }}
+                      className="mt-1 h-9 w-full rounded-md border border-amber-300/70 bg-background px-2 text-sm text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-400/50 dark:border-amber-300/40"
+                    />
+                    <span className="mt-1 block text-[10px] font-normal text-amber-700/80 dark:text-amber-200/80">
+                      {restMinutesHint(draft.transition_rest_seconds)}
+                    </span>
+                  </label>
                 </div>
               );
             })}

--- a/backoffice/src/components/gc-fitness/schedule/workout-assignment-edit-dialog.tsx
+++ b/backoffice/src/components/gc-fitness/schedule/workout-assignment-edit-dialog.tsx
@@ -272,22 +272,6 @@ export function WorkoutAssignmentEditDialog({
                           className="h-8 w-20 rounded-md border bg-background px-2 text-sm text-foreground"
                         />
                       </label>
-                      <label className="flex items-center gap-1.5 rounded-full border border-amber-400/60 bg-amber-500/5 px-2 py-1 text-xs text-amber-700 dark:text-amber-100">
-                        Descanso entre ejercicios (s)
-                        <InfoTooltip
-                          text="Este es el descanso que el cliente ve después de terminar el ejercicio anterior. Si el siguiente ejercicio planificado es distinto, se usa como pausa antes de empezar el siguiente bloque."
-                          label="Explicar descanso entre ejercicios"
-                        />
-                        <input
-                          type="text"
-                          inputMode="numeric"
-                          value={draft.transitionRest}
-                          onChange={(e) =>
-                            patch(ex.index, { transitionRest: e.target.value })
-                          }
-                          className="h-8 w-20 rounded-md border border-amber-400/50 bg-background px-2 text-sm text-foreground"
-                        />
-                      </label>
                     </div>
                   </div>
                   <div className="grid grid-cols-[28px_minmax(80px,1fr)_minmax(80px,1fr)_max-content] items-center gap-2 text-[10px] font-semibold uppercase tracking-wide text-muted-foreground">
@@ -390,6 +374,24 @@ export function WorkoutAssignmentEditDialog({
                     placeholder="Notas específicas para este cliente en este ejercicio"
                     className="mt-2 min-h-16 w-full rounded-md border bg-background px-2 py-2 text-sm"
                   />
+                  {/* Transition rest sits below the coach notes — the client
+                      sees it after finishing this exercise. */}
+                  <label className="mt-2 flex flex-wrap items-center gap-1.5 rounded-md border border-amber-400/60 bg-amber-500/5 px-2 py-1.5 text-xs text-amber-700 dark:text-amber-100">
+                    Descanso entre ejercicios (s)
+                    <InfoTooltip
+                      text="Este es el descanso que el cliente ve después de terminar el ejercicio anterior. Si el siguiente ejercicio planificado es distinto, se usa como pausa antes de empezar el siguiente bloque."
+                      label="Explicar descanso entre ejercicios"
+                    />
+                    <input
+                      type="text"
+                      inputMode="numeric"
+                      value={draft.transitionRest}
+                      onChange={(e) =>
+                        patch(ex.index, { transitionRest: e.target.value })
+                      }
+                      className="h-8 w-20 rounded-md border border-amber-400/50 bg-background px-2 text-sm text-foreground"
+                    />
+                  </label>
                 </div>
               );
             })

--- a/backoffice/src/components/gc-fitness/template-form.tsx
+++ b/backoffice/src/components/gc-fitness/template-form.tsx
@@ -1874,75 +1874,8 @@ export function TemplateForm({
                       />
                     </div>
 
-                    {/* Superset group — shared across all matching exercises.
-                        Chips let the trainer reuse existing group letters
-                        without retyping them. */}
-                    <FormField
-                      control={form.control}
-                      name={`exercises.${index}.supersetGroup` as const}
-                      render={({ field: supersetField }) => (
-                        <FormItem>
-                          <FormLabel>{t("supersetGroup")}</FormLabel>
-                          {supersetGroupOptions.length > 0 ? (
-                            <div className="mt-2 flex flex-wrap gap-2">
-                              {supersetGroupOptions.map((group) => {
-                                const active = supersetField.value?.trim() === group;
-                                return (
-                                  <button
-                                    key={group}
-                                    type="button"
-                                    onClick={() => applySupersetGroup(index, group)}
-                                    className={cn(
-                                      "inline-flex h-8 items-center rounded-full border px-3 text-xs font-medium transition-colors",
-                                      active
-                                        ? "border-amber-400 bg-amber-400/15 text-amber-700 dark:text-amber-100"
-                                        : "border-border/70 bg-background text-foreground hover:border-amber-400/60 hover:text-amber-700 dark:text-amber-100",
-                                    )}
-                                  >
-                                    {group}
-                                  </button>
-                                );
-                              })}
-                            </div>
-                          ) : null}
-                          <FormControl>
-                            <Input
-                              placeholder={t("supersetGroupPlaceholder")}
-                              data-field-superset
-                              data-exercise-card={index}
-                              onKeyDown={(e) => {
-                                if (e.key === "Tab" && !e.shiftKey) {
-                                  // Skip exercise-name inputs / drag handles /
-                                  // helper buttons and land directly on the
-                                  // NEXT exercise card's Sets field.
-                                  const root = (e.currentTarget.closest(
-                                    "form",
-                                  ) ?? document) as ParentNode;
-                                  const target = root.querySelector<HTMLInputElement>(
-                                    `[data-field-sets="${index + 1}"]`,
-                                  );
-                                  if (target) {
-                                    e.preventDefault();
-                                    target.focus();
-                                    target.select();
-                                  }
-                                }
-                              }}
-                              value={supersetField.value ?? ""}
-                              onChange={(e) => {
-                                const nextGroup = e.target.value;
-                                supersetField.onChange(nextGroup);
-                              }}
-                              onBlur={() => {
-                                supersetField.onBlur();
-                                applySupersetGroup(index, supersetField.value ?? "");
-                              }}
-                            />
-                          </FormControl>
-                          <FormDescription>{t("supersetGroupHint")}</FormDescription>
-                        </FormItem>
-                      )}
-                    />
+                    {/* Transition rest sits below the coach notes — the client
+                        sees it after finishing this exercise. */}
                     <div className="rounded-lg border border-amber-500/40 bg-amber-500/5 p-3">
                       <div className="flex items-center gap-2">
                         <FormLabel className="text-amber-700 dark:text-amber-100">
@@ -2012,6 +1945,76 @@ export function TemplateForm({
                         )}
                       />
                     </div>
+
+                    {/* Superset group — shared across all matching exercises.
+                        Chips let the trainer reuse existing group letters
+                        without retyping them. */}
+                    <FormField
+                      control={form.control}
+                      name={`exercises.${index}.supersetGroup` as const}
+                      render={({ field: supersetField }) => (
+                        <FormItem>
+                          <FormLabel>{t("supersetGroup")}</FormLabel>
+                          {supersetGroupOptions.length > 0 ? (
+                            <div className="mt-2 flex flex-wrap gap-2">
+                              {supersetGroupOptions.map((group) => {
+                                const active = supersetField.value?.trim() === group;
+                                return (
+                                  <button
+                                    key={group}
+                                    type="button"
+                                    onClick={() => applySupersetGroup(index, group)}
+                                    className={cn(
+                                      "inline-flex h-8 items-center rounded-full border px-3 text-xs font-medium transition-colors",
+                                      active
+                                        ? "border-amber-400 bg-amber-400/15 text-amber-700 dark:text-amber-100"
+                                        : "border-border/70 bg-background text-foreground hover:border-amber-400/60 hover:text-amber-700 dark:text-amber-100",
+                                    )}
+                                  >
+                                    {group}
+                                  </button>
+                                );
+                              })}
+                            </div>
+                          ) : null}
+                          <FormControl>
+                            <Input
+                              placeholder={t("supersetGroupPlaceholder")}
+                              data-field-superset
+                              data-exercise-card={index}
+                              onKeyDown={(e) => {
+                                if (e.key === "Tab" && !e.shiftKey) {
+                                  // Skip exercise-name inputs / drag handles /
+                                  // helper buttons and land directly on the
+                                  // NEXT exercise card's Sets field.
+                                  const root = (e.currentTarget.closest(
+                                    "form",
+                                  ) ?? document) as ParentNode;
+                                  const target = root.querySelector<HTMLInputElement>(
+                                    `[data-field-sets="${index + 1}"]`,
+                                  );
+                                  if (target) {
+                                    e.preventDefault();
+                                    target.focus();
+                                    target.select();
+                                  }
+                                }
+                              }}
+                              value={supersetField.value ?? ""}
+                              onChange={(e) => {
+                                const nextGroup = e.target.value;
+                                supersetField.onChange(nextGroup);
+                              }}
+                              onBlur={() => {
+                                supersetField.onBlur();
+                                applySupersetGroup(index, supersetField.value ?? "");
+                              }}
+                            />
+                          </FormControl>
+                          <FormDescription>{t("supersetGroupHint")}</FormDescription>
+                        </FormItem>
+                      )}
+                    />
                   </CardContent>
                 </Card>
                     )}

--- a/backoffice/src/lib/app-version.ts
+++ b/backoffice/src/lib/app-version.ts
@@ -1,1 +1,1 @@
-export const BACKOFFICE_VERSION = "2.124";
+export const BACKOFFICE_VERSION = "2.125";

--- a/backoffice/src/lib/app-version.ts
+++ b/backoffice/src/lib/app-version.ts
@@ -1,1 +1,1 @@
-export const BACKOFFICE_VERSION = "2.122";
+export const BACKOFFICE_VERSION = "2.123";

--- a/backoffice/src/lib/app-version.ts
+++ b/backoffice/src/lib/app-version.ts
@@ -1,1 +1,1 @@
-export const BACKOFFICE_VERSION = "2.123";
+export const BACKOFFICE_VERSION = "2.124";

--- a/backoffice/src/lib/gc-fitness/new-client-activation-listener.ts
+++ b/backoffice/src/lib/gc-fitness/new-client-activation-listener.ts
@@ -1,0 +1,95 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import { useQuery } from "@tanstack/react-query";
+
+import { listRecentLogsForTrainerPage } from "./recent-logs-actions";
+
+const ACTIVATIONS_QUERY_KEY = ["gc-fitness", "new-client-activations"] as const;
+const STORAGE_PREFIX = "gc-fitness:new-client-activations-seen";
+
+type SeenState = {
+  notifications: number | null;
+  clients: number | null;
+};
+
+function storageKey(trainerUid: string, surface: keyof SeenState): string {
+  return `${STORAGE_PREFIX}:${trainerUid}:${surface}`;
+}
+
+function readSeenMs(trainerUid: string, surface: keyof SeenState, fallbackMs: number): number {
+  const key = storageKey(trainerUid, surface);
+  const raw = window.localStorage.getItem(key);
+  const parsed = raw ? Number(raw) : Number.NaN;
+  if (Number.isFinite(parsed) && parsed >= 0) return parsed;
+  window.localStorage.setItem(key, String(fallbackMs));
+  return fallbackMs;
+}
+
+function writeSeenMs(trainerUid: string, surface: keyof SeenState, value: number) {
+  window.localStorage.setItem(storageKey(trainerUid, surface), String(value));
+}
+
+function isoMs(iso: string | null | undefined): number {
+  if (!iso) return 0;
+  const ms = new Date(iso).getTime();
+  return Number.isNaN(ms) ? 0 : ms;
+}
+
+export function useNewClientActivationBadges({
+  enabled,
+  pathname,
+  trainerUid,
+}: {
+  enabled: boolean;
+  pathname: string;
+  trainerUid: string | null;
+}) {
+  const query = useQuery({
+    queryKey: ACTIVATIONS_QUERY_KEY,
+    queryFn: () => listRecentLogsForTrainerPage(null, 20, null, "signup"),
+    enabled,
+    staleTime: 10_000,
+    refetchInterval: 120_000,
+    refetchIntervalInBackground: true,
+    refetchOnWindowFocus: true,
+  });
+  const activations = query.data?.logs ?? [];
+  const activationTimes = useMemo(
+    () => activations.map((item) => isoMs(item.eventAt)).filter((ms) => ms > 0),
+    [activations],
+  );
+  const latestMs = activationTimes.length > 0 ? Math.max(...activationTimes) : 0;
+  const [seen, setSeen] = useState<SeenState>({
+    notifications: null,
+    clients: null,
+  });
+
+  useEffect(() => {
+    if (!enabled || !trainerUid || latestMs <= 0) return;
+    setSeen({
+      notifications: readSeenMs(trainerUid, "notifications", latestMs),
+      clients: readSeenMs(trainerUid, "clients", latestMs),
+    });
+  }, [enabled, latestMs, trainerUid]);
+
+  useEffect(() => {
+    if (!enabled || !trainerUid || latestMs <= 0) return;
+    if (pathname === "/gc-fitness/notifications" || pathname.startsWith("/gc-fitness/notifications/")) {
+      writeSeenMs(trainerUid, "notifications", latestMs);
+      setSeen((prev) => ({ ...prev, notifications: latestMs }));
+    }
+    if (pathname === "/gc-fitness/clients" || pathname.startsWith("/gc-fitness/clients/")) {
+      writeSeenMs(trainerUid, "clients", latestMs);
+      setSeen((prev) => ({ ...prev, clients: latestMs }));
+    }
+  }, [enabled, latestMs, pathname, trainerUid]);
+
+  const notificationsSeen = seen.notifications ?? latestMs;
+  const clientsSeen = seen.clients ?? latestMs;
+
+  return {
+    notifications: activationTimes.filter((ms) => ms > notificationsSeen).length,
+    clients: activationTimes.filter((ms) => ms > clientsSeen).length,
+  };
+}


### PR DESCRIPTION
## Summary
- add sidebar badges for new client activations on Notifications and Clients
- keep separate seen markers per tab using trainer-scoped localStorage
- clear each badge when the coach opens its corresponding tab
- preserve existing chat unread badge behavior
- bump backoffice version to 2.123

## Verification
- npx tsc --noEmit
- npx jest --runInBand
- git diff --check

## QA checklist
- Create or simulate a new active client for a coach after the local seen marker exists.
- Confirm both Notifications and Clientes sidebar items show the same numeric badge.
- Open /gc-fitness/notifications and confirm only the Notifications badge clears.
- Open /gc-fitness/clients and confirm only the Clientes badge clears.
- Confirm the Chat badge still shows unread messages independently.
- Refresh the page and confirm cleared badges stay cleared for that browser/coach.