### PR TITLE
Backoffice: hide orphaned duplicate clients (#270) + tap staged chat photo to preview (#258)

### DIFF
--- a/backoffice/messages/en.json
+++ b/backoffice/messages/en.json
@@ -1231,6 +1231,7 @@
       "photoCta": "Attach photo",
       "photoLabel": "Photo",
       "removeAttachment": "Remove photo",
+      "previewAttachment": "View photo full size",
       "voiceCta": "Attach audio",
       "voiceLabel": "Audio",
       "voiceRecordCta": "Record audio",

--- a/backoffice/messages/es.json
+++ b/backoffice/messages/es.json
@@ -1231,6 +1231,7 @@
       "photoCta": "Adjuntar foto",
       "photoLabel": "Foto",
       "removeAttachment": "Quitar foto",
+      "previewAttachment": "Ver foto en grande",
       "voiceCta": "Adjuntar audio",
       "voiceLabel": "Audio",
       "voiceRecordCta": "Grabar audio",

--- a/backoffice/src/app/gc-fitness/chat/_components/ChatConversation.tsx
+++ b/backoffice/src/app/gc-fitness/chat/_components/ChatConversation.tsx
@@ -70,6 +70,7 @@ import {
 } from "@/components/ui/alert-dialog";
 import { Button } from "@/components/ui/button";
 import { ClientAvatar } from "@/components/gc-fitness/ClientAvatar";
+import { ChatImageLightbox } from "./ChatImageLightbox";
 
 import type { ClientRosterEntry } from "../client";
 import { MessageInput } from "./MessageInput";
@@ -719,56 +720,6 @@ function ChatImageBubble({
           onClose={() => setExpanded(false)}
         />
       ) : null}
-    </div>
-  );
-}
-
-/**
- * Issue #252 — minimal full-screen image viewer for chat photos. A fixed
- * overlay (click anywhere or Escape to close) rather than the shadcn Dialog,
- * so the photo can use the whole viewport without DialogContent's max-width
- * styling fighting the image's natural size.
- */
-function ChatImageLightbox({
-  url,
-  alt,
-  onClose,
-}: {
-  url: string;
-  alt: string;
-  onClose: () => void;
-}) {
-  useEffect(() => {
-    function onKeyDown(event: KeyboardEvent) {
-      if (event.key === "Escape") onClose();
-    }
-    window.addEventListener("keydown", onKeyDown);
-    return () => window.removeEventListener("keydown", onKeyDown);
-  }, [onClose]);
-
-  return (
-    <div
-      role="dialog"
-      aria-modal="true"
-      aria-label={alt}
-      className="fixed inset-0 z-[100] flex items-center justify-center bg-black/85 p-4"
-      onClick={onClose}
-    >
-      {/* eslint-disable-next-line @next/next/no-img-element */}
-      <img
-        src={url}
-        alt={alt}
-        className="max-h-full max-w-full rounded-lg object-contain"
-        onClick={(event) => event.stopPropagation()}
-      />
-      <button
-        type="button"
-        onClick={onClose}
-        aria-label="Close"
-        className="absolute right-4 top-4 flex size-10 items-center justify-center rounded-full bg-black/60 text-xl text-white transition-colors hover:bg-black/80"
-      >
-        ×
-      </button>
     </div>
   );
 }

--- a/backoffice/src/app/gc-fitness/chat/_components/ChatImageLightbox.tsx
+++ b/backoffice/src/app/gc-fitness/chat/_components/ChatImageLightbox.tsx
@@ -1,0 +1,56 @@
+"use client";
+
+// Issue #252 / #258 — minimal full-screen image viewer for chat photos. A
+// fixed overlay (click anywhere or Escape to close) rather than the shadcn
+// Dialog, so the photo can use the whole viewport without DialogContent's
+// max-width styling fighting the image's natural size.
+//
+// Shared by the conversation bubbles (#252 — sent images) and the composer's
+// staged-attachment preview (#258 — the coach checks the photo BEFORE
+// sending it).
+
+import { useEffect } from "react";
+
+export function ChatImageLightbox({
+  url,
+  alt,
+  onClose,
+}: {
+  url: string;
+  alt: string;
+  onClose: () => void;
+}) {
+  useEffect(() => {
+    function onKeyDown(event: KeyboardEvent) {
+      if (event.key === "Escape") onClose();
+    }
+    window.addEventListener("keydown", onKeyDown);
+    return () => window.removeEventListener("keydown", onKeyDown);
+  }, [onClose]);
+
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-label={alt}
+      className="fixed inset-0 z-[100] flex items-center justify-center bg-black/85 p-4"
+      onClick={onClose}
+    >
+      {/* eslint-disable-next-line @next/next/no-img-element */}
+      <img
+        src={url}
+        alt={alt}
+        className="max-h-full max-w-full rounded-lg object-contain"
+        onClick={(event) => event.stopPropagation()}
+      />
+      <button
+        type="button"
+        onClick={onClose}
+        aria-label="Close"
+        className="absolute right-4 top-4 flex size-10 items-center justify-center rounded-full bg-black/60 text-xl text-white transition-colors hover:bg-black/80"
+      >
+        ×
+      </button>
+    </div>
+  );
+}

