### PR TITLE
Habit compliance: legacy-tolerant log value collapse (gc-fitness#173 round 2)

### DIFF
--- a/backoffice/src/app/gc-fitness/clients/[id]/_components/HabitTrendsWidget.tsx
+++ b/backoffice/src/app/gc-fitness/clients/[id]/_components/HabitTrendsWidget.tsx
@@ -21,6 +21,7 @@ import { getTranslations } from "next-intl/server";
 import { gcFitnessFirestore } from "@/lib/firebase/gc-fitness-admin";
 import { FirestoreCollections } from "@/lib/gc-fitness/collections";
 import { civilDateFormat } from "@/lib/gc-fitness/civil-date";
+import { coerceLegacyHabitLogValue } from "@/lib/gc-fitness/habit-compliance";
 import { isHabitScheduledOn } from "@/lib/gc-fitness/habit-schedule";
 import { TREND_RANGES, type TrendRangeKey, addCivilDays } from "./trend-range";
 import { HabitTrendsClient, type HabitTrendRow } from "./HabitTrendsClient";
@@ -82,7 +83,7 @@ export async function HabitTrendsWidget({ clientId, timezone }: HabitTrendsWidge
         if (data.deleted === true) continue;
         const date = typeof data.civilDate === "string" ? data.civilDate : "";
         if (!date) continue;
-        if (data.value === true) completedDates.add(date);
+        if (coerceLegacyHabitLogValue(data.value)) completedDates.add(date);
       }
 
       const byRange = {} as Record<

--- a/backoffice/src/lib/gc-fitness/__tests__/habit-compliance.test.ts
+++ b/backoffice/src/lib/gc-fitness/__tests__/habit-compliance.test.ts
@@ -35,6 +35,7 @@
 // Habits are BINARY-ONLY now: a log counts iff `!deleted && value === true`.
 
 import {
+  coerceLegacyHabitLogValue,
   computeCompliance,
   logCountsAsCompleted,
   type HabitLogRow,
@@ -70,6 +71,44 @@ describe("habit-compliance — logCountsAsCompleted", () => {
         binaryLog({ date: "2026-05-19", value: true, deleted: true }),
       ),
     ).toBe(false);
+  });
+});
+
+describe("habit-compliance — coerceLegacyHabitLogValue", () => {
+  // TS twin of the Swift HabitLogValue.init(from:) collapse and the Android
+  // fromWire fix (gc-fitness #173 round 2). Fixtures IDENTICAL to the Swift
+  // and Kotlin parity tests — a strict `=== true` coercion under-counted
+  // legacy numeric/string completed days (the 34% vs 36% mismatch).
+  it("passes booleans through", () => {
+    expect(coerceLegacyHabitLogValue(true)).toBe(true);
+    expect(coerceLegacyHabitLogValue(false)).toBe(false);
+  });
+
+  it("collapses legacy numbers: non-zero counts, zero does not", () => {
+    expect(coerceLegacyHabitLogValue(1.0)).toBe(true);
+    expect(coerceLegacyHabitLogValue(3)).toBe(true);
+    expect(coerceLegacyHabitLogValue(0)).toBe(false);
+  });
+
+  it("collapses legacy strings: non-empty counts, empty does not", () => {
+    expect(coerceLegacyHabitLogValue("done")).toBe(true);
+    expect(coerceLegacyHabitLogValue("")).toBe(false);
+  });
+
+  it("null/undefined/unknown shapes never count", () => {
+    expect(coerceLegacyHabitLogValue(null)).toBe(false);
+    expect(coerceLegacyHabitLogValue(undefined)).toBe(false);
+    expect(coerceLegacyHabitLogValue({ legacy: true })).toBe(false);
+  });
+
+  it("repro: a legacy 1.0-valued completed day counts toward compliance (36% not 34%)", () => {
+    // The wire-boundary mapping must collapse BEFORE logCountsAsCompleted.
+    const legacyWire: unknown = 1.0;
+    const log = binaryLog({
+      date: "2026-05-19",
+      value: coerceLegacyHabitLogValue(legacyWire),
+    });
+    expect(logCountsAsCompleted(log)).toBe(true);
   });
 });
 

