### PR TITLE
feat(backoffice): localized per-section browser tab titles (#170)

### DIFF
--- a/backoffice/src/app/gc-fitness/admin/app-config/page.tsx
+++ b/backoffice/src/app/gc-fitness/admin/app-config/page.tsx
@@ -9,6 +9,10 @@ import {
 import { getCurrentAdmin } from "@/lib/gc-fitness/auth-helpers";
 import { PageHeader } from "@/components/gc-fitness/page-header";
 import { AppVersionForm } from "./app-version-form";
+import { sectionMetadata } from "@/lib/gc-fitness/page-metadata";
+
+// Tab title: "GC Fitness - <adminPanel>" (issue #170).
+export const generateMetadata = () => sectionMetadata("adminPanel");
 
 export const dynamic = "force-dynamic";
 

--- a/backoffice/src/app/gc-fitness/admin/coach-activity/page.tsx
+++ b/backoffice/src/app/gc-fitness/admin/coach-activity/page.tsx
@@ -14,6 +14,10 @@ import {
 } from "@/components/ui/table";
 import { getCurrentAdmin } from "@/lib/gc-fitness/auth-helpers";
 import { listRecentCoachActivity } from "@/lib/gc-fitness/admin-actions";
+import { sectionMetadata } from "@/lib/gc-fitness/page-metadata";
+
+// Tab title: "GC Fitness - <adminPanel>" (issue #170).
+export const generateMetadata = () => sectionMetadata("adminPanel");
 
 export const dynamic = "force-dynamic";
 

--- a/backoffice/src/app/gc-fitness/admin/coaches/[uid]/clients/[clientId]/page.tsx
+++ b/backoffice/src/app/gc-fitness/admin/coaches/[uid]/clients/[clientId]/page.tsx
@@ -41,6 +41,10 @@ import { PageHeader } from "@/components/gc-fitness/page-header";
 
 import { ClientRecentLogsFeed } from "@/app/gc-fitness/clients/[id]/_components/ClientRecentLogsFeed";
 import { ProgressPhotosGridClient } from "@/app/gc-fitness/clients/[id]/_components/ProgressPhotosGridClient";
+import { sectionMetadata } from "@/lib/gc-fitness/page-metadata";
+
+// Tab title: "GC Fitness - <adminPanel>" (issue #170).
+export const generateMetadata = () => sectionMetadata("adminPanel");
 
 export const dynamic = "force-dynamic";
 

--- a/backoffice/src/app/gc-fitness/admin/coaches/[uid]/clients/[clientId]/photos/page.tsx
+++ b/backoffice/src/app/gc-fitness/admin/coaches/[uid]/clients/[clientId]/photos/page.tsx
@@ -14,6 +14,10 @@ import { FirestoreCollections } from "@/lib/gc-fitness/collections";
 import { listProgressPhotosForClientAsAdmin } from "@/lib/gc-fitness/progress-photo-actions";
 import { gcFitnessFirestore } from "@/lib/firebase/gc-fitness-admin";
 import { ProgressPhotoCompareEditor } from "@/app/gc-fitness/clients/[id]/compare-photos/photo-compare-editor";
+import { sectionMetadata } from "@/lib/gc-fitness/page-metadata";
+
+// Tab title: "GC Fitness - <adminPanel>" (issue #170).
+export const generateMetadata = () => sectionMetadata("adminPanel");
 
 export const dynamic = "force-dynamic";
 

--- a/backoffice/src/app/gc-fitness/admin/coaches/[uid]/clients/[clientId]/workouts/[logId]/page.tsx
+++ b/backoffice/src/app/gc-fitness/admin/coaches/[uid]/clients/[clientId]/workouts/[logId]/page.tsx
@@ -11,6 +11,10 @@ import { Badge } from "@/components/ui/badge";
 import { getCurrentAdmin } from "@/lib/gc-fitness/auth-helpers";
 import { getWorkoutLogDetailAsAdmin } from "@/lib/gc-fitness/recent-logs-actions";
 import { WorkoutLogDetailView } from "@/components/gc-fitness/workout-log-detail-view";
+import { sectionMetadata } from "@/lib/gc-fitness/page-metadata";
+
+// Tab title: "GC Fitness - <adminPanel>" (issue #170).
+export const generateMetadata = () => sectionMetadata("adminPanel");
 
 export const dynamic = "force-dynamic";
 

--- a/backoffice/src/app/gc-fitness/admin/coaches/[uid]/page.tsx
+++ b/backoffice/src/app/gc-fitness/admin/coaches/[uid]/page.tsx
@@ -27,6 +27,10 @@ import {
   transferClientToCoach,
 } from "@/lib/gc-fitness/admin-actions";
 import { AdminSubmitButton } from "../../_components/admin-submit-button";
+import { sectionMetadata } from "@/lib/gc-fitness/page-metadata";
+
+// Tab title: "GC Fitness - <adminPanel>" (issue #170).
+export const generateMetadata = () => sectionMetadata("adminPanel");
 
 export const dynamic = "force-dynamic";
 

--- a/backoffice/src/app/gc-fitness/admin/hygiene/page.tsx
+++ b/backoffice/src/app/gc-fitness/admin/hygiene/page.tsx
@@ -8,6 +8,10 @@ import { getCurrentAdmin } from "@/lib/gc-fitness/auth-helpers";
 import { listDataHygienePage, type DataHygienePage } from "@/lib/gc-fitness/data-hygiene-actions";
 
 import { DataHygieneFeed } from "./DataHygieneFeed";
+import { sectionMetadata } from "@/lib/gc-fitness/page-metadata";
+
+// Tab title: "GC Fitness - <adminPanel>" (issue #170).
+export const generateMetadata = () => sectionMetadata("adminPanel");
 
 export const dynamic = "force-dynamic";
 

--- a/backoffice/src/app/gc-fitness/admin/page.tsx
+++ b/backoffice/src/app/gc-fitness/admin/page.tsx
@@ -25,6 +25,10 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/ui/table";
+import { sectionMetadata } from "@/lib/gc-fitness/page-metadata";
+
+// Tab title: "GC Fitness - <adminPanel>" (issue #170).
+export const generateMetadata = () => sectionMetadata("adminPanel");
 
 export const dynamic = "force-dynamic";
 

--- a/backoffice/src/app/gc-fitness/admin/users/page.tsx
+++ b/backoffice/src/app/gc-fitness/admin/users/page.tsx
@@ -18,6 +18,10 @@ import {
   type UserSearchResultRow,
 } from "@/lib/gc-fitness/admin-actions";
 import { getCurrentAdmin } from "@/lib/gc-fitness/auth-helpers";
+import { sectionMetadata } from "@/lib/gc-fitness/page-metadata";
+
+// Tab title: "GC Fitness - <adminPanel>" (issue #170).
+export const generateMetadata = () => sectionMetadata("adminPanel");
 
 export const dynamic = "force-dynamic";
 

--- a/backoffice/src/app/gc-fitness/chat/page.tsx
+++ b/backoffice/src/app/gc-fitness/chat/page.tsx
@@ -41,6 +41,10 @@ import {
 import { listClients } from "@/lib/gc-fitness/client-roster";
 import { getTrainerTimezone } from "@/lib/gc-fitness/trainer-timezone";
 import { ChatInboxClient } from "./client";
+import { sectionMetadata } from "@/lib/gc-fitness/page-metadata";
+
+// Tab title: "GC Fitness - <chat>" (issue #170).
+export const generateMetadata = () => sectionMetadata("chat");
 
 export const dynamic = "force-dynamic";
 

--- a/backoffice/src/app/gc-fitness/checklist/page.tsx
+++ b/backoffice/src/app/gc-fitness/checklist/page.tsx
@@ -6,6 +6,10 @@ import { getCurrentTrainer } from "@/lib/gc-fitness/auth-helpers";
 import { listCoachChecklistItems } from "@/lib/gc-fitness/coach-checklist-actions";
 import { listClients } from "@/lib/gc-fitness/client-roster";
 import { CoachChecklistClient } from "./CoachChecklistClient";
+import { sectionMetadata } from "@/lib/gc-fitness/page-metadata";
+
+// Tab title: "GC Fitness - <checklist>" (issue #170).
+export const generateMetadata = () => sectionMetadata("checklist");
 
 export const dynamic = "force-dynamic";
 

--- a/backoffice/src/app/gc-fitness/clients/[id]/compare-photos/page.tsx
+++ b/backoffice/src/app/gc-fitness/clients/[id]/compare-photos/page.tsx
@@ -8,6 +8,10 @@ import { FirestoreCollections } from "@/lib/gc-fitness/collections";
 import { gcFitnessFirestore } from "@/lib/firebase/gc-fitness-admin";
 import { listProgressPhotosForClient } from "@/lib/gc-fitness/progress-photo-actions";
 import { ProgressPhotoCompareEditor } from "./photo-compare-editor";
+import { sectionMetadata } from "@/lib/gc-fitness/page-metadata";
+
+// Tab title: "GC Fitness - <clients>" (issue #170).
+export const generateMetadata = () => sectionMetadata("clients");
 
 export const dynamic = "force-dynamic";
 

--- a/backoffice/src/app/gc-fitness/clients/[id]/page.tsx
+++ b/backoffice/src/app/gc-fitness/clients/[id]/page.tsx
@@ -54,6 +54,10 @@ import {
 } from "@/lib/gc-fitness/client-request-fulfillment";
 import { PendingClientPreload } from "./_components/PendingClientPreload";
 import { ClientSummaryCard } from "./_components/ClientSummaryCard";
+import { sectionMetadata } from "@/lib/gc-fitness/page-metadata";
+
+// Tab title: "GC Fitness - <clients>" (issue #170).
+export const generateMetadata = () => sectionMetadata("clients");
 
 export const dynamic = "force-dynamic";
 

--- a/backoffice/src/app/gc-fitness/clients/[id]/progress/page.tsx
+++ b/backoffice/src/app/gc-fitness/clients/[id]/progress/page.tsx
@@ -25,6 +25,10 @@ import { getClientExerciseProgress } from "@/lib/gc-fitness/exercise-progress-ac
 import { PageHeader } from "@/components/gc-fitness/page-header";
 import { addCivilDays } from "../_components/trend-range";
 import { ExerciseProgressClient } from "./ExerciseProgressClient";
+import { sectionMetadata } from "@/lib/gc-fitness/page-metadata";
+
+// Tab title: "GC Fitness - <clients>" (issue #170).
+export const generateMetadata = () => sectionMetadata("clients");
 
 export const dynamic = "force-dynamic";
 

--- a/backoffice/src/app/gc-fitness/clients/[id]/sessions/[assignmentId]/run/page.tsx
+++ b/backoffice/src/app/gc-fitness/clients/[id]/sessions/[assignmentId]/run/page.tsx
@@ -14,6 +14,10 @@ import {
 } from "@/lib/gc-fitness/live-workout-actions";
 
 import { ActiveWorkoutSession } from "./_components/active-workout-session";
+import { sectionMetadata } from "@/lib/gc-fitness/page-metadata";
+
+// Tab title: "GC Fitness - <activeWorkout>" (issue #170).
+export const generateMetadata = () => sectionMetadata("activeWorkout");
 
 export const dynamic = "force-dynamic";
 

--- a/backoffice/src/app/gc-fitness/clients/page.tsx
+++ b/backoffice/src/app/gc-fitness/clients/page.tsx
@@ -20,6 +20,10 @@ import { listClientsForRoster } from "@/lib/gc-fitness/client-roster";
 import { AddClientPanel } from "./_components/AddClientPanel";
 import { RosterTable } from "./_components/RosterTable";
 import { RosterQueryProvider } from "./providers";
+import { sectionMetadata } from "@/lib/gc-fitness/page-metadata";
+
+// Tab title: "GC Fitness - <clients>" (issue #170).
+export const generateMetadata = () => sectionMetadata("clients");
 
 export const dynamic = "force-dynamic";
 

--- a/backoffice/src/app/gc-fitness/clients/pending/[email]/page.tsx
+++ b/backoffice/src/app/gc-fitness/clients/pending/[email]/page.tsx
@@ -1,4 +1,8 @@
 import ClientDetailPage from "../../[id]/page";
+import { sectionMetadata } from "@/lib/gc-fitness/page-metadata";
+
+// Tab title: "GC Fitness - <clients>" (issue #170).
+export const generateMetadata = () => sectionMetadata("clients");
 
 export const dynamic = "force-dynamic";
 

--- a/backoffice/src/app/gc-fitness/dashboard/page.tsx
+++ b/backoffice/src/app/gc-fitness/dashboard/page.tsx
@@ -40,6 +40,10 @@ import {
   TopPerformers,
 } from "./_components/coach-pulse";
 import { ChecklistPending } from "./_components/checklist-pending";
+import { sectionMetadata } from "@/lib/gc-fitness/page-metadata";
+
+// Tab title: "GC Fitness - <dashboard>" (issue #170).
+export const generateMetadata = () => sectionMetadata("dashboard");
 
 export const dynamic = "force-dynamic";
 const ATTENTION_PAGE_SIZE = 10;

--- a/backoffice/src/app/gc-fitness/exercises/[id]/edit/page.tsx
+++ b/backoffice/src/app/gc-fitness/exercises/[id]/edit/page.tsx
@@ -24,6 +24,10 @@ import {
 import { gcFitnessFirestore } from "@/lib/firebase/gc-fitness-admin";
 import { ExerciseForm } from "../../_components/ExerciseForm";
 import type { ExerciseInput } from "@/lib/gc-fitness/exercise-schema";
+import { sectionMetadata } from "@/lib/gc-fitness/page-metadata";
+
+// Tab title: "GC Fitness - <exercises>" (issue #170).
+export const generateMetadata = () => sectionMetadata("exercises");
 
 export const dynamic = "force-dynamic";
 

--- a/backoffice/src/app/gc-fitness/exercises/[id]/view/page.tsx
+++ b/backoffice/src/app/gc-fitness/exercises/[id]/view/page.tsx
@@ -16,6 +16,10 @@ import {
 import { gcFitnessFirestore } from "@/lib/firebase/gc-fitness-admin";
 import { ExerciseForm } from "../../_components/ExerciseForm";
 import type { ExerciseInput } from "@/lib/gc-fitness/exercise-schema";
+import { sectionMetadata } from "@/lib/gc-fitness/page-metadata";
+
+// Tab title: "GC Fitness - <exercises>" (issue #170).
+export const generateMetadata = () => sectionMetadata("exercises");
 
 export const dynamic = "force-dynamic";
 

--- a/backoffice/src/app/gc-fitness/exercises/new/page.tsx
+++ b/backoffice/src/app/gc-fitness/exercises/new/page.tsx
@@ -8,6 +8,10 @@ import { getTranslations } from "next-intl/server";
 
 import { getCurrentTrainer } from "@/lib/gc-fitness/auth-helpers";
 import { ExerciseForm } from "../_components/ExerciseForm";
+import { sectionMetadata } from "@/lib/gc-fitness/page-metadata";
+
+// Tab title: "GC Fitness - <exercises>" (issue #170).
+export const generateMetadata = () => sectionMetadata("exercises");
 
 export const dynamic = "force-dynamic";
 

--- a/backoffice/src/app/gc-fitness/exercises/page.tsx
+++ b/backoffice/src/app/gc-fitness/exercises/page.tsx
@@ -2,6 +2,10 @@
 // The exercises LIST now lives under /gc-fitness/library?tab=exercises. The
 // create/edit/view routes are unaffected.
 import { redirect } from "next/navigation";
+import { sectionMetadata } from "@/lib/gc-fitness/page-metadata";
+
+// Tab title: "GC Fitness - <exercises>" (issue #170).
+export const generateMetadata = () => sectionMetadata("exercises");
 
 export const dynamic = "force-dynamic";
 

--- a/backoffice/src/app/gc-fitness/habits/[id]/edit/page.tsx
+++ b/backoffice/src/app/gc-fitness/habits/[id]/edit/page.tsx
@@ -25,6 +25,10 @@ import type {
   HabitType,
 } from "@/lib/gc-fitness/habit-schema";
 import { EditHabitClient } from "./client";
+import { sectionMetadata } from "@/lib/gc-fitness/page-metadata";
+
+// Tab title: "GC Fitness - <habits>" (issue #170).
+export const generateMetadata = () => sectionMetadata("habits");
 
 export const dynamic = "force-dynamic";
 

--- a/backoffice/src/app/gc-fitness/habits/[id]/page.tsx
+++ b/backoffice/src/app/gc-fitness/habits/[id]/page.tsx
@@ -29,6 +29,10 @@ import {
   ComplianceWidget,
   ComplianceWidgetSkeleton,
 } from "./_components/ComplianceWidget";
+import { sectionMetadata } from "@/lib/gc-fitness/page-metadata";
+
+// Tab title: "GC Fitness - <habits>" (issue #170).
+export const generateMetadata = () => sectionMetadata("habits");
 
 export const dynamic = "force-dynamic";
 

--- a/backoffice/src/app/gc-fitness/habits/new/page.tsx
+++ b/backoffice/src/app/gc-fitness/habits/new/page.tsx
@@ -8,6 +8,10 @@ import { redirect } from "next/navigation";
 
 import { getCurrentTrainer } from "@/lib/gc-fitness/auth-helpers";
 import { NewHabitClient } from "./client";
+import { sectionMetadata } from "@/lib/gc-fitness/page-metadata";
+
+// Tab title: "GC Fitness - <habits>" (issue #170).
+export const generateMetadata = () => sectionMetadata("habits");
 
 export const dynamic = "force-dynamic";
 

--- a/backoffice/src/app/gc-fitness/habits/page.tsx
+++ b/backoffice/src/app/gc-fitness/habits/page.tsx
@@ -2,6 +2,10 @@
 // The habits LIST now lives under /gc-fitness/library?tab=habits. The
 // create/edit/detail routes are unaffected.
 import { redirect } from "next/navigation";
+import { sectionMetadata } from "@/lib/gc-fitness/page-metadata";
+
+// Tab title: "GC Fitness - <habits>" (issue #170).
+export const generateMetadata = () => sectionMetadata("habits");
 
 export const dynamic = "force-dynamic";
 

--- a/backoffice/src/app/gc-fitness/layout.tsx
+++ b/backoffice/src/app/gc-fitness/layout.tsx
@@ -13,8 +13,15 @@ import { civilDateToday } from "@/lib/gc-fitness/civil-date";
 import { getTrainerTimezone } from "@/lib/gc-fitness/trainer-timezone";
 import { getCurrentGCFitnessUser } from "@/lib/gc-fitness/auth-helpers";
 
+// Issue #170 — tab titles. Pages export `generateMetadata` with their section
+// name (see lib/gc-fitness/page-metadata.ts); the template prefixes it so tabs
+// read "GC Fitness - Agenda", "GC Fitness - Inicio", etc. Pages without a
+// title (login, redirects) fall back to the default.
 export const metadata: Metadata = {
-  title: "GC Fitness Admin",
+  title: {
+    template: "GC Fitness - %s",
+    default: "GC Fitness Admin",
+  },
   description: "GC Fitness trainer backoffice.",
 };
 

--- a/backoffice/src/app/gc-fitness/library/page.tsx
+++ b/backoffice/src/app/gc-fitness/library/page.tsx
@@ -23,6 +23,10 @@ import { ExerciseQueryProvider } from "../exercises/providers";
 import { ExerciseLibraryClient } from "../exercises/client";
 import { HabitsQueryProvider } from "../habits/providers";
 import { HabitsLibraryClient } from "../habits/client";
+import { sectionMetadata } from "@/lib/gc-fitness/page-metadata";
+
+// Tab title: "GC Fitness - <library>" (issue #170).
+export const generateMetadata = () => sectionMetadata("library");
 
 export const dynamic = "force-dynamic";
 

--- a/backoffice/src/app/gc-fitness/my-activity/page.tsx
+++ b/backoffice/src/app/gc-fitness/my-activity/page.tsx
@@ -10,6 +10,10 @@ import {
   listMyCoachActivityPage,
 } from "@/lib/gc-fitness/coach-activity-actions";
 import { MyActivityFeed } from "./MyActivityFeed";
+import { sectionMetadata } from "@/lib/gc-fitness/page-metadata";
+
+// Tab title: "GC Fitness - <myActivity>" (issue #170).
+export const generateMetadata = () => sectionMetadata("myActivity");
 
 export const dynamic = "force-dynamic";
 

--- a/backoffice/src/app/gc-fitness/notifications/page.tsx
+++ b/backoffice/src/app/gc-fitness/notifications/page.tsx
@@ -35,6 +35,10 @@ import {
 import type { ActiveWorkoutSummary } from "@/lib/gc-fitness/live-workout-types";
 import { listRecentLogsForTrainerPage } from "@/lib/gc-fitness/recent-logs-actions";
 import { UpcomingWorkoutAlerts } from "@/components/gc-fitness/upcoming-workout-alerts";
+import { sectionMetadata } from "@/lib/gc-fitness/page-metadata";
+
+// Tab title: "GC Fitness - <notifications>" (issue #170).
+export const generateMetadata = () => sectionMetadata("notifications");
 
 export const dynamic = "force-dynamic";
 

--- a/backoffice/src/app/gc-fitness/recent-logs/page.tsx
+++ b/backoffice/src/app/gc-fitness/recent-logs/page.tsx
@@ -11,6 +11,10 @@ import {
 import { getTrainerTimezone } from "@/lib/gc-fitness/trainer-timezone";
 import { listClients } from "@/lib/gc-fitness/client-roster";
 import { RecentLogsFeed } from "./_components/RecentLogsFeed";
+import { sectionMetadata } from "@/lib/gc-fitness/page-metadata";
+
+// Tab title: "GC Fitness - <recentLogs>" (issue #170).
+export const generateMetadata = () => sectionMetadata("recentLogs");
 
 export const dynamic = "force-dynamic";
 

--- a/backoffice/src/app/gc-fitness/recent-logs/workouts/[logId]/page.tsx
+++ b/backoffice/src/app/gc-fitness/recent-logs/workouts/[logId]/page.tsx
@@ -7,10 +7,14 @@ import { Button } from "@/components/ui/button";
 import { ShareWorkoutCard } from "@/components/gc-fitness/share-workout-card";
 import { WorkoutLogDetailView } from "@/components/gc-fitness/workout-log-detail-view";
 import { getWorkoutLogDetail } from "@/lib/gc-fitness/recent-logs-actions";
+import { sectionMetadata } from "@/lib/gc-fitness/page-metadata";
 
 interface PageProps {
   params: Promise<{ logId: string }>;
 }
+
+// Tab title: "GC Fitness - <recentLogs>" (issue #170).
+export const generateMetadata = () => sectionMetadata("recentLogs");
 
 export const dynamic = "force-dynamic";
 

--- a/backoffice/src/app/gc-fitness/schedule/bulk/page.tsx
+++ b/backoffice/src/app/gc-fitness/schedule/bulk/page.tsx
@@ -18,6 +18,10 @@ import { listClients } from "@/lib/gc-fitness/client-roster";
 
 import { ScheduleQueryProvider } from "../providers";
 import { BulkAssignForm } from "@/components/gc-fitness/schedule/bulk-assign-form";
+import { sectionMetadata } from "@/lib/gc-fitness/page-metadata";
+
+// Tab title: "GC Fitness - <schedule>" (issue #170).
+export const generateMetadata = () => sectionMetadata("schedule");
 
 export const dynamic = "force-dynamic";
 

--- a/backoffice/src/app/gc-fitness/schedule/page.tsx
+++ b/backoffice/src/app/gc-fitness/schedule/page.tsx
@@ -18,6 +18,10 @@ import { listMonthForClients } from "@/lib/gc-fitness/schedule-month-actions";
 
 import { ScheduleQueryProvider } from "./providers";
 import { MonthCalendar } from "@/components/gc-fitness/schedule/month-calendar";
+import { sectionMetadata } from "@/lib/gc-fitness/page-metadata";
+
+// Tab title: "GC Fitness - <schedule>" (issue #170).
+export const generateMetadata = () => sectionMetadata("schedule");
 
 export const dynamic = "force-dynamic";
 

--- a/backoffice/src/app/gc-fitness/settings/page.tsx
+++ b/backoffice/src/app/gc-fitness/settings/page.tsx
@@ -35,6 +35,10 @@ import { PageHeader } from "@/components/gc-fitness/page-header";
 
 import { SettingsSections } from "./settings-sections";
 import { CoachProfileForm } from "./coach-profile-form";
+import { sectionMetadata } from "@/lib/gc-fitness/page-metadata";
+
+// Tab title: "GC Fitness - <settings>" (issue #170).
+export const generateMetadata = () => sectionMetadata("settings");
 
 export const dynamic = "force-dynamic";
 

--- a/backoffice/src/app/gc-fitness/templates/[id]/edit/page.tsx
+++ b/backoffice/src/app/gc-fitness/templates/[id]/edit/page.tsx
@@ -23,6 +23,10 @@ import { forkStandardWorkoutTemplate } from "@/lib/gc-fitness/workout-template-a
 import { ExerciseQueryProvider } from "../../../exercises/providers";
 import { TemplatesQueryProvider } from "../../providers";
 import { EditTemplateClient } from "./client";
+import { sectionMetadata } from "@/lib/gc-fitness/page-metadata";
+
+// Tab title: "GC Fitness - <workouts>" (issue #170).
+export const generateMetadata = () => sectionMetadata("workouts");
 
 export const dynamic = "force-dynamic";
 

--- a/backoffice/src/app/gc-fitness/templates/new/page.tsx
+++ b/backoffice/src/app/gc-fitness/templates/new/page.tsx
@@ -16,6 +16,10 @@ import { getCurrentTrainer } from "@/lib/gc-fitness/auth-helpers";
 import { ExerciseQueryProvider } from "../../exercises/providers";
 import { TemplatesQueryProvider } from "../providers";
 import { NewTemplateClient } from "./client";
+import { sectionMetadata } from "@/lib/gc-fitness/page-metadata";
+
+// Tab title: "GC Fitness - <workouts>" (issue #170).
+export const generateMetadata = () => sectionMetadata("workouts");
 
 export const dynamic = "force-dynamic";
 

--- a/backoffice/src/app/gc-fitness/templates/page.tsx
+++ b/backoffice/src/app/gc-fitness/templates/page.tsx
@@ -2,6 +2,10 @@
 // The workouts LIST now lives under /gc-fitness/library?tab=workouts. The
 // create/edit routes (templates/new, templates/[id]/edit) are unaffected.
 import { redirect } from "next/navigation";
+import { sectionMetadata } from "@/lib/gc-fitness/page-metadata";
+
+// Tab title: "GC Fitness - <workouts>" (issue #170).
+export const generateMetadata = () => sectionMetadata("workouts");
 
 export const dynamic = "force-dynamic";
 

--- a/backoffice/src/lib/gc-fitness/page-metadata.ts
+++ b/backoffice/src/lib/gc-fitness/page-metadata.ts
@@ -1,0 +1,15 @@
+// page-metadata.ts — per-section browser-tab titles (issue #170).
+//
+// Every gc-fitness page exports `generateMetadata = () => sectionMetadata(navKey)`
+// with the SAME `nav.*` translation key its sidebar entry uses, so the tab
+// reads "GC Fitness - <section>" in the trainer's language. The "GC Fitness - "
+// prefix comes from the title template in `src/app/gc-fitness/layout.tsx`;
+// pages only supply the section name.
+
+import type { Metadata } from "next";
+import { getTranslations } from "next-intl/server";
+
+export async function sectionMetadata(navKey: string): Promise<Metadata> {
+  const t = await getTranslations("nav");
+  return { title: t(navKey) };
+}


### PR DESCRIPTION
## Issue
Fixes mdb1/gc-fitness#170 — browser tabs all said "GC Fitness Admin"; they should identify the section ("GC Fitness - Dashboard", "GC Fitness - Agenda", …).

## Change
- `gc-fitness/layout.tsx` metadata now uses a **title template**: `"GC Fitness - %s"` with default `"GC Fitness Admin"` (login/redirect pages keep the default).
- New `lib/gc-fitness/page-metadata.ts` helper: `sectionMetadata(navKey)` resolves the page title from the **same `nav.*` next-intl keys the sidebar uses**, so titles are localized (es: "GC Fitness - Agenda", "GC Fitness - Inicio"; en: "GC Fitness - Schedule", …).
- Every gc-fitness page (37 pages) exports `generateMetadata` with its section key — nested pages inherit their section (e.g. exercise edit → "Ejercicios", live session → "Workout en vivo", admin subtree → "Admin Panel").

## Test gate
`npx next build` clean, `npx tsc --noEmit` clean, `npx jest` → 488 passed, 1 failed: pre-existing `client-activity-time` local locale flake (green in CI).