### PR TITLE
GC Fitness legal pages: privacy policy + account deletion (es/en)

### DIFF
--- a/pocket-genes/src/pages/en/gc-fitness/delete-account.astro
+++ b/pocket-genes/src/pages/en/gc-fitness/delete-account.astro
@@ -1,0 +1,85 @@
+---
+import BaseLayout from '../../../layouts/BaseLayout.astro';
+---
+
+<BaseLayout title="GC Fitness — Account deletion">
+  <main class="legal-page">
+    <div class="legal-container">
+      <p class="legal-lang"><a href="/gc-fitness/delete-account">Versión en español</a></p>
+      <h1>Account deletion — GC Fitness</h1>
+
+      <p>
+        You can delete your GC Fitness account (app <code>com.goldencrow.fitness</code>) and all
+        associated data in two ways:
+      </p>
+
+      <h2>1. From the app (recommended)</h2>
+      <ol>
+        <li>Open GC Fitness and sign in.</li>
+        <li>Go to <strong>Settings</strong>.</li>
+        <li>Tap <strong>Delete account</strong> at the bottom of the screen.</li>
+        <li>Confirm by typing the requested word. Deletion is immediate and permanent.</li>
+      </ol>
+
+      <h2>2. By email</h2>
+      <p>
+        If you no longer have access to the app, email
+        <a href="mailto:support@goldencrowvs.com?subject=Delete%20GC%20Fitness%20account">support@goldencrowvs.com</a>
+        with the subject "Delete GC Fitness account" from your account's email address. We process
+        requests within 30 days.
+      </p>
+
+      <h2>What gets deleted</h2>
+      <ul>
+        <li>Your account and profile (name, email, photo).</li>
+        <li>Your entire workout, habit, and body-metric history.</li>
+        <li>Your progress photos and uploaded files.</li>
+        <li>The chat with your trainer (messages, photos, and voice notes).</li>
+        <li>Your devices' push-notification tokens.</li>
+      </ul>
+
+      <h2>What is kept</h2>
+      <ul>
+        <li>A minimal <strong>anonymized</strong> record (no name, email, or content) for system
+          integrity.</li>
+        <li>Crash reports and usage analytics are removed per Firebase's (Google's) retention
+          windows.</li>
+      </ul>
+
+      <p>
+        See our <a href="/en/gc-fitness/privacy">Privacy Policy</a> for more details.
+      </p>
+    </div>
+  </main>
+</BaseLayout>
+
+<style>
+  .legal-page {
+    padding: 7rem 1.5rem 4rem;
+    min-height: 60vh;
+  }
+  .legal-container {
+    max-width: 760px;
+    margin: 0 auto;
+    line-height: 1.65;
+  }
+  .legal-container h1 {
+    font-size: 2rem;
+    margin-bottom: 1rem;
+  }
+  .legal-container h2 {
+    font-size: 1.2rem;
+    margin: 2rem 0 0.5rem;
+  }
+  .legal-container ul,
+  .legal-container ol {
+    padding-left: 1.25rem;
+  }
+  .legal-container li {
+    margin-bottom: 0.4rem;
+  }
+  .legal-lang {
+    font-size: 0.85rem;
+    margin-bottom: 1rem;
+  }
+</style>

