### PR TITLE
GC Fitness Admin search follow-ups: admin client view routing + contains matching (mdb1/gc-fitness#163)

### DIFF
--- a/backoffice/src/app/gc-fitness/admin/users/page.tsx
+++ b/backoffice/src/app/gc-fitness/admin/users/page.tsx
@@ -23,13 +23,18 @@ export const dynamic = "force-dynamic";
 
 /**
  * Resolve the right profile destination for a user by role precedence:
- *   client  → existing client detail page
+ *   client  → ADMIN client view under their coach. The trainer-facing
+ *             /gc-fitness/clients/{uid} page is ownership-gated (404s for
+ *             clients of other coaches), so admin search must never link it.
  *   trainer → existing coach detail page
- *   else (admin-only) → no dedicated page; render an inline read-only summary.
+ *   else (admin-only, or a client with no coach) → no dedicated page;
+ *             render an inline read-only summary.
  */
 function profileHrefForRow(row: UserSearchResultRow): string | null {
   if (row.roles.includes("client")) {
-    return `/gc-fitness/clients/${row.uid}`;
+    return row.coachId
+      ? `/gc-fitness/admin/coaches/${row.coachId}/clients/${row.uid}`
+      : null;
   }
   if (row.roles.includes("trainer")) {
     return `/gc-fitness/admin/coaches/${row.uid}`;

--- a/backoffice/src/lib/gc-fitness/__tests__/admin-user-search.test.ts
+++ b/backoffice/src/lib/gc-fitness/__tests__/admin-user-search.test.ts
@@ -1,16 +1,13 @@
 // __tests__/admin-user-search.test.ts
 //
-// Unit coverage for the pure email-prefix range-bound builder used by the
-// admin user-email search (GitHub issue #163). These exports are side-effect
-// free (no firebase imports) — the unit-testable seam for the Admin-SDK query.
+// Unit coverage for the pure email CONTAINS matcher used by the admin
+// user-email search (GitHub issue #163). These exports are side-effect free
+// (no firebase imports) — the unit-testable seam for the Admin-SDK scan.
 //
 // The server-action block (searchUsersByEmailForAdmin) is appended later and
 // mirrors admin-actions.app-config.test.ts mocks.
 
-import {
-  buildEmailPrefixBounds,
-  normalizeSearchQuery,
-} from "../admin-user-search";
+import { emailMatchesQuery, normalizeSearchQuery } from "../admin-user-search";
 
 // ── Mocks for the server-action block (mirrors admin-actions.app-config.test.ts).
 // jest.mock is hoisted, so these apply file-wide; the pure helper above has NO
@@ -20,11 +17,8 @@ jest.mock("@/lib/gc-fitness/auth-helpers", () => ({
 }));
 
 const mockGet = jest.fn();
-const mockLimit = jest.fn(() => ({ get: mockGet }));
-const mockEndAt = jest.fn(() => ({ limit: mockLimit }));
-const mockStartAt = jest.fn(() => ({ endAt: mockEndAt }));
-const mockOrderBy = jest.fn(() => ({ startAt: mockStartAt }));
-const mockCollection = jest.fn(() => ({ orderBy: mockOrderBy }));
+const mockSelect = jest.fn(() => ({ get: mockGet }));
+const mockCollection = jest.fn(() => ({ select: mockSelect }));
 const mockGetUser = jest.fn();
 
 jest.mock("@/lib/firebase/gc-fitness-admin", () => ({
@@ -40,19 +34,23 @@ jest.mock("firebase-admin/firestore", () => ({
   },
 }));
 
-// Standard Firestore prefix-range upper-bound sentinel (highest BMP private-use
-// code point). The PLAN renders `endAt` as the bare query because the sentinel
-// is a non-printing glyph; the real upper bound is `q + SENTINEL`.
-const SENTINEL = "";
+/** Build a mock projected QueryDocumentSnapshot: supports .data() and .get(field). */
+function mockDoc(id: string, fields: Record<string, unknown>) {
+  return {
+    id,
+    data: () => fields,
+    get: (field: string) => fields[field],
+  };
+}
 
 describe("normalizeSearchQuery", () => {
   it("trims surrounding whitespace and lowercases", () => {
     expect(normalizeSearchQuery("  Foo@Example.COM ")).toBe("foo@example.com");
   });
 
-  it("does NOT apply gmail dot/plus canonicalization (literal prefix matching)", () => {
+  it("does NOT apply gmail dot/plus canonicalization (literal matching)", () => {
     // Unlike normalizeMirrorEmail, this keeps dots + the +tag so the literal
-    // stored email prefix matches.
+    // stored email substring matches.
     expect(normalizeSearchQuery("First.Last+tag@Gmail.com")).toBe(
       "first.last+tag@gmail.com",
     );
@@ -63,41 +61,39 @@ describe("normalizeSearchQuery", () => {
   });
 });
 
-describe("buildEmailPrefixBounds", () => {
-  it("builds a [q, q+sentinel] range for a non-empty query", () => {
-    expect(buildEmailPrefixBounds("ab")).toEqual({
-      startAt: "ab",
-      endAt: "ab" + SENTINEL,
-    });
+describe("emailMatchesQuery", () => {
+  it("matches a prefix", () => {
+    expect(emailMatchesQuery("carba.nico@gmail.com", "carba")).toBe(true);
   });
 
-  it("returns null for an empty query", () => {
-    expect(buildEmailPrefixBounds("")).toBeNull();
+  it("matches a mid-string substring (the #163 follow-up case)", () => {
+    expect(emailMatchesQuery("ncarballal@gmail.com", "carba")).toBe(true);
   });
 
-  it("returns null for an all-whitespace query", () => {
-    expect(buildEmailPrefixBounds("   ")).toBeNull();
+  it("matches case-insensitively against the stored value", () => {
+    expect(emailMatchesQuery("NCarballal@Gmail.com", "carba")).toBe(true);
   });
 
-  it("normalizes (trim + lowercase) before building bounds", () => {
-    expect(buildEmailPrefixBounds("  AB ")).toEqual({
-      startAt: "ab",
-      endAt: "ab" + SENTINEL,
-    });
+  it("does not match when the substring is absent", () => {
+    expect(emailMatchesQuery("someone@example.com", "carba")).toBe(false);
   });
 
-  it("uses the high-codepoint sentinel as the upper bound", () => {
-    const bounds = buildEmailPrefixBounds("john@");
-    expect(bounds).not.toBeNull();
-    expect(bounds!.startAt).toBe("john@");
-    expect(bounds!.endAt).toBe("john@" + SENTINEL);
+  it("never matches an empty query", () => {
+    expect(emailMatchesQuery("someone@example.com", "")).toBe(false);
+  });
+
+  it("never matches non-string or empty stored emails", () => {
+    expect(emailMatchesQuery(undefined, "a")).toBe(false);
+    expect(emailMatchesQuery(null, "a")).toBe(false);
+    expect(emailMatchesQuery(42, "a")).toBe(false);
+    expect(emailMatchesQuery("", "a")).toBe(false);
   });
 });
 
 // ── Server-action block ───────────────────────────────────────────────────────
 // Imported AFTER the mocks above are declared. searchUsersByEmailForAdmin is
-// admin-gated, runs the prefix-range query via the Admin SDK, and merges claim
-// roles into the doc role.
+// admin-gated, scans the users collection with a field projection, filters
+// CONTAINS in memory, and merges claim roles into the doc role.
 
 import { searchUsersByEmailForAdmin } from "../admin-actions";
 import { getCurrentAdmin } from "@/lib/gc-fitness/auth-helpers";
@@ -124,53 +120,65 @@ describe("searchUsersByEmailForAdmin", () => {
   it("propagates Forbidden when the caller is not an admin", async () => {
     mockedGetCurrentAdmin.mockRejectedValueOnce(new Error("Forbidden"));
     await expect(searchUsersByEmailForAdmin("foo")).rejects.toThrow("Forbidden");
-    expect(mockOrderBy).not.toHaveBeenCalled();
+    expect(mockCollection).not.toHaveBeenCalled();
   });
 
   it("returns [] for an empty query WITHOUT querying firestore", async () => {
     const rows = await searchUsersByEmailForAdmin("   ");
     expect(rows).toEqual([]);
     expect(mockCollection).not.toHaveBeenCalled();
-    expect(mockOrderBy).not.toHaveBeenCalled();
   });
 
-  it("runs the orderBy(email).startAt/endAt prefix range for a non-empty query", async () => {
-    mockGet.mockResolvedValueOnce({ docs: [] });
-    await searchUsersByEmailForAdmin("  John@ ");
+  it("scans users with a field projection and filters CONTAINS (not prefix-only)", async () => {
+    const docs = [
+      mockDoc("uid-prefix", { email: "carba.nico@gmail.com", role: "trainer" }),
+      mockDoc("uid-substr", { email: "ncarballal@gmail.com", role: "client", coachId: "coach-1" }),
+      mockDoc("uid-other", { email: "someone@example.com", role: "client" }),
+    ];
+    mockGet.mockResolvedValueOnce({ docs });
+
+    const rows = await searchUsersByEmailForAdmin("  Carba ");
 
     expect(mockCollection).toHaveBeenCalledWith("users");
-    expect(mockOrderBy).toHaveBeenCalledWith("email");
-    expect(mockStartAt).toHaveBeenCalledWith("john@");
-    expect(mockEndAt).toHaveBeenCalledWith("john@" + SENTINEL);
+    expect(mockSelect).toHaveBeenCalledWith(
+      "email",
+      "displayName",
+      "role",
+      "photoURL",
+      "deleted",
+      "coachId",
+    );
+    // Both the prefix match AND the mid-string match come back; the non-match doesn't.
+    expect(rows.map((r) => r.uid).sort()).toEqual(["uid-prefix", "uid-substr"]);
+    // Auth lookups only ran for the matches.
+    expect(mockGetUser).toHaveBeenCalledTimes(2);
   });
 
-  it("caps the limit to 50", async () => {
-    mockGet.mockResolvedValueOnce({ docs: [] });
-    await searchUsersByEmailForAdmin("john", 9999);
-    expect(mockLimit).toHaveBeenCalledWith(50);
+  it("caps the result list to 50 matches", async () => {
+    const docs = Array.from({ length: 60 }, (_, i) =>
+      mockDoc(`uid-${i}`, { email: `user${String(i).padStart(2, "0")}@carba.com` }),
+    );
+    mockGet.mockResolvedValueOnce({ docs });
+
+    const rows = await searchUsersByEmailForAdmin("carba", 9999);
+    expect(rows).toHaveLength(50);
   });
 
-  it("maps a snapshot into rows and merges claim roles with the doc role", async () => {
+  it("maps matches into rows and merges claim roles with the doc role", async () => {
     const docs = [
-      {
-        id: "uid-client",
-        data: () => ({
-          email: "client@example.com",
-          displayName: "Client One",
-          role: "client",
-          photoURL: "https://example.com/c.jpg",
-          deleted: false,
-          coachId: "coach-9",
-        }),
-      },
-      {
-        id: "uid-admin",
-        data: () => ({
-          email: "admin2@example.com",
-          displayName: "Admin Two",
-          // No doc role — admin lives only in claims.
-        }),
-      },
+      mockDoc("uid-client", {
+        email: "client@example.com",
+        displayName: "Client One",
+        role: "client",
+        photoURL: "https://example.com/c.jpg",
+        deleted: false,
+        coachId: "coach-9",
+      }),
+      mockDoc("uid-admin", {
+        email: "admin2@example.com",
+        displayName: "Admin Two",
+        // No doc role — admin lives only in claims.
+      }),
     ];
     mockGet.mockResolvedValueOnce({ docs });
     // Per-uid claims: the first user has no extra claims, the second is admin.
@@ -180,7 +188,7 @@ describe("searchUsersByEmailForAdmin", () => {
         : Promise.resolve({ customClaims: {} }),
     );
 
-    const rows = await searchUsersByEmailForAdmin("a");
+    const rows = await searchUsersByEmailForAdmin("example.com");
 
     expect(rows).toHaveLength(2);
 
@@ -205,10 +213,7 @@ describe("searchUsersByEmailForAdmin", () => {
 
   it("does not throw when getUser fails for a doc (tolerant role merge)", async () => {
     const docs = [
-      {
-        id: "uid-x",
-        data: () => ({ email: "x@example.com", displayName: "X", role: "trainer" }),
-      },
+      mockDoc("uid-x", { email: "x@example.com", displayName: "X", role: "trainer" }),
     ];
     mockGet.mockResolvedValueOnce({ docs });
     mockGetUser.mockRejectedValueOnce(new Error("auth/user-not-found"));

--- a/backoffice/src/lib/gc-fitness/admin-actions.ts
+++ b/backoffice/src/lib/gc-fitness/admin-actions.ts
@@ -4,7 +4,7 @@ import { FieldValue } from "firebase-admin/firestore";
 import { z } from "zod";
 
 import { gcFitnessAuth, gcFitnessFirestore } from "@/lib/firebase/gc-fitness-admin";
-import { buildEmailPrefixBounds } from "@/lib/gc-fitness/admin-user-search";
+import { emailMatchesQuery, normalizeSearchQuery } from "@/lib/gc-fitness/admin-user-search";
 import { getCurrentAdmin } from "@/lib/gc-fitness/auth-helpers";
 import { FirestoreCollections } from "@/lib/gc-fitness/collections";
 import { recurrenceLabel } from "@/lib/gc-fitness/coach-activity-log";
@@ -191,24 +191,32 @@ export async function searchUsersByEmailForAdmin(
   await getCurrentAdmin();
 
   // (2) Empty / whitespace query → no query, empty result.
-  const bounds = buildEmailPrefixBounds(rawQuery);
-  if (!bounds) return [];
+  const q = normalizeSearchQuery(rawQuery);
+  if (q.length === 0) return [];
 
-  // (3) Admin-SDK prefix-range query over the always-present `email` index.
+  // (3) CONTAINS search: Firestore has no substring operator (a prefix range
+  // misses "carba" → ncarballal@…), so scan the users collection with a field
+  // projection and filter in memory. Admin-only tool over a small user base —
+  // the projected scan is cheap, and the per-user Auth lookup below only runs
+  // on the capped matches.
   const db = gcFitnessFirestore();
   const cappedLimit = Math.min(Math.max(limit, 1), 50);
   const snap = await db
     .collection(FirestoreCollections.users)
-    .orderBy("email")
-    .startAt(bounds.startAt)
-    .endAt(bounds.endAt)
-    .limit(cappedLimit)
+    .select("email", "displayName", "role", "photoURL", "deleted", "coachId")
     .get();
+
+  const matches = snap.docs
+    .filter((doc) => emailMatchesQuery(doc.get("email"), q))
+    .sort((a, b) =>
+      String(a.get("email") ?? "").localeCompare(String(b.get("email") ?? "")),
+    )
+    .slice(0, cappedLimit);
 
   // (4) Map each doc; merge doc.role with claim roles. Tolerant — a single bad
   // doc never throws (missing field → "" / null / false; getUser failure → []).
   const rows = await Promise.all(
-    snap.docs.map(async (doc) => {
+    matches.map(async (doc) => {
       const data = doc.data() as Record<string, unknown>;
       const uid = doc.id;
       const authUser = await gcFitnessAuth().getUser(uid).catch(() => null);

--- a/backoffice/src/lib/gc-fitness/admin-user-search.ts
+++ b/backoffice/src/lib/gc-fitness/admin-user-search.ts
@@ -1,26 +1,22 @@
 // admin-user-search.ts
 //
 // PURE, side-effect-free helpers for the admin user-email search (GitHub issue
-// #163). NO firebase imports live here — this file is the unit-testable seam the
-// Admin-SDK query in `admin-actions.ts` builds its range from.
+// #163). NO firebase imports live here — this file is the unit-testable seam
+// for the Admin-SDK scan in `admin-actions.ts`.
 //
-// WHY a prefix range and not a full-text search: Firestore has no substring/
-// contains operator, but an `orderBy("email").startAt(q).endAt(q + SENTINEL)`
-// range matches every email that STARTS WITH `q`. Emails are stored lowercase
-// at provisioning (`user-actions.ts`: `.trim().toLowerCase()`) and Google
-// sign-in emails are already lowercase, so we lowercase the query to line up
-// with the stored values (Firestore range queries are case-sensitive).
+// WHY an in-memory CONTAINS filter and not a Firestore query: the admin wants
+// substring matches ("carba" must find both carba.nico@… AND ncarballal@…),
+// and Firestore has no substring/contains operator — a prefix range
+// (startAt/endAt) only matches emails that START with the query. The user base
+// is small (admin-only tool), so the action scans the `users` collection with
+// a field projection and filters here. Emails are stored lowercase at
+// provisioning (`user-actions.ts`: `.trim().toLowerCase()`) and Google sign-in
+// emails are already lowercase, so we lowercase the query to line up; the
+// stored email is lowercased defensively at match time anyway.
 //
 // NOTE: unlike `normalizeMirrorEmail`, we do NOT canonicalize Gmail dots/plus —
-// we want a LITERAL prefix match of the stored email, so `john.doe@` and
+// we want a LITERAL substring match of the stored email, so `john.doe@` and
 // `john+tag@` must keep their dots/plus.
-
-/**
- * High-codepoint sentinel (U+F8FF, the highest BMP private-use code point) —
- * the standard Firestore prefix-range upper bound. Appending it to the query
- * yields an `endAt` that sorts just after every string starting with `query`.
- */
-const PREFIX_SENTINEL = "";
 
 /** Trim + lowercase ONLY. No Gmail dot/plus canonicalization (see file header). */
 export function normalizeSearchQuery(raw: string): string {
@@ -28,14 +24,14 @@ export function normalizeSearchQuery(raw: string): string {
 }
 
 /**
- * Build the Firestore prefix-range bounds for an email search.
- * Returns `null` for an empty (or whitespace-only) query so the caller can
- * short-circuit to `[]` without issuing a query.
+ * Literal case-insensitive CONTAINS match of `normalizedQuery` against a
+ * stored email value. `email` is `unknown` because Firestore doc fields are
+ * untyped — non-string / empty values never match. Pass the query through
+ * `normalizeSearchQuery` first; an empty query matches nothing (callers
+ * short-circuit before querying anyway).
  */
-export function buildEmailPrefixBounds(
-  raw: string,
-): { startAt: string; endAt: string } | null {
-  const q = normalizeSearchQuery(raw);
-  if (q.length === 0) return null;
-  return { startAt: q, endAt: q + PREFIX_SENTINEL };
+export function emailMatchesQuery(email: unknown, normalizedQuery: string): boolean {
+  if (normalizedQuery.length === 0) return false;
+  if (typeof email !== "string" || email.length === 0) return false;
+  return email.toLowerCase().includes(normalizedQuery);
 }


### PR DESCRIPTION
Follow-up to #138 (merged before these review fixes landed on the branch).

## What's in here
1. **Client "View" routes to the ADMIN client view** — `/gc-fitness/admin/coaches/{coachId}/clients/{uid}` instead of the trainer-facing `/gc-fitness/clients/{uid}`, which is ownership-gated and 404s for clients of other coaches. Clients with no coach fall back to the inline read-only summary.
2. **Substring (contains) matching** — "carba" now finds both `carba.nico@…` AND `ncarballal@gmail.com`. Firestore has no substring operator, so the admin action scans the users collection with a field projection and filters in memory (admin-only tool, small user base; Auth role lookups still only run on the capped 50 matches). `buildEmailPrefixBounds` replaced by `emailMatchesQuery`.

## Tests
- `admin-user-search` suite: **15/15** (incl. the ncarballal mid-string case)
- `tsc --noEmit` clean; full jest **472 passed / 1 failed** (the documented pre-existing locale flake, green in CI)

## How to verify
1. Admin → User search → "carba" → both users appear.
2. Tap View on the client → lands on `/gc-fitness/admin/coaches/6zf48…/clients/UdNJ…` (the admin view), no 404.