### PR TITLE
fix(backoffice): make live-session start atomic to prevent duplicate sessions (#169)

### DIFF
--- a/backoffice/src/lib/gc-fitness/__tests__/live-workout-actions.start-dedupe.test.ts
+++ b/backoffice/src/lib/gc-fitness/__tests__/live-workout-actions.start-dedupe.test.ts
@@ -1,0 +1,223 @@
+// __tests__/live-workout-actions.start-dedupe.test.ts
+//
+// Issue #169 — multiple live sessions of the same workout could be created.
+// `startWorkoutSession` used a read-then-write idempotency check: two
+// concurrent starts (double click, two tabs, page render + client retry)
+// both saw "no active log" and each created one. The fix moves the
+// existing-active query AND the create into one `runTransaction`, and
+// self-heals pre-existing duplicates (keeps the freshest active log,
+// abandons the rest).
+//
+// The mock Firestore below serializes `runTransaction` bodies through a
+// mutex chain — the same guarantee (one committed txn at a time) the real
+// server gives. If the create ever moves back OUTSIDE the transaction, the
+// concurrency test fails with two created logs.
+
+const mockState: { db: MockDb | null } = { db: null };
+
+jest.mock("@/lib/firebase/gc-fitness-admin", () => ({
+  gcFitnessFirestore: () => mockState.db,
+  gcFitnessStorage: () => {
+    throw new Error("storage not used in this test");
+  },
+}));
+jest.mock("@/lib/gc-fitness/auth-helpers", () => ({
+  getCurrentTrainer: jest.fn(async () => ({ uid: "t1", email: "t@x.com" })),
+}));
+jest.mock("@/lib/gc-fitness/trainer-timezone", () => ({
+  getTrainerTimezone: jest.fn(async () => "UTC"),
+}));
+
+import { startWorkoutSession } from "../live-workout-actions";
+
+// ── In-memory Firestore mock ──────────────────────────────────────────────
+
+type DocData = Record<string, unknown>;
+
+class MockDocRef {
+  constructor(
+    private store: Map<string, DocData>,
+    public readonly id: string,
+  ) {}
+  async get() {
+    const data = this.store.get(this.id);
+    return {
+      exists: data !== undefined,
+      id: this.id,
+      data: () => data,
+      ref: this,
+    };
+  }
+  async set(data: DocData) {
+    this.store.set(this.id, { ...data });
+  }
+  async update(patch: DocData) {
+    const current = this.store.get(this.id);
+    if (!current) throw new Error(`update on missing doc ${this.id}`);
+    this.store.set(this.id, { ...current, ...patch });
+  }
+}
+
+class MockQuery {
+  constructor(
+    private store: Map<string, DocData>,
+    private filters: Array<{ field: string; value: unknown }> = [],
+    private max: number | null = null,
+  ) {}
+  where(field: string, _op: string, value: unknown) {
+    return new MockQuery(this.store, [...this.filters, { field, value }], this.max);
+  }
+  limit(n: number) {
+    return new MockQuery(this.store, this.filters, n);
+  }
+  async get() {
+    let rows = [...this.store.entries()].filter(([, data]) =>
+      this.filters.every((f) => data[f.field] === f.value),
+    );
+    if (this.max !== null) rows = rows.slice(0, this.max);
+    const docs = rows.map(([id, data]) => ({
+      id,
+      data: () => data,
+      ref: new MockDocRef(this.store, id),
+      exists: true,
+    }));
+    return { docs, empty: docs.length === 0, size: docs.length };
+  }
+}
+
+class MockCollection extends MockQuery {
+  constructor(private colStore: Map<string, DocData>) {
+    super(colStore);
+  }
+  doc(id: string) {
+    return new MockDocRef(this.colStore, id);
+  }
+}
+
+class MockDb {
+  collections = new Map<string, Map<string, DocData>>();
+  private txnChain: Promise<unknown> = Promise.resolve();
+
+  collection(name: string) {
+    if (!this.collections.has(name)) this.collections.set(name, new Map());
+    return new MockCollection(this.collections.get(name)!);
+  }
+
+  // Serialized transactions: bodies run one-at-a-time (mutex chain), writes
+  // buffered and applied at commit — mirroring the server-side guarantee the
+  // fix relies on. A create issued OUTSIDE runTransaction bypasses the mutex
+  // and the concurrency test below catches the duplicate.
+  runTransaction<T>(fn: (tx: MockTxn) => Promise<T>): Promise<T> {
+    const run = this.txnChain.then(async () => {
+      const tx = new MockTxn();
+      const result = await fn(tx);
+      tx.commit();
+      return result;
+    });
+    this.txnChain = run.catch(() => undefined);
+    return run;
+  }
+}
+
+class MockTxn {
+  private writes: Array<() => void> = [];
+  async get(target: MockQuery | MockDocRef) {
+    return target.get();
+  }
+  set(ref: MockDocRef, data: DocData) {
+    this.writes.push(() => void ref.set(data));
+  }
+  update(ref: MockDocRef, patch: DocData) {
+    this.writes.push(() => void ref.update(patch));
+  }
+  commit() {
+    for (const w of this.writes) w();
+  }
+}
+
+// ── Fixtures ──────────────────────────────────────────────────────────────
+
+const ASSIGNMENT_ID = "asg-1";
+
+function seedAssignment(db: MockDb, status = "scheduled") {
+  db.collection("workout_assignments");
+  db.collections.get("workout_assignments")!.set(ASSIGNMENT_ID, {
+    trainerId: "t1",
+    clientId: "c1",
+    status,
+    scheduledFor: "2026-06-11",
+    templateSnapshot: { name: { en: "Push Day", es: "Día de empuje" }, exercises: [] },
+  });
+}
+
+function activeLogs(db: MockDb) {
+  return [...(db.collections.get("workout_logs") ?? new Map()).entries()].filter(
+    ([, d]) => d.status === "active" && d.assignment_id === ASSIGNMENT_ID,
+  );
+}
+
+beforeEach(() => {
+  mockState.db = new MockDb();
+});
+
+// ── Tests ─────────────────────────────────────────────────────────────────
+
+describe("startWorkoutSession dedupe (issue #169)", () => {
+  test("first start creates exactly one active log and marks assignment started", async () => {
+    const db = mockState.db!;
+    seedAssignment(db);
+    const session = await startWorkoutSession({ assignmentId: ASSIGNMENT_ID });
+    expect(session.status).toBe("active");
+    expect(activeLogs(db)).toHaveLength(1);
+    expect(db.collections.get("workout_assignments")!.get(ASSIGNMENT_ID)!.status).toBe(
+      "started",
+    );
+  });
+
+  test("second start reuses the existing active log instead of creating another", async () => {
+    const db = mockState.db!;
+    seedAssignment(db);
+    const first = await startWorkoutSession({ assignmentId: ASSIGNMENT_ID });
+    const second = await startWorkoutSession({ assignmentId: ASSIGNMENT_ID });
+    expect(second.logId).toBe(first.logId);
+    expect(activeLogs(db)).toHaveLength(1);
+  });
+
+  test("CONCURRENT starts produce exactly one active log (the #169 race)", async () => {
+    const db = mockState.db!;
+    seedAssignment(db);
+    const [a, b] = await Promise.all([
+      startWorkoutSession({ assignmentId: ASSIGNMENT_ID }),
+      startWorkoutSession({ assignmentId: ASSIGNMENT_ID }),
+    ]);
+    expect(activeLogs(db)).toHaveLength(1);
+    expect(a.logId).toBe(b.logId);
+  });
+
+  test("self-heals pre-existing duplicates: keeps freshest, abandons the rest", async () => {
+    const db = mockState.db!;
+    seedAssignment(db, "started");
+    const logs = db.collection("workout_logs");
+    void logs; // ensure collection exists
+    const logStore = db.collections.get("workout_logs")!;
+    const base = {
+      trainerId: "t1",
+      clientId: "c1",
+      source: "coach",
+      assignment_id: ASSIGNMENT_ID,
+      templateSnapshot: {},
+      status: "active",
+      sets: [],
+      prs: [],
+    };
+    logStore.set("stale-log", { ...base, updatedAt: { toMillis: () => 1000 } });
+    logStore.set("fresh-log", { ...base, updatedAt: { toMillis: () => 2000 } });
+
+    const session = await startWorkoutSession({ assignmentId: ASSIGNMENT_ID });
+
+    expect(session.logId).toBe("fresh-log");
+    expect(activeLogs(db)).toHaveLength(1);
+    expect(logStore.get("stale-log")!.status).toBe("abandoned");
+    expect(logStore.get("fresh-log")!.status).toBe("active");
+  });
+});

--- a/backoffice/src/lib/gc-fitness/live-workout-actions.ts
+++ b/backoffice/src/lib/gc-fitness/live-workout-actions.ts
@@ -458,71 +458,90 @@ export async function startWorkoutSession(
   );
 
   // Idempotent: reuse an existing active log for this assignment.
-  const existing = await db
-    .collection(LOGS)
-    .where("assignment_id", "==", assignmentId)
-    .where("status", "==", "active")
-    .limit(1)
-    .get();
+  //
+  // Issue #169 — the existing-active check and the create MUST be one atomic
+  // unit. The previous read-then-write let two concurrent starts (double
+  // click, page render + client-hook retry, two tabs) BOTH observe "no active
+  // log" and each create one — the sidebar then listed N live sessions of the
+  // same workout. Firestore server transactions serialize the query against
+  // concurrent commits: the loser retries, sees the winner's log, and reuses
+  // it. While here, self-heal any duplicates that already exist: keep the
+  // most recently updated active log (the one the coach is actually driving)
+  // and abandon the rest.
+  const now = FieldValue.serverTimestamp();
+  const candidateLogId = randomUUID();
+  const newLogData = {
+    clientId: asg.clientId,
+    trainerId: trainer.uid,
+    source: "coach",
+    assignment_id: assignmentId,
+    templateSnapshot: asg.templateSnapshot ?? {},
+    status: "active",
+    sets: [],
+    prs: [],
+    startedAt: now,
+    createdAt: now,
+    updatedAt: now,
+  };
 
-  if (!existing.empty) {
-    const doc = existing.docs[0];
-    if (asg.status === "scheduled") {
-      await asgRef.update({
-        status: "started",
-        updatedAt: FieldValue.serverTimestamp(),
+  const reused = await db.runTransaction(async (tx) => {
+    const existing = await tx.get(
+      db
+        .collection(LOGS)
+        .where("assignment_id", "==", assignmentId)
+        .where("status", "==", "active"),
+    );
+
+    const markStarted = () => {
+      if (asg.status === "scheduled") {
+        tx.update(asgRef, { status: "started", updatedAt: now });
+      }
+    };
+
+    if (!existing.empty) {
+      const byFreshness = [...existing.docs].sort((a, b) => {
+        const ms = (d: (typeof existing.docs)[number]) => {
+          const u = (d.data() as Record<string, unknown>).updatedAt as
+            | { toMillis?: () => number }
+            | undefined;
+          return u?.toMillis?.() ?? 0;
+        };
+        return ms(b) - ms(a);
       });
+      const keeper = byFreshness[0];
+      for (const dup of byFreshness.slice(1)) {
+        tx.update(dup.ref, {
+          status: "abandoned",
+          updatedAt: FieldValue.serverTimestamp(),
+        });
+      }
+      markStarted();
+      return { id: keeper.id, data: keeper.data() as Record<string, unknown> };
     }
+
+    tx.set(db.collection(LOGS).doc(candidateLogId), newLogData);
+    markStarted();
+    return null;
+  });
+
+  if (reused) {
     return buildActiveSession(
-      doc.id,
+      reused.id,
       assignmentId,
       asg,
-      doc.data(),
+      reused.data,
       { resolveMedia: false },
     );
   }
 
-  const logId = randomUUID();
-  const now = FieldValue.serverTimestamp();
-  await db
-    .collection(LOGS)
-      .doc(logId)
-      .set({
-        clientId: asg.clientId,
-        trainerId: trainer.uid,
-        source: "coach",
-        assignment_id: assignmentId,
-        templateSnapshot: asg.templateSnapshot ?? {},
-        status: "active",
-      sets: [],
-      prs: [],
-      startedAt: now,
-      createdAt: now,
-      updatedAt: now,
-    });
-
-  if (asg.status === "scheduled") {
-    await asgRef.update({ status: "started", updatedAt: now });
-  }
+  const logId = candidateLogId;
 
   // Re-read the just-written log so startedAt resolves to a real instant.
   return buildActiveSession(
     logId,
     assignmentId,
     asg,
-    {
-      clientId: asg.clientId,
-      trainerId: trainer.uid,
-      source: "coach",
-      assignment_id: assignmentId,
-      templateSnapshot: asg.templateSnapshot ?? {},
-      status: "active",
-      sets: [],
-      prs: [],
-      startedAt: now,
-      createdAt: now,
-      updatedAt: now,
-    } as Record<string, unknown>,
+    newLogData as Record<string, unknown>,
     { resolveMedia: false },
     new Date().toISOString(),
   );


### PR DESCRIPTION
## Issue
Fixes mdb1/gc-fitness#169 — multiple live sessions of the same workout could be created (sidebar showed 4 "Workout en vivo" entries for the same entrenamiento).

## Root cause
`startWorkoutSession` used a **read-then-write** idempotency check: query for an active `workout_logs` doc for the assignment, create one if none found. Two concurrent starts (double click, two tabs, page render + client-hook retry) both saw "no active log" and each created one. Nothing ever cleaned the extras up, so they accumulated in the live-workout sidebar feed.

## Fix
- Moved the existing-active query AND the create into a single `db.runTransaction` (same pattern `cancelWorkoutSession` already uses). Firestore server transactions serialize the query against concurrent commits — the losing start retries, sees the winner's log, and reuses it.
- **Self-heal:** if duplicates already exist (like the ones in the screenshot), the next start keeps the most-recently-updated active log and marks the rest `abandoned`, so prod cleans itself the next time the coach opens the session.

## Tests
New `live-workout-actions.start-dedupe.test.ts` (4 tests): single create, reuse on second start, **concurrent starts produce exactly one log**, and duplicate self-healing. The mock serializes transaction bodies the way the real server does — if the create ever moves back outside the transaction, the concurrency test fails.

## Test gate
`npx jest` → 492 passed, 1 failed: `client-activity-time.test.ts` — pre-existing local locale flake (green in CI). `tsc --noEmit` clean.