--- a/pocket-genes/src/pages/en/gc-fitness/privacy.astro
+++ b/pocket-genes/src/pages/en/gc-fitness/privacy.astro
@@ -1,0 +1,137 @@
+---
+import BaseLayout from '../../../layouts/BaseLayout.astro';
+---
+
+<BaseLayout title="GC Fitness — Privacy Policy">
+  <main class="legal-page">
+    <div class="legal-container">
+      <p class="legal-lang"><a href="/gc-fitness/privacy">Versión en español</a></p>
+      <h1>Privacy Policy — GC Fitness</h1>
+      <p class="legal-updated">Effective date: June 12, 2026</p>
+
+      <p>
+        This policy describes how Golden Crow ("we") handles your personal data when you use the
+        <strong>GC Fitness</strong> mobile app (package <code>com.goldencrow.fitness</code>,
+        available for iOS and Android). GC Fitness is a coaching platform: it connects each client
+        with their personal trainer.
+      </p>
+
+      <h2>Data we collect</h2>
+      <ul>
+        <li><strong>Account:</strong> name, email address, and profile photo provided by your
+          sign-in method (Google or Apple).</li>
+        <li><strong>Training and health data:</strong> logged workouts (sets, reps, weights,
+          durations), habits and their completion, body metrics you enter (weight, height),
+          personal records, and goals.</li>
+        <li><strong>Progress photos:</strong> photos you voluntarily upload for visual
+          tracking.</li>
+        <li><strong>Messages:</strong> your chat with your coach (text, photos, and voice
+          notes).</li>
+        <li><strong>Technical data:</strong> device push token (FCM), crash reports (Firebase
+          Crashlytics), and product-usage events (Firebase Analytics: e.g. "workout started",
+          "set logged", screen views — associated with your user ID). We do not use advertising
+          identifiers.</li>
+        <li><strong>Preferences:</strong> language, theme, units, notification settings, and
+          timezone.</li>
+      </ul>
+
+      <h2>How we use your data</h2>
+      <ul>
+        <li>Providing the service: your trainer sees your workouts, habits, metrics, progress
+          photos, and messages in order to coach you.</li>
+        <li>App functionality: syncing across your devices, notifications (workout and habit
+          reminders, coach messages, rest-timer alerts).</li>
+        <li>Diagnostics and improvement: crash reports and product analytics.</li>
+      </ul>
+      <p>
+        On iOS, with your permission, the app writes your workouts to Apple Health and reads data
+        such as heart rate, active energy, and steps to display them in the app. Apple Health data
+        is processed on your device and is never used for advertising.
+      </p>
+
+      <h2>Who we share data with</h2>
+      <ul>
+        <li><strong>Your trainer:</strong> sees the fitness data, photos, and messages associated
+          with your account — that is the purpose of the service.</li>
+        <li><strong>Infrastructure providers:</strong> we use Google Firebase (authentication,
+          database, storage, push notifications, Crashlytics, and Analytics) to operate the app.
+          Google acts as a data processor.</li>
+      </ul>
+      <p>
+        <strong>We do not sell your data.</strong> There are no ads, and we never share your data
+        with third parties for marketing.
+      </p>
+
+      <h2>Security and storage</h2>
+      <p>
+        Your data is stored on Google Cloud (Firebase) and encrypted in transit (TLS). Access is
+        restricted by security rules: only you and your trainer can access your data.
+      </p>
+
+      <h2>Retention and deletion</h2>
+      <p>
+        We keep your data while your account is active. You can delete your account at any time
+        from the app (Settings → Delete account) or by emailing us — see
+        <a href="/en/gc-fitness/delete-account">Account deletion</a>. Deletion removes your
+        profile, workouts, habits, metrics, photos, and messages; a minimal anonymized record
+        (no name or email) is kept for system integrity, and crash/analytics telemetry is removed
+        per Firebase's retention windows.
+      </p>
+
+      <h2>Your rights</h2>
+      <p>
+        You can request access to, correction of, or deletion of your data by writing to
+        <a href="mailto:support@goldencrowvs.com">support@goldencrowvs.com</a>.
+      </p>
+
+      <h2>Children</h2>
+      <p>The app is not directed at children under 13.</p>
+
+      <h2>Changes</h2>
+      <p>
+        If we change this policy we will publish the updated version on this page with a new
+        effective date.
+      </p>
+
+      <h2>Contact</h2>
+      <p>
+        Golden Crow — <a href="mailto:support@goldencrowvs.com">support@goldencrowvs.com</a>
+      </p>
+    </div>
+  </main>
+</BaseLayout>
+
+<style>
+  .legal-page {
+    padding: 7rem 1.5rem 4rem;
+    min-height: 60vh;
+  }
+  .legal-container {
+    max-width: 760px;
+    margin: 0 auto;
+    line-height: 1.65;
+  }
+  .legal-container h1 {
+    font-size: 2rem;
+    margin-bottom: 0.25rem;
+  }
+  .legal-container h2 {
+    font-size: 1.2rem;
+    margin: 2rem 0 0.5rem;
+  }
+  .legal-container ul {
+    padding-left: 1.25rem;
+  }
+  .legal-container li {
+    margin-bottom: 0.4rem;
+  }
+  .legal-updated {
+    opacity: 0.7;
+    font-size: 0.9rem;
+    margin-bottom: 2rem;
+  }
+  .legal-lang {
+    font-size: 0.85rem;
+    margin-bottom: 1rem;
+  }
+</style>

