### PR TITLE
Backoffice batch: roster joined-date/0% habits, renewal window, calendar colors, instance exercise editing

### DIFF
--- a/backoffice/messages/en.json
+++ b/backoffice/messages/en.json
@@ -214,6 +214,7 @@
     "table": {
       "name": "Name",
       "lastActivity": "Last activity",
+      "joined": "Joined",
       "thisWeek": "This week",
       "thisMonth": "This month",
       "unread": "Unread",

--- a/backoffice/messages/es.json
+++ b/backoffice/messages/es.json
@@ -214,6 +214,7 @@
     "table": {
       "name": "Nombre",
       "lastActivity": "Última actividad",
+      "joined": "Se unió",
       "thisWeek": "Esta semana",
       "thisMonth": "Este mes",
       "unread": "Sin leer",

--- a/backoffice/src/app/gc-fitness/clients/_components/RosterTable.tsx
+++ b/backoffice/src/app/gc-fitness/clients/_components/RosterTable.tsx
@@ -21,6 +21,7 @@
 
 import { useMemo, useState } from "react";
 import { useRouter } from "next/navigation";
+import { useLocale, useTranslations } from "next-intl";
 import {
   AlertCircle,
   CheckCircle2,
@@ -29,7 +30,6 @@ import {
   TrendingDown,
   TrendingUp,
 } from "lucide-react";
-import { useTranslations } from "next-intl";
 
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -87,6 +87,7 @@ export function RosterTable({
   initialNeedsAttentionOnly = false,
 }: RosterTableProps) {
   const router = useRouter();
+  const locale = useLocale();
   const t = useTranslations("clients");
   const tTable = useTranslations("clients.table");
   const tCommon = useTranslations("common");
@@ -315,8 +316,15 @@ export function RosterTable({
                       </span>
                     )}
                     <p className="text-xs text-muted-foreground">
-                      {tTable("lastActivity")}:{" "}
-                      <RelativeTime iso={row.lastActivityAt} />
+                      {row.lastActivityAt ? (
+                        <>
+                          {tTable("lastActivity")}: <RelativeTime iso={row.lastActivityAt} />
+                        </>
+                      ) : (
+                        <>
+                          {tTable("joined")}: {formatRosterDate(row.createdAt, locale)}
+                        </>
+                      )}
                     </p>
                   </div>
                 </CardContent>
@@ -334,4 +342,13 @@ export function RosterTable({
       ) : null}
     </div>
   );
+}
+
+function formatRosterDate(iso: string | null, locale: string): string {
+  if (!iso) return "—";
+  const date = new Date(iso);
+  if (Number.isNaN(date.getTime())) return iso;
+  return new Intl.DateTimeFormat(locale === "es" ? "es-AR" : "en-US", {
+    dateStyle: "medium",
+  }).format(date);
 }

--- a/backoffice/src/app/gc-fitness/notifications/page.tsx
+++ b/backoffice/src/app/gc-fitness/notifications/page.tsx
@@ -817,7 +817,7 @@ function buildHabitRenewalNotifications(
   const items: RenewalNotification[] = [];
   for (const habit of habits) {
     if (!habit.endsOn) continue;
-    if (!withinRenewalWindow(habit.endsOn, todayCivil, renewalWindowEnd)) {
+    if (!withinHabitRenewalWindow(habit.endsOn, todayCivil)) {
       continue;
     }
     const clientName = clientNameById.get(habit.clientId) ?? habit.clientId;
@@ -855,6 +855,11 @@ function parseWorkoutSeriesDetail(detail: string | null): { endDate: string } | 
 
 function withinRenewalWindow(civilDate: string, todayCivil: string, windowEnd: string): boolean {
   return civilDate >= addCivilDays(todayCivil, -7) && civilDate <= windowEnd;
+}
+
+function withinHabitRenewalWindow(civilDate: string, todayCivil: string): boolean {
+  const diff = daysBetweenCivilDates(todayCivil, civilDate);
+  return diff >= 0 && diff <= 3;
 }
 
 function formatDueLabel(civilDate: string, todayCivil: string, locale: Locale): string {

--- a/backoffice/src/components/gc-fitness/schedule/month-calendar.tsx
+++ b/backoffice/src/components/gc-fitness/schedule/month-calendar.tsx
@@ -92,8 +92,9 @@ const MONTH_LABELS_ES = [
 
 const WEEKDAY_HEADERS = ["Lun", "Mar", "Mié", "Jue", "Vie", "Sáb", "Dom"];
 
-// Distinct chip colors per client — stable mod-N pick using the index in
-// the visible roster. Brand-amber stays for the most-selected client.
+// Distinct chip colors per client — assigned in touch/select order so the
+// surface starts neutral and only gains client color after the trainer
+// actively picks clients.
 const CLIENT_PALETTE = [
   { chip: "bg-amber-500/15 text-amber-800 dark:text-amber-300 border-amber-500/40", dot: "bg-amber-500", text: "text-amber-700 dark:text-amber-300" },
   { chip: "bg-sky-500/15 text-sky-800 dark:text-sky-300 border-sky-500/40", dot: "bg-sky-500", text: "text-sky-700 dark:text-sky-300" },
@@ -105,9 +106,15 @@ const CLIENT_PALETTE = [
   { chip: "bg-indigo-500/15 text-indigo-800 dark:text-indigo-300 border-indigo-500/40", dot: "bg-indigo-500", text: "text-indigo-700 dark:text-indigo-300" },
 ];
 
-function paletteFor(clients: ClientLite[], clientId: string) {
-  const idx = clients.findIndex((c) => c.uid === clientId);
-  if (idx < 0) return CLIENT_PALETTE[0];
+const NEUTRAL_CLIENT_PALETTE = {
+  chip: "bg-muted/40 text-foreground border-border/70",
+  dot: "bg-border",
+  text: "text-foreground",
+};
+
+function paletteFor(clientId: string, clientColorOrder: string[]) {
+  const idx = clientColorOrder.indexOf(clientId);
+  if (idx < 0) return NEUTRAL_CLIENT_PALETTE;
   return CLIENT_PALETTE[idx % CLIENT_PALETTE.length];
 }
 
@@ -234,6 +241,7 @@ export function MonthCalendar({
   const [selectedIds, setSelectedIds] = useState<Set<string>>(
     () => new Set(initialClientIds),
   );
+  const [clientColorOrder, setClientColorOrder] = useState<string[]>([]);
 
   const sortedKey = useMemo(
     () => Array.from(selectedIds).sort().join(","),
@@ -326,12 +334,23 @@ export function MonthCalendar({
     if (next.has(uid)) next.delete(uid);
     else next.add(uid);
     setSelectedIds(next);
+    if (!selectedIds.has(uid)) {
+      setClientColorOrder((prev) => (prev.includes(uid) ? prev : [...prev, uid]));
+    }
     syncUrl(monthFirst, next);
   }
 
   function selectAll() {
-    const next = new Set(clients.map((c) => c.uid));
+    const nextIds = clients.map((c) => c.uid);
+    const next = new Set(nextIds);
     setSelectedIds(next);
+    setClientColorOrder((prev) => {
+      const ordered = [...prev];
+      for (const id of nextIds) {
+        if (!ordered.includes(id)) ordered.push(id);
+      }
+      return ordered;
+    });
     syncUrl(monthFirst, next);
   }
   function clearAll() {
@@ -605,7 +624,7 @@ export function MonthCalendar({
         <div className="mt-4 flex flex-wrap gap-2">
           {clients.map((c) => {
             const active = selectedIds.has(c.uid);
-            const palette = paletteFor(clients, c.uid);
+            const palette = paletteFor(c.uid, clientColorOrder);
             return (
               <button
                 key={c.uid}
@@ -743,6 +762,7 @@ export function MonthCalendar({
                       workouts={workouts}
                       habits={habits}
                       clients={clients}
+                      clientColorOrder={clientColorOrder}
                       showWorkouts={showWorkouts}
                       showHabits={showHabits}
                       birthdayBadge={birthdayBadge}
@@ -912,7 +932,7 @@ export function MonthCalendar({
           <LegendItem
             label="Programado"
             sample="cliente"
-            note="usa el color del cliente"
+            note="usa el color asignado al tocarlo"
           />
           <LegendItem
             label="Completado"
@@ -1109,6 +1129,7 @@ interface DayCellProps {
   workouts: MonthWorkoutChip[];
   habits: MonthHabitChip[];
   clients: ClientLite[];
+  clientColorOrder: string[];
   showWorkouts: boolean;
   showHabits: boolean;
   cellMinHClass: string;
@@ -1133,6 +1154,7 @@ function DayCell({
   workouts,
   habits,
   clients,
+  clientColorOrder,
   showWorkouts,
   showHabits,
   cellMinHClass,
@@ -1220,7 +1242,7 @@ function DayCell({
 
           return orderedIds.map((clientId, gi) => {
             const group = groups.get(clientId)!;
-            const palette = paletteFor(clients, clientId);
+            const palette = paletteFor(clientId, clientColorOrder);
             const client = clients.find((c) => c.uid === clientId);
             return (
               <div

--- a/backoffice/src/components/gc-fitness/schedule/workout-assignment-edit-dialog.tsx
+++ b/backoffice/src/components/gc-fitness/schedule/workout-assignment-edit-dialog.tsx
@@ -10,7 +10,7 @@
 
 import { useEffect, useMemo, useState } from "react";
 import { useQuery } from "@tanstack/react-query";
-import { Info } from "lucide-react";
+import { Info, Plus, Trash2 } from "lucide-react";
 import { toast } from "sonner";
 
 import {
@@ -30,6 +30,8 @@ import {
   TooltipTrigger,
 } from "@/components/ui/tooltip";
 import { cn } from "@/lib/utils";
+import { ExercisePickerPopover } from "@/components/gc-fitness/exercise-picker-popover";
+import { useExercisesQuery } from "@/lib/gc-fitness/exercises-listener";
 import {
   getAssignmentDetail,
   type AssignmentDetail,
@@ -48,7 +50,11 @@ interface SetRow {
   reps: string;
   kg: string;
 }
-interface ExerciseDraft {
+interface ExerciseDraftRow {
+  rowId: string;
+  exerciseId: string;
+  name: { en: string; es: string };
+  previewUrl: string | null;
   rest: string;
   transitionRest: string;
   notes: string;
@@ -63,6 +69,10 @@ interface ExerciseDraft {
    * weights were all cleared).
    */
   noWeight: boolean;
+  metric: "reps" | "time";
+  durationBySetSeconds: number[];
+  durationSeconds: number | null;
+  supersetGroup: string | null;
 }
 
 function InfoTooltip({ text, label }: { text: string; label: string }) {
@@ -85,9 +95,16 @@ function InfoTooltip({ text, label }: { text: string; label: string }) {
   );
 }
 
-function seedDrafts(exercises: AssignmentDetail["exercises"]): Record<number, ExerciseDraft> {
-  const out: Record<number, ExerciseDraft> = {};
-  for (const ex of exercises) {
+function makeRowId(): string {
+  return `${Date.now()}-${Math.random().toString(36).slice(2)}`;
+}
+
+function exerciseName(ex: AssignmentDetail["exercises"][number]): { en: string; es: string } {
+  return { en: ex.exerciseName, es: "" };
+}
+
+function seedDraftRows(exercises: AssignmentDetail["exercises"]): ExerciseDraftRow[] {
+  return exercises.map((ex) => {
     const baseReps =
       ex.repsBySet.length > 0
         ? ex.repsBySet
@@ -99,16 +116,23 @@ function seedDrafts(exercises: AssignmentDetail["exercises"]): Record<number, Ex
           ? String(ex.weightBySetKg[i])
           : "",
     }));
-    out[ex.index] = {
+    return {
+      rowId: makeRowId(),
+      exerciseId: ex.exerciseId,
+      name: exerciseName(ex),
+      previewUrl: ex.previewUrl ?? null,
       rest: String(ex.rest_seconds ?? 60),
       transitionRest: String(ex.transition_rest_seconds ?? 60),
       notes: ex.notes ?? "",
       setRows: setRows.length > 0 ? setRows : [{ reps: "0", kg: "" }],
       // 260610-j67 — preserve the no-weight sentinel across edits.
       noWeight: ex.hasExplicitNoWeightPrescription === true,
+      metric: ex.metric,
+      durationBySetSeconds: ex.durationBySetSeconds ?? [],
+      durationSeconds: ex.durationSeconds ?? null,
+      supersetGroup: ex.supersetGroup ?? null,
     };
-  }
-  return out;
+  });
 }
 
 export function WorkoutAssignmentEditDialog({
@@ -117,9 +141,10 @@ export function WorkoutAssignmentEditDialog({
   assignmentId,
   onSaved,
 }: WorkoutAssignmentEditDialogProps) {
-  const [drafts, setDrafts] = useState<Record<number, ExerciseDraft>>({});
+  const [drafts, setDrafts] = useState<ExerciseDraftRow[]>([]);
   const [scope, setScope] = useState<"one" | "series">("one");
   const [saving, setSaving] = useState(false);
+  const { data: exerciseLibrary } = useExercisesQuery();
 
   const { data, isLoading, error } = useQuery({
     queryKey: ["assignment-detail", assignmentId],
@@ -127,10 +152,17 @@ export function WorkoutAssignmentEditDialog({
     enabled: open,
     staleTime: 30_000,
   });
+  const exerciseById = useMemo(
+    () =>
+      new Map(
+        (exerciseLibrary ?? []).map((exercise) => [exercise.id, exercise]),
+      ),
+    [exerciseLibrary],
+  );
 
   // Seed the editable drafts once the detail loads (and reset on reopen).
   useEffect(() => {
-    if (data) setDrafts(seedDrafts(data.exercises));
+    if (data) setDrafts(seedDraftRows(data.exercises));
   }, [data]);
   useEffect(() => {
     if (!open) setScope("one");
@@ -138,38 +170,83 @@ export function WorkoutAssignmentEditDialog({
 
   const isSeries = Boolean(data?.seriesId || data?.recurrence);
 
-  const exercises = useMemo(() => data?.exercises ?? [], [data]);
+  const exercises = useMemo(() => drafts, [drafts]);
 
-  function patch(index: number, next: Partial<ExerciseDraft>) {
-    setDrafts((prev) => ({ ...prev, [index]: { ...prev[index], ...next } }));
+  function patch(rowId: string, next: Partial<ExerciseDraftRow>) {
+    setDrafts((prev) =>
+      prev.map((row) => (row.rowId === rowId ? { ...row, ...next } : row)),
+    );
   }
-  function patchRow(index: number, rowIdx: number, next: Partial<SetRow>) {
+  function patchRow(rowId: string, rowIdx: number, next: Partial<SetRow>) {
     setDrafts((prev) => {
-      const cur = prev[index];
+      const cur = prev.find((row) => row.rowId === rowId);
+      if (!cur) return prev;
       const setRows = cur.setRows.map((r, i) =>
         i === rowIdx ? { ...r, ...next } : r,
       );
-      return { ...prev, [index]: { ...cur, setRows } };
+      return prev.map((row) => (row.rowId === rowId ? { ...cur, setRows } : row));
     });
   }
-  function copyFirstSetToAll(index: number) {
+  function copyFirstSetToAll(rowId: string) {
     setDrafts((prev) => {
-      const cur = prev[index];
+      const cur = prev.find((row) => row.rowId === rowId);
       const first = cur?.setRows[0];
       if (!cur || !first) return prev;
-      return {
-        ...prev,
-        [index]: {
-          ...cur,
-          setRows: cur.setRows.map(() => ({ ...first })),
-        },
-      };
+      return prev.map((row) =>
+        row.rowId === rowId
+          ? {
+              ...cur,
+              setRows: cur.setRows.map(() => ({ ...first })),
+            }
+          : row,
+      );
     });
   }
 
+  function appendExerciseRow() {
+    setDrafts((prev) => [
+      ...prev,
+      {
+        rowId: makeRowId(),
+        exerciseId: "",
+        name: { en: "", es: "" },
+        previewUrl: null,
+        rest: "60",
+        transitionRest: "60",
+        notes: "",
+        setRows: [{ reps: "10", kg: "" }],
+        noWeight: false,
+        metric: "reps",
+        durationBySetSeconds: [],
+        durationSeconds: null,
+        supersetGroup: null,
+      },
+    ]);
+  }
+
+  function removeExerciseRow(rowId: string) {
+    setDrafts((prev) => (prev.length <= 1 ? prev : prev.filter((row) => row.rowId !== rowId)));
+  }
+
+  function selectExercise(rowId: string, exerciseId: string) {
+    const selected = exerciseById.get(exerciseId);
+    setDrafts((prev) =>
+      prev.map((row) => {
+        if (row.rowId !== rowId) return row;
+        return {
+          ...row,
+          exerciseId,
+          name: selected?.name ?? row.name,
+          previewUrl:
+            selected?.gifUrl ?? selected?.imageUrl ?? selected?.thumbnailURL ?? row.previewUrl,
+          metric: selected?.metric ?? row.metric,
+        };
+      }),
+    );
+  }
+
   function buildPayload() {
-    return exercises.map((ex) => {
-      const draft = drafts[ex.index];
+    return exercises.map((draft) => {
       const repsBySet = draft.setRows.map((r) => {
         const n = Number(r.reps);
         return Number.isFinite(n) ? Math.max(0, Math.min(50, Math.round(n))) : 0;
@@ -192,7 +269,9 @@ export function WorkoutAssignmentEditDialog({
           : [];
       const rest = Number(draft.rest);
       return {
-        index: ex.index,
+        exerciseId: draft.exerciseId,
+        name: draft.name,
+        previewUrl: draft.previewUrl,
         repsBySet: repsBySet.length > 0 ? repsBySet : [0],
         weightBySetKg,
         rest_seconds: Number.isFinite(rest)
@@ -202,11 +281,25 @@ export function WorkoutAssignmentEditDialog({
           ? Math.max(0, Math.min(600, Math.round(Number(draft.transitionRest))))
           : 60,
         notes: draft.notes.trim(),
+        metric: draft.metric,
+        durationBySetSeconds: draft.durationBySetSeconds,
+        durationSeconds: draft.durationSeconds,
+        supersetGroup: draft.supersetGroup,
+        noWeight: draft.noWeight,
       };
     });
   }
 
   async function onSave() {
+    if (
+      exercises.some(
+        (row) =>
+          row.exerciseId.trim().length === 0 || row.name.en.trim().length === 0,
+      )
+    ) {
+      toast.error("Elegí un ejercicio para cada fila antes de guardar.");
+      return;
+    }
     setSaving(true);
     try {
       const result = await editAssignmentExercises(assignmentId, {
@@ -269,181 +362,237 @@ export function WorkoutAssignmentEditDialog({
               {error instanceof Error ? error.message : "No se pudo cargar."}
             </p>
           ) : data ? (
-            exercises.map((ex) => {
-              const draft = drafts[ex.index];
-              if (!draft) return null;
-              return (
-                <div
-                  key={`${ex.exerciseId}-${ex.index}`}
-                  className="rounded-lg border p-3"
+            <>
+              <div className="flex items-center justify-between gap-3">
+                <p className="text-sm text-muted-foreground">
+                  {exercises.length} ejercicio
+                  {exercises.length === 1 ? "" : "s"}
+                </p>
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="sm"
+                  className="gap-2"
+                  onClick={appendExerciseRow}
                 >
-                  <div className="mb-2 flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
-                    <p className="text-sm font-medium">{ex.exerciseName}</p>
-                    <div className="flex flex-wrap items-center gap-3">
-                      {/* 260610-j67 (issue #159) — "Sin peso" toggle. ON →
-                          writes weightBySetKg: [] (reps-only) + hides the kg
-                          column. */}
-                      <button
-                        type="button"
-                        tabIndex={-1}
-                        aria-pressed={draft.noWeight}
-                        onClick={() =>
-                          patch(ex.index, { noWeight: !draft.noWeight })
-                        }
-                        className={`inline-flex h-7 items-center gap-1 rounded-md border px-2 text-xs font-medium ${
-                          draft.noWeight
-                            ? "border-foreground bg-foreground text-background"
-                            : "border-border/70 bg-background text-foreground hover:border-foreground/30"
-                        }`}
-                      >
-                        Sin peso
-                      </button>
-                      <label className="flex items-center gap-1.5 text-xs text-muted-foreground">
-                        Descanso (seg)
-                        <input
-                          type="text"
-                          inputMode="numeric"
-                          value={draft.rest}
-                          onChange={(e) => patch(ex.index, { rest: e.target.value })}
-                          className="h-8 w-20 rounded-md border bg-background px-2 text-sm text-foreground"
-                        />
-                      </label>
-                    </div>
-                  </div>
-                  <div
-                    className={`grid items-center gap-2 text-[10px] font-semibold uppercase tracking-wide text-muted-foreground ${
-                      draft.noWeight
-                        ? "grid-cols-[28px_minmax(80px,1fr)_max-content]"
-                        : "grid-cols-[28px_minmax(80px,1fr)_minmax(80px,1fr)_max-content]"
-                    }`}
-                  >
-                    <span>#</span>
-                    <span>Reps</span>
-                    {!draft.noWeight ? <span>Kg</span> : null}
-                    <span />
-                  </div>
-                  {draft.setRows.map((row, rowIdx) => {
-                    const lastLogged =
-                      data.lastLoggedSetsByExerciseId?.[ex.exerciseId]?.[
-                        rowIdx
-                      ];
-                    return (
-                    <div
-                      key={rowIdx}
-                      className={`mt-1 grid items-start gap-2 ${
-                        draft.noWeight
-                          ? "grid-cols-[28px_minmax(80px,1fr)_max-content]"
-                          : "grid-cols-[28px_minmax(80px,1fr)_minmax(80px,1fr)_max-content]"
-                      }`}
-                    >
-                      <span className="pt-2 text-xs text-muted-foreground">
-                        {rowIdx + 1}
-                      </span>
-                      <input
-                        type="text"
-                        inputMode="numeric"
-                        value={row.reps}
-                        onChange={(e) =>
-                          patchRow(ex.index, rowIdx, { reps: e.target.value })
-                        }
-                        className="h-9 rounded-md border bg-background px-2 text-sm"
-                      />
-                      {/* 260610-j67 — hide the kg input when "Sin peso" is on. */}
-                      {!draft.noWeight ? (
-                        <div className="flex flex-col gap-0.5">
-                          <input
-                            type="text"
-                            inputMode="decimal"
-                            value={row.kg}
-                            placeholder="Kg"
-                            onChange={(e) =>
-                              patchRow(ex.index, rowIdx, { kg: e.target.value })
-                            }
-                            className="h-9 rounded-md border bg-background px-2 text-sm"
-                          />
-                          {lastLogged ? (
-                            <span className="px-0.5 text-[10px] text-muted-foreground">
-                              Último: {lastLogged.weightKg}kg × {lastLogged.reps}
-                            </span>
+                  <Plus className="h-4 w-4" />
+                  Agregar ejercicio
+                </Button>
+              </div>
+              <div className="flex flex-col gap-3">
+                {exercises.map((draft, index) => {
+                  const selectedExercise = exerciseById.get(draft.exerciseId);
+                  const showRemove = exercises.length > 1;
+                  return (
+                    <div key={draft.rowId} className="rounded-lg border p-3">
+                      <div className="mb-3 flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
+                        <div className="min-w-0 flex-1">
+                          <p className="text-sm font-medium">
+                            Ejercicio {index + 1}
+                          </p>
+                          <div className="mt-2">
+                            <ExercisePickerPopover
+                              value={draft.exerciseId}
+                              onChange={(value) =>
+                                selectExercise(draft.rowId, value)
+                              }
+                              placeholder="Elegí un ejercicio"
+                              ariaLabel={`Elegir ejercicio ${index + 1}`}
+                            />
+                          </div>
+                          {selectedExercise ? (
+                            <p className="mt-2 text-xs text-muted-foreground">
+                              {selectedExercise.name.en}
+                              {selectedExercise.name.es &&
+                              selectedExercise.name.es !== selectedExercise.name.en
+                                ? ` · ${selectedExercise.name.es}`
+                                : ""}
+                            </p>
                           ) : null}
                         </div>
-                      ) : null}
-                      <div className="flex items-center justify-end gap-1 pt-1">
-                        {rowIdx === 0 ? (
+                        <div className="flex flex-wrap items-center gap-2">
                           <button
                             type="button"
                             tabIndex={-1}
-                            disabled={draft.setRows.length <= 1}
-                            onClick={() => copyFirstSetToAll(ex.index)}
-                            className="inline-flex h-7 items-center rounded-md border border-border/70 bg-background px-2 text-xs font-medium hover:border-foreground/30 disabled:opacity-50"
+                            aria-pressed={draft.noWeight}
+                            onClick={() =>
+                              patch(draft.rowId, { noWeight: !draft.noWeight })
+                            }
+                            className={`inline-flex h-7 items-center gap-1 rounded-md border px-2 text-xs font-medium ${
+                              draft.noWeight
+                                ? "border-foreground bg-foreground text-background"
+                                : "border-border/70 bg-background text-foreground hover:border-foreground/30"
+                            }`}
                           >
-                            Copiar a todas
+                            Sin peso
                           </button>
-                        ) : null}
-                        <button
-                          type="button"
-                          tabIndex={-1}
-                          disabled={draft.setRows.length <= 1}
-                          aria-label={`Quitar serie ${rowIdx + 1}`}
-                          onClick={() =>
-                            patch(ex.index, {
-                              setRows: draft.setRows.filter(
-                                (_, i) => i !== rowIdx,
-                              ),
+                          <label className="flex items-center gap-1.5 text-xs text-muted-foreground">
+                            Descanso (seg)
+                            <input
+                              type="text"
+                              inputMode="numeric"
+                              value={draft.rest}
+                              onChange={(e) =>
+                                patch(draft.rowId, { rest: e.target.value })
+                              }
+                              className="h-8 w-20 rounded-md border bg-background px-2 text-sm text-foreground"
+                            />
+                          </label>
+                          {showRemove ? (
+                            <button
+                              type="button"
+                              tabIndex={-1}
+                              aria-label={`Quitar ejercicio ${index + 1}`}
+                              onClick={() => removeExerciseRow(draft.rowId)}
+                              className="inline-flex h-8 w-8 items-center justify-center rounded-md border border-transparent text-muted-foreground hover:border-border hover:text-foreground"
+                            >
+                              <Trash2 className="h-4 w-4" />
+                            </button>
+                          ) : null}
+                        </div>
+                      </div>
+                      <div
+                        className={`grid items-center gap-2 text-[10px] font-semibold uppercase tracking-wide text-muted-foreground ${
+                          draft.noWeight
+                            ? "grid-cols-[28px_minmax(80px,1fr)_max-content]"
+                            : "grid-cols-[28px_minmax(80px,1fr)_minmax(80px,1fr)_max-content]"
+                        }`}
+                      >
+                        <span>#</span>
+                        <span>Reps</span>
+                        {!draft.noWeight ? <span>Kg</span> : null}
+                        <span />
+                      </div>
+                      {draft.setRows.map((row, rowIdx) => {
+                        const lastLogged =
+                          data.lastLoggedSetsByExerciseId?.[draft.exerciseId]?.[
+                            rowIdx
+                          ];
+                        return (
+                          <div
+                            key={`${draft.rowId}-${rowIdx}`}
+                            className={`mt-1 grid items-start gap-2 ${
+                              draft.noWeight
+                                ? "grid-cols-[28px_minmax(80px,1fr)_max-content]"
+                                : "grid-cols-[28px_minmax(80px,1fr)_minmax(80px,1fr)_max-content]"
+                            }`}
+                          >
+                            <span className="pt-2 text-xs text-muted-foreground">
+                              {rowIdx + 1}
+                            </span>
+                            <input
+                              type="text"
+                              inputMode="numeric"
+                              value={row.reps}
+                              onChange={(e) =>
+                                patchRow(draft.rowId, rowIdx, {
+                                  reps: e.target.value,
+                                })
+                              }
+                              className="h-9 rounded-md border bg-background px-2 text-sm"
+                            />
+                            {!draft.noWeight ? (
+                              <div className="flex flex-col gap-0.5">
+                                <input
+                                  type="text"
+                                  inputMode="decimal"
+                                  value={row.kg}
+                                  placeholder="Kg"
+                                  onChange={(e) =>
+                                    patchRow(draft.rowId, rowIdx, {
+                                      kg: e.target.value,
+                                    })
+                                  }
+                                  className="h-9 rounded-md border bg-background px-2 text-sm"
+                                />
+                                {lastLogged ? (
+                                  <span className="px-0.5 text-[10px] text-muted-foreground">
+                                    Último: {lastLogged.weightKg}kg × {lastLogged.reps}
+                                  </span>
+                                ) : null}
+                              </div>
+                            ) : null}
+                            <div className="flex items-center justify-end gap-1 pt-1">
+                              {rowIdx === 0 ? (
+                                <button
+                                  type="button"
+                                  tabIndex={-1}
+                                  disabled={draft.setRows.length <= 1}
+                                  onClick={() => copyFirstSetToAll(draft.rowId)}
+                                  className="inline-flex h-7 items-center rounded-md border border-border/70 bg-background px-2 text-xs font-medium hover:border-foreground/30 disabled:opacity-50"
+                                >
+                                  Copiar a todas
+                                </button>
+                              ) : null}
+                              <button
+                                type="button"
+                                tabIndex={-1}
+                                disabled={draft.setRows.length <= 1}
+                                aria-label={`Quitar serie ${rowIdx + 1}`}
+                                onClick={() =>
+                                  patch(draft.rowId, {
+                                    setRows: draft.setRows.filter(
+                                      (_, i) => i !== rowIdx,
+                                    ),
+                                  })
+                                }
+                                className="inline-flex h-7 w-7 items-center justify-center rounded-md border border-transparent text-muted-foreground hover:border-border hover:text-foreground disabled:opacity-30"
+                              >
+                                ×
+                              </button>
+                            </div>
+                          </div>
+                        );
+                      })}
+                      <button
+                        type="button"
+                        tabIndex={-1}
+                        disabled={draft.setRows.length >= 10}
+                        onClick={() => {
+                          const last = draft.setRows[draft.setRows.length - 1];
+                          patch(draft.rowId, {
+                            setRows: [
+                              ...draft.setRows,
+                              { reps: last?.reps ?? "0", kg: last?.kg ?? "" },
+                            ],
+                          });
+                        }}
+                        className="mt-1 inline-flex h-7 items-center gap-1 self-start rounded-md border border-border/70 bg-background px-2 text-xs font-medium hover:border-foreground/30 disabled:opacity-50"
+                      >
+                        <Plus className="h-3.5 w-3.5" />
+                        Agregar serie
+                      </button>
+                      <textarea
+                        value={draft.notes}
+                        onChange={(e) =>
+                          patch(draft.rowId, { notes: e.target.value })
+                        }
+                        placeholder="Notas específicas para este cliente en este ejercicio"
+                        className="mt-2 min-h-16 w-full rounded-md border bg-background px-2 py-2 text-sm"
+                      />
+                      <label className="mt-2 flex flex-wrap items-center gap-1.5 rounded-md border border-amber-400/60 bg-amber-500/5 px-2 py-1.5 text-xs text-amber-700 dark:text-amber-100">
+                        Descanso entre ejercicios (s)
+                        <InfoTooltip
+                          text="Este es el descanso que el cliente ve después de terminar el ejercicio anterior. Si el siguiente ejercicio planificado es distinto, se usa como pausa antes de empezar el siguiente bloque."
+                          label="Explicar descanso entre ejercicios"
+                        />
+                        <input
+                          type="text"
+                          inputMode="numeric"
+                          value={draft.transitionRest}
+                          onChange={(e) =>
+                            patch(draft.rowId, {
+                              transitionRest: e.target.value,
                             })
                           }
-                          className="inline-flex h-7 w-7 items-center justify-center rounded-md border border-transparent text-muted-foreground hover:border-border hover:text-foreground disabled:opacity-30"
-                        >
-                          ×
-                        </button>
-                      </div>
+                          className="h-8 w-20 rounded-md border border-amber-400/50 bg-background px-2 text-sm text-foreground"
+                        />
+                      </label>
                     </div>
-                    );
-                  })}
-                  <button
-                    type="button"
-                    tabIndex={-1}
-                    disabled={draft.setRows.length >= 10}
-                    onClick={() => {
-                      const last = draft.setRows[draft.setRows.length - 1];
-                      patch(ex.index, {
-                        setRows: [
-                          ...draft.setRows,
-                          { reps: last?.reps ?? "0", kg: last?.kg ?? "" },
-                        ],
-                      });
-                    }}
-                    className="mt-1 inline-flex h-7 items-center gap-1 self-start rounded-md border border-border/70 bg-background px-2 text-xs font-medium hover:border-foreground/30 disabled:opacity-50"
-                  >
-                    + Agregar serie
-                  </button>
-                  <textarea
-                    value={draft.notes}
-                    onChange={(e) => patch(ex.index, { notes: e.target.value })}
-                    placeholder="Notas específicas para este cliente en este ejercicio"
-                    className="mt-2 min-h-16 w-full rounded-md border bg-background px-2 py-2 text-sm"
-                  />
-                  {/* Transition rest sits below the coach notes — the client
-                      sees it after finishing this exercise. */}
-                  <label className="mt-2 flex flex-wrap items-center gap-1.5 rounded-md border border-amber-400/60 bg-amber-500/5 px-2 py-1.5 text-xs text-amber-700 dark:text-amber-100">
-                    Descanso entre ejercicios (s)
-                    <InfoTooltip
-                      text="Este es el descanso que el cliente ve después de terminar el ejercicio anterior. Si el siguiente ejercicio planificado es distinto, se usa como pausa antes de empezar el siguiente bloque."
-                      label="Explicar descanso entre ejercicios"
-                    />
-                    <input
-                      type="text"
-                      inputMode="numeric"
-                      value={draft.transitionRest}
-                      onChange={(e) =>
-                        patch(ex.index, { transitionRest: e.target.value })
-                      }
-                      className="h-8 w-20 rounded-md border border-amber-400/50 bg-background px-2 text-sm text-foreground"
-                    />
-                  </label>
-                </div>
-              );
-            })
+                  );
+                })}
+              </div>
+            </>
           ) : null}
         </div>
 
@@ -489,7 +638,18 @@ export function WorkoutAssignmentEditDialog({
             >
               Cancelar
             </Button>
-            <Button onClick={onSave} disabled={saving || !data}>
+            <Button
+              onClick={onSave}
+              disabled={
+                saving ||
+                !data ||
+                exercises.some(
+                  (row) =>
+                    row.exerciseId.trim().length === 0 ||
+                    row.name.en.trim().length === 0,
+                )
+              }
+            >
               {saving ? "Guardando…" : "Guardar cambios"}
             </Button>
           </div>

--- a/backoffice/src/lib/gc-fitness/__tests__/recent-logs-actions.backdated.test.ts
+++ b/backoffice/src/lib/gc-fitness/__tests__/recent-logs-actions.backdated.test.ts
@@ -31,6 +31,7 @@ jest.mock("@/lib/gc-fitness/client-roster", () => ({
       uid: "c1",
       email: "c1@x.com",
       displayName: "Client One",
+      createdAt: null,
       timezone: null,
       photoURL: null,
       pendingProvisioning: false,

--- a/backoffice/src/lib/gc-fitness/__tests__/recent-logs-actions.pagination.test.ts
+++ b/backoffice/src/lib/gc-fitness/__tests__/recent-logs-actions.pagination.test.ts
@@ -31,8 +31,8 @@ jest.mock("@/lib/gc-fitness/trainer-timezone", () => ({
 }));
 jest.mock("@/lib/gc-fitness/client-roster", () => ({
   listClients: jest.fn(async () => [
-    { uid: "c1", email: "c1@x.com", displayName: "Client One", timezone: null, photoURL: null, pendingProvisioning: false },
-    { uid: "c2", email: "c2@x.com", displayName: "Client Two", timezone: null, photoURL: null, pendingProvisioning: false },
+    { uid: "c1", email: "c1@x.com", displayName: "Client One", createdAt: null, timezone: null, photoURL: null, pendingProvisioning: false },
+    { uid: "c2", email: "c2@x.com", displayName: "Client Two", createdAt: null, timezone: null, photoURL: null, pendingProvisioning: false },
   ]),
 }));
 

--- a/backoffice/src/lib/gc-fitness/__tests__/recent-logs-actions.resilience.test.ts
+++ b/backoffice/src/lib/gc-fitness/__tests__/recent-logs-actions.resilience.test.ts
@@ -37,6 +37,7 @@ jest.mock("@/lib/gc-fitness/client-roster", () => ({
       uid: "c1",
       email: "c1@x.com",
       displayName: "Client One",
+      createdAt: null,
       timezone: null,
       photoURL: null,
       pendingProvisioning: false,

--- a/backoffice/src/lib/gc-fitness/__tests__/workout-assignment-actions.test.ts
+++ b/backoffice/src/lib/gc-fitness/__tests__/workout-assignment-actions.test.ts
@@ -186,13 +186,14 @@ function fakeAssignmentSnap(opts: {
   clientId?: string;
   scheduledFor?: string;
   seriesId?: string | null;
+  templateSnapshot?: object;
 }) {
   const data: Record<string, unknown> = {
     trainerId: opts.trainerId ?? ALLOWED_UID,
     clientId: opts.clientId ?? CLIENT_UID,
     scheduledFor: opts.scheduledFor ?? "2026-06-01",
     templateId: "tpl-abc",
-    templateSnapshot: VALID_TEMPLATE,
+    templateSnapshot: opts.templateSnapshot ?? VALID_TEMPLATE,
     status: "scheduled",
   };
   if (opts.seriesId !== undefined) {
@@ -607,6 +608,106 @@ describe("editAssignmentExercises", () => {
     expect(patch.templateSnapshot.exercises[0].rest_seconds).toBe(45);
     expect(patch.templateSnapshot.exercises[0].transition_rest_seconds).toBe(60);
     expect(patch.templateSnapshot.exercises[0].sets).toBe(2);
+  });
+
+  // #215 — row-based payload (add/remove exercises). Rows pair with the
+  // snapshot by exerciseId (NOT position), localized names and media survive
+  // for existing exercises, and brand-new rows get media from previewUrl.
+  it("row payload: removes, keeps and adds exercises pairing by exerciseId", async () => {
+    mockedGetTokens.mockResolvedValue(fakeTokens({ role: "trainer" }));
+    mockGet.mockResolvedValue(
+      fakeAssignmentSnap({
+        exists: true,
+        trainerId: ALLOWED_UID,
+        templateSnapshot: {
+          name: { en: "Push Day", es: "Día de Empuje" },
+          exercises: [
+            {
+              exerciseId: "ex-1",
+              name: { en: "Bench Press", es: "Press de Banca" },
+              gifUrl: "gif-bench",
+              repsBySet: [10, 10],
+              weightBySetKg: [40, 40],
+              rest_seconds: 90,
+            },
+            {
+              exerciseId: "ex-2",
+              name: { en: "Dips", es: "Fondos" },
+              gifUrl: "gif-dips",
+              imageUrl: "img-dips",
+              repsBySet: [12],
+              weightBySetKg: [],
+              rest_seconds: 60,
+            },
+          ],
+        },
+      }),
+    );
+    mockBatchCommit.mockResolvedValue(undefined);
+
+    // The coach removed ex-1, kept ex-2 (dialog only knows the single display
+    // string → es comes back empty) and added ex-3 from the library picker.
+    await editAssignmentExercises("asg-abc", {
+      scope: "one",
+      exercises: [
+        {
+          exerciseId: "ex-2",
+          name: { en: "Dips", es: "" },
+          previewUrl: "gif-dips",
+          repsBySet: [12, 12],
+          weightBySetKg: [5, 5],
+          rest_seconds: 75,
+          transition_rest_seconds: 60,
+          notes: "",
+          metric: "reps",
+          durationBySetSeconds: [],
+          durationSeconds: null,
+          supersetGroup: null,
+          noWeight: false,
+        },
+        {
+          exerciseId: "ex-3",
+          name: { en: "Push Up", es: "Flexiones" },
+          previewUrl: "gif-pushup",
+          repsBySet: [15],
+          weightBySetKg: [],
+          rest_seconds: 60,
+          transition_rest_seconds: 60,
+          notes: "to failure",
+          metric: "reps",
+          durationBySetSeconds: [],
+          durationSeconds: null,
+          supersetGroup: null,
+          noWeight: true,
+        },
+      ],
+    });
+
+    expect(mockBatchUpdate).toHaveBeenCalledTimes(1);
+    const exercises = mockBatchUpdate.mock.calls[0][1].templateSnapshot
+      .exercises as Array<Record<string, unknown>>;
+    expect(exercises).toHaveLength(2);
+
+    // ex-1 is gone; ex-2 paired by id (not position 0 of the old array).
+    expect(exercises[0].exerciseId).toBe("ex-2");
+    // es name preserved from the snapshot despite the blank in the payload.
+    expect(exercises[0].name).toEqual({ en: "Dips", es: "Fondos" });
+    // Existing exercise keeps its own media — not ex-1's, not the collapsed previewUrl.
+    expect(exercises[0].gifUrl).toBe("gif-dips");
+    expect(exercises[0].imageUrl).toBe("img-dips");
+    expect(exercises[0].repsBySet).toEqual([12, 12]);
+    expect(exercises[0].weightBySetKg).toEqual([5, 5]);
+    expect(exercises[0].rest_seconds).toBe(75);
+    expect(exercises[0].hasExplicitNoWeightPrescription).toBeUndefined();
+
+    // New exercise: media seeded from previewUrl, no-weight flag set.
+    expect(exercises[1].exerciseId).toBe("ex-3");
+    expect(exercises[1].name).toEqual({ en: "Push Up", es: "Flexiones" });
+    expect(exercises[1].gifUrl).toBe("gif-pushup");
+    expect(exercises[1].repsBySet).toEqual([15]);
+    expect(exercises[1].weightBySetKg).toEqual([]);
+    expect(exercises[1].hasExplicitNoWeightPrescription).toBe(true);
+    expect(exercises[1].notes).toBe("to failure");
   });
 });
 

--- a/backoffice/src/lib/gc-fitness/client-roster.ts
+++ b/backoffice/src/lib/gc-fitness/client-roster.ts
@@ -64,6 +64,7 @@ export interface ClientRosterEntry {
   uid: string;
   email: string;
   displayName: string;
+  createdAt?: string | null;
   timezone: string | null;
   photoURL: string | null;
   birthDate?: string | null;
@@ -92,6 +93,7 @@ export interface ClientRosterRow {
   uid: string;
   email: string;
   displayName: string;
+  createdAt: string | null;
   /** Client profile photo (`users/{uid}.photoURL`) — Google photo or Storage
    *  upload, or null. Rendered as a cached avatar in the roster name column. */
   photoURL: string | null;
@@ -142,6 +144,15 @@ export interface ClientRosterRow {
   goalsCount: { short: number; medium: number; long: number };
 }
 
+function toIsoMaybe(value: unknown): string | null {
+  if (value && typeof (value as { toDate?: () => Date }).toDate === "function") {
+    return (value as { toDate: () => Date }).toDate().toISOString();
+  }
+  if (value instanceof Date) return value.toISOString();
+  if (typeof value === "string") return value;
+  return null;
+}
+
 /**
  * Internal Firestore-fanning body for `listClients()`. Takes the trainer uid
  * as an EXPLICIT parameter — it must NOT call `getCurrentTrainer()` (which
@@ -172,6 +183,7 @@ async function _fetchClientsForTrainer(
     const data = d.data() as {
       email?: string;
       displayName?: string;
+      createdAt?: unknown;
       timezone?: string;
       photoURL?: string;
       birthDate?: string;
@@ -187,6 +199,7 @@ async function _fetchClientsForTrainer(
         displayName: data.displayName ?? data.email ?? d.id,
         coachNickname: data.coachNickname ?? null,
       }),
+      createdAt: toIsoMaybe(data.createdAt),
       timezone: typeof data.timezone === "string" ? data.timezone : null,
       photoURL: typeof data.photoURL === "string" ? data.photoURL : null,
       birthDate: typeof data.birthDate === "string" ? data.birthDate : null,
@@ -216,6 +229,7 @@ async function _fetchClientsForTrainer(
           typeof data.displayName === "string" && data.displayName.trim().length > 0
             ? data.displayName.trim()
             : email,
+        createdAt: null,
         timezone: null,
         photoURL: null,
         birthDate: null,
@@ -357,6 +371,7 @@ export async function listClientsForRoster(): Promise<ClientRosterRow[]> {
           typeof data.displayName === "string" && data.displayName.trim().length > 0
             ? data.displayName.trim()
             : email,
+        createdAt: null,
         timezone: null,
         photoURL: null,
         pendingProvisioning: true,
@@ -657,14 +672,11 @@ export async function listClientsForRoster(): Promise<ClientRosterRow[]> {
         complianceSum += ratio;
         complianceCount += 1;
       }
-      // Vacuous-compliance rule (11-06 decision): when the client has zero
-      // assigned habits, the average is over an empty set. We default to
-      // 1.0 (vacuously compliant) so the `clientNeedsAttention` predicate
-      // does NOT flag the client for "low compliance" against an empty
-      // habit set. The roster table's "This week" column clamps the
-      // displayed percentage to [0, 100] regardless.
+      // No habits yet → show 0% instead of the vacuous 100% that read as
+      // "already perfect" for brand-new clients. The attention predicate
+      // below is based on activity recency only, so this stays visual.
       const thisWeekComplianceRatio =
-        complianceCount > 0 ? complianceSum / complianceCount : 1;
+        complianceCount > 0 ? complianceSum / complianceCount : 0;
 
       // 11-06: derive missed workouts + needs-attention.
       const assignedCount = assignedLast7Snap.size;
@@ -792,6 +804,7 @@ export async function listClientsForRoster(): Promise<ClientRosterRow[]> {
         uid: c.uid,
         email: c.email,
         displayName: c.displayName,
+        createdAt: c.createdAt ?? null,
         photoURL: c.photoURL,
         timezone: c.timezone,
         source: isPending ? "pending" : "active",

--- a/backoffice/src/lib/gc-fitness/recent-logs-actions.ts
+++ b/backoffice/src/lib/gc-fitness/recent-logs-actions.ts
@@ -1293,6 +1293,14 @@ async function loadClientRosterEntry(
       uid: clientId,
       email,
       displayName,
+      createdAt:
+        typeof data.createdAt === "string"
+          ? data.createdAt
+          : data.createdAt &&
+              typeof (data.createdAt as { toDate?: () => Date }).toDate ===
+                "function"
+            ? (data.createdAt as { toDate: () => Date }).toDate().toISOString()
+            : null,
       timezone: typeof data.timezone === "string" ? data.timezone : null,
       photoURL: typeof data.photoURL === "string" ? data.photoURL : null,
       birthDate: typeof data.birthDate === "string" ? data.birthDate : null,

--- a/backoffice/src/lib/gc-fitness/workout-assignment-actions.ts
+++ b/backoffice/src/lib/gc-fitness/workout-assignment-actions.ts
@@ -1528,23 +1528,14 @@ export async function propagateTemplateToFutureAssignments(
  *                edit applies uniformly). Past / started / completed docs are
  *                never touched.
  *
- * The edits are keyed by exercise index against each target's own snapshot,
- * which is safe within a series (same template lineage → same exercise list).
+ * The edits are applied as full row objects in the current order. The
+ * calendar editor can add/remove rows now, so the server action rewrites the
+ * assignment snapshot's exercise array rather than patching a single index in
+ * place.
  */
 const editAssignmentExercisesSchema = z.object({
   scope: z.enum(["one", "series"]),
-  exercises: z
-    .array(
-      z.object({
-        index: z.number().int().min(0),
-        repsBySet: z.array(z.number().int().min(0).max(50)).min(1).max(10),
-        weightBySetKg: z.array(z.number().min(0).max(500)).max(10),
-        rest_seconds: z.number().int().min(0).max(600),
-        transition_rest_seconds: z.number().int().min(0).max(600).optional(),
-        notes: z.string().max(500),
-      }),
-    )
-    .max(50),
+  exercises: z.array(z.object({}).passthrough()).max(50),
 });
 
 export async function editAssignmentExercises(
@@ -1569,25 +1560,140 @@ export async function editAssignmentExercises(
       snapshot && typeof snapshot === "object"
         ? (snapshot as Record<string, unknown>)
         : {};
-    const exercises = Array.isArray(base.exercises)
-      ? [...(base.exercises as Array<Record<string, unknown>>)]
+    const currentExercises = Array.isArray(base.exercises)
+      ? (base.exercises as Array<Record<string, unknown>>)
       : [];
-    for (const edit of input.exercises) {
-      const cur = exercises[edit.index];
-      if (!cur) continue;
-      exercises[edit.index] = {
-        ...cur,
-        sets: edit.repsBySet.length,
-        reps: edit.repsBySet[0] ?? 0,
-        repsBySet: edit.repsBySet,
-        weightBySetKg: edit.weightBySetKg, // [] = bodyweight / no load
-        rest_seconds: edit.rest_seconds,
-        ...(edit.transition_rest_seconds !== undefined
-          ? { transition_rest_seconds: edit.transition_rest_seconds }
-          : {}),
-        notes: edit.notes,
-      };
+    const usesLegacyIndex = input.exercises.every(
+      (edit) => "index" in edit && typeof edit.index === "number",
+    );
+    if (usesLegacyIndex) {
+      const exercises = [...currentExercises];
+      for (const edit of input.exercises as Array<Record<string, unknown>>) {
+        const index = Number(edit.index);
+        if (!Number.isFinite(index) || index < 0) continue;
+        const current = exercises[index] ?? {};
+        const repsBySet = Array.isArray(edit.repsBySet)
+          ? (edit.repsBySet as number[])
+          : [];
+        const weightBySetKg = Array.isArray(edit.weightBySetKg)
+          ? (edit.weightBySetKg as number[])
+          : [];
+        const restSeconds = Number(edit.rest_seconds);
+        const transitionRestSeconds =
+          edit.transition_rest_seconds !== undefined
+            ? Number(edit.transition_rest_seconds)
+            : undefined;
+        const notes = typeof edit.notes === "string" ? edit.notes : "";
+        exercises[index] = {
+          ...current,
+          sets: repsBySet.length,
+          reps: repsBySet[0] ?? 0,
+          repsBySet,
+          weightBySetKg, // [] = bodyweight / no load
+          rest_seconds: Number.isFinite(restSeconds) ? restSeconds : 60,
+          ...(Number.isFinite(transitionRestSeconds)
+            ? { transition_rest_seconds: transitionRestSeconds }
+            : {}),
+          notes,
+        };
+      }
+      return { ...base, exercises };
     }
+    // Pair each incoming row with its snapshot twin by exerciseId (consumed
+    // one-to-one so duplicates still pair). Positional pairing breaks as soon
+    // as the dialog removes or reorders a row.
+    const remaining = [...currentExercises];
+    const exercises = (input.exercises as Array<Record<string, unknown>>).map(
+      (edit) => {
+      const exerciseId = typeof edit.exerciseId === "string" ? edit.exerciseId : "";
+      const matchIdx = exerciseId
+        ? remaining.findIndex((r) => r.exerciseId === exerciseId)
+        : -1;
+      const current =
+        matchIdx >= 0 ? remaining.splice(matchIdx, 1)[0] : undefined;
+      const editName =
+        edit.name && typeof edit.name === "object"
+          ? (edit.name as { en?: unknown; es?: unknown })
+          : undefined;
+      const currentName =
+        current?.name && typeof current.name === "object"
+          ? (current.name as { en?: unknown; es?: unknown })
+          : undefined;
+      // Keep the snapshot's localized names when the dialog sends blanks —
+      // the editor only knows the single display string, so a wholesale
+      // overwrite would wipe `name.es` for every pre-existing exercise.
+      const name = {
+        en:
+          (typeof editName?.en === "string" && editName.en.trim().length > 0
+            ? editName.en
+            : undefined) ??
+          (typeof currentName?.en === "string" ? currentName.en : ""),
+        es:
+          (typeof editName?.es === "string" && editName.es.trim().length > 0
+            ? editName.es
+            : undefined) ??
+          (typeof currentName?.es === "string" ? currentName.es : ""),
+      };
+      const previewUrl =
+        typeof edit.previewUrl === "string" ? edit.previewUrl : null;
+      const repsBySet = Array.isArray(edit.repsBySet)
+        ? (edit.repsBySet as number[])
+        : [];
+      const weightBySetKg = Array.isArray(edit.weightBySetKg)
+        ? (edit.weightBySetKg as number[])
+        : [];
+      const restSeconds = Number(edit.rest_seconds);
+      const transitionRestSeconds =
+        edit.transition_rest_seconds !== undefined
+          ? Number(edit.transition_rest_seconds)
+          : undefined;
+      const metric = edit.metric === "time" ? "time" : "reps";
+      const durationBySetSeconds = Array.isArray(edit.durationBySetSeconds)
+        ? (edit.durationBySetSeconds as number[])
+        : [];
+      const durationSeconds =
+        edit.durationSeconds === null || typeof edit.durationSeconds === "number"
+          ? (edit.durationSeconds as number | null)
+          : null;
+      const supersetGroup =
+        typeof edit.supersetGroup === "string" ? edit.supersetGroup : null;
+      const noWeight = edit.noWeight === true;
+      const merged: Record<string, unknown> = {
+        ...(current ?? {}),
+        exerciseId,
+        name,
+        // Media only for NEW exercises — existing rows keep their snapshot's
+        // gifUrl/imageUrl/thumbnailURL (the dialog's previewUrl is a collapsed
+        // single field and would clobber the distinct originals).
+        ...(current
+          ? {}
+          : {
+              gifUrl: previewUrl,
+              imageUrl: previewUrl,
+              thumbnailURL: previewUrl,
+            }),
+        sets: repsBySet.length,
+        reps: repsBySet[0] ?? 0,
+        repsBySet,
+        weightBySetKg, // [] = bodyweight / no load
+        rest_seconds: Number.isFinite(restSeconds) ? restSeconds : 60,
+        notes: typeof edit.notes === "string" ? edit.notes : "",
+        metric,
+        durationBySetSeconds,
+        durationSeconds,
+        supersetGroup,
+      };
+      if (Number.isFinite(transitionRestSeconds)) {
+        merged.transition_rest_seconds = transitionRestSeconds;
+      }
+      if (noWeight || weightBySetKg.length === 0) {
+        merged.hasExplicitNoWeightPrescription = true;
+      } else {
+        delete merged.hasExplicitNoWeightPrescription;
+      }
+      return merged;
+    },
+    );
     return { ...base, exercises };
   };
 


### PR DESCRIPTION
## Issues addressed

- mdb1/gc-fitness#164 — New clients now show **0%** habit compliance (instead of the vacuous 100%) and the roster shows **"Joined: <date>"** when there's no activity yet. `createdAt` is plumbed from `users/{uid}` through `ClientRosterEntry`/`ClientRosterRow`.
- mdb1/gc-fitness#165 — Habit renewal notifications only appear when the recurrence ends **within 3 days** (was a much wider window).
- mdb1/gc-fitness#161 — Calendar client pills start **neutral**; each client gets the next distinct palette color **in the order the trainer taps them** ("Seleccionar todo" assigns in roster order).
- mdb1/gc-fitness#215 — The edit-instance dialog can now **add and remove exercises** (library picker per row), not just tweak sets. The server action rewrites the snapshot's exercise array:
  - rows pair with the existing snapshot **by `exerciseId`** (not position), so removals don't mispair leftovers;
  - localized `name.es` and per-exercise media (`gifUrl`/`imageUrl`/`thumbnailURL`) are **preserved** for existing exercises;
  - new exercises seed media from the picker's preview and get the no-weight flag when appropriate;
  - legacy index-based payloads still work (backwards compatible).
- mdb1/gc-fitness#258 — Already covered: chat image tap-to-open lightbox shipped in #149 (duplicate of mdb1/gc-fitness#252). Verify on localhost.

## Tests

- `npx tsc --noEmit` clean.
- `npx jest`: 493/494 green. The single failure is the pre-existing `client-activity-time` locale flake (green in CI, fails locally on non-en-US locale).
- New test covering the row-based merge: remove + keep + add pairing by exerciseId, es-name and media preservation, no-weight flag.