### PR TITLE
fix(backoffice): client profile header loads iOS-uploaded photos (#193)

### DIFF
--- a/backoffice/src/app/gc-fitness/clients/[id]/_components/ClientHeader.tsx
+++ b/backoffice/src/app/gc-fitness/clients/[id]/_components/ClientHeader.tsx
@@ -22,9 +22,9 @@ import Link from "next/link";
 import { ArrowLeft, Calendar, LineChart, MessagesSquare } from "lucide-react";
 import { useTranslations } from "next-intl";
 
-import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
+import { ClientAvatar } from "@/components/gc-fitness/ClientAvatar";
 
 export interface ClientHeaderProps {
   clientId: string;
@@ -64,13 +64,6 @@ export function ClientHeader({
     cleanAppDisplayName && cleanAppDisplayName !== cleanDisplayName
       ? `${cleanDisplayName} (${cleanAppDisplayName})`
       : cleanDisplayName;
-  const initials = displayName
-    .split(/\s+/)
-    .map((s) => s[0]?.toUpperCase() ?? "")
-    .filter(Boolean)
-    .slice(0, 2)
-    .join("");
-
   return (
     <div className="flex flex-col gap-4">
       <Link
@@ -82,10 +75,12 @@ export function ClientHeader({
       </Link>
       <div className="flex flex-wrap items-center justify-between gap-4">
         <div className="flex items-center gap-4">
-          <Avatar className="size-16">
-            {photoURL ? <AvatarImage src={photoURL} alt={displayName} /> : null}
-            <AvatarFallback>{initials || "?"}</AvatarFallback>
-          </Avatar>
+          {/* Issue #193 — iOS-uploaded photos are BARE Storage paths
+              ("profile_photos/{uid}/avatar.jpg"); a raw <AvatarImage> can't
+              load them. ClientAvatar routes non-https values through
+              /api/gc-fitness/storage-image (same as the roster + calendar,
+              which is why those surfaces worked and this one didn't). */}
+          <ClientAvatar name={displayName} photoURL={photoURL} size="lg" />
           <div className="flex min-w-0 flex-col gap-1">
             <h1 className="gc-page-title text-[1.7rem] leading-tight sm:text-3xl">
               {headerDisplayName}

--- a/backoffice/src/components/gc-fitness/ClientAvatar.tsx
+++ b/backoffice/src/components/gc-fitness/ClientAvatar.tsx
@@ -19,16 +19,18 @@ import Image from "next/image";
 
 import { cn } from "@/lib/utils";
 
-type AvatarSize = "sm" | "md";
+type AvatarSize = "sm" | "md" | "lg";
 
 const SIZE_PX: Record<AvatarSize, number> = {
   sm: 24,
   md: 40,
+  lg: 64,
 };
 
 const SIZE_CLASS: Record<AvatarSize, string> = {
   sm: "h-6 w-6 text-[10px]",
   md: "h-10 w-10 text-sm",
+  lg: "h-16 w-16 text-lg",
 };
 
 function resolveAvatarSrc(photoURL: string): string {


### PR DESCRIPTION
## Issue
Fixes the backoffice half of mdb1/gc-fitness#193 — the client photo showed on the clients roster and calendar but not on the client profile page. (The Android half — same root cause — is fixed in mdb1/gc-fitness#241.)

## Root cause
iOS writes `/users/{uid}.photoURL` as a **bare Storage path** (`profile_photos/{uid}/avatar.jpg`). The roster and calendar render through `ClientAvatar`, which routes non-https values through the authenticated `/api/gc-fitness/storage-image` endpoint — that's why they worked. `ClientHeader` passed the raw value straight into `<AvatarImage src>`, which can't load a schemeless path, so the profile page fell back to initials.

## Fix
`ClientHeader` now renders the same `ClientAvatar` component (new `lg` 64 px size), keeping a single resolution path for client photos everywhere.

## Test gate
`npx tsc --noEmit` clean; `npx jest` → 492 passed, 1 failed: the pre-existing `client-activity-time` local locale flake (green in CI).