### PR TITLE
GC Fitness Admin: user search by email (mdb1/gc-fitness#163)

### DIFF
--- a/backoffice/src/app/gc-fitness/admin/page.tsx
+++ b/backoffice/src/app/gc-fitness/admin/page.tsx
@@ -205,6 +205,18 @@ export default async function AdminPage({
 
       <Card>
         <CardHeader>
+          <CardTitle className="text-xl">User search</CardTitle>
+          <CardDescription>Find any user (client, coach, or admin) by email and open their profile.</CardDescription>
+        </CardHeader>
+        <CardContent>
+          <Button asChild variant="outline" className="rounded-full">
+            <Link href="/gc-fitness/admin/users">Open user search</Link>
+          </Button>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
           <CardTitle className="text-xl">Coaches</CardTitle>
           <CardDescription>Email, roles, clients, custom workouts, custom exercises.</CardDescription>
         </CardHeader>

--- a/backoffice/src/app/gc-fitness/admin/users/page.tsx
+++ b/backoffice/src/app/gc-fitness/admin/users/page.tsx
@@ -1,0 +1,190 @@
+import Link from "next/link";
+import { redirect } from "next/navigation";
+
+import { AdminSubmitButton } from "../_components/admin-submit-button";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { PageHeader } from "@/components/gc-fitness/page-header";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import {
+  searchUsersByEmailForAdmin,
+  type UserSearchResultRow,
+} from "@/lib/gc-fitness/admin-actions";
+import { getCurrentAdmin } from "@/lib/gc-fitness/auth-helpers";
+
+export const dynamic = "force-dynamic";
+
+/**
+ * Resolve the right profile destination for a user by role precedence:
+ *   client  → existing client detail page
+ *   trainer → existing coach detail page
+ *   else (admin-only) → no dedicated page; render an inline read-only summary.
+ */
+function profileHrefForRow(row: UserSearchResultRow): string | null {
+  if (row.roles.includes("client")) {
+    return `/gc-fitness/clients/${row.uid}`;
+  }
+  if (row.roles.includes("trainer")) {
+    return `/gc-fitness/admin/coaches/${row.uid}`;
+  }
+  return null;
+}
+
+export default async function AdminUserSearchPage({
+  searchParams,
+}: {
+  searchParams: Promise<Record<string, string | string[] | undefined>>;
+}) {
+  try {
+    await getCurrentAdmin();
+  } catch (err) {
+    const message = err instanceof Error ? err.message : "Forbidden";
+    if (message === "Forbidden") {
+      redirect("/gc-fitness/forbidden");
+    }
+    throw err;
+  }
+
+  const sp = await searchParams;
+  const q = typeof sp.q === "string" ? sp.q.trim() : "";
+  const rows = q.length > 0 ? await searchUsersByEmailForAdmin(q) : [];
+
+  return (
+    <div className="gc-page flex flex-col gap-6">
+      <PageHeader
+        title="User search"
+        subtitle="Find any user (client, coach, or admin) by email or email fragment, then open their profile."
+      />
+
+      <Button asChild variant="outline" size="sm" className="self-start rounded-full">
+        <Link href="/gc-fitness/admin">Back to admin</Link>
+      </Button>
+
+      <form
+        method="get"
+        action="/gc-fitness/admin/users"
+        className="flex flex-col gap-3 sm:flex-row sm:items-center"
+      >
+        <Input
+          name="q"
+          defaultValue={q}
+          placeholder="email or fragment"
+          className="sm:max-w-md"
+        />
+        <AdminSubmitButton
+          idleLabel="Search"
+          pendingLabel="Searching…"
+          className="h-10 rounded-full bg-primary px-5 text-primary-foreground hover:bg-primary/90"
+        />
+      </form>
+
+      <div className="overflow-x-auto rounded-2xl border">
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead>User</TableHead>
+              <TableHead>UID</TableHead>
+              <TableHead>Roles</TableHead>
+              <TableHead className="text-right">Profile</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {q.length === 0 ? (
+              <TableRow>
+                <TableCell colSpan={4} className="text-sm text-muted-foreground">
+                  Type an email or email fragment above to search.
+                </TableCell>
+              </TableRow>
+            ) : rows.length === 0 ? (
+              <TableRow>
+                <TableCell colSpan={4} className="text-sm text-muted-foreground">
+                  No matches.
+                </TableCell>
+              </TableRow>
+            ) : (
+              rows.map((row) => {
+                const href = profileHrefForRow(row);
+                return (
+                  <TableRow key={row.uid}>
+                    <TableCell>
+                      <div className="flex items-center gap-3">
+                        {row.photoURL ? (
+                          // eslint-disable-next-line @next/next/no-img-element
+                          <img
+                            src={row.photoURL}
+                            alt=""
+                            className="h-8 w-8 rounded-full object-cover"
+                          />
+                        ) : (
+                          <div className="h-8 w-8 rounded-full bg-muted" aria-hidden />
+                        )}
+                        <div>
+                          <div className="font-medium">
+                            {row.displayName || "—"}
+                            {row.deleted ? (
+                              <span className="ml-2 text-xs text-destructive">
+                                (deleted)
+                              </span>
+                            ) : null}
+                          </div>
+                          <div className="text-xs text-muted-foreground">
+                            {row.email}
+                          </div>
+                        </div>
+                      </div>
+                    </TableCell>
+                    <TableCell className="font-mono text-xs">{row.uid}</TableCell>
+                    <TableCell>{row.roles.join(", ") || "—"}</TableCell>
+                    <TableCell className="text-right">
+                      {href ? (
+                        <Button
+                          asChild
+                          variant="outline"
+                          size="sm"
+                          className="rounded-full"
+                        >
+                          <Link href={href}>View</Link>
+                        </Button>
+                      ) : (
+                        <details className="text-left">
+                          <summary className="cursor-pointer text-sm underline underline-offset-2">
+                            Admin profile (read-only)
+                          </summary>
+                          <div className="mt-2 space-y-1 rounded-xl border bg-muted/40 p-3 text-xs">
+                            <div>
+                              <span className="text-muted-foreground">Email:</span>{" "}
+                              {row.email || "—"}
+                            </div>
+                            <div>
+                              <span className="text-muted-foreground">Name:</span>{" "}
+                              {row.displayName || "—"}
+                            </div>
+                            <div>
+                              <span className="text-muted-foreground">UID:</span>{" "}
+                              <span className="font-mono">{row.uid}</span>
+                            </div>
+                            <div>
+                              <span className="text-muted-foreground">Roles:</span>{" "}
+                              {row.roles.join(", ") || "—"}
+                            </div>
+                          </div>
+                        </details>
+                      )}
+                    </TableCell>
+                  </TableRow>
+                );
+              })
+            )}
+          </TableBody>
+        </Table>
+      </div>
+    </div>
+  );
+}

--- a/backoffice/src/lib/gc-fitness/__tests__/admin-user-search.test.ts
+++ b/backoffice/src/lib/gc-fitness/__tests__/admin-user-search.test.ts
@@ -1,0 +1,67 @@
+// __tests__/admin-user-search.test.ts
+//
+// Unit coverage for the pure email-prefix range-bound builder used by the
+// admin user-email search (GitHub issue #163). These exports are side-effect
+// free (no firebase imports) — the unit-testable seam for the Admin-SDK query.
+//
+// The server-action block (searchUsersByEmailForAdmin) is appended later and
+// mirrors admin-actions.app-config.test.ts mocks.
+
+import {
+  buildEmailPrefixBounds,
+  normalizeSearchQuery,
+} from "../admin-user-search";
+
+// Standard Firestore prefix-range upper-bound sentinel (highest BMP private-use
+// code point). The PLAN renders `endAt` as the bare query because the sentinel
+// is a non-printing glyph; the real upper bound is `q + SENTINEL`.
+const SENTINEL = "";
+
+describe("normalizeSearchQuery", () => {
+  it("trims surrounding whitespace and lowercases", () => {
+    expect(normalizeSearchQuery("  Foo@Example.COM ")).toBe("foo@example.com");
+  });
+
+  it("does NOT apply gmail dot/plus canonicalization (literal prefix matching)", () => {
+    // Unlike normalizeMirrorEmail, this keeps dots + the +tag so the literal
+    // stored email prefix matches.
+    expect(normalizeSearchQuery("First.Last+tag@Gmail.com")).toBe(
+      "first.last+tag@gmail.com",
+    );
+  });
+
+  it("returns empty string for an all-whitespace input", () => {
+    expect(normalizeSearchQuery("   ")).toBe("");
+  });
+});
+
+describe("buildEmailPrefixBounds", () => {
+  it("builds a [q, q+sentinel] range for a non-empty query", () => {
+    expect(buildEmailPrefixBounds("ab")).toEqual({
+      startAt: "ab",
+      endAt: "ab" + SENTINEL,
+    });
+  });
+
+  it("returns null for an empty query", () => {
+    expect(buildEmailPrefixBounds("")).toBeNull();
+  });
+
+  it("returns null for an all-whitespace query", () => {
+    expect(buildEmailPrefixBounds("   ")).toBeNull();
+  });
+
+  it("normalizes (trim + lowercase) before building bounds", () => {
+    expect(buildEmailPrefixBounds("  AB ")).toEqual({
+      startAt: "ab",
+      endAt: "ab" + SENTINEL,
+    });
+  });
+
+  it("uses the high-codepoint sentinel as the upper bound", () => {
+    const bounds = buildEmailPrefixBounds("john@");
+    expect(bounds).not.toBeNull();
+    expect(bounds!.startAt).toBe("john@");
+    expect(bounds!.endAt).toBe("john@" + SENTINEL);
+  });
+});

--- a/backoffice/src/lib/gc-fitness/__tests__/admin-user-search.test.ts
+++ b/backoffice/src/lib/gc-fitness/__tests__/admin-user-search.test.ts
@@ -12,6 +12,34 @@ import {
   normalizeSearchQuery,
 } from "../admin-user-search";
 
+// ── Mocks for the server-action block (mirrors admin-actions.app-config.test.ts).
+// jest.mock is hoisted, so these apply file-wide; the pure helper above has NO
+// firebase imports, so mocking firebase does not affect its tests.
+jest.mock("@/lib/gc-fitness/auth-helpers", () => ({
+  getCurrentAdmin: jest.fn(),
+}));
+
+const mockGet = jest.fn();
+const mockLimit = jest.fn(() => ({ get: mockGet }));
+const mockEndAt = jest.fn(() => ({ limit: mockLimit }));
+const mockStartAt = jest.fn(() => ({ endAt: mockEndAt }));
+const mockOrderBy = jest.fn(() => ({ startAt: mockStartAt }));
+const mockCollection = jest.fn(() => ({ orderBy: mockOrderBy }));
+const mockGetUser = jest.fn();
+
+jest.mock("@/lib/firebase/gc-fitness-admin", () => ({
+  gcFitnessFirestore: jest.fn(() => ({ collection: mockCollection })),
+  gcFitnessAuth: jest.fn(() => ({ getUser: mockGetUser })),
+}));
+
+jest.mock("firebase-admin/firestore", () => ({
+  FieldValue: {
+    serverTimestamp: jest.fn(() => "SERVER_TIMESTAMP_SENTINEL"),
+    increment: jest.fn((n: number) => ({ __increment: n })),
+    delete: jest.fn(() => "DELETE_SENTINEL"),
+  },
+}));
+
 // Standard Firestore prefix-range upper-bound sentinel (highest BMP private-use
 // code point). The PLAN renders `endAt` as the bare query because the sentinel
 // is a non-printing glyph; the real upper bound is `q + SENTINEL`.
@@ -63,5 +91,130 @@ describe("buildEmailPrefixBounds", () => {
     expect(bounds).not.toBeNull();
     expect(bounds!.startAt).toBe("john@");
     expect(bounds!.endAt).toBe("john@" + SENTINEL);
+  });
+});
+
+// ── Server-action block ───────────────────────────────────────────────────────
+// Imported AFTER the mocks above are declared. searchUsersByEmailForAdmin is
+// admin-gated, runs the prefix-range query via the Admin SDK, and merges claim
+// roles into the doc role.
+
+import { searchUsersByEmailForAdmin } from "../admin-actions";
+import { getCurrentAdmin } from "@/lib/gc-fitness/auth-helpers";
+
+const mockedGetCurrentAdmin = getCurrentAdmin as jest.MockedFunction<
+  typeof getCurrentAdmin
+>;
+
+const ADMIN = {
+  uid: "admin-1",
+  email: "admin@example.com",
+  role: "admin" as const,
+  isTrainer: false,
+  roles: ["admin"],
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockedGetCurrentAdmin.mockResolvedValue(ADMIN);
+  mockGetUser.mockResolvedValue({ customClaims: {} });
+});
+
+describe("searchUsersByEmailForAdmin", () => {
+  it("propagates Forbidden when the caller is not an admin", async () => {
+    mockedGetCurrentAdmin.mockRejectedValueOnce(new Error("Forbidden"));
+    await expect(searchUsersByEmailForAdmin("foo")).rejects.toThrow("Forbidden");
+    expect(mockOrderBy).not.toHaveBeenCalled();
+  });
+
+  it("returns [] for an empty query WITHOUT querying firestore", async () => {
+    const rows = await searchUsersByEmailForAdmin("   ");
+    expect(rows).toEqual([]);
+    expect(mockCollection).not.toHaveBeenCalled();
+    expect(mockOrderBy).not.toHaveBeenCalled();
+  });
+
+  it("runs the orderBy(email).startAt/endAt prefix range for a non-empty query", async () => {
+    mockGet.mockResolvedValueOnce({ docs: [] });
+    await searchUsersByEmailForAdmin("  John@ ");
+
+    expect(mockCollection).toHaveBeenCalledWith("users");
+    expect(mockOrderBy).toHaveBeenCalledWith("email");
+    expect(mockStartAt).toHaveBeenCalledWith("john@");
+    expect(mockEndAt).toHaveBeenCalledWith("john@" + SENTINEL);
+  });
+
+  it("caps the limit to 50", async () => {
+    mockGet.mockResolvedValueOnce({ docs: [] });
+    await searchUsersByEmailForAdmin("john", 9999);
+    expect(mockLimit).toHaveBeenCalledWith(50);
+  });
+
+  it("maps a snapshot into rows and merges claim roles with the doc role", async () => {
+    const docs = [
+      {
+        id: "uid-client",
+        data: () => ({
+          email: "client@example.com",
+          displayName: "Client One",
+          role: "client",
+          photoURL: "https://example.com/c.jpg",
+          deleted: false,
+          coachId: "coach-9",
+        }),
+      },
+      {
+        id: "uid-admin",
+        data: () => ({
+          email: "admin2@example.com",
+          displayName: "Admin Two",
+          // No doc role — admin lives only in claims.
+        }),
+      },
+    ];
+    mockGet.mockResolvedValueOnce({ docs });
+    // Per-uid claims: the first user has no extra claims, the second is admin.
+    mockGetUser.mockImplementation((uid: string) =>
+      uid === "uid-admin"
+        ? Promise.resolve({ customClaims: { admin: true } })
+        : Promise.resolve({ customClaims: {} }),
+    );
+
+    const rows = await searchUsersByEmailForAdmin("a");
+
+    expect(rows).toHaveLength(2);
+
+    const adminRow = rows.find((r) => r.uid === "uid-admin")!;
+    expect(adminRow.email).toBe("admin2@example.com");
+    expect(adminRow.roles).toEqual(["admin"]);
+    expect(adminRow.photoURL).toBeNull();
+    expect(adminRow.coachId).toBeNull();
+    expect(adminRow.deleted).toBe(false);
+
+    const clientRow = rows.find((r) => r.uid === "uid-client")!;
+    expect(clientRow.roles).toEqual(["client"]);
+    expect(clientRow.photoURL).toBe("https://example.com/c.jpg");
+    expect(clientRow.coachId).toBe("coach-9");
+
+    // Sorted by email asc (admin2@ before client@).
+    expect(rows.map((r) => r.email)).toEqual([
+      "admin2@example.com",
+      "client@example.com",
+    ]);
+  });
+
+  it("does not throw when getUser fails for a doc (tolerant role merge)", async () => {
+    const docs = [
+      {
+        id: "uid-x",
+        data: () => ({ email: "x@example.com", displayName: "X", role: "trainer" }),
+      },
+    ];
+    mockGet.mockResolvedValueOnce({ docs });
+    mockGetUser.mockRejectedValueOnce(new Error("auth/user-not-found"));
+
+    const rows = await searchUsersByEmailForAdmin("x");
+    expect(rows).toHaveLength(1);
+    expect(rows[0].roles).toEqual(["trainer"]);
   });
 });

