### PR TITLE
fix(backoffice): upload coach photo server-side via Admin SDK (#166 round 2)

### DIFF
--- a/backoffice/src/app/api/gc-fitness/coach-profile-photo/route.ts
+++ b/backoffice/src/app/api/gc-fitness/coach-profile-photo/route.ts
@@ -1,0 +1,86 @@
+import { randomUUID } from "node:crypto";
+
+import { NextResponse } from "next/server";
+
+import { gcFitnessStorage } from "@/lib/firebase/gc-fitness-admin";
+import { getCurrentTrainer } from "@/lib/gc-fitness/auth-helpers";
+
+export const runtime = "nodejs";
+
+// POST /api/gc-fitness/coach-profile-photo — body: image bytes (JPEG).
+//
+// Issue #166 (round 2). The coach-profile form used the Firebase JS client
+// SDK (`uploadBytes`) to write `profile_photos/{uid}/avatar.jpg`, but the
+// backoffice authenticates with next-firebase-auth-edge COOKIES — the
+// browser-side Firebase Auth session is a separate, unreliable context (it
+// can be absent or signed into a different Google account than the cookie),
+// and when it doesn't match, Storage rules correctly reject the write with
+// `storage/unauthorized`. That's exactly why `storage-image/route.ts` exists
+// for READS; this route is its WRITE twin: the trainer cookie is the
+// authorization boundary and the Admin SDK performs the upload.
+//
+// The path is fixed to the caller's own uid — a trainer can only ever write
+// their own avatar, mirroring the Storage rule (`request.auth.uid == userId`)
+// this replaces.
+//
+// Returns `{ photoURL }` as a tokened https download URL (the same shape the
+// old client-side `getDownloadURL` produced), so every existing consumer of
+// the denormalized `coachPhotoURL` — iOS, Android (including builds that
+// predate the bare-path resolver), backoffice — keeps working unchanged.
+
+const MAX_BYTES = 2 * 1024 * 1024;
+
+export async function POST(request: Request) {
+  let trainerUid: string;
+  try {
+    trainerUid = (await getCurrentTrainer()).uid;
+  } catch {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+
+  const contentType = request.headers.get("content-type") ?? "";
+  if (!contentType.startsWith("image/")) {
+    return NextResponse.json({ error: "Expected an image body" }, { status: 415 });
+  }
+
+  const bytes = Buffer.from(await request.arrayBuffer());
+  if (bytes.length === 0) {
+    return NextResponse.json({ error: "Empty body" }, { status: 400 });
+  }
+  if (bytes.length > MAX_BYTES) {
+    return NextResponse.json({ error: "Image too large" }, { status: 413 });
+  }
+
+  const objectPath = `profile_photos/${trainerUid}/avatar.jpg`;
+  const downloadToken = randomUUID();
+
+  const projectId = process.env.NEXT_PUBLIC_GC_FITNESS_FIREBASE_PROJECT_ID;
+  const candidates = [
+    process.env.NEXT_PUBLIC_GC_FITNESS_FIREBASE_STORAGE_BUCKET,
+    projectId ? `${projectId}.firebasestorage.app` : undefined,
+    projectId ? `${projectId}.appspot.com` : undefined,
+  ].filter((value): value is string => Boolean(value));
+
+  for (const bucketName of candidates) {
+    try {
+      const file = gcFitnessStorage().bucket(bucketName).file(objectPath);
+      await file.save(bytes, {
+        contentType,
+        metadata: {
+          cacheControl: "public, max-age=300",
+          // Standard Firebase download-token convention — makes the returned
+          // URL identical in shape to a client-side getDownloadURL() result.
+          metadata: { firebaseStorageDownloadTokens: downloadToken },
+        },
+      });
+      const photoURL =
+        `https://firebasestorage.googleapis.com/v0/b/${bucketName}/o/` +
+        `${encodeURIComponent(objectPath)}?alt=media&token=${downloadToken}`;
+      return NextResponse.json({ photoURL });
+    } catch {
+      // Try the next bucket candidate (same fallback chain as storage-image).
+    }
+  }
+
+  return NextResponse.json({ error: "Upload failed" }, { status: 502 });
+}

--- a/backoffice/src/app/gc-fitness/settings/coach-profile-form.tsx
+++ b/backoffice/src/app/gc-fitness/settings/coach-profile-form.tsx
@@ -2,7 +2,6 @@
 
 import { useEffect, useMemo, useRef, useState, useTransition } from "react";
 import { useRouter } from "next/navigation";
-import { uploadBytes, ref, getDownloadURL } from "firebase/storage";
 import { toast } from "sonner";
 import { useTranslations } from "next-intl";
 
@@ -10,7 +9,7 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
-import { getGCFitnessAuth, getGCFitnessStorage } from "@/lib/firebase/gc-fitness-client";
+import { getGCFitnessAuth } from "@/lib/firebase/gc-fitness-client";
 import { updateTrainerProfile } from "@/lib/gc-fitness/user-actions";
 
 export function CoachProfileForm({
@@ -63,17 +62,32 @@ export function CoachProfileForm({
       try {
         let resolvedPhotoURL = photoURL;
         if (pickedFile) {
-          const storage = getGCFitnessStorage();
-          const path = `profile_photos/${uid}/avatar.jpg`;
-          const uploadRef = ref(storage, path);
-          // The `profile_photos` Storage rule caps writes at 1 MB. The iOS /
-          // Android apps normalize avatars before upload; the backoffice must
-          // too, or a raw photo (often > 1 MB) gets rejected with
-          // `storage/unauthorized`. Downscale + JPEG-compress to well under
-          // the cap before uploading.
+          // Issue #166 (round 2) — upload through the trainer-authenticated
+          // server route instead of the Firebase JS client SDK. The
+          // backoffice session lives in next-firebase-auth-edge COOKIES; the
+          // browser-side Firebase Auth context is separate and unreliable
+          // (absent / different account), and when it doesn't match the
+          // trainer, Storage rules reject the client upload with
+          // `storage/unauthorized`. The server route is gated by the same
+          // cookie every other backoffice write trusts, and uploads via the
+          // Admin SDK. Compression stays client-side (bandwidth + consistent
+          // avatar sizing across surfaces).
           const compressed = await compressImageToJpeg(pickedFile);
-          await uploadBytes(uploadRef, compressed, { contentType: "image/jpeg" });
-          resolvedPhotoURL = await getDownloadURL(uploadRef);
+          const response = await fetch("/api/gc-fitness/coach-profile-photo", {
+            method: "POST",
+            headers: { "Content-Type": "image/jpeg" },
+            body: compressed,
+          });
+          if (!response.ok) {
+            const payload = (await response.json().catch(() => null)) as
+              | { error?: string }
+              | null;
+            throw new Error(payload?.error ?? t("saveFailedToast"));
+          }
+          const { photoURL: uploadedURL } = (await response.json()) as {
+            photoURL: string;
+          };
+          resolvedPhotoURL = uploadedURL;
           setPhotoURL(resolvedPhotoURL);
           setPickedFile(null);
         }


### PR DESCRIPTION
## Issue
Fixes mdb1/gc-fitness#166 (round 2) — cambiar la foto del coach still failed with `storage/unauthorized` on `profile_photos/{uid}/avatar.jpg`, even though the deployed Storage rule provably allows the owner write (verified again: the uid in the error IS the signed-in trainer, and their `photoURL` still points at the Google avatar — no upload ever landed).

## Real root cause
The form uploaded with the **Firebase JS client SDK**, but the backoffice authenticates with **next-firebase-auth-edge cookies** — the browser's Firebase Auth context is a separate session that can be absent or signed into a different Google account than the cookie. When it doesn't match, Storage rules correctly reject the write. This is the exact reason `/api/gc-fitness/storage-image` exists for *reads*; writes had no equivalent.

## Fix
New `POST /api/gc-fitness/coach-profile-photo` — the WRITE twin of `storage-image`:
- Authorization = the trainer **cookie** (`getCurrentTrainer()`), the same boundary every other backoffice write trusts; upload via the **Admin SDK**.
- The object path is fixed server-side to the **caller's own uid** (mirrors the `request.auth.uid == userId` Storage rule it bypasses).
- Caps at 2 MB, requires an `image/*` body, and returns a tokened https download URL — identical shape to the old client-side `getDownloadURL`, so every consumer of the denormalized `coachPhotoURL` (iOS, Android — including builds predating the bare-path resolver — and the backoffice) keeps working unchanged.

The form keeps the client-side downscale/JPEG compression (bandwidth + consistent avatars) and now POSTs the blob to the route; the brittle `uploadBytes`/`getDownloadURL` client path is gone.

## Test gate
`npx tsc --noEmit` clean; `npx jest` → 492 passed, 1 failed: the pre-existing `client-activity-time` local locale flake (green in CI).