### PR TITLE
Make exercise description optional

### DIFF
--- a/backoffice/src/components/gc-fitness/exercise-quick-create.tsx
+++ b/backoffice/src/components/gc-fitness/exercise-quick-create.tsx
@@ -142,8 +142,8 @@ export function QuickCreateExercise({
   async function onCreate() {
     const trimmedName = name.trim();
     const trimmedDescription = description.trim();
-    if (!trimmedName || !trimmedDescription) {
-      setError("Name and description are required.");
+    if (!trimmedName) {
+      setError("Name is required.");
       return;
     }
     setCreating(true);
@@ -192,8 +192,8 @@ export function QuickCreateExercise({
     gifUrl,
   };
   const isDuplicate = !!seed && seedEquals(seed, currentValues);
-  const requiredMissing =
-    name.trim().length === 0 || description.trim().length === 0;
+  // Description is optional — only the name gates Create.
+  const requiredMissing = name.trim().length === 0;
   const disabled = creating || requiredMissing || isDuplicate;
   // Keep the locale read so future copy can branch per-locale without
   // adding another import; not used today but cheap.
@@ -246,7 +246,7 @@ export function QuickCreateExercise({
           <Input
             id="quick-create-description"
             value={description}
-            placeholder="Description"
+            placeholder="Description (optional)"
             onChange={(event) => setDescription(event.target.value)}
           />
         </div>

--- a/backoffice/src/lib/app-version.ts
+++ b/backoffice/src/lib/app-version.ts
@@ -1,1 +1,1 @@
-export const BACKOFFICE_VERSION = "2.126";
+export const BACKOFFICE_VERSION = "2.127";

--- a/backoffice/src/lib/gc-fitness/__tests__/exercise-form-validation.test.tsx
+++ b/backoffice/src/lib/gc-fitness/__tests__/exercise-form-validation.test.tsx
@@ -156,9 +156,10 @@ describe("ExerciseForm — UI-SPEC verbatim validation copy", () => {
         screen.getByText("Name in English is required."),
       ).toBeInTheDocument();
     });
+    // Description is now optional — no description-required error surfaces.
     expect(
-      screen.getByText("Add a short description so clients know what to do."),
-    ).toBeInTheDocument();
+      screen.queryByText("Add a short description so clients know what to do."),
+    ).not.toBeInTheDocument();
     expect(
       screen.getByText("Pick at least one muscle group."),
     ).toBeInTheDocument();

--- a/backoffice/src/lib/gc-fitness/__tests__/exercise-schema.test.ts
+++ b/backoffice/src/lib/gc-fitness/__tests__/exercise-schema.test.ts
@@ -59,14 +59,13 @@ describe("exerciseSchema", () => {
     ).toBe("Keep the name under 120 characters.");
   });
 
-  // T4: descriptionEn empty → verbatim UI-SPEC copy
-  it("rejects empty description.en with the exact UI-SPEC copy", () => {
-    expect(
-      firstError({
-        ...VALID_INPUT,
-        description: { en: "", es: "x" },
-      }),
-    ).toBe("Add a short description so clients know what to do.");
+  // T4: descriptionEn is optional — trainers can quick-create without one.
+  it("accepts an empty description.en", () => {
+    const parsed = exerciseSchema.parse({
+      ...VALID_INPUT,
+      description: { en: "", es: "" },
+    });
+    expect(parsed.description.en).toBe("");
   });
 
   // T5: muscleGroups: [] → verbatim UI-SPEC copy

--- a/backoffice/src/lib/gc-fitness/exercise-schema.ts
+++ b/backoffice/src/lib/gc-fitness/exercise-schema.ts
@@ -138,7 +138,8 @@ const equipmentListSchema = z.preprocess(
 //    the trainer's perspective (wger seed has both, but a custom exercise
 //    may start English-only — trainer fills ES later). Both share the
 //    120-char ceiling.
-//  - `description.en` is REQUIRED (UI-SPEC). `description.es` is optional.
+//  - `description.en` / `description.es` are BOTH optional (trainers can
+//    quick-create an exercise with no description and fill it in later).
 //    Both share a 4,000-char ceiling (matches the 4000 cap in the iOS
 //    `ExerciseModel.swift` Codable validation from 03-01).
 //  - `muscleGroups` requires at least one entry (UI-SPEC), with a defensive
@@ -172,8 +173,8 @@ export const exerciseSchema = z.object({
   description: z.object({
     en: z
       .string()
-      .min(1, "Add a short description so clients know what to do.")
-      .max(4000, "Description must be under 4,000 characters."),
+      .max(4000, "Description must be under 4,000 characters.")
+      .default(""),
     es: z
       .string()
       .max(4000, "Description must be under 4,000 characters.")


### PR DESCRIPTION
## What

Exercises can now be created **without a description**. The Quick-create panel's **Create exercise** button no longer stays disabled when the Description field is empty, and the full exercise editor likewise accepts an empty description.

## Why

User feedback: "dejemos que se pueda crear ejercicio sin description (hacerla optional)." In the Quick-create panel ("Exercise not found"), the Create button was blocked until a description was typed.

## How

- `exercise-schema.ts`: `description.en` dropped from `.min(1)` to optional (`.default("")`) — same shape `description.es` already had. The field is still always written (as `{ en, es }`), just possibly with empty strings, so iOS/Android decoding is unaffected.
- `exercise-quick-create.tsx`: Create now gates on **name only**; description placeholder reads "Description (optional)"; error copy updated to "Name is required."
- Tests updated to match the new contract:
  - `exercise-schema.test.ts` T4: empty `description.en` is now **accepted**.
  - `exercise-form-validation.test.tsx` T2: asserts the description-required error **no longer** surfaces (name + muscle group still required).

## Notes

- Creation goes through the Admin SDK server action, which bypasses Firestore rules — no rules change needed.
- Parity: exercises are authored backoffice-only; iOS/Android only read them, and the `description` object is still always present, so no client change required.

## Test gate

- `tsc --noEmit` clean
- `npx jest` green except the pre-existing `client-activity-time.test.ts` locale flake (passes in CI)