### PR TITLE
feat(gc-fitness): gate 'request progress photos' to client's next check-in date (#160)

### DIFF
--- a/backoffice/messages/en.json
+++ b/backoffice/messages/en.json
@@ -301,7 +301,8 @@
           "reactivatesOn": "Reactivates on {date}",
           "readyHelp": "You can request it again now.",
           "active": "Request is active for 3 days",
-          "ready": "Ready to request"
+          "ready": "Ready to request",
+          "photoGatedUntil": "Next check-in available on {date}"
         },
         "fulfillment": {
           "photos": "Photos uploaded · {ago}",

--- a/backoffice/messages/es.json
+++ b/backoffice/messages/es.json
@@ -301,7 +301,8 @@
           "reactivatesOn": "Se reactiva el {date}",
           "readyHelp": "Podés volver a pedirlo ahora.",
           "active": "El pedido queda activo por 3 días",
-          "ready": "Listo para pedir"
+          "ready": "Listo para pedir",
+          "photoGatedUntil": "Próximo check-in disponible el {date}"
         },
         "fulfillment": {
           "photos": "Ya subió fotos · {ago}",

--- a/backoffice/src/app/gc-fitness/clients/[id]/_components/ClientRequestActionsCard.tsx
+++ b/backoffice/src/app/gc-fitness/clients/[id]/_components/ClientRequestActionsCard.tsx
@@ -39,9 +39,10 @@ export default async function ClientRequestActionsCard({
   progressPhotosFulfilled?: RequestFulfillment;
   bodyWeightFulfilled?: RequestFulfillment;
   // Issue #160 — when the client is NOT eligible (baseline complete AND within
-  // the 7-day window), the progress-photos request button is disabled with a
-  // helper naming the next-eligible date. Derived in page.tsx from the photos it
-  // already loads — no extra read. Only affects the photos row.
+  // the 7-day window), both request buttons are disabled with a helper naming
+  // the next-eligible date. Derived in page.tsx from the photos it already
+  // loads — no extra read. The weekly check-in covers photos AND weight in the
+  // coaching flow, so the weight row is gated by the same date.
   progressPhotosCheckInEligible?: boolean;
   progressPhotosNextEligibleDate?: string | null;
 }) {
@@ -67,9 +68,9 @@ export default async function ClientRequestActionsCard({
     t,
   );
 
-  // Issue #160 — gate the PHOTOS row only. When the client is within their
-  // weekly check-in window, re-requesting can't help, so disable the button and
-  // explain the next-eligible date. The weight row is untouched.
+  // Issue #160 — gate BOTH request rows. When the client is within their
+  // weekly check-in window, re-requesting can't help, so disable the buttons
+  // and explain the next-eligible date (the check-in covers photos + weight).
   const photoGated =
     !progressPhotosCheckInEligible && Boolean(progressPhotosNextEligibleDate);
   const photoGatedHelper = photoGated
@@ -120,6 +121,8 @@ export default async function ClientRequestActionsCard({
           submitLabel={t("request.cta")}
           activeLabel={t("status.active")}
           readyLabel={t("status.ready")}
+          gated={photoGated}
+          gatedHelper={photoGatedHelper}
         />
       </CardContent>
     </Card>

--- a/backoffice/src/app/gc-fitness/clients/[id]/_components/ClientRequestActionsCard.tsx
+++ b/backoffice/src/app/gc-fitness/clients/[id]/_components/ClientRequestActionsCard.tsx
@@ -28,6 +28,8 @@ export default async function ClientRequestActionsCard({
   bodyWeightRequestedAt,
   progressPhotosFulfilled,
   bodyWeightFulfilled,
+  progressPhotosCheckInEligible = true,
+  progressPhotosNextEligibleDate = null,
 }: {
   clientId: string;
   clientName: string;
@@ -36,6 +38,12 @@ export default async function ClientRequestActionsCard({
   bodyWeightRequestedAt: unknown;
   progressPhotosFulfilled?: RequestFulfillment;
   bodyWeightFulfilled?: RequestFulfillment;
+  // Issue #160 — when the client is NOT eligible (baseline complete AND within
+  // the 7-day window), the progress-photos request button is disabled with a
+  // helper naming the next-eligible date. Derived in page.tsx from the photos it
+  // already loads — no extra read. Only affects the photos row.
+  progressPhotosCheckInEligible?: boolean;
+  progressPhotosNextEligibleDate?: string | null;
 }) {
   const locale = await getLocale();
   const t = await getTranslations("clients.detail.requests");
@@ -58,6 +66,17 @@ export default async function ClientRequestActionsCard({
     locale,
     t,
   );
+
+  // Issue #160 — gate the PHOTOS row only. When the client is within their
+  // weekly check-in window, re-requesting can't help, so disable the button and
+  // explain the next-eligible date. The weight row is untouched.
+  const photoGated =
+    !progressPhotosCheckInEligible && Boolean(progressPhotosNextEligibleDate);
+  const photoGatedHelper = photoGated
+    ? t("status.photoGatedUntil", {
+        date: formatCivilDate(progressPhotosNextEligibleDate!, locale),
+      })
+    : null;
 
   async function requestProgressPhotos() {
     "use server";
@@ -89,6 +108,8 @@ export default async function ClientRequestActionsCard({
           submitLabel={t("request.cta")}
           activeLabel={t("status.active")}
           readyLabel={t("status.ready")}
+          gated={photoGated}
+          gatedHelper={photoGatedHelper}
         />
         <RequestRow
           title={t("weight.title")}
@@ -210,6 +231,27 @@ function formatDate(
   }
 }
 
+/**
+ * Render a civil-date ("YYYY-MM-DD") for display without letting the host
+ * timezone reinterpret it as an instant — anchor at UTC noon and format in UTC.
+ * Mirrors the civil-date label convention used elsewhere in the backoffice.
+ */
+function formatCivilDate(civilDate: string, locale: string): string {
+  const [y, m, d] = civilDate.split("-").map((part) => Number.parseInt(part, 10));
+  if (!y || !m || !d) return civilDate;
+  const date = new Date(Date.UTC(y, m - 1, d, 12, 0, 0));
+  try {
+    return new Intl.DateTimeFormat(locale, {
+      timeZone: "UTC",
+      day: "2-digit",
+      month: "short",
+      year: "numeric",
+    }).format(date);
+  } catch {
+    return civilDate;
+  }
+}
+
 function RequestRow({
   title,
   description,
@@ -219,6 +261,8 @@ function RequestRow({
   submitLabel,
   activeLabel,
   readyLabel,
+  gated = false,
+  gatedHelper = null,
 }: {
   title: string;
   description: string;
@@ -228,6 +272,8 @@ function RequestRow({
   submitLabel: string;
   activeLabel: string;
   readyLabel: string;
+  gated?: boolean;
+  gatedHelper?: string | null;
 }) {
   return (
     <form action={action} className="rounded-xl border bg-muted/20 p-4">
@@ -254,11 +300,18 @@ function RequestRow({
             </Badge>
           )
         ) : null}
+        {gated && gatedHelper ? (
+          <p className="text-xs text-muted-foreground">{gatedHelper}</p>
+        ) : null}
         <div className="mt-auto flex items-center justify-between gap-3">
           <p className="text-xs text-muted-foreground">
-            {state.isActive ? activeLabel : readyLabel}
+            {gated ? (gatedHelper ?? readyLabel) : state.isActive ? activeLabel : readyLabel}
           </p>
-          <Button type="submit" variant={state.isActive ? "secondary" : "default"} disabled={state.isActive}>
+          <Button
+            type="submit"
+            variant={state.isActive || gated ? "secondary" : "default"}
+            disabled={state.isActive || gated}
+          >
             {submitLabel}
           </Button>
         </div>

--- a/backoffice/src/app/gc-fitness/clients/[id]/_components/ClientRequestActionsCard.tsx
+++ b/backoffice/src/app/gc-fitness/clients/[id]/_components/ClientRequestActionsCard.tsx
@@ -289,7 +289,12 @@ function RequestRow({
           <span className="rounded-full border bg-background px-3 py-1 text-xs text-muted-foreground">
             {state.statusText}
           </span>
-          <span className="text-xs text-muted-foreground">{state.helperText}</span>
+          {/* When gated (#160) the ready-again helper ("you can request now")
+              contradicts the next-eligible-date line below — hide it. The
+              active-request helper ("reactivates on …") stays. */}
+          {gated && !state.isActive ? null : (
+            <span className="text-xs text-muted-foreground">{state.helperText}</span>
+          )}
         </div>
         {note ? (
           note.fulfilled ? (
@@ -302,9 +307,6 @@ function RequestRow({
               {note.text}
             </Badge>
           )
-        ) : null}
-        {gated && gatedHelper ? (
-          <p className="text-xs text-muted-foreground">{gatedHelper}</p>
         ) : null}
         <div className="mt-auto flex items-center justify-between gap-3">
           <p className="text-xs text-muted-foreground">

--- a/backoffice/src/app/gc-fitness/clients/[id]/page.tsx
+++ b/backoffice/src/app/gc-fitness/clients/[id]/page.tsx
@@ -29,6 +29,7 @@ import {
   type CurrentTrainer,
 } from "@/lib/gc-fitness/auth-helpers";
 import { civilDateToday } from "@/lib/gc-fitness/civil-date";
+import { evaluateProgressPhotoCheckIn } from "@/lib/gc-fitness/progress-photo-checkin-policy";
 import { gcFitnessFirestore } from "@/lib/firebase/gc-fitness-admin";
 import { FirestoreCollections } from "@/lib/gc-fitness/collections";
 import { coachVisibleClientName } from "@/lib/gc-fitness/client-name";
@@ -162,6 +163,20 @@ export default async function ClientDetailPage({
     client.progressPhotosRequestedAt ?? null,
     progressPhotos,
   );
+  // Issue #160 — derive the client's next-eligible check-in date from the photos
+  // already loaded above (no extra Firestore read). Once the client's baseline is
+  // complete (every used angle ≥2), the coach's "request progress photos" button
+  // stays disabled until that date — re-requesting before then can't help.
+  const progressPhotosCheckIn = evaluateProgressPhotoCheckIn(
+    progressPhotos.map((p) => ({
+      angle: p.angle,
+      checkInDate: p.checkInDate,
+      takenAt: p.takenAt,
+      createdAt: p.createdAt,
+    })),
+    todayCivil,
+    timezone,
+  );
   const tSkeleton = await getTranslations("clients.detail.skeleton");
 
   return (
@@ -198,6 +213,8 @@ export default async function ClientDetailPage({
         bodyWeightRequestedAt={client.bodyWeightRequestedAt ?? null}
         progressPhotosFulfilled={progressPhotosFulfilled}
         bodyWeightFulfilled={bodyWeightFulfilled}
+        progressPhotosCheckInEligible={progressPhotosCheckIn.isEligible}
+        progressPhotosNextEligibleDate={progressPhotosCheckIn.nextEligibleDate}
       />
 
       <div className="grid grid-cols-1 gap-6 xl:grid-cols-2">

--- a/backoffice/src/app/gc-fitness/clients/[id]/page.tsx
+++ b/backoffice/src/app/gc-fitness/clients/[id]/page.tsx
@@ -165,8 +165,8 @@ export default async function ClientDetailPage({
   );
   // Issue #160 — derive the client's next-eligible check-in date from the photos
   // already loaded above (no extra Firestore read). Once the client's baseline is
-  // complete (every used angle ≥2), the coach's "request progress photos" button
-  // stays disabled until that date — re-requesting before then can't help.
+  // complete (ANY angle group ≥2 photos), the coach's "request progress photos"
+  // button stays disabled until that date — re-requesting before then can't help.
   const progressPhotosCheckIn = evaluateProgressPhotoCheckIn(
     progressPhotos.map((p) => ({
       angle: p.angle,

--- a/backoffice/src/lib/gc-fitness/__tests__/client-request-actions.test.ts
+++ b/backoffice/src/lib/gc-fitness/__tests__/client-request-actions.test.ts
@@ -14,7 +14,7 @@ describe("client-request-actions", () => {
     expect(status.isActive).toBe(false);
   });
 
-  it("keeps the request active for three days", () => {
+  it("keeps the request active for seven days", () => {
     const requestedAt = new Date("2026-06-02T15:00:00.000Z");
     const status = getClientRequestStatus(requestedAt, now);
 
@@ -26,7 +26,7 @@ describe("client-request-actions", () => {
   });
 
   it("turns inactive after the TTL passes", () => {
-    const requestedAt = new Date("2026-05-30T15:00:00.000Z");
+    const requestedAt = new Date("2026-05-26T15:00:00.000Z");
     const status = getClientRequestStatus(requestedAt, now);
 
     expect(status.requestedAt?.toISOString()).toBe(requestedAt.toISOString());

--- a/backoffice/src/lib/gc-fitness/__tests__/progress-photo-checkin-policy.test.ts
+++ b/backoffice/src/lib/gc-fitness/__tests__/progress-photo-checkin-policy.test.ts
@@ -1,0 +1,125 @@
+// progress-photo-checkin-policy.test.ts
+//
+// Twin suite for the progress-photo weekly check-in gate (issue #160). The SAME fixtures +
+// expected outputs are mirrored in the iOS Swift Testing suite and the Android jUnit suite.
+// Identical output for identical input is the load-bearing parity invariant.
+
+import {
+  addCivilDays,
+  evaluateProgressPhotoCheckIn,
+  type ProgressPhotoCheckInInput,
+} from "../progress-photo-checkin-policy";
+
+const tz = "UTC";
+
+function photo(angle: string | null, checkInDate: string | null): ProgressPhotoCheckInInput {
+  return { angle, checkInDate };
+}
+
+describe("evaluateProgressPhotoCheckIn (issue #160)", () => {
+  it("empty list → baseline incomplete, eligible, no next date", () => {
+    const r = evaluateProgressPhotoCheckIn([], "2026-06-10", tz);
+    expect(r.baselineComplete).toBe(false);
+    expect(r.lastCheckInDate).toBeNull();
+    expect(r.nextEligibleDate).toBeNull();
+    expect(r.isEligible).toBe(true);
+  });
+
+  it("one angle x1 → baseline incomplete → eligible", () => {
+    const r = evaluateProgressPhotoCheckIn([photo("front", "2026-06-10")], "2026-06-10", tz);
+    expect(r.baselineComplete).toBe(false);
+    expect(r.isEligible).toBe(true);
+  });
+
+  it("front x2 only → baseline complete → gated; next = last + 7", () => {
+    const r = evaluateProgressPhotoCheckIn(
+      [photo("front", "2026-06-10"), photo("front", "2026-06-10")],
+      "2026-06-10",
+      tz,
+    );
+    expect(r.baselineComplete).toBe(true);
+    expect(r.lastCheckInDate).toBe("2026-06-10");
+    expect(r.nextEligibleDate).toBe("2026-06-17");
+    expect(r.isEligible).toBe(false);
+  });
+
+  it("front x2 + side x1 → baseline INCOMPLETE (side stuck at 1) → eligible", () => {
+    const r = evaluateProgressPhotoCheckIn(
+      [photo("front", "2026-06-10"), photo("front", "2026-06-10"), photo("side", "2026-06-10")],
+      "2026-06-10",
+      tz,
+    );
+    expect(r.baselineComplete).toBe(false);
+    expect(r.isEligible).toBe(true);
+  });
+
+  it("all angles x2, last check-in 6 days ago → gated, not eligible", () => {
+    const photos = [
+      photo("front", "2026-06-04"),
+      photo("front", "2026-06-04"),
+      photo("side", "2026-06-04"),
+      photo("side", "2026-06-04"),
+      photo("back", "2026-06-04"),
+      photo("back", "2026-06-04"),
+    ];
+    const r = evaluateProgressPhotoCheckIn(photos, "2026-06-10", tz);
+    expect(r.baselineComplete).toBe(true);
+    expect(r.lastCheckInDate).toBe("2026-06-04");
+    expect(r.nextEligibleDate).toBe("2026-06-11");
+    expect(r.isEligible).toBe(false);
+  });
+
+  it("all angles x2, last check-in exactly 7 days ago → eligible", () => {
+    const photos = [
+      photo("front", "2026-06-03"),
+      photo("front", "2026-06-03"),
+      photo("side", "2026-06-03"),
+      photo("side", "2026-06-03"),
+      photo("back", "2026-06-03"),
+      photo("back", "2026-06-03"),
+    ];
+    const r = evaluateProgressPhotoCheckIn(photos, "2026-06-10", tz);
+    expect(r.baselineComplete).toBe(true);
+    expect(r.nextEligibleDate).toBe("2026-06-10");
+    expect(r.isEligible).toBe(true);
+  });
+
+  it("missing checkInDate falls back to civil date of takenAt ?? createdAt", () => {
+    const withTaken: ProgressPhotoCheckInInput = {
+      angle: "front",
+      takenAt: "2026-06-04T15:00:00Z",
+    };
+    const withCreated: ProgressPhotoCheckInInput = {
+      angle: "front",
+      createdAt: "2026-06-04T09:00:00Z",
+    };
+    const r = evaluateProgressPhotoCheckIn([withTaken, withCreated], "2026-06-10", tz);
+    expect(r.baselineComplete).toBe(true);
+    expect(r.lastCheckInDate).toBe("2026-06-04");
+    expect(r.nextEligibleDate).toBe("2026-06-11");
+  });
+
+  it("mixed dates → lastCheckInDate is the MAX civil date", () => {
+    const photos = [
+      photo("front", "2026-06-01"),
+      photo("front", "2026-06-08"),
+      photo("side", "2026-06-03"),
+      photo("side", "2026-06-05"),
+    ];
+    const r = evaluateProgressPhotoCheckIn(photos, "2026-06-20", tz);
+    expect(r.baselineComplete).toBe(true);
+    expect(r.lastCheckInDate).toBe("2026-06-08");
+    expect(r.nextEligibleDate).toBe("2026-06-15");
+    expect(r.isEligible).toBe(true);
+  });
+});
+
+describe("addCivilDays", () => {
+  it("crosses month boundary", () => {
+    expect(addCivilDays("2026-06-28", 7)).toBe("2026-07-05");
+  });
+
+  it("crosses year boundary", () => {
+    expect(addCivilDays("2026-12-31", 7)).toBe("2027-01-07");
+  });
+});

--- a/backoffice/src/lib/gc-fitness/__tests__/progress-photo-checkin-policy.test.ts
+++ b/backoffice/src/lib/gc-fitness/__tests__/progress-photo-checkin-policy.test.ts
@@ -43,13 +43,26 @@ describe("evaluateProgressPhotoCheckIn (issue #160)", () => {
     expect(r.isEligible).toBe(false);
   });
 
-  it("front x2 + side x1 → baseline INCOMPLETE (side stuck at 1) → eligible", () => {
+  it("front x2 + side x1 → baseline COMPLETE (front reached 2) → gated", () => {
     const r = evaluateProgressPhotoCheckIn(
       [photo("front", "2026-06-10"), photo("front", "2026-06-10"), photo("side", "2026-06-10")],
       "2026-06-10",
       tz,
     );
+    expect(r.baselineComplete).toBe(true);
+    expect(r.lastCheckInDate).toBe("2026-06-10");
+    expect(r.nextEligibleDate).toBe("2026-06-17");
+    expect(r.isEligible).toBe(false);
+  });
+
+  it("front x1 + side x1 + back x1 → no angle reached 2 → baseline incomplete → eligible", () => {
+    const r = evaluateProgressPhotoCheckIn(
+      [photo("front", "2026-06-10"), photo("side", "2026-06-10"), photo("back", "2026-06-10")],
+      "2026-06-10",
+      tz,
+    );
     expect(r.baselineComplete).toBe(false);
+    expect(r.nextEligibleDate).toBeNull();
     expect(r.isEligible).toBe(true);
   });
 

--- a/backoffice/src/lib/gc-fitness/client-request-state.ts
+++ b/backoffice/src/lib/gc-fitness/client-request-state.ts
@@ -1,4 +1,6 @@
-export const CLIENT_REQUEST_TTL_MS = 3 * 24 * 60 * 60 * 1000;
+// 7 days — matches the weekly progress-photo check-in window (#160) so the
+// request cooldown and the client's check-in gate use the same cadence.
+export const CLIENT_REQUEST_TTL_MS = 7 * 24 * 60 * 60 * 1000;
 
 export type ClientRequestKind = "progressPhotos" | "weight";
 

--- a/backoffice/src/lib/gc-fitness/progress-photo-checkin-policy.ts
+++ b/backoffice/src/lib/gc-fitness/progress-photo-checkin-policy.ts
@@ -1,0 +1,141 @@
+// progress-photo-checkin-policy.ts
+// Pure eligibility policy for the progress-photo weekly check-in gate (issue #160) —
+// TypeScript twin of iOS `ProgressPhotoCheckInPolicy` (GCFitnessCore) and the Android
+// Kotlin twin (`:core` progress/ProgressPhotoCheckInPolicy.kt).
+//
+// SAME-SOURCE-OF-TRUTH CONTRACT: any behavioral change here MUST be matched in the SAME
+// commit in the Swift + Kotlin twins, and the shared fixtures in all three test suites
+// must continue to agree.
+//
+// Firebase/React-free: takes plain values in, civil-date strings out, so the backoffice
+// computes the SAME next-eligible date from the `progressPhotos` it already loads — NO new
+// Firestore read, NO new denormalized field.
+//
+// Eligibility model (issue #160, LOCKED):
+//  - Baseline complete == at least one photo AND no used angle is stuck at exactly 1 (every
+//    angle the client has ANY photo of has >= 2). While baseline incomplete, uploads are FREE.
+//  - Once baseline complete: gate to one check-in per 7 days.
+//  - A "check-in" groups photos by civil date (`checkInDate ?? civilDate(takenAt ?? createdAt)`);
+//    the last check-in date is the MAX such civil date.
+//  - nextEligibleDate = lastCheckInDate + 7 days. isEligible = !baselineComplete || today >= next
+//    (lexicographic compare of zero-padded "YYYY-MM-DD").
+
+import { civilDateFormat } from "./civil-date";
+
+/** The gate window, in days, once a client's baseline is complete. */
+export const PROGRESS_PHOTO_GATE_DAYS = 7;
+
+/** One photo's eligibility-relevant inputs. Pure value type — no Firestore. */
+export interface ProgressPhotoCheckInInput {
+  angle?: string | null;
+  checkInDate?: string | null;
+  /** ISO instant string (or Date) for fallback grouping when checkInDate is absent. */
+  takenAt?: string | Date | null;
+  createdAt?: string | Date | null;
+}
+
+export interface ProgressPhotoCheckInResult {
+  baselineComplete: boolean;
+  lastCheckInDate: string | null;
+  nextEligibleDate: string | null;
+  isEligible: boolean;
+}
+
+/**
+ * Evaluate the weekly check-in gate over a list of photos.
+ *
+ * @param photos the client's progress photos (any order).
+ * @param today today's civil date "YYYY-MM-DD" in the client's timezone.
+ * @param timezone IANA zone used to derive a photo's civil date from its
+ *   `takenAt ?? createdAt` instant when `checkInDate` is absent.
+ */
+export function evaluateProgressPhotoCheckIn(
+  photos: readonly ProgressPhotoCheckInInput[],
+  today: string,
+  timezone: string,
+): ProgressPhotoCheckInResult {
+  if (photos.length === 0) {
+    return {
+      baselineComplete: false,
+      lastCheckInDate: null,
+      nextEligibleDate: null,
+      isEligible: true,
+    };
+  }
+
+  // Baseline: bucket counts by angle (null angle is its own "single" bucket, consistent with
+  // the `angle ?? "single"` upload convention).
+  const counts = new Map<string, number>();
+  for (const photo of photos) {
+    const bucket = photo.angle ?? "single";
+    counts.set(bucket, (counts.get(bucket) ?? 0) + 1);
+  }
+  const baselineComplete =
+    counts.size > 0 && ![...counts.values()].some((count) => count === 1);
+
+  // Last check-in date == MAX civil date across all photos.
+  let lastCheckInDate: string | null = null;
+  for (const photo of photos) {
+    const civil = civilDateForPhoto(photo, timezone);
+    if (!civil) continue;
+    if (lastCheckInDate === null || civil > lastCheckInDate) {
+      lastCheckInDate = civil;
+    }
+  }
+
+  const nextEligibleDate: string | null =
+    baselineComplete && lastCheckInDate
+      ? addCivilDays(lastCheckInDate, PROGRESS_PHOTO_GATE_DAYS)
+      : null;
+
+  let isEligible: boolean;
+  if (!baselineComplete) {
+    isEligible = true;
+  } else if (nextEligibleDate) {
+    isEligible = today >= nextEligibleDate;
+  } else {
+    // Baseline complete but no resolvable date — degrade open rather than lock out forever.
+    isEligible = true;
+  }
+
+  return { baselineComplete, lastCheckInDate, nextEligibleDate, isEligible };
+}
+
+// MARK: - Helpers
+
+/**
+ * A photo's civil date: explicit `checkInDate`, else the civil date of
+ * `takenAt ?? createdAt` in the given zone, else null.
+ */
+function civilDateForPhoto(
+  photo: ProgressPhotoCheckInInput,
+  timezone: string,
+): string | null {
+  if (photo.checkInDate) return photo.checkInDate;
+  const instant = toDate(photo.takenAt) ?? toDate(photo.createdAt);
+  if (!instant) return null;
+  return civilDateFormat(instant, timezone);
+}
+
+function toDate(value: string | Date | null | undefined): Date | null {
+  if (!value) return null;
+  const date = value instanceof Date ? value : new Date(value);
+  return Number.isNaN(date.getTime()) ? null : date;
+}
+
+/**
+ * Add `days` to a "YYYY-MM-DD" civil date via UTC date math. The input has no time
+ * component, so anchoring at UTC noon makes the day shift DST-independent. Returns the
+ * input unchanged on malformed input (defensive — callers pass well-formed civil dates).
+ */
+export function addCivilDays(civilDate: string, days: number): string {
+  const [yearText, monthText, dayText] = civilDate.split("-");
+  const year = Number.parseInt(yearText ?? "", 10);
+  const month = Number.parseInt(monthText ?? "", 10);
+  const day = Number.parseInt(dayText ?? "", 10);
+  if (!year || !month || !day) return civilDate;
+
+  const base = new Date(Date.UTC(year, month - 1, day, 12, 0, 0));
+  base.setUTCDate(base.getUTCDate() + days);
+  return civilDateFormat(base, "UTC");
+}

--- a/backoffice/src/lib/gc-fitness/progress-photo-checkin-policy.ts
+++ b/backoffice/src/lib/gc-fitness/progress-photo-checkin-policy.ts
@@ -12,8 +12,9 @@
 // Firestore read, NO new denormalized field.
 //
 // Eligibility model (issue #160, LOCKED):
-//  - Baseline complete == at least one photo AND no used angle is stuck at exactly 1 (every
-//    angle the client has ANY photo of has >= 2). While baseline incomplete, uploads are FREE.
+//  - Baseline complete == ANY angle group has >= 2 photos. As soon as a single angle (e.g.
+//    front) reaches 2 photos, the weekly gate applies. While NO angle has reached 2, uploads
+//    are FREE. (front x2 + side x1 -> GATED; front x1 + side x1 + back x1 -> FREE.)
 //  - Once baseline complete: gate to one check-in per 7 days.
 //  - A "check-in" groups photos by civil date (`checkInDate ?? civilDate(takenAt ?? createdAt)`);
 //    the last check-in date is the MAX such civil date.
@@ -70,8 +71,7 @@ export function evaluateProgressPhotoCheckIn(
     const bucket = photo.angle ?? "single";
     counts.set(bucket, (counts.get(bucket) ?? 0) + 1);
   }
-  const baselineComplete =
-    counts.size > 0 && ![...counts.values()].some((count) => count === 1);
+  const baselineComplete = [...counts.values()].some((count) => count >= 2);
 
   // Last check-in date == MAX civil date across all photos.
   let lastCheckInDate: string | null = null;


### PR DESCRIPTION
Backoffice half of mdb1/gc-fitness#160 (mobile half: mdb1/gc-fitness#234).

## What
- New TS twin `progress-photo-checkin-policy.ts` (`evaluateProgressPhotoCheckIn(photos, todayCivil, timezone)`) — identical logic + fixtures to the Swift/Kotlin twins: baseline = every used angle has ≥2 photos; after baseline, next check-in = last check-in civil date + 7 days.
- Client detail page computes eligibility from the `progressPhotos` it ALREADY loads (zero extra Firestore reads) and passes it to `ClientRequestActionsCard`.
- The PHOTOS request row only: when the client is gated, the "request progress photos" button is disabled with a helper naming the next-eligible date — EN "Next check-in available on {date}" / ES "Próximo check-in disponible el {date}". Weight request row and the existing active-request disable logic untouched.

## Test gates (all green)
- New policy suite: 10/10
- Full jest: 487 pass / 488 (the 1 fail is the documented pre-existing `client-activity-time` locale flake — green in CI)
- `tsc --noEmit`: clean

## How to test
Open a client whose photos satisfy the baseline (every used angle ≥2) with the latest check-in <7 days ago → the photos request button is disabled with the date helper. A client missing baseline (e.g. one angle with a single photo) keeps the button enabled.