### PR TITLE
fix(backoffice): apply theme pre-paint to kill dark-mode light flash (#168)

### DIFF
--- a/backoffice/src/app/layout.tsx
+++ b/backoffice/src/app/layout.tsx
@@ -25,6 +25,18 @@ export const metadata: Metadata = {
     "Pocket Genes Admin moderation console for accounts, community, reports, and learning operations.",
 };
 
+// Pre-paint theme script (issue #168). The base `:root` tokens are DARK and
+// the light palette only applies under `html[data-theme="light"]`, so the
+// document MUST carry the right data-theme before first paint. Previously the
+// attribute was hardcoded to "light" in the SSR HTML and corrected in a
+// post-hydration useEffect (ThemeBootstrap) — every full document load (new
+// tab, reload, login redirect) painted ~0.5s of light mode for dark-mode
+// users. This script runs synchronously in <head>, before any paint, reading
+// the same localStorage keys ThemeBootstrap uses ("gc-fitness-appearance"
+// first, then the Pocket Genes key). The attribute is no longer rendered by
+// React, so RSC refreshes can't stomp the runtime value back to light.
+const themeInitScript = `(function(){var t="light";try{var s=localStorage.getItem("gc-fitness-appearance")||localStorage.getItem("pocket-genes-admin-appearance");if(s==="dark"||s==="light")t=s;}catch(e){}var d=document.documentElement;d.dataset.theme=t;d.style.colorScheme=t;d.classList.toggle("dark",t==="dark");})();`;
+
 export default function RootLayout({
   children,
 }: Readonly<{
@@ -33,10 +45,12 @@ export default function RootLayout({
   return (
     <html
       lang="en"
-      data-theme="light"
       suppressHydrationWarning
       className={`${publicSans.variable} ${spaceGrotesk.variable} ${ibmPlexMono.variable}`}
     >
+      <head>
+        <script dangerouslySetInnerHTML={{ __html: themeInitScript }} />
+      </head>
       <body className="font-sans antialiased">
         <ThemeBootstrap />
         {children}


### PR DESCRIPTION
## Issue
Fixes mdb1/gc-fitness#168 — in dark mode, page changes showed ~0.5 s of light mode.

## Root cause
The base `:root` CSS tokens are dark and the light palette applies under `html[data-theme="light"]` — but the root layout **hardcoded `data-theme="light"` into the SSR HTML**, and the correction to the stored appearance only ran in a post-hydration `useEffect` (`ThemeBootstrap`). Every full document load (new tab, reload, login redirect, hard navigation) therefore painted light first and flipped to dark ~0.5 s later.

## Fix
- Inject a tiny synchronous script in `<head>` that reads the stored appearance (`gc-fitness-appearance`, falling back to the Pocket Genes key) and sets `data-theme` / `color-scheme` / `.dark` **before first paint** — the standard next-themes-style bootstrap.
- Stop rendering `data-theme` from React entirely, so an RSC re-render/`router.refresh()` can never stomp the runtime value back to `"light"`.

`ThemeBootstrap` stays (it also syncs language and remains idempotent for the theme).

## Test gate
`npx jest` → 488 passed, 1 failed: `client-activity-time.test.ts` — the **pre-existing local locale flake** (fails on non-en-US machines, green in CI; unrelated to this change).