### PR TITLE
Fix templates draft title using wrong i18n namespace

### DIFF
--- a/backoffice/src/app/gc-fitness/templates/client.tsx
+++ b/backoffice/src/app/gc-fitness/templates/client.tsx
@@ -393,7 +393,9 @@ export function TemplatesLibraryClient({
                 const title =
                   row.name.en ||
                   row.name.es ||
-                  (row.__isDraft ? t("draftUntitled") : columnsT("untitled"));
+                  (row.__isDraft
+                    ? columnsT("draftUntitled")
+                    : columnsT("untitled"));
                 const duration =
                   row.estimatedDurationMinutes > 0
                     ? columnsT("durationValue", {

--- a/backoffice/src/lib/app-version.ts
+++ b/backoffice/src/lib/app-version.ts
@@ -1,1 +1,1 @@
-export const BACKOFFICE_VERSION = "2.126";
+export const BACKOFFICE_VERSION = "2.128";


### PR DESCRIPTION
## What

Fixes `MISSING_MESSAGE: Could not resolve 'templates.list.draftUntitled'` crashing the templates list page.

## Root cause

`client.tsx:396` rendered a draft template's title with `t("draftUntitled")`, where `t` is bound to the **`templates.list`** namespace — so it resolved to the nonexistent `templates.list.draftUntitled`. The key actually lives at **`templates.columns.draftUntitled`** (it already exists in both en/es), which is the `columnsT` namespace — and its sibling fallback `columnsT("untitled")` on the very same line already used it correctly. `columns.tsx` was unaffected (its `t` is bound to `templates.columns`).

## Fix

One line — draft titles now resolve `draftUntitled` via `columnsT`, matching `untitled`:

```diff
- (row.__isDraft ? t("draftUntitled") : columnsT("untitled"));
+ (row.__isDraft ? columnsT("draftUntitled") : columnsT("untitled"));
```

No message files changed (the keys already exist in `templates.columns` for en + es).

## Test gate

- `tsc --noEmit` clean
- `npx jest` green except the pre-existing `client-activity-time.test.ts` locale flake (passes in CI)