--- a/backoffice/src/lib/gc-fitness/admin-actions.ts
+++ b/backoffice/src/lib/gc-fitness/admin-actions.ts
@@ -4,6 +4,7 @@ import { FieldValue } from "firebase-admin/firestore";
 import { z } from "zod";
 
 import { gcFitnessAuth, gcFitnessFirestore } from "@/lib/firebase/gc-fitness-admin";
+import { buildEmailPrefixBounds } from "@/lib/gc-fitness/admin-user-search";
 import { getCurrentAdmin } from "@/lib/gc-fitness/auth-helpers";
 import { FirestoreCollections } from "@/lib/gc-fitness/collections";
 import { recurrenceLabel } from "@/lib/gc-fitness/coach-activity-log";
@@ -155,6 +156,80 @@ export async function listCoachesForAdmin(): Promise<CoachAdminRow[]> {
         customWorkoutsCount: workoutsAgg.data().count,
         customExercisesCount: exercisesAgg.data().count,
       } satisfies CoachAdminRow;
+    }),
+  );
+
+  rows.sort((a, b) => a.email.localeCompare(b.email));
+  return rows;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Admin user-email search (GitHub issue #163)
+//
+// Finds ANY user (client / coach / admin) by an email prefix. Runs through the
+// Admin SDK, which BYPASSES firestore.rules — so no rules change and no
+// composite index is needed (the single-field `email` index is always present).
+// Role is merged from the user doc `role` PLUS the custom claims (`admin` lives
+// only in claims, never in the doc), so an admin-only user surfaces correctly.
+// ─────────────────────────────────────────────────────────────────────────────
+
+export interface UserSearchResultRow {
+  uid: string;
+  email: string;
+  displayName: string;
+  roles: string[];
+  photoURL: string | null;
+  deleted: boolean;
+  coachId: string | null;
+}
+
+export async function searchUsersByEmailForAdmin(
+  rawQuery: string,
+  limit = 25,
+): Promise<UserSearchResultRow[]> {
+  // (1) Admin gate FIRST — throws Error("Forbidden") for non-admins.
+  await getCurrentAdmin();
+
+  // (2) Empty / whitespace query → no query, empty result.
+  const bounds = buildEmailPrefixBounds(rawQuery);
+  if (!bounds) return [];
+
+  // (3) Admin-SDK prefix-range query over the always-present `email` index.
+  const db = gcFitnessFirestore();
+  const cappedLimit = Math.min(Math.max(limit, 1), 50);
+  const snap = await db
+    .collection(FirestoreCollections.users)
+    .orderBy("email")
+    .startAt(bounds.startAt)
+    .endAt(bounds.endAt)
+    .limit(cappedLimit)
+    .get();
+
+  // (4) Map each doc; merge doc.role with claim roles. Tolerant — a single bad
+  // doc never throws (missing field → "" / null / false; getUser failure → []).
+  const rows = await Promise.all(
+    snap.docs.map(async (doc) => {
+      const data = doc.data() as Record<string, unknown>;
+      const uid = doc.id;
+      const authUser = await gcFitnessAuth().getUser(uid).catch(() => null);
+
+      const roles = new Set<string>(
+        rolesFromClaims(authUser?.customClaims as Record<string, unknown> | undefined),
+      );
+      const docRole = data.role;
+      if (typeof docRole === "string" && docRole.trim().length > 0) {
+        roles.add(docRole.trim().toLowerCase());
+      }
+
+      return {
+        uid,
+        email: typeof data.email === "string" ? data.email : "",
+        displayName: typeof data.displayName === "string" ? data.displayName : "",
+        roles: Array.from(roles),
+        photoURL: typeof data.photoURL === "string" ? data.photoURL : null,
+        deleted: data.deleted === true,
+        coachId: typeof data.coachId === "string" ? data.coachId : null,
+      } satisfies UserSearchResultRow;
     }),
   );
 

--- a/backoffice/src/lib/gc-fitness/admin-user-search.ts
+++ b/backoffice/src/lib/gc-fitness/admin-user-search.ts
@@ -1,0 +1,41 @@
+// admin-user-search.ts
+//
+// PURE, side-effect-free helpers for the admin user-email search (GitHub issue
+// #163). NO firebase imports live here — this file is the unit-testable seam the
+// Admin-SDK query in `admin-actions.ts` builds its range from.
+//
+// WHY a prefix range and not a full-text search: Firestore has no substring/
+// contains operator, but an `orderBy("email").startAt(q).endAt(q + SENTINEL)`
+// range matches every email that STARTS WITH `q`. Emails are stored lowercase
+// at provisioning (`user-actions.ts`: `.trim().toLowerCase()`) and Google
+// sign-in emails are already lowercase, so we lowercase the query to line up
+// with the stored values (Firestore range queries are case-sensitive).
+//
+// NOTE: unlike `normalizeMirrorEmail`, we do NOT canonicalize Gmail dots/plus —
+// we want a LITERAL prefix match of the stored email, so `john.doe@` and
+// `john+tag@` must keep their dots/plus.
+
+/**
+ * High-codepoint sentinel (U+F8FF, the highest BMP private-use code point) —
+ * the standard Firestore prefix-range upper bound. Appending it to the query
+ * yields an `endAt` that sorts just after every string starting with `query`.
+ */
+const PREFIX_SENTINEL = "";
+
+/** Trim + lowercase ONLY. No Gmail dot/plus canonicalization (see file header). */
+export function normalizeSearchQuery(raw: string): string {
+  return raw.trim().toLowerCase();
+}
+
+/**
+ * Build the Firestore prefix-range bounds for an email search.
+ * Returns `null` for an empty (or whitespace-only) query so the caller can
+ * short-circuit to `[]` without issuing a query.
+ */
+export function buildEmailPrefixBounds(
+  raw: string,
+): { startAt: string; endAt: string } | null {
+  const q = normalizeSearchQuery(raw);
+  if (q.length === 0) return null;
+  return { startAt: q, endAt: q + PREFIX_SENTINEL };
+}


### PR DESCRIPTION
Implements mdb1/gc-fitness#163 — Admin mode user search by email.

## What
New `/gc-fitness/admin/users` page (linked from a card on the Admin Console): type an email (or prefix), get matching users with photo, name, email, UID and roles, and jump to their profile.

## How
- **Query**: Admin-SDK Firestore email **prefix range query** (`orderBy("email").startAt(q).endAt(q + "")`) — uses the built-in single-field `email` index, no composite index, no `firestore.rules` change (Admin SDK is server-side, page is admin-gated like every other admin action via `getCurrentAdmin()`; non-admins → `/gc-fitness/forbidden`).
- **Pure helper seam** (`admin-user-search.ts`): `normalizeSearchQuery` (trim + lowercase) + `buildEmailPrefixBounds`, fully unit-tested.
- **Roles**: merged from the `/users/{uid}` doc `role` plus Auth custom claims, so admin-only users (no user doc role) still surface.
- **"Ver perfil" per role**: client → `/gc-fitness/clients/{uid}`; coach → `/gc-fitness/admin/coaches/{uid}`; admin-only → inline read-only summary (no dedicated admin profile page exists).

## Tests
- New `admin-user-search` suite: **14/14 green** (8 helper + 6 server-action).
- `tsc --noEmit` clean; full jest **471 passed / 1 failed** — the one failure is the documented pre-existing `client-activity-time` locale flake (green in CI).

## How to verify
1. Sign in as an admin → Admin Console → "User search" card.
2. Search a partial email (e.g. `manu`) → matches listed with roles.
3. Click through: a client lands on their client page, a coach on the coach detail page, an admin shows the inline summary.
4. Non-admin hitting `/gc-fitness/admin/users` is redirected to forbidden.