### PR TITLE
fix(backoffice): route active-workout exercise link directly, kill redirect chain (#171)

### DIFF
--- a/backoffice/src/app/gc-fitness/clients/[id]/sessions/[assignmentId]/run/_components/session-exercise-card.tsx
+++ b/backoffice/src/app/gc-fitness/clients/[id]/sessions/[assignmentId]/run/_components/session-exercise-card.tsx
@@ -254,8 +254,14 @@ export function SessionExerciseCard({
             title="Editar ejercicio en otra ventana"
             asChild
           >
+            {/* Issue #171 — enter at /view, not /edit. Nearly every workout
+                exercise is library-sourced (wger / free-exercise-db), for
+                which /edit always 307s to /view — a 2-hop chain of
+                force-dynamic SSR pages that flashed an error before landing.
+                /view renders library exercises directly (0 redirects) and
+                bounces trainer-owned ones to /edit (1 redirect, rare case). */}
             <a
-              href={`/gc-fitness/exercises/${exercise.exerciseId}/edit`}
+              href={`/gc-fitness/exercises/${exercise.exerciseId}/view`}
               target="_blank"
               rel="noopener noreferrer"
             >

--- a/backoffice/src/app/gc-fitness/exercises/[id]/edit/page.tsx
+++ b/backoffice/src/app/gc-fitness/exercises/[id]/edit/page.tsx
@@ -66,7 +66,10 @@ export default async function EditExercisePage({ params }: PageParams) {
   const db = gcFitnessFirestore();
   const snap = await db.collection("exercises").doc(id).get();
   if (!snap.exists) {
-    redirect("/gc-fitness/exercises");
+    // Straight to the Biblioteca tab — /gc-fitness/exercises is itself just a
+    // redirect to this URL, and chaining two 307s through force-dynamic pages
+    // was half of the issue-#171 error-flash window.
+    redirect("/gc-fitness/library?tab=exercises");
   }
   const data = snap.data() as Record<string, unknown> & {
     source?: string;

--- a/backoffice/src/app/gc-fitness/exercises/[id]/view/page.tsx
+++ b/backoffice/src/app/gc-fitness/exercises/[id]/view/page.tsx
@@ -58,7 +58,8 @@ export default async function ViewExercisePage({ params }: PageParams) {
   const db = gcFitnessFirestore();
   const snap = await db.collection("exercises").doc(id).get();
   if (!snap.exists) {
-    redirect("/gc-fitness/exercises");
+    // Straight to the Biblioteca tab (see edit/page.tsx — issue #171).
+    redirect("/gc-fitness/library?tab=exercises");
   }
   const data = snap.data() as Record<string, unknown>;
 


### PR DESCRIPTION
## Issue
Fixes mdb1/gc-fitness#171 — clicking the ↗ icon on an active-workout exercise card opened a tab that flashed an error for ~2 s before landing (sometimes in the Biblioteca instead of the exercise).

## Root cause
The icon always entered at `/gc-fitness/exercises/{id}/edit`, which for **library-sourced exercises (wger / free-exercise-db — nearly every exercise in assigned workouts)** immediately 307s to `/view`. For ids whose doc no longer exists (workout snapshots survive exercise deletion by design), it bounced `/edit` → `/exercises` → `/library?tab=exercises` — **three** sequential force-dynamic SSR passes (each doing session-cookie verification + an Admin-SDK Firestore read). The new tab spent ~2 s inside that chain, flashing intermediate states before settling.

## Fix
- The session card now links to **`/view`** directly: library exercises render with **zero redirects**; trainer-owned ones get exactly one bounce to `/edit` (the view page's existing ownership redirect).
- Missing docs in `/edit` and `/view` now redirect **straight to `/gc-fitness/library?tab=exercises`** instead of chaining through the `/gc-fitness/exercises` redirect stub.

Worst case drops from 3 redirect hops to 1; common case from 1–2 to 0.

## Test gate
`npx tsc --noEmit` clean; `npx jest` → 488 passed, 1 failed: pre-existing `client-activity-time` local locale flake (green in CI).