--- a/backoffice/src/lib/gc-fitness/client-roster.ts
+++ b/backoffice/src/lib/gc-fitness/client-roster.ts
@@ -46,6 +46,7 @@ import { gcFitnessFirestore } from "@/lib/firebase/gc-fitness-admin";
 import { getCurrentTrainer } from "./auth-helpers";
 import { FirestoreCollections } from "./collections";
 import { coachVisibleClientName } from "./client-name";
+import { coerceLegacyHabitLogValue } from "./habit-compliance";
 import { civilDateToday } from "./civil-date";
 import { getTrainerTimezone } from "./trainer-timezone";
 import {
@@ -623,7 +624,7 @@ export async function listClientsForRoster(): Promise<ClientRosterRow[]> {
           habitId: hid,
           clientId: (data.clientId as string) ?? "",
           civilDate: typeof data.civilDate === "string" ? data.civilDate : "",
-          value: data.value === true,
+          value: coerceLegacyHabitLogValue(data.value),
           unit: typeof data.unit === "string" ? data.unit : undefined,
           deleted: data.deleted === true,
         };

--- a/backoffice/src/lib/gc-fitness/coach-pulse-actions.ts
+++ b/backoffice/src/lib/gc-fitness/coach-pulse-actions.ts
@@ -6,6 +6,7 @@ import { getCurrentTrainer } from "./auth-helpers";
 import { civilDateFormat, civilDateToday } from "./civil-date";
 import { FirestoreCollections } from "./collections";
 import { listClients, type ClientRosterEntry } from "./client-roster";
+import { coerceLegacyHabitLogValue } from "./habit-compliance";
 import { isHabitScheduledOn } from "./habit-schedule";
 import { getTrainerTimezone } from "./trainer-timezone";
 
@@ -76,7 +77,7 @@ function habitLogCountsAsCompleted(
   // Habits are binary-only: a log counts iff it isn't soft-deleted AND its
   // value is `true`. Mirrors `logCountsAsCompleted` in habit-compliance.ts.
   if (data.deleted === true) return false;
-  return data.value === true;
+  return coerceLegacyHabitLogValue(data.value);
 }
 
 function buildWindowDays(timezone: string): string[] {

--- a/backoffice/src/lib/gc-fitness/habit-compliance-actions.ts
+++ b/backoffice/src/lib/gc-fitness/habit-compliance-actions.ts
@@ -42,6 +42,7 @@
 import { gcFitnessFirestore } from "@/lib/firebase/gc-fitness-admin";
 
 import {
+  coerceLegacyHabitLogValue,
   computeAdherence,
   type HabitLogRow,
 } from "./habit-compliance";
@@ -199,7 +200,7 @@ export async function fetchHabitCompliance(
         habitId: (data.habitId as string) ?? "",
         clientId: (data.clientId as string) ?? "",
         civilDate: (data.civilDate as string) ?? "",
-        value: data.value === true,
+        value: coerceLegacyHabitLogValue(data.value),
         unit: typeof data.unit === "string" ? data.unit : undefined,
         loggedAt: toIsoOrEmpty(data.loggedAt),
         deleted: data.deleted === true,

--- a/backoffice/src/lib/gc-fitness/habit-compliance.ts
+++ b/backoffice/src/lib/gc-fitness/habit-compliance.ts
@@ -103,6 +103,23 @@ export function logCountsAsCompleted(
 }
 
 /**
+ * Legacy-tolerant wire→binary collapse for `habit_logs.value`. TS twin of the
+ * Swift `HabitLogValue.init(from:)` collapse (and the Android `fromWire` fix,
+ * gc-fitness #173 round 2): pre-v1.1 clients wrote numeric/string values, and
+ * a strict `data.value === true` coercion silently UNDER-COUNTS those
+ * completed days (the 34% vs 36% mismatch). Every wire-boundary read of
+ * `habit_logs.value` MUST go through this before `logCountsAsCompleted`.
+ *
+ *   boolean → itself · number → value != 0 · string → !isEmpty · else → false
+ */
+export function coerceLegacyHabitLogValue(value: unknown): boolean {
+  if (typeof value === "boolean") return value;
+  if (typeof value === "number") return value !== 0;
+  if (typeof value === "string") return value.length > 0;
+  return false;
+}
+
+/**
  * Computes the compliance ratio over a window ending at `today` plus a
  * day-by-day completion timeline suitable for sparkline rendering.
  *

--- a/backoffice/src/lib/gc-fitness/recent-logs-actions.ts
+++ b/backoffice/src/lib/gc-fitness/recent-logs-actions.ts
@@ -6,6 +6,7 @@ import { gcFitnessFirestore } from "@/lib/firebase/gc-fitness-admin";
 
 import { getCurrentAdmin, getCurrentTrainer } from "./auth-helpers";
 import { civilDateFormat, civilDateToday } from "./civil-date";
+import { coerceLegacyHabitLogValue } from "./habit-compliance";
 import { FirestoreCollections } from "./collections";
 import {
   listClients,
@@ -268,7 +269,7 @@ function habitLogCountsAsCompleted(
   _habit: Record<string, unknown> | undefined,
 ): boolean {
   if (data.deleted === true) return false;
-  return data.value === true;
+  return coerceLegacyHabitLogValue(data.value);
 }
 
 /**

--- a/backoffice/src/lib/gc-fitness/schedule-month-actions.ts
+++ b/backoffice/src/lib/gc-fitness/schedule-month-actions.ts
@@ -26,7 +26,11 @@ import { getCurrentTrainer } from "./auth-helpers";
 import { FirestoreCollections } from "./collections";
 import { civilDateFormat } from "./civil-date";
 import { coachVisibleClientName } from "./client-name";
-import { logCountsAsCompleted, type HabitLogRow } from "./habit-compliance";
+import {
+  coerceLegacyHabitLogValue,
+  logCountsAsCompleted,
+  type HabitLogRow,
+} from "./habit-compliance";
 import type { HabitType } from "./habit-schema";
 
 const ASSIGNMENTS = FirestoreCollections.workoutAssignments;
@@ -693,7 +697,7 @@ export async function listMonthForClients(input: {
         habitId,
         clientId: (data.clientId as string) ?? "",
         civilDate: civil,
-        value: data.value === true,
+        value: coerceLegacyHabitLogValue(data.value),
         unit: typeof data.unit === "string" ? data.unit : undefined,
         deleted: data.deleted === true,
       };


### PR DESCRIPTION
TS side of mdb1/gc-fitness#226 — the backoffice shared the same bug that made Android read 34% where iOS read 36%.

## Root cause
Pre-v1.1 clients wrote numeric/string `habit_logs.value`. The backoffice coerced at every wire boundary with a strict `data.value === true`, so legacy completed days didn't count — the trainer-facing compliance %, roster, schedule month, coach pulse, recent logs, and habit trends all under-counted vs iOS (which collapses any legacy shape to binary at decode).

## Fix
- New pure `coerceLegacyHabitLogValue` in `habit-compliance.ts` — exact TS twin of the Swift `HabitLogValue` collapse and the Android `fromWire` fix in gc-fitness#226: boolean → itself, number → `!= 0`, string → non-empty, anything else → false.
- Applied at all six wire-boundary reads of `habit_logs.value` (habit-compliance-actions, client-roster, schedule-month-actions, coach-pulse-actions, recent-logs-actions, HabitTrendsWidget).
- Twin parity tests with fixtures identical to the Swift/Kotlin suites, incl. the legacy `1.0`-counts repro.

## Tests
- habit suites: **79 passing** (5 suites); `tsc --noEmit` clean
- full jest: **477 passed / 1 failed** — the documented pre-existing locale flake (green in CI)

## How to verify
A client with pre-v1.1 habit logs shows the same compliance % in the backoffice as on iOS/Android (with gc-fitness#226 installed) — e.g. 36%, not 34%.