--- a/pocket-genes/src/pages/gc-fitness/delete-account.astro
+++ b/pocket-genes/src/pages/gc-fitness/delete-account.astro
@@ -1,0 +1,86 @@
+---
+import BaseLayout from '../../layouts/BaseLayout.astro';
+---
+
+<BaseLayout title="GC Fitness — Eliminación de cuenta">
+  <main class="legal-page">
+    <div class="legal-container">
+      <p class="legal-lang"><a href="/en/gc-fitness/delete-account">English version</a></p>
+      <h1>Eliminación de cuenta — GC Fitness</h1>
+
+      <p>
+        Podés eliminar tu cuenta de GC Fitness (app <code>com.goldencrow.fitness</code>) y todos
+        los datos asociados de dos maneras:
+      </p>
+
+      <h2>1. Desde la app (recomendado)</h2>
+      <ol>
+        <li>Abrí GC Fitness e iniciá sesión.</li>
+        <li>Andá a <strong>Ajustes</strong> (pestaña de configuración).</li>
+        <li>Tocá <strong>Eliminar cuenta</strong>, al final de la pantalla.</li>
+        <li>Confirmá escribiendo la palabra solicitada. La eliminación es inmediata y definitiva.</li>
+      </ol>
+
+      <h2>2. Por email</h2>
+      <p>
+        Si ya no tenés acceso a la app, escribí a
+        <a href="mailto:support@goldencrowvs.com?subject=Eliminar%20cuenta%20GC%20Fitness">support@goldencrowvs.com</a>
+        con el asunto «Eliminar cuenta GC Fitness» desde la dirección de email de tu cuenta.
+        Procesamos las solicitudes dentro de los 30 días.
+      </p>
+
+      <h2>Qué se elimina</h2>
+      <ul>
+        <li>Tu cuenta y perfil (nombre, email, foto).</li>
+        <li>Todo tu historial de entrenamientos, hábitos y métricas corporales.</li>
+        <li>Tus fotos de progreso y archivos subidos.</li>
+        <li>El chat con tu entrenador (mensajes, fotos y audios).</li>
+        <li>Los tokens de notificaciones de tus dispositivos.</li>
+      </ul>
+
+      <h2>Qué se conserva</h2>
+      <ul>
+        <li>Un registro mínimo <strong>anonimizado</strong> (sin nombre, email ni contenido) por
+          integridad del sistema.</li>
+        <li>Los informes de fallos y la analítica de uso se eliminan según los plazos de
+          retención de Firebase (Google).</li>
+      </ul>
+
+      <p>
+        Más información en nuestra
+        <a href="/gc-fitness/privacy">Política de Privacidad</a>.
+      </p>
+    </div>
+  </main>
+</BaseLayout>
+
+<style>
+  .legal-page {
+    padding: 7rem 1.5rem 4rem;
+    min-height: 60vh;
+  }
+  .legal-container {
+    max-width: 760px;
+    margin: 0 auto;
+    line-height: 1.65;
+  }
+  .legal-container h1 {
+    font-size: 2rem;
+    margin-bottom: 1rem;
+  }
+  .legal-container h2 {
+    font-size: 1.2rem;
+    margin: 2rem 0 0.5rem;
+  }
+  .legal-container ul,
+  .legal-container ol {
+    padding-left: 1.25rem;
+  }
+  .legal-container li {
+    margin-bottom: 0.4rem;
+  }
+  .legal-lang {
+    font-size: 0.85rem;
+    margin-bottom: 1rem;
+  }
+</style>

