### PR TITLE
Add week-based duration presets to habit end date

### DIFF
--- a/backoffice/messages/en.json
+++ b/backoffice/messages/en.json
@@ -902,6 +902,7 @@
       "scheduleStartLabel": "Start date",
       "scheduleEndLabel": "End date (optional)",
       "scheduleEndPreset": "{months, plural, one {# month} other {# months}}",
+      "scheduleEndPresetWeeks": "{weeks, plural, one {# week} other {# weeks}}",
       "scheduleEndHint": "Leave empty for no end date.",
       "cadenceLabel": "Cadence",
       "cadenceDaily": "Daily",

--- a/backoffice/messages/es.json
+++ b/backoffice/messages/es.json
@@ -902,6 +902,7 @@
       "scheduleStartLabel": "Fecha de inicio",
       "scheduleEndLabel": "Fecha de fin (opcional)",
       "scheduleEndPreset": "{months, plural, one {# mes} other {# meses}}",
+      "scheduleEndPresetWeeks": "{weeks, plural, one {# semana} other {# semanas}}",
       "scheduleEndHint": "Dejá vacío para que no tenga fecha de fin.",
       "cadenceLabel": "Frecuencia",
       "cadenceDaily": "Diario",

--- a/backoffice/src/app/gc-fitness/habits/_components/HabitForm.tsx
+++ b/backoffice/src/app/gc-fitness/habits/_components/HabitForm.tsx
@@ -51,7 +51,10 @@ import {
 import {
   addCivilMonths,
   END_DATE_PRESET_MONTHS,
+  END_DATE_PRESET_WEEKS,
+  endDateForWeeks,
   inferEndDatePresetMonths,
+  inferEndDatePresetWeeks,
   localDateToCivil,
 } from "@/lib/gc-fitness/end-date-presets";
 import { HabitPhotoDropzone } from "./HabitPhotoDropzone";
@@ -224,19 +227,34 @@ export function HabitForm({
     typeof initialDefaults.startsOn === "string" ? initialDefaults.startsOn : "";
   const initialEndsOn =
     typeof initialDefaults.endsOn === "string" ? initialDefaults.endsOn : undefined;
+  // End-date duration is expressed as EITHER a month preset OR a week preset
+  // (mutually exclusive), or a custom date (both null). Whichever is set is
+  // re-anchored to startsOn whenever startsOn changes — the end date is ALWAYS
+  // derived from the start, never from "today".
   const [selectedEndPresetMonths, setSelectedEndPresetMonths] = useState<
     number | null
-  >(() =>
-    inferEndDatePresetMonths(initialStartsOn, initialEndsOn),
-  );
+  >(() => inferEndDatePresetMonths(initialStartsOn, initialEndsOn));
+  const [selectedEndPresetWeeks, setSelectedEndPresetWeeks] = useState<
+    number | null
+  >(() => inferEndDatePresetWeeks(initialStartsOn, initialEndsOn));
 
   useEffect(() => {
-    if (selectedEndPresetMonths == null) return;
     if (watchedStartsOn.length === 0) return;
-    const nextEndsOn = addCivilMonths(watchedStartsOn, selectedEndPresetMonths);
-    if (watchedEndsOn === nextEndsOn) return;
+    const nextEndsOn =
+      selectedEndPresetWeeks != null
+        ? endDateForWeeks(watchedStartsOn, selectedEndPresetWeeks)
+        : selectedEndPresetMonths != null
+          ? addCivilMonths(watchedStartsOn, selectedEndPresetMonths)
+          : null;
+    if (nextEndsOn == null || watchedEndsOn === nextEndsOn) return;
     form.setValue("endsOn", nextEndsOn, { shouldDirty: true });
-  }, [form, selectedEndPresetMonths, watchedEndsOn, watchedStartsOn]);
+  }, [
+    form,
+    selectedEndPresetMonths,
+    selectedEndPresetWeeks,
+    watchedEndsOn,
+    watchedStartsOn,
+  ]);
 
   const submit = form.handleSubmit((values) => {
     startTransition(async () => {
@@ -574,7 +592,12 @@ export function HabitForm({
                       onChange={(event) => {
                         const next = event.target.value;
                         field.onChange(next);
-                        if (selectedEndPresetMonths != null && next.length > 0) {
+                        if (next.length === 0) return;
+                        if (selectedEndPresetWeeks != null) {
+                          form.setValue("endsOn", endDateForWeeks(next, selectedEndPresetWeeks), {
+                            shouldDirty: true,
+                          });
+                        } else if (selectedEndPresetMonths != null) {
                           form.setValue("endsOn", addCivilMonths(next, selectedEndPresetMonths), {
                             shouldDirty: true,
                           });
@@ -594,6 +617,29 @@ export function HabitForm({
                 <FormItem>
                   <FormLabel>{t("scheduleEndLabel")}</FormLabel>
                   <div className="flex flex-wrap gap-2">
+                    {END_DATE_PRESET_WEEKS.map((weeks) => {
+                      const active =
+                        selectedEndPresetWeeks === weeks &&
+                        typeof watchedStartsOn === "string" &&
+                        watchedEndsOn === endDateForWeeks(watchedStartsOn, weeks);
+                      return (
+                        <Button
+                          key={`w-${weeks}`}
+                          type="button"
+                          variant={active ? "default" : "outline"}
+                          size="sm"
+                          className="rounded-full"
+                          aria-pressed={active}
+                          onClick={() => {
+                            setSelectedEndPresetWeeks(weeks);
+                            setSelectedEndPresetMonths(null);
+                            field.onChange(endDateForWeeks(watchedStartsOn, weeks));
+                          }}
+                        >
+                          {t("scheduleEndPresetWeeks", { weeks })}
+                        </Button>
+                      );
+                    })}
                     {END_DATE_PRESET_MONTHS.map((months) => {
                       const active =
                         selectedEndPresetMonths === months &&
@@ -601,7 +647,7 @@ export function HabitForm({
                         watchedEndsOn === addCivilMonths(watchedStartsOn, months);
                       return (
                         <Button
-                          key={months}
+                          key={`m-${months}`}
                           type="button"
                           variant={active ? "default" : "outline"}
                           size="sm"
@@ -609,6 +655,7 @@ export function HabitForm({
                           aria-pressed={active}
                           onClick={() => {
                             setSelectedEndPresetMonths(months);
+                            setSelectedEndPresetWeeks(null);
                             const next = addCivilMonths(watchedStartsOn, months);
                             field.onChange(next);
                           }}
@@ -632,6 +679,11 @@ export function HabitForm({
                         setSelectedEndPresetMonths(
                           next.length > 0
                             ? inferEndDatePresetMonths(watchedStartsOn, next)
+                            : null,
+                        );
+                        setSelectedEndPresetWeeks(
+                          next.length > 0
+                            ? inferEndDatePresetWeeks(watchedStartsOn, next)
                             : null,
                         );
                       }}

--- a/backoffice/src/lib/app-version.ts
+++ b/backoffice/src/lib/app-version.ts
@@ -1,1 +1,1 @@
-export const BACKOFFICE_VERSION = "2.127";
+export const BACKOFFICE_VERSION = "2.129";

--- a/backoffice/src/lib/gc-fitness/__tests__/end-date-presets.test.ts
+++ b/backoffice/src/lib/gc-fitness/__tests__/end-date-presets.test.ts
@@ -1,6 +1,9 @@
 import {
+  addCivilDays,
   addCivilMonths,
+  endDateForWeeks,
   inferEndDatePresetMonths,
+  inferEndDatePresetWeeks,
 } from "../end-date-presets";
 
 describe("addCivilMonths", () => {
@@ -24,5 +27,33 @@ describe("inferEndDatePresetMonths", () => {
 
   it("returns null for custom end dates", () => {
     expect(inferEndDatePresetMonths("2026-01-15", "2026-05-01")).toBeNull();
+  });
+});
+
+describe("addCivilDays", () => {
+  it("adds whole days across a month boundary", () => {
+    expect(addCivilDays("2026-05-08", 13)).toBe("2026-05-21");
+    expect(addCivilDays("2026-05-31", 1)).toBe("2026-06-01");
+  });
+});
+
+describe("endDateForWeeks", () => {
+  // 2 weeks of a daily habit = 14 occurrences over an INCLUSIVE window, so
+  // the end date is startsOn + 13 days (NOT +14). This is the fix for the
+  // "daily for 2 weeks showed 46 occurrences" bug.
+  it("returns an inclusive N*7-day window anchored to the start", () => {
+    expect(endDateForWeeks("2026-05-08", 2)).toBe("2026-05-21");
+    expect(endDateForWeeks("2026-05-08", 1)).toBe("2026-05-14");
+    expect(endDateForWeeks("2026-05-08", 4)).toBe("2026-06-04");
+  });
+});
+
+describe("inferEndDatePresetWeeks", () => {
+  it("returns the matching week preset", () => {
+    expect(inferEndDatePresetWeeks("2026-05-08", "2026-05-21")).toBe(2);
+  });
+
+  it("returns null for non-matching end dates", () => {
+    expect(inferEndDatePresetWeeks("2026-05-08", "2026-06-22")).toBeNull();
   });
 });

--- a/backoffice/src/lib/gc-fitness/end-date-presets.ts
+++ b/backoffice/src/lib/gc-fitness/end-date-presets.ts
@@ -10,6 +10,10 @@ export const END_DATE_PRESET_MONTHS = [1, 3, 6, 12] as const;
 
 export type EndDatePresetMonths = (typeof END_DATE_PRESET_MONTHS)[number];
 
+export const END_DATE_PRESET_WEEKS = [1, 2, 4] as const;
+
+export type EndDatePresetWeeks = (typeof END_DATE_PRESET_WEEKS)[number];
+
 /**
  * Add whole calendar months to a civil date string and clamp overflow to the
  * last valid day of the target month.
@@ -24,6 +28,37 @@ export function addCivilMonths(civilDate: string, months: number): string {
   const clampedDay = Math.min(d, lastDay);
   const shifted = new Date(Date.UTC(y, m - 1 + months, clampedDay));
   return civilDateFormat(shifted, "UTC");
+}
+
+/** Add whole calendar days to a civil date string (UTC-anchored, no DST drift). */
+export function addCivilDays(civilDate: string, days: number): string {
+  const [y, m, d] = civilDate.split("-").map(Number);
+  const shifted = new Date(Date.UTC(y, m - 1, d + days));
+  return civilDateFormat(shifted, "UTC");
+}
+
+/**
+ * Inclusive end date for an N-week window anchored to the START date.
+ *
+ * The habit/assignment window [startsOn, endsOn] is INCLUSIVE, so an N-week
+ * duration must end (N*7 - 1) days after the start for a daily cadence to
+ * yield exactly N*7 occurrences. Example: a 2-week daily habit starting
+ * 2026-05-08 ends 2026-05-21 → 14 occurrences (NOT 2026-05-22 → 15).
+ */
+export function endDateForWeeks(startCivilDate: string, weeks: number): string {
+  return addCivilDays(startCivilDate, weeks * 7 - 1);
+}
+
+export function inferEndDatePresetWeeks(
+  startCivilDate: string,
+  endCivilDate?: string,
+): EndDatePresetWeeks | null {
+  if (!endCivilDate) return null;
+  return (
+    END_DATE_PRESET_WEEKS.find(
+      (weeks) => endDateForWeeks(startCivilDate, weeks) === endCivilDate,
+    ) ?? null
+  );
 }
 
 export function localDateToCivil(date: Date): string {


### PR DESCRIPTION
## What

Habits can now be scheduled in **weeks** (1 / 2 / 4), not just months. Picking "2 semanas" for a daily habit produces exactly **14 occurrences** — fixing the report where a "daily, 2 weeks" habit showed **46 fechas**.

## Root cause

The "Movilidad" card in Notifications is a **habit**; its occurrence count is computed correctly by `countHabitOccurrences(startsOn, endsOn)`. The real problem was upstream: the habit form's end-date control only offered **month** presets (`[1, 3, 6, 12]`) — there was no way to express a short "2 week" duration. A trainer wanting 2 weeks had to hand-type an end date, easily landing on the wrong day (here `startsOn=2026-05-08`, `endsOn=2026-06-22` → 46 daily dates) rather than the intended `2026-05-21`.

## How

- **`end-date-presets.ts`** — new `END_DATE_PRESET_WEEKS = [1, 2, 4]`, `addCivilDays`, `endDateForWeeks`, `inferEndDatePresetWeeks`. `endDateForWeeks` returns an **inclusive** `startsOn + (N*7 − 1)` window, so a daily habit yields exactly N×7 occurrences (2 weeks from 05-08 → 05-21 → 14, not 05-22 → 15).
- **`HabitForm.tsx`** — week preset pills alongside the month pills (mutually exclusive). The end date is now **always re-anchored to `startsOn`** (never "today"): changing the start re-derives the end from whichever duration is selected; a custom typed date clears both presets. Picking a week pill sets `endsOn = startsOn + N weeks − 1`.
- i18n: new `habits.scheduleEndPresetWeeks` plural (en: "# week(s)", es: "# semana(s)").
- Tests for `addCivilDays`, `endDateForWeeks`, `inferEndDatePresetWeeks` (incl. the 2-week → 05-21 case).

## Notes / scope

- The standalone workout-assignment recurrence modal and the pending-client habit-preload form share the same month-only preset limitation; left out of this PR to keep it focused — can follow up if you want week presets there too.
- No data migration: existing habits are unaffected; this only changes the authoring UI + adds a derived end date.

## Test gate

- `tsc --noEmit` clean
- `end-date-presets` + all `habit*` suites pass (83 tests); full `npx jest` green except the pre-existing `client-activity-time.test.ts` locale flake (passes in CI).