--- a/backoffice/src/app/gc-fitness/chat/_components/MessageInput.tsx
+++ b/backoffice/src/app/gc-fitness/chat/_components/MessageInput.tsx
@@ -46,6 +46,7 @@ import { CHATS_BASE_KEY } from "@/lib/gc-fitness/chat-listener";
 import { buildReplyQuote } from "@/lib/gc-fitness/chat-reply";
 import type { MessageRow } from "@/lib/gc-fitness/chat-schema";
 
+import { ChatImageLightbox } from "./ChatImageLightbox";
 import { QuickReplyDropdown } from "./QuickReplyDropdown";
 
 export interface MessageInputProps {
@@ -84,6 +85,9 @@ export function MessageInput({
     fileName: string;
   } | null>(null);
   const pendingImageRef = useRef(pendingImage);
+  // Issue #258 — full-size preview of the STAGED attachment so the coach can
+  // check the photo before hitting Send. Same lightbox the sent bubbles use.
+  const [previewingPendingImage, setPreviewingPendingImage] = useState(false);
   const [isRecording, setIsRecording] = useState(false);
   const [supportsRecording, setSupportsRecording] = useState(false);
   const mediaRecorderRef = useRef<MediaRecorder | null>(null);
@@ -126,6 +130,9 @@ export function MessageInput({
   // without re-running on every staged image.
   useEffect(() => {
     pendingImageRef.current = pendingImage;
+    // Issue #258 — close the full-size preview whenever the staged file
+    // changes (sent / removed / replaced) so it never shows a stale image.
+    setPreviewingPendingImage(false);
   }, [pendingImage]);
   useEffect(() => {
     return () => {
@@ -412,12 +419,22 @@ export function MessageInput({
       ) : null}
       {pendingImage ? (
         <div className="flex items-center gap-2 rounded-xl border border-border bg-muted/40 px-3 py-2">
-          {/* eslint-disable-next-line @next/next/no-img-element -- local object URL, not optimizable */}
-          <img
-            src={pendingImage.previewUrl}
-            alt={pendingImage.fileName}
-            className="h-14 w-14 shrink-0 rounded-md border border-border object-cover"
-          />
+          {/* Issue #258 — the staged thumbnail opens full-size so the coach
+              can check the photo before sending it. */}
+          <button
+            type="button"
+            onClick={() => setPreviewingPendingImage(true)}
+            aria-label={t("previewAttachment")}
+            title={t("previewAttachment")}
+            className="shrink-0 cursor-zoom-in appearance-none border-0 bg-transparent p-0"
+          >
+            {/* eslint-disable-next-line @next/next/no-img-element -- local object URL, not optimizable */}
+            <img
+              src={pendingImage.previewUrl}
+              alt={pendingImage.fileName}
+              className="h-14 w-14 shrink-0 rounded-md border border-border object-cover"
+            />
+          </button>
           <span className="min-w-0 flex-1 truncate text-xs text-muted-foreground">
             {pendingImage.fileName}
           </span>
@@ -432,6 +449,13 @@ export function MessageInput({
             <X className="h-4 w-4" />
           </button>
         </div>
+      ) : null}
+      {pendingImage && previewingPendingImage ? (
+        <ChatImageLightbox
+          url={pendingImage.previewUrl}
+          alt={pendingImage.fileName}
+          onClose={() => setPreviewingPendingImage(false)}
+        />
       ) : null}
       <div className="flex items-end gap-2 rounded-3xl border border-border bg-background p-1.5 shadow-sm focus-within:ring-2 focus-within:ring-ring/40">
         <label

--- a/backoffice/src/lib/gc-fitness/client-roster.ts
+++ b/backoffice/src/lib/gc-fitness/client-roster.ts
@@ -42,7 +42,7 @@
 import { cache } from "react";
 import { unstable_cache } from "next/cache";
 
-import { gcFitnessFirestore } from "@/lib/firebase/gc-fitness-admin";
+import { gcFitnessAuth, gcFitnessFirestore } from "@/lib/firebase/gc-fitness-admin";
 import { getCurrentTrainer } from "./auth-helpers";
 import { FirestoreCollections } from "./collections";
 import { coachVisibleClientName } from "./client-name";
@@ -209,8 +209,20 @@ async function _fetchClientsForTrainer(
     };
   });
 
+  // Issue #270 — drop ORPHANED docs: a failed `onBeforeUserCreated` run can
+  // leave a `/users/{uid}` doc whose Auth account was never committed (the
+  // blocking function writes the provisioning docs, then the account create
+  // aborts — e.g. the 7s budget on a cold start; the client retries and gets
+  // a FRESH uid, so the same person shows twice in the roster). Such docs are
+  // unreachable by any user — filter them by verifying the uid still exists
+  // in Firebase Auth. Fails OPEN (lookup error ⇒ keep everyone).
+  const liveAuthUids = await fetchExistingAuthUids(activeRows.map((r) => r.uid));
+  const liveRows = liveAuthUids
+    ? activeRows.filter((row) => liveAuthUids.has(row.uid))
+    : activeRows;
+
   const activeEmails = new Set(
-    activeRows.map((row) => row.email.trim().toLowerCase()).filter(Boolean),
+    liveRows.map((row) => row.email.trim().toLowerCase()).filter(Boolean),
   );
   const pendingRows: ClientRosterEntry[] = mirrorSnap.docs
     .reduce<ClientRosterEntry[]>((rows, doc) => {
@@ -240,7 +252,7 @@ async function _fetchClientsForTrainer(
       return rows;
     }, []);
 
-  const rows = [...activeRows, ...pendingRows];
+  const rows = [...liveRows, ...pendingRows];
 
   rows.sort((a, b) =>
     coachVisibleClientName(a).localeCompare(coachVisibleClientName(b), undefined, {
@@ -249,6 +261,27 @@ async function _fetchClientsForTrainer(
   );
 
   return rows;
+}
+
+/**
+ * Issue #270 — the set of uids that still exist in Firebase Auth, batched 100
+ * per `getUsers` call (the Admin SDK cap). Returns null on ANY failure so the
+ * caller fails open (an Auth hiccup must never blank the roster).
+ */
+async function fetchExistingAuthUids(uids: string[]): Promise<Set<string> | null> {
+  if (uids.length === 0) return new Set();
+  try {
+    const auth = gcFitnessAuth();
+    const found = new Set<string>();
+    for (let i = 0; i < uids.length; i += 100) {
+      const chunk = uids.slice(i, i + 100).map((uid) => ({ uid }));
+      const res = await auth.getUsers(chunk);
+      for (const user of res.users) found.add(user.uid);
+    }
+    return found;
+  } catch {
+    return null;
+  }
 }
 
 /**


### PR DESCRIPTION
Closes mdb1/gc-fitness#270, closes mdb1/gc-fitness#258.

## #270 — duplicate client in roster

**Root cause (investigated in prod):** Melinda Barton had TWO `/users` docs with the same (normalized) email, created 32 seconds apart — but only the second uid still exists in Firebase Auth. A failed `onBeforeUserCreated` run wrote the provisioning docs (`/users/{uid}`, `/chats/{uid}`) and then the Auth account creation aborted (the blocking function has a 7s budget; a cold start can blow it). She retried sign-in 32s later, got a fresh uid, and the orphaned doc made her appear twice (and as "2 nuevos clientes activados").

**Fixes:**
- **Prod cleanup (already done):** deleted the orphan `/users/UIJdPDiopMfr0Ik07UTUxh2Vsgl1` + its empty `/chats` doc (verified: no Auth account, no habits/assignments/activity/messages, zero data loss). The duplicate is gone now — a hard refresh of the roster (≤60s cache) shows her once.
- **Durable fix (this PR):** the roster pipeline (`_fetchClientsForTrainer`, which feeds every surface via `listClients`) now verifies each active doc's uid against Firebase Auth (batched `getUsers`, 100/call) and drops orphans. Fails open on lookup errors so an Auth hiccup never blanks the roster.
- This was the only orphan in prod (checked all 23 user docs against Auth).

**Note for later (not this PR):** the real prevention would be hardening `onBeforeUserCreated` (e.g. moving non-essential writes out of the blocking path, or an orphan-reaper) — functions deploys are manual, so left out of this backoffice PR.

## #258 — check the attached photo before sending

The issue's screenshot is the **composer**: the staged ("pasted-….png") attachment preview. The thumbnail is now a button that opens the photo full-size in the same lightbox the sent bubbles use (`ChatImageLightbox` extracted to a shared component). Preview auto-closes when the staged file is sent/removed/replaced. New `chat.composer.previewAttachment` string (en/es).

## Tests
- `npx tsc --noEmit` clean; `npx jest` 493/494 (the one red is the known `client-activity-time` locale flake, green in CI).