--- a/pocket-genes/src/pages/gc-fitness/privacy.astro
+++ b/pocket-genes/src/pages/gc-fitness/privacy.astro
@@ -1,0 +1,137 @@
+---
+import BaseLayout from '../../layouts/BaseLayout.astro';
+---
+
+<BaseLayout title="GC Fitness — Política de Privacidad">
+  <main class="legal-page">
+    <div class="legal-container">
+      <p class="legal-lang"><a href="/en/gc-fitness/privacy">English version</a></p>
+      <h1>Política de Privacidad — GC Fitness</h1>
+      <p class="legal-updated">Vigente desde: 12 de junio de 2026</p>
+
+      <p>
+        Esta política describe cómo Golden Crow («nosotros») trata tus datos personales cuando
+        usás la aplicación móvil <strong>GC Fitness</strong> (paquete
+        <code>com.goldencrow.fitness</code>, disponible para iOS y Android). GC Fitness es una
+        plataforma de coaching: conecta a cada cliente con su entrenador personal.
+      </p>
+
+      <h2>Qué datos recopilamos</h2>
+      <ul>
+        <li><strong>Cuenta:</strong> nombre, dirección de email y foto de perfil provistos por tu
+          método de inicio de sesión (Google o Apple).</li>
+        <li><strong>Datos de entrenamiento y salud:</strong> entrenamientos registrados (series,
+          repeticiones, pesos, duraciones), hábitos y su cumplimiento, métricas corporales que
+          cargues (peso, altura), récords personales y objetivos.</li>
+        <li><strong>Fotos de progreso:</strong> las fotos que subas voluntariamente para tu
+          seguimiento visual.</li>
+        <li><strong>Mensajes:</strong> el chat con tu entrenador (texto, fotos y notas de voz).</li>
+        <li><strong>Datos técnicos:</strong> token del dispositivo para notificaciones push (FCM),
+          informes de fallos (Firebase Crashlytics) y eventos de uso de la app (Firebase
+          Analytics: por ejemplo «entrenamiento iniciado», «serie registrada» y vistas de
+          pantalla, asociados a tu ID de usuario). No usamos identificadores publicitarios.</li>
+        <li><strong>Preferencias:</strong> idioma, tema, unidades, configuración de notificaciones
+          y zona horaria.</li>
+      </ul>
+
+      <h2>Para qué usamos tus datos</h2>
+      <ul>
+        <li>Brindar el servicio: tu entrenador ve tus entrenamientos, hábitos, métricas, fotos de
+          progreso y mensajes para poder entrenarte.</li>
+        <li>Funcionamiento de la app: sincronización entre tus dispositivos, notificaciones
+          (recordatorios de entrenamientos y hábitos, mensajes del coach, fin del descanso).</li>
+        <li>Diagnóstico y mejora: informes de fallos y analítica de uso del producto.</li>
+      </ul>
+      <p>
+        En iOS, si lo autorizás, la app escribe tus entrenamientos en Apple Health y lee datos como
+        frecuencia cardíaca, energía activa y pasos para mostrarlos en la app. Esos datos de Apple
+        Health se procesan en tu dispositivo y no se usan con fines publicitarios.
+      </p>
+
+      <h2>Con quién compartimos datos</h2>
+      <ul>
+        <li><strong>Tu entrenador:</strong> ve los datos de fitness, fotos y mensajes asociados a tu
+          cuenta — es el propósito del servicio.</li>
+        <li><strong>Proveedores de infraestructura:</strong> usamos Google Firebase
+          (autenticación, base de datos, almacenamiento, notificaciones, Crashlytics y Analytics)
+          para operar la app. Google actúa como encargado del tratamiento.</li>
+      </ul>
+      <p>
+        <strong>No vendemos tus datos.</strong> No mostramos publicidad ni compartimos tus datos
+        con terceros con fines de marketing.
+      </p>
+
+      <h2>Seguridad y almacenamiento</h2>
+      <p>
+        Tus datos se almacenan en Google Cloud (Firebase) y se transmiten cifrados (TLS). El acceso
+        está restringido por reglas de seguridad: solo vos y tu entrenador pueden acceder a tus
+        datos.
+      </p>
+
+      <h2>Retención y eliminación</h2>
+      <p>
+        Conservamos tus datos mientras tu cuenta esté activa. Podés eliminar tu cuenta en cualquier
+        momento desde la app (Ajustes → Eliminar cuenta) o solicitándolo por email — ver
+        <a href="/gc-fitness/delete-account">Eliminación de cuenta</a>. Al eliminarla se borran tu
+        perfil, entrenamientos, hábitos, métricas, fotos y mensajes; se conserva un registro mínimo
+        anonimizado (sin nombre ni email) por integridad del sistema, y los informes de fallos /
+        analítica se eliminan según los plazos de retención de Firebase.
+      </p>
+
+      <h2>Tus derechos</h2>
+      <p>
+        Podés solicitar acceso, corrección o eliminación de tus datos escribiendo a
+        <a href="mailto:support@goldencrowvs.com">support@goldencrowvs.com</a>.
+      </p>
+
+      <h2>Menores</h2>
+      <p>La app no está dirigida a menores de 13 años.</p>
+
+      <h2>Cambios</h2>
+      <p>
+        Si modificamos esta política publicaremos la versión actualizada en esta página con su
+        nueva fecha de vigencia.
+      </p>
+
+      <h2>Contacto</h2>
+      <p>
+        Golden Crow — <a href="mailto:support@goldencrowvs.com">support@goldencrowvs.com</a>
+      </p>
+    </div>
+  </main>
+</BaseLayout>
+
+<style>
+  .legal-page {
+    padding: 7rem 1.5rem 4rem;
+    min-height: 60vh;
+  }
+  .legal-container {
+    max-width: 760px;
+    margin: 0 auto;
+    line-height: 1.65;
+  }
+  .legal-container h1 {
+    font-size: 2rem;
+    margin-bottom: 0.25rem;
+  }
+  .legal-container h2 {
+    font-size: 1.2rem;
+    margin: 2rem 0 0.5rem;
+  }
+  .legal-container ul {
+    padding-left: 1.25rem;
+  }
+  .legal-container li {
+    margin-bottom: 0.4rem;
+  }
+  .legal-updated {
+    opacity: 0.7;
+    font-size: 0.9rem;
+    margin-bottom: 2rem;
+  }
+  .legal-lang {
+    font-size: 0.85rem;
+    margin-bottom: 1rem;
+  }
+</style>


### PR DESCRIPTION
Play Store launch prerequisites — public URLs for the Play Console Data safety form:

- **Privacy policy**: `/gc-fitness/privacy` (es) + `/en/gc-fitness/privacy`
- **Account deletion**: `/gc-fitness/delete-account` (es) + `/en/gc-fitness/delete-account`

Content is accurate to the app: Firebase SDK inventory from `gc-fitness/PRIVACY_DATA_MAP.md` (Auth, Firestore, Storage, FCM, Crashlytics, Analytics — no ads, no tracking, no data sale), the coach-sees-your-data disclosure, Apple Health note (iOS), and the `deleteMyAccount` cascade incl. the anonymized-tombstone disclosure.

Astro build green (20 pages). Once merged, GitHub Pages deploys to goldencrowvs.com and the URLs go into Play Console → App content.