### PR TITLE
feat(backoffice): bulk assignment recurrence + dashboard urgency card

### DIFF
--- a/backoffice/messages/en.json
+++ b/backoffice/messages/en.json
@@ -1411,7 +1411,35 @@
       "errorBulkFailed": "Bulk assign failed.",
       "successSingular": "Assigned to {count} client.",
       "successPlural": "Assigned to {count} clients.",
-      "unknownTemplate": "(unknown template)"
+      "unknownTemplate": "(unknown template)",
+      "modeLabel": "Frequency",
+      "modeOnce": "One-time",
+      "modeWeekly": "Weekly recurring",
+      "modeDaily": "Daily",
+      "modeEveryN": "Every N days",
+      "modeMonthly": "Monthly",
+      "repeatOnLabel": "Repeat on",
+      "repeatEveryNLabel": "Every (days)",
+      "repeatEveryNHint": "Repeats every {n} days from the start date.",
+      "repeatMonthlyHint": "Repeats on day {day} of every month (months without that day use their last day).",
+      "setEndDate": "Set end date",
+      "endDateLabel": "End date",
+      "endDatePresetMonths": "{months, plural, one {# month} other {# months}}",
+      "endDateValue": "Ends on {date}.",
+      "successRecurring": "Assigned a recurring series to {count, plural, one {# client} other {# clients}}.",
+      "summaryDaily": "Every day",
+      "summaryEveryN": "Every {n} days",
+      "summaryWeekly": "Weekly: {days}",
+      "summaryMonthly": "Monthly on day {day}",
+      "weekdays": {
+        "sunday": "Sunday",
+        "monday": "Monday",
+        "tuesday": "Tuesday",
+        "wednesday": "Wednesday",
+        "thursday": "Thursday",
+        "friday": "Friday",
+        "saturday": "Saturday"
+      }
     },
     "bulkConfirm": {
       "titleSingular": "Assign “{template}” to {count} client on {date}?",
@@ -1421,7 +1449,9 @@
       "cancel": "Cancel",
       "assigning": "Assigning…",
       "confirmSingular": "Confirm {count} assignment",
-      "confirmPlural": "Confirm {count} assignments"
+      "confirmPlural": "Confirm {count} assignments",
+      "recurrenceLabel": "Recurrence:",
+      "recurrenceHint": "Each of the {count, plural, one {# client} other {# clients}} gets a recurring series starting {start}."
     },
     "assignModal": {
       "title": "Assign a workout template",

--- a/backoffice/messages/en.json
+++ b/backoffice/messages/en.json
@@ -1350,7 +1350,8 @@
       "habits": "Habits",
       "birthdayBadge": "Birthday",
       "pickClientsPrompt": "Pick one or more clients above to see their agenda.",
-      "pickClientFirstToast": "Pick at least one client first"
+      "pickClientFirstToast": "Pick at least one client first",
+      "bulkAssignHabit": "Assign habit"
     },
     "clientPicker": {
       "emptyTitle": "No clients yet",

--- a/backoffice/messages/en.json
+++ b/backoffice/messages/en.json
@@ -157,7 +157,11 @@
       "habitsDescription": "Create habit assignments for clients.",
       "chatTitle": "Chat",
       "chatDescription": "Reply to client conversations."
-    }
+    },
+    "unassignedSoonTitle": "Nothing assigned this week",
+    "unassignedSoonSubtitle": "Active clients with no workout or active habit in the next 4 days.",
+    "unassignedSoonEmpty": "All caught up — every active client has something assigned.",
+    "unassignedSoonAssignCta": "Assign"
   },
   "notifications": {
     "title": "Notifications",

--- a/backoffice/messages/es.json
+++ b/backoffice/messages/es.json
@@ -1350,7 +1350,8 @@
       "habits": "Hábitos",
       "birthdayBadge": "Cumpleaños",
       "pickClientsPrompt": "Elegí uno o más clientes arriba para ver su agenda.",
-      "pickClientFirstToast": "Elegí al menos un cliente primero"
+      "pickClientFirstToast": "Elegí al menos un cliente primero",
+      "bulkAssignHabit": "Asignar hábito"
     },
     "clientPicker": {
       "emptyTitle": "Aún no tenés clientes",

--- a/backoffice/messages/es.json
+++ b/backoffice/messages/es.json
@@ -1411,7 +1411,35 @@
       "errorBulkFailed": "Falló la asignación masiva.",
       "successSingular": "Asignado a {count} cliente.",
       "successPlural": "Asignado a {count} clientes.",
-      "unknownTemplate": "(plantilla desconocida)"
+      "unknownTemplate": "(plantilla desconocida)",
+      "modeLabel": "Frecuencia",
+      "modeOnce": "Única",
+      "modeWeekly": "Semanal recurrente",
+      "modeDaily": "Diaria",
+      "modeEveryN": "Cada N días",
+      "modeMonthly": "Mensual",
+      "repeatOnLabel": "Repetir los",
+      "repeatEveryNLabel": "Cada (días)",
+      "repeatEveryNHint": "Se repite cada {n} días desde la fecha de inicio.",
+      "repeatMonthlyHint": "Se repite el día {day} de cada mes (si el mes no tiene ese día, se usa el último día del mes).",
+      "setEndDate": "Definir fecha de fin",
+      "endDateLabel": "Fecha de fin",
+      "endDatePresetMonths": "{months, plural, one {# mes} other {# meses}}",
+      "endDateValue": "Termina el {date}.",
+      "successRecurring": "Se asignó una serie recurrente a {count, plural, one {# cliente} other {# clientes}}.",
+      "summaryDaily": "Todos los días",
+      "summaryEveryN": "Cada {n} días",
+      "summaryWeekly": "Semanal: {days}",
+      "summaryMonthly": "Mensual el día {day}",
+      "weekdays": {
+        "sunday": "Domingo",
+        "monday": "Lunes",
+        "tuesday": "Martes",
+        "wednesday": "Miércoles",
+        "thursday": "Jueves",
+        "friday": "Viernes",
+        "saturday": "Sábado"
+      }
     },
     "bulkConfirm": {
       "titleSingular": "¿Asignar “{template}” a {count} cliente el {date}?",
@@ -1421,7 +1449,9 @@
       "cancel": "Cancelar",
       "assigning": "Asignando…",
       "confirmSingular": "Confirmar {count} asignación",
-      "confirmPlural": "Confirmar {count} asignaciones"
+      "confirmPlural": "Confirmar {count} asignaciones",
+      "recurrenceLabel": "Recurrencia:",
+      "recurrenceHint": "Cada uno de los {count, plural, one {# cliente} other {# clientes}} recibe una serie recurrente que empieza el {start}."
     },
     "assignModal": {
       "title": "Asignar una plantilla de entrenamiento",

--- a/backoffice/messages/es.json
+++ b/backoffice/messages/es.json
@@ -157,7 +157,11 @@
       "habitsDescription": "Creá asignaciones de hábitos para los clientes.",
       "chatTitle": "Chat",
       "chatDescription": "Respondé las conversaciones con tus clientes."
-    }
+    },
+    "unassignedSoonTitle": "Sin nada asignado esta semana",
+    "unassignedSoonSubtitle": "Clientes activos sin entrenamiento ni hábito activo en los próximos 4 días.",
+    "unassignedSoonEmpty": "Todo al día — cada cliente activo tiene algo asignado.",
+    "unassignedSoonAssignCta": "Asignar"
   },
   "notifications": {
     "title": "Notificaciones",

--- a/backoffice/src/app/gc-fitness/dashboard/_components/unassigned-clients-card.tsx
+++ b/backoffice/src/app/gc-fitness/dashboard/_components/unassigned-clients-card.tsx
@@ -1,0 +1,75 @@
+import Link from "next/link";
+import { CalendarPlus, CheckCircle2 } from "lucide-react";
+import { getTranslations } from "next-intl/server";
+
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { ClientAvatar } from "@/components/gc-fitness/ClientAvatar";
+import type { UnassignedClientRow } from "@/lib/gc-fitness/coach-attention-actions";
+
+interface Props {
+  rows: UnassignedClientRow[];
+}
+
+/**
+ * 260612-e9t (#245): dashboard urgency card. Lists the active clients with
+ * NOTHING assigned in the next 4 days (no workout assignment AND no active
+ * habit), each linking to the schedule prefiltered to that client so the
+ * trainer can assign immediately. Renders an "all caught up" empty state when
+ * everyone is covered. Server component (read-only).
+ */
+export async function UnassignedClientsCard({ rows }: Props) {
+  const t = await getTranslations("dashboard");
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="gc-page-title flex items-center gap-2 text-xl">
+          <CalendarPlus className="size-5" />
+          {t("unassignedSoonTitle")}
+        </CardTitle>
+        <CardDescription>{t("unassignedSoonSubtitle")}</CardDescription>
+      </CardHeader>
+      <CardContent>
+        {rows.length === 0 ? (
+          <div className="flex items-center gap-2 text-sm text-muted-foreground">
+            <CheckCircle2 className="size-4 text-emerald-500" />
+            {t("unassignedSoonEmpty")}
+          </div>
+        ) : (
+          <ul className="flex flex-col gap-1.5">
+            {rows.map((row) => (
+              <li key={row.uid}>
+                <Link
+                  href={`/gc-fitness/schedule?clientId=${row.uid}`}
+                  className="flex items-center justify-between gap-3 rounded-lg px-2 py-2 transition-colors hover:bg-muted"
+                >
+                  <span className="flex min-w-0 items-center gap-3">
+                    <ClientAvatar name={row.displayName} photoURL={row.photoURL} />
+                    <span className="truncate font-medium">
+                      {row.displayName}
+                    </span>
+                  </span>
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    className="rounded-full"
+                    tabIndex={-1}
+                  >
+                    {t("unassignedSoonAssignCta")}
+                  </Button>
+                </Link>
+              </li>
+            ))}
+          </ul>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/backoffice/src/app/gc-fitness/dashboard/page.tsx
+++ b/backoffice/src/app/gc-fitness/dashboard/page.tsx
@@ -29,6 +29,7 @@ import {
 } from "@/lib/gc-fitness/auth-helpers";
 import { listClientsForRoster } from "@/lib/gc-fitness/client-roster";
 import { getCoachPulse } from "@/lib/gc-fitness/coach-pulse-actions";
+import { listClientsWithNothingAssignedSoon } from "@/lib/gc-fitness/coach-attention-actions";
 import { listPendingChecklistItems } from "@/lib/gc-fitness/coach-checklist-actions";
 import { safe } from "@/lib/gc-fitness/safe-load";
 import { NEEDS_ATTENTION_INACTIVITY_HOURS } from "@/lib/gc-fitness/client-attention";
@@ -40,6 +41,7 @@ import {
   TopPerformers,
 } from "./_components/coach-pulse";
 import { ChecklistPending } from "./_components/checklist-pending";
+import { UnassignedClientsCard } from "./_components/unassigned-clients-card";
 import { sectionMetadata } from "@/lib/gc-fitness/page-metadata";
 
 // Tab title: "GC Fitness - <dashboard>" (issue #170).
@@ -88,6 +90,12 @@ export default async function GCFitnessDashboardPage({
   // `safe()` so a checklist read failure degrades to no widget, never a 500.
   const pendingChecklist =
     (await safe("coach checklist", () => listPendingChecklistItems())) ?? [];
+  // 260612-e9t (#245): active clients with nothing assigned in the next 4 days.
+  // Behind safe() so a query failure degrades to no card, never a 500.
+  const unassignedSoon =
+    (await safe("unassigned clients", () =>
+      listClientsWithNothingAssignedSoon(),
+    )) ?? [];
 
   const tDashboard = await getTranslations("dashboard");
   const tNav = await getTranslations("nav");
@@ -209,6 +217,9 @@ export default async function GCFitnessDashboardPage({
 
       {/* Pending checklist (overdue + due today) */}
       <ChecklistPending items={pendingChecklist} />
+
+      {/* 260612-e9t (#245): clients with nothing assigned in the next 4 days */}
+      <UnassignedClientsCard rows={unassignedSoon} />
 
       {/* Charts: workouts (gold bars) + habits (line) */}
       <div className="grid gap-4 xl:grid-cols-2">

--- a/backoffice/src/components/gc-fitness/schedule/bulk-assign-form.tsx
+++ b/backoffice/src/components/gc-fitness/schedule/bulk-assign-form.tsx
@@ -44,6 +44,10 @@ import { civilDateToday } from "@/lib/gc-fitness/civil-date";
 import { useWorkoutTemplates } from "@/lib/gc-fitness/workout-templates-listener";
 import { bulkAssignTemplate } from "@/lib/gc-fitness/workout-assignment-actions";
 import { MAX_CLIENTS_PER_BATCH } from "@/lib/gc-fitness/workout-assignment-schema";
+import {
+  addCivilMonths,
+  END_DATE_PRESET_MONTHS,
+} from "@/lib/gc-fitness/end-date-presets";
 import type { ClientRosterEntry } from "@/lib/gc-fitness/client-roster";
 
 import { BulkConfirmModal } from "./bulk-confirm-modal";
@@ -52,6 +56,28 @@ interface BulkAssignFormProps {
   clients: ClientRosterEntry[];
   trainerTimezone?: string;
 }
+
+// 260612-e9t (#175): same cadence vocabulary the single-client
+// AssignTemplateModal exposes. "once" → no recurrence (single date on the
+// picked day, byte-identical to the pre-recurrence bulk path).
+type RecurrenceMode = "once" | "weekly" | "daily" | "everyN" | "monthly";
+
+type BulkRecurrenceRule =
+  | { kind: "daily" }
+  | { kind: "weekly"; weekday: number }
+  | { kind: "weekly_days"; weekdays: number[] }
+  | { kind: "every_n_days"; everyN: number }
+  | { kind: "monthly"; dayOfMonth: number };
+
+const BULK_WEEKDAY_KEYS = [
+  "sunday",
+  "monday",
+  "tuesday",
+  "wednesday",
+  "thursday",
+  "friday",
+  "saturday",
+] as const;
 
 function parseCivilToLocalDate(civil: string): Date {
   const [y, m, d] = civil.split("-").map(Number);
@@ -86,6 +112,66 @@ export function BulkAssignForm({
   const [selectedUids, setSelectedUids] = useState<Set<string>>(new Set());
   const [confirmOpen, setConfirmOpen] = useState(false);
   const [submitting, setSubmitting] = useState(false);
+
+  // 260612-e9t (#175): recurrence picker state, mirroring AssignTemplateModal.
+  const [mode, setMode] = useState<RecurrenceMode>("once");
+  const [recurringWeekdays, setRecurringWeekdays] = useState<Set<number>>(
+    () => new Set([parseCivilToLocalDate(civilDateToday(resolvedTimezone)).getDay()]),
+  );
+  const [recurringEveryN, setRecurringEveryN] = useState<number>(2);
+  const [recurringEveryNDraft, setRecurringEveryNDraft] = useState<string>("2");
+  const [recurringEndEnabled, setRecurringEndEnabled] = useState(true);
+  const [recurringEndDate, setRecurringEndDate] = useState<string>(() =>
+    addCivilMonths(civilDateToday(resolvedTimezone), 3),
+  );
+  const [recurringEndPresetMonths, setRecurringEndPresetMonths] = useState<
+    number | null
+  >(3);
+
+  function toggleWeekday(idx: number) {
+    setRecurringWeekdays((prev) => {
+      const next = new Set(prev);
+      if (next.has(idx)) {
+        // Never let the multi-select drop to zero weekdays.
+        if (next.size > 1) next.delete(idx);
+      } else {
+        next.add(idx);
+      }
+      return next;
+    });
+  }
+
+  // Build the canonical recurrence rule from the current mode (null for "once").
+  function buildRecurrence(): BulkRecurrenceRule | null {
+    if (mode === "once") return null;
+    if (mode === "daily") return { kind: "daily" };
+    if (mode === "everyN") return { kind: "every_n_days", everyN: recurringEveryN };
+    if (mode === "monthly") {
+      return { kind: "monthly", dayOfMonth: parseCivilToLocalDate(civilDate).getDate() };
+    }
+    const weekdays = Array.from(recurringWeekdays).sort((a, b) => a - b);
+    return weekdays.length === 1
+      ? { kind: "weekly", weekday: weekdays[0] }
+      : { kind: "weekly_days", weekdays };
+  }
+
+  // Human-readable recurrence summary for the confirm modal (null when once).
+  const recurrenceSummary = useMemo(() => {
+    if (mode === "once") return null;
+    if (mode === "daily") return t("summaryDaily");
+    if (mode === "everyN") return t("summaryEveryN", { n: recurringEveryN });
+    if (mode === "monthly") {
+      return t("summaryMonthly", {
+        day: parseCivilToLocalDate(civilDate).getDate(),
+      });
+    }
+    const labels = Array.from(recurringWeekdays)
+      .sort((a, b) => a - b)
+      .map((idx) => t(`weekdays.${BULK_WEEKDAY_KEYS[idx]}`).slice(0, 3))
+      .join(", ");
+    return t("summaryWeekly", { days: labels });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [mode, recurringEveryN, recurringWeekdays, civilDate, t]);
 
   const selectedClients = useMemo(
     () => clients.filter((c) => selectedUids.has(c.uid)),
@@ -146,6 +232,7 @@ export function BulkAssignForm({
     }
     setSubmitting(true);
     try {
+      const recurrence = buildRecurrence();
       const result = await bulkAssignTemplate({
         templateId,
         clientIds: finalClientIds,
@@ -153,12 +240,26 @@ export function BulkAssignForm({
         scheduledTime: scheduledTime || undefined,
         meetingNotes: meetingNotes.trim() || undefined,
         timezone: resolvedTimezone,
+        // Only send recurrence/endDate when recurring — keeps the "once" path
+        // byte-identical to the pre-260612 single-date submit.
+        ...(recurrence ? { recurrence } : {}),
+        ...(recurrence && recurringEndEnabled
+          ? { endDate: recurringEndDate }
+          : {}),
       });
-      toast.success(
-        result.ids.length === 1
-          ? t("successSingular", { count: result.ids.length })
-          : t("successPlural", { count: result.ids.length }),
-      );
+      if (recurrence) {
+        // Recurring: one doc per (client × matching date). result.ids.length is
+        // the total doc count; surface the CLIENT count in the success toast.
+        toast.success(
+          t("successRecurring", { count: finalClientIds.length }),
+        );
+      } else {
+        toast.success(
+          result.ids.length === 1
+            ? t("successSingular", { count: result.ids.length })
+            : t("successPlural", { count: result.ids.length }),
+        );
+      }
       setConfirmOpen(false);
       // Navigate to the first client's schedule view to give the trainer
       // an immediate "here's what you just wrote" surface.
@@ -235,6 +336,158 @@ export function BulkAssignForm({
                 className="min-h-24 rounded-md border bg-background px-3 py-2 text-sm"
               />
             </div>
+          </div>
+
+          {/* 260612-e9t (#175): recurrence picker (mirrors AssignTemplateModal). */}
+          <div className="flex flex-col gap-3 md:col-span-2">
+            <div className="flex flex-col gap-1.5">
+              <label className="text-sm font-medium">{t("modeLabel")}</label>
+              <Select
+                value={mode}
+                onValueChange={(value) => setMode(value as RecurrenceMode)}
+              >
+                <SelectTrigger className="w-full md:w-64">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="once">{t("modeOnce")}</SelectItem>
+                  <SelectItem value="weekly">{t("modeWeekly")}</SelectItem>
+                  <SelectItem value="daily">{t("modeDaily")}</SelectItem>
+                  <SelectItem value="everyN">{t("modeEveryN")}</SelectItem>
+                  <SelectItem value="monthly">{t("modeMonthly")}</SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
+
+            {mode === "weekly" ? (
+              <div className="flex flex-col gap-1.5">
+                <label className="text-sm font-medium">{t("repeatOnLabel")}</label>
+                <div className="flex flex-wrap gap-2">
+                  {BULK_WEEKDAY_KEYS.map((key, idx) => {
+                    const active = recurringWeekdays.has(idx);
+                    return (
+                      <Button
+                        key={key}
+                        type="button"
+                        variant={active ? "default" : "outline"}
+                        size="sm"
+                        onClick={() => toggleWeekday(idx)}
+                        aria-pressed={active}
+                      >
+                        {t(`weekdays.${key}`).slice(0, 3)}
+                      </Button>
+                    );
+                  })}
+                </div>
+              </div>
+            ) : null}
+
+            {mode === "everyN" ? (
+              <div className="flex flex-col gap-1.5">
+                <label
+                  className="text-sm font-medium"
+                  htmlFor="bulk-every-n-input"
+                >
+                  {t("repeatEveryNLabel")}
+                </label>
+                <input
+                  id="bulk-every-n-input"
+                  type="number"
+                  min={2}
+                  max={30}
+                  value={recurringEveryNDraft}
+                  onChange={(event) => {
+                    const raw = event.target.value;
+                    setRecurringEveryNDraft(raw);
+                    if (raw.trim() === "") return;
+                    const next = Number(raw);
+                    if (!Number.isFinite(next)) return;
+                    setRecurringEveryN(Math.max(2, Math.min(30, next)));
+                  }}
+                  onBlur={() => {
+                    const next = Number(recurringEveryNDraft);
+                    const normalized = Number.isFinite(next)
+                      ? Math.max(2, Math.min(30, next))
+                      : recurringEveryN;
+                    setRecurringEveryN(normalized);
+                    setRecurringEveryNDraft(String(normalized));
+                  }}
+                  className="h-10 w-24 rounded-md border bg-background px-3 text-sm"
+                />
+                <p className="text-xs text-muted-foreground">
+                  {t("repeatEveryNHint", { n: recurringEveryN })}
+                </p>
+              </div>
+            ) : null}
+
+            {mode === "monthly" ? (
+              <p className="text-xs text-muted-foreground">
+                {t("repeatMonthlyHint", {
+                  day: parseCivilToLocalDate(civilDate).getDate(),
+                })}
+              </p>
+            ) : null}
+
+            {mode !== "once" ? (
+              <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+                <div className="flex items-center gap-2">
+                  <input
+                    id="bulk-recurring-end-enabled"
+                    type="checkbox"
+                    checked={recurringEndEnabled}
+                    onChange={(event) => {
+                      const next = event.target.checked;
+                      setRecurringEndEnabled(next);
+                      if (next) {
+                        const preset = recurringEndPresetMonths ?? 3;
+                        setRecurringEndPresetMonths(preset);
+                        setRecurringEndDate(addCivilMonths(civilDate, preset));
+                      }
+                    }}
+                    className="h-4 w-4 rounded border"
+                  />
+                  <label
+                    htmlFor="bulk-recurring-end-enabled"
+                    className="text-sm"
+                  >
+                    {t("setEndDate")}
+                  </label>
+                </div>
+                {recurringEndEnabled ? (
+                  <div className="flex flex-col gap-1.5">
+                    <label className="text-sm font-medium">
+                      {t("endDateLabel")}
+                    </label>
+                    <div className="flex flex-wrap gap-2">
+                      {END_DATE_PRESET_MONTHS.map((months) => {
+                        const active =
+                          recurringEndPresetMonths === months &&
+                          recurringEndDate === addCivilMonths(civilDate, months);
+                        return (
+                          <Button
+                            key={months}
+                            type="button"
+                            variant={active ? "default" : "outline"}
+                            size="sm"
+                            onClick={() => {
+                              setRecurringEndPresetMonths(months);
+                              setRecurringEndDate(
+                                addCivilMonths(civilDate, months),
+                              );
+                            }}
+                          >
+                            {t("endDatePresetMonths", { months })}
+                          </Button>
+                        );
+                      })}
+                    </div>
+                    <p className="text-xs text-muted-foreground">
+                      {t("endDateValue", { date: recurringEndDate })}
+                    </p>
+                  </div>
+                ) : null}
+              </div>
+            ) : null}
           </div>
         </CardContent>
       </Card>
@@ -330,6 +583,7 @@ export function BulkAssignForm({
         }
         scheduledFor={civilDate}
         candidates={selectedClients}
+        recurrenceSummary={recurrenceSummary}
         submitting={submitting}
         onConfirm={onConfirm}
       />

--- a/backoffice/src/components/gc-fitness/schedule/bulk-confirm-modal.tsx
+++ b/backoffice/src/components/gc-fitness/schedule/bulk-confirm-modal.tsx
@@ -39,6 +39,13 @@ interface BulkConfirmModalProps {
   scheduledFor: string;
   /** Initially-selected clients passed in from BulkAssignForm. */
   candidates: ClientRosterEntry[];
+  /**
+   * 260612-e9t (#175): human-readable recurrence summary (e.g. "Cada semana:
+   * Lun, Mié"). Null/undefined on the single-date ("once") path. When present,
+   * the modal shows the trainer they're rolling out a recurring SERIES per
+   * client rather than a single session.
+   */
+  recurrenceSummary?: string | null;
   submitting: boolean;
   onConfirm: (finalClientIds: string[]) => void;
 }
@@ -49,6 +56,7 @@ export function BulkConfirmModal({
   templateName,
   scheduledFor,
   candidates,
+  recurrenceSummary,
   submitting,
   onConfirm,
 }: BulkConfirmModalProps) {
@@ -95,6 +103,16 @@ export function BulkConfirmModal({
           </DialogTitle>
           <DialogDescription>{t("description")}</DialogDescription>
         </DialogHeader>
+
+        {recurrenceSummary ? (
+          <div className="rounded-md border border-primary/30 bg-primary/5 px-3 py-2 text-sm">
+            <span className="font-medium">{t("recurrenceLabel")}</span>{" "}
+            <span className="text-muted-foreground">{recurrenceSummary}</span>
+            <p className="mt-1 text-xs text-muted-foreground">
+              {t("recurrenceHint", { count: finalCount, start: scheduledFor })}
+            </p>
+          </div>
+        ) : null}
 
         <div className="max-h-72 overflow-y-auto rounded border p-2">
           <ul className="flex flex-col gap-1.5">

--- a/backoffice/src/components/gc-fitness/schedule/month-calendar.tsx
+++ b/backoffice/src/components/gc-fitness/schedule/month-calendar.tsx
@@ -67,6 +67,7 @@ import { MoveAssignmentDialog } from "./move-assignment-dialog";
 import { NewHabitDialog } from "./new-habit-dialog";
 import { WorkoutDetailDialog } from "./workout-detail-dialog";
 import { HabitDetailDialog } from "./habit-detail-dialog";
+import { BulkAssignHabitDialog } from "./bulk-assign-habit-dialog";
 
 interface ClientLite {
   uid: string;
@@ -392,6 +393,8 @@ export function MonthCalendar({
     | { date: string; clientId: string; clientName: string }
     | null
   >(null);
+  // 260612-e9t (#176): bulk habit assignment reachable from the Agenda.
+  const [bulkHabitOpen, setBulkHabitOpen] = useState(false);
   // Day-cell "+" was clicked but multiple clients are selected — show a
   // micro-picker first. `kind` carries through so we know which surface
   // to open after the client is chosen.
@@ -581,6 +584,19 @@ export function MonthCalendar({
           asChild
         >
           <Link href="/gc-fitness/schedule/bulk">{t("bulkAssign")}</Link>
+        </Button>
+        {/* 260612-e9t (#176): bulk habit assignment from the Agenda. The
+            assigned habit carries its template's recurring schedule (the dialog
+            copies scheduleCadence/Weekdays/etc. server-side). */}
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          className="min-h-[40px] rounded-full"
+          onClick={() => setBulkHabitOpen(true)}
+          disabled={clients.length === 0}
+        >
+          {t("bulkAssignHabit")}
         </Button>
       </div>
 
@@ -1104,6 +1120,21 @@ export function MonthCalendar({
           }}
         />
       ) : null}
+
+      {/* ── 260612-e9t (#176): bulk habit assignment from the Agenda ─────── */}
+      <BulkAssignHabitDialog
+        open={bulkHabitOpen}
+        onOpenChange={setBulkHabitOpen}
+        clients={clients.map((c) => ({
+          uid: c.uid,
+          displayName: c.displayName,
+        }))}
+        onAssigned={() => {
+          // Refresh the month so newly assigned habits appear on the calendar.
+          queryClient.invalidateQueries({ queryKey: ["schedule"] });
+          setBulkHabitOpen(false);
+        }}
+      />
 
       {clients.length === 0 ? (
         <p className="rounded-[1.25rem] border border-dashed p-6 text-center text-sm text-muted-foreground">

--- a/backoffice/src/lib/gc-fitness/__tests__/coach-attention-actions.test.ts
+++ b/backoffice/src/lib/gc-fitness/__tests__/coach-attention-actions.test.ts
@@ -1,0 +1,259 @@
+// __tests__/coach-attention-actions.test.ts
+//
+// 260612-e9t (#245): listClientsWithNothingAssignedSoon — the dashboard
+// urgency-card data source. A client is INCLUDED only when they have NO workout
+// assignment AND NO active habit in the next 4 days. Bounded reads: ONE windowed
+// trainerId assignment query (with the index-error fallback) + capped per-client
+// habit reads. These tests lock the coverage logic + the fallback path.
+
+const mockState: { db: unknown } = { db: null };
+
+jest.mock("@/lib/firebase/gc-fitness-admin", () => ({
+  gcFitnessFirestore: () => mockState.db,
+}));
+jest.mock("@/lib/gc-fitness/auth-helpers", () => ({
+  getCurrentTrainer: jest.fn(async () => ({ uid: "t1", email: "t@x.com" })),
+}));
+jest.mock("@/lib/gc-fitness/trainer-timezone", () => ({
+  getTrainerTimezone: jest.fn(async () => "UTC"),
+}));
+
+// Roster mock is reassigned per-test via mockListClients.
+const mockListClients = jest.fn();
+jest.mock("@/lib/gc-fitness/client-roster", () => ({
+  listClients: (...args: unknown[]) => mockListClients(...args),
+}));
+
+import { listClientsWithNothingAssignedSoon } from "../coach-attention-actions";
+import { FirestoreCollections } from "../collections";
+import { civilDateToday, civilDateFormat } from "../civil-date";
+
+function snap(docs: unknown[]) {
+  return { docs, size: docs.length, empty: docs.length === 0 };
+}
+function doc(id: string, data: Record<string, unknown>) {
+  return { id, data: () => data };
+}
+
+const TODAY = civilDateToday("UTC");
+function plusDays(civil: string, n: number): string {
+  const base = new Date(`${civil}T12:00:00Z`);
+  return civilDateFormat(
+    new Date(base.getTime() + n * 24 * 60 * 60 * 1000),
+    "UTC",
+  );
+}
+const IN_WINDOW = plusDays(TODAY, 2); // within [today, today+3]
+const PAST = plusDays(TODAY, -5);
+const FAR_FUTURE = plusDays(TODAY, 30);
+
+function client(uid: string) {
+  return {
+    uid,
+    email: `${uid}@x.com`,
+    displayName: `Client ${uid}`,
+    timezone: "UTC",
+    photoURL: null,
+    pendingProvisioning: false,
+  };
+}
+
+interface DbOpts {
+  /** Assignment docs the windowed trainerId query returns. */
+  assignments: Array<{ clientId: string; scheduledFor: string }>;
+  /** Per-clientId habit docs. */
+  habitsByClient: Record<string, Array<Record<string, unknown>>>;
+  /** When true, the windowed (scheduledFor) assignment query throws → fallback. */
+  failWindowedAssignments?: boolean;
+  flags?: { windowedAttempted: boolean; fallbackUsed: boolean };
+}
+
+function makeDb(opts: DbOpts) {
+  function makeQuery(coll: string): Record<string, unknown> {
+    const wheres: Array<{ field: string; value: unknown }> = [];
+    const q: Record<string, unknown> = {
+      where(field: string, _op: string, value: unknown) {
+        wheres.push({ field, value });
+        return q;
+      },
+      limit: () => q,
+      get() {
+        if (coll === FirestoreCollections.workoutAssignments) {
+          const windowed = wheres.some((w) => w.field === "scheduledFor");
+          if (windowed) {
+            if (opts.flags) opts.flags.windowedAttempted = true;
+            if (opts.failWindowedAssignments) {
+              const err = new Error(
+                "9 FAILED_PRECONDITION: requires an index",
+              ) as Error & { code: number };
+              err.code = 9;
+              return Promise.reject(err);
+            }
+            // Indexed query: pre-trim to the window (server-side range).
+            const inWin = opts.assignments.filter(
+              (a) => a.scheduledFor >= TODAY && a.scheduledFor <= plusDays(TODAY, 3),
+            );
+            return Promise.resolve(
+              snap(inWin.map((a, i) => doc(`asg-${i}`, a))),
+            );
+          }
+          // trainerId-only fallback: return EVERYTHING (the action trims in memory).
+          if (opts.flags) opts.flags.fallbackUsed = true;
+          return Promise.resolve(
+            snap(opts.assignments.map((a, i) => doc(`asg-${i}`, a))),
+          );
+        }
+        if (coll === FirestoreCollections.habits) {
+          const clientId = wheres.find((w) => w.field === "clientId")
+            ?.value as string;
+          const habits = opts.habitsByClient[clientId] ?? [];
+          return Promise.resolve(
+            snap(habits.map((h, i) => doc(`hab-${clientId}-${i}`, h))),
+          );
+        }
+        return Promise.resolve(snap([]));
+      },
+    };
+    return q;
+  }
+  return { collection: (name: string) => makeQuery(name) };
+}
+
+describe("listClientsWithNothingAssignedSoon (#245)", () => {
+  let errSpy: jest.SpyInstance;
+  beforeEach(() => {
+    jest.clearAllMocks();
+    errSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+  });
+  afterEach(() => errSpy.mockRestore());
+
+  it("excludes a client with an in-window workout assignment", async () => {
+    mockListClients.mockResolvedValue([client("c1"), client("c2")]);
+    mockState.db = makeDb({
+      assignments: [{ clientId: "c1", scheduledFor: IN_WINDOW }],
+      habitsByClient: {},
+    });
+
+    const rows = await listClientsWithNothingAssignedSoon();
+    const uids = rows.map((r) => r.uid);
+    expect(uids).not.toContain("c1"); // covered by workout
+    expect(uids).toContain("c2"); // nothing assigned
+  });
+
+  it("excludes a client with an in-window active (daily) habit", async () => {
+    mockListClients.mockResolvedValue([client("c1"), client("c2")]);
+    mockState.db = makeDb({
+      assignments: [],
+      habitsByClient: {
+        c1: [
+          {
+            clientId: "c1",
+            deleted: false,
+            scheduleType: "recurring",
+            scheduleCadence: "daily",
+          },
+        ],
+      },
+    });
+
+    const rows = await listClientsWithNothingAssignedSoon();
+    const uids = rows.map((r) => r.uid);
+    expect(uids).not.toContain("c1"); // covered by habit
+    expect(uids).toContain("c2");
+  });
+
+  it("includes a client with neither a workout nor an active habit", async () => {
+    mockListClients.mockResolvedValue([client("c1")]);
+    mockState.db = makeDb({ assignments: [], habitsByClient: {} });
+
+    const rows = await listClientsWithNothingAssignedSoon();
+    expect(rows.map((r) => r.uid)).toEqual(["c1"]);
+  });
+
+  it("includes a client whose only habit ended before the window (endsOn)", async () => {
+    mockListClients.mockResolvedValue([client("c1")]);
+    mockState.db = makeDb({
+      assignments: [],
+      habitsByClient: {
+        c1: [
+          {
+            clientId: "c1",
+            deleted: false,
+            scheduleType: "recurring",
+            scheduleCadence: "daily",
+            endsOn: PAST, // expired before today
+          },
+        ],
+      },
+    });
+
+    const rows = await listClientsWithNothingAssignedSoon();
+    expect(rows.map((r) => r.uid)).toContain("c1");
+  });
+
+  it("excludes a workout outside the window (assignment too far in the future)", async () => {
+    mockListClients.mockResolvedValue([client("c1")]);
+    mockState.db = makeDb({
+      assignments: [{ clientId: "c1", scheduledFor: FAR_FUTURE }],
+      habitsByClient: {},
+    });
+
+    const rows = await listClientsWithNothingAssignedSoon();
+    // The far-future assignment does NOT cover the client → still surfaced.
+    expect(rows.map((r) => r.uid)).toContain("c1");
+  });
+
+  it("ignores soft-deleted habits when deciding coverage", async () => {
+    mockListClients.mockResolvedValue([client("c1")]);
+    mockState.db = makeDb({
+      assignments: [],
+      habitsByClient: {
+        c1: [
+          {
+            clientId: "c1",
+            deleted: true, // soft-deleted → does NOT cover
+            scheduleType: "recurring",
+            scheduleCadence: "daily",
+          },
+        ],
+      },
+    });
+
+    const rows = await listClientsWithNothingAssignedSoon();
+    expect(rows.map((r) => r.uid)).toContain("c1");
+  });
+
+  it("the windowed-query index-error fallback still produces correct coverage", async () => {
+    mockListClients.mockResolvedValue([client("c1"), client("c2")]);
+    const flags = { windowedAttempted: false, fallbackUsed: false };
+    mockState.db = makeDb({
+      // c1 has an in-window assignment, c2 has a far-future one. The fallback
+      // returns BOTH; the in-memory window filter must still cover only c1.
+      assignments: [
+        { clientId: "c1", scheduledFor: IN_WINDOW },
+        { clientId: "c2", scheduledFor: FAR_FUTURE },
+      ],
+      habitsByClient: {},
+      failWindowedAssignments: true,
+      flags,
+    });
+
+    const rows = await listClientsWithNothingAssignedSoon();
+    expect(flags.windowedAttempted).toBe(true);
+    expect(flags.fallbackUsed).toBe(true);
+    const uids = rows.map((r) => r.uid);
+    expect(uids).not.toContain("c1"); // in-window assignment covers c1
+    expect(uids).toContain("c2"); // far-future assignment does NOT cover c2
+  });
+
+  it("skips pendingProvisioning clients entirely", async () => {
+    const pending = { ...client("cp"), pendingProvisioning: true };
+    mockListClients.mockResolvedValue([pending, client("c1")]);
+    mockState.db = makeDb({ assignments: [], habitsByClient: {} });
+
+    const rows = await listClientsWithNothingAssignedSoon();
+    const uids = rows.map((r) => r.uid);
+    expect(uids).not.toContain("cp");
+    expect(uids).toContain("c1");
+  });
+});

--- a/backoffice/src/lib/gc-fitness/__tests__/workout-assignment-actions.test.ts
+++ b/backoffice/src/lib/gc-fitness/__tests__/workout-assignment-actions.test.ts
@@ -512,6 +512,161 @@ describe("bulkAssignTemplate", () => {
     // collide on overwriting writes).
     expect(result.ids[0]).not.toBe(result.ids[1]);
   });
+
+  // ───────────────────────────────────────────────────────────────────────────
+  // 260612-e9t (#175): bulk RECURRENCE
+  // ───────────────────────────────────────────────────────────────────────────
+
+  it("no-recurrence path is unchanged: 1 doc/client, no seriesId/recurrence", async () => {
+    mockedGetTokens.mockResolvedValue(fakeTokens({ role: "trainer" }));
+    mockGet.mockResolvedValue(fakeTemplateSnap({ exists: true }));
+    mockBatchCommit.mockResolvedValue(undefined);
+
+    const result = await bulkAssignTemplate({
+      templateId: "tpl-abc",
+      clientIds: ["c1", "c2", "c3"],
+      scheduledFor: "2026-06-01",
+    });
+
+    expect(result.ids).toHaveLength(3);
+    expect(mockBatch).toHaveBeenCalledTimes(1);
+    expect(mockBatchSet).toHaveBeenCalledTimes(3);
+    expect(mockBatchCommit).toHaveBeenCalledTimes(1);
+    // No seriesId / recurrence on any doc on the single-date path.
+    for (const call of mockBatchSet.mock.calls) {
+      const doc = call[1];
+      expect(doc.seriesId).toBeUndefined();
+      expect(doc.recurrence).toBeUndefined();
+      expect(doc.scheduledFor).toBe("2026-06-01");
+    }
+  });
+
+  it("single-kind recurrence behaves like the no-recurrence path", async () => {
+    mockedGetTokens.mockResolvedValue(fakeTokens({ role: "trainer" }));
+    mockGet.mockResolvedValue(fakeTemplateSnap({ exists: true }));
+    mockBatchCommit.mockResolvedValue(undefined);
+
+    const result = await bulkAssignTemplate({
+      templateId: "tpl-abc",
+      clientIds: ["c1", "c2"],
+      scheduledFor: "2026-06-01",
+      recurrence: { kind: "single" },
+    });
+
+    expect(result.ids).toHaveLength(2);
+    expect(mockBatchSet).toHaveBeenCalledTimes(2);
+    for (const call of mockBatchSet.mock.calls) {
+      expect(call[1].seriesId).toBeUndefined();
+      expect(call[1].recurrence).toBeUndefined();
+    }
+  });
+
+  it("weekly recurrence expands to one doc per (client × matching date) with a per-client seriesId", async () => {
+    mockedGetTokens.mockResolvedValue(fakeTokens({ role: "trainer" }));
+    mockGet.mockResolvedValue(fakeTemplateSnap({ exists: true }));
+    mockBatchCommit.mockResolvedValue(undefined);
+
+    // 2026-06-01 is a Monday (weekday 1). Window 2026-06-01..2026-06-22 has
+    // 4 Mondays: 06-01, 06-08, 06-15, 06-22.
+    const result = await bulkAssignTemplate({
+      templateId: "tpl-abc",
+      clientIds: ["c1", "c2"],
+      scheduledFor: "2026-06-01",
+      recurrence: { kind: "weekly", weekday: 1 },
+      endDate: "2026-06-22",
+    });
+
+    // 2 clients × 4 Mondays = 8 docs.
+    expect(result.ids).toHaveLength(8);
+    expect(mockBatchSet).toHaveBeenCalledTimes(8);
+
+    // Each doc carries a recurrence rule + a seriesId; the seriesId is shared
+    // WITHIN a client's series but DIFFERS across clients.
+    const byClient = new Map<string, Set<string>>();
+    const expectedDates = ["2026-06-01", "2026-06-08", "2026-06-15", "2026-06-22"];
+    const datesByClient = new Map<string, string[]>();
+    for (const call of mockBatchSet.mock.calls) {
+      const doc = call[1];
+      expect(doc.recurrence).toEqual({ kind: "weekly", weekday: 1 });
+      expect(typeof doc.seriesId).toBe("string");
+      const set = byClient.get(doc.clientId) ?? new Set<string>();
+      set.add(doc.seriesId);
+      byClient.set(doc.clientId, set);
+      const dates = datesByClient.get(doc.clientId) ?? [];
+      dates.push(doc.scheduledFor);
+      datesByClient.set(doc.clientId, dates);
+    }
+    // One seriesId per client (shared across that client's 4 docs).
+    expect(byClient.get("c1")!.size).toBe(1);
+    expect(byClient.get("c2")!.size).toBe(1);
+    // Different clients get different series.
+    const s1 = [...byClient.get("c1")!][0];
+    const s2 = [...byClient.get("c2")!][0];
+    expect(s1).not.toBe(s2);
+    // Expected dates per client.
+    expect(datesByClient.get("c1")!.sort()).toEqual(expectedDates);
+    expect(datesByClient.get("c2")!.sort()).toEqual(expectedDates);
+  });
+
+  it("chunks writes across multiple batches when clients × dates × 3 ops > 500", async () => {
+    mockedGetTokens.mockResolvedValue(fakeTokens({ role: "trainer" }));
+    mockGet.mockResolvedValue(fakeTemplateSnap({ exists: true }));
+    mockBatchCommit.mockResolvedValue(undefined);
+
+    // 10 clients × daily over 2026-06-01..2026-06-30 = 30 dates = 300 docs.
+    // 300 docs × 3 ops = 900 ops > 500 → must commit across ⌈300/166⌉ = 2 batches.
+    const clientIds = Array.from({ length: 10 }, (_, i) => `client-${i}`);
+    const result = await bulkAssignTemplate({
+      templateId: "tpl-abc",
+      clientIds,
+      scheduledFor: "2026-06-01",
+      recurrence: { kind: "daily" },
+      endDate: "2026-06-30",
+    });
+
+    expect(result.ids).toHaveLength(300);
+    expect(mockBatchSet).toHaveBeenCalledTimes(300);
+    // 300 set ops / floor(500/3)=166 per batch → 2 commits.
+    expect(mockBatchCommit).toHaveBeenCalledTimes(2);
+    expect(mockBatch.mock.calls.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it("rejects an over-cap recurring submit BEFORE any commit (total-ops guard)", async () => {
+    mockedGetTokens.mockResolvedValue(fakeTokens({ role: "trainer" }));
+    mockGet.mockResolvedValue(fakeTemplateSnap({ exists: true }));
+    mockBatchCommit.mockResolvedValue(undefined);
+
+    // 100 clients × daily-for-a-year (capped at 104 occurrences) = 10400 docs,
+    // well over MAX_TOTAL_BULK_RECURRING_DOCS (5000) → reject, no writes.
+    const clientIds = Array.from({ length: 100 }, (_, i) => `c-${i}`);
+    await expect(
+      bulkAssignTemplate({
+        templateId: "tpl-abc",
+        clientIds,
+        scheduledFor: "2026-06-01",
+        recurrence: { kind: "daily" },
+        // No endDate → rolling horizon, capped at 104 occurrences per client.
+      }),
+    ).rejects.toThrow(/exceeds the 5000 limit/i);
+    expect(mockBatchSet).not.toHaveBeenCalled();
+    expect(mockBatchCommit).not.toHaveBeenCalled();
+  });
+
+  it("rejects endDate before scheduledFor at Zod parse time", async () => {
+    mockedGetTokens.mockResolvedValue(fakeTokens({ role: "trainer" }));
+    mockGet.mockResolvedValue(fakeTemplateSnap({ exists: true }));
+
+    await expect(
+      bulkAssignTemplate({
+        templateId: "tpl-abc",
+        clientIds: ["c1"],
+        scheduledFor: "2026-06-10",
+        recurrence: { kind: "daily" },
+        endDate: "2026-06-01",
+      }),
+    ).rejects.toThrow();
+    expect(mockBatchSet).not.toHaveBeenCalled();
+  });
 });
 
 // ─────────────────────────────────────────────────────────────────────────────

--- a/backoffice/src/lib/gc-fitness/coach-attention-actions.ts
+++ b/backoffice/src/lib/gc-fitness/coach-attention-actions.ts
@@ -1,0 +1,163 @@
+"use server";
+
+// coach-attention-actions.ts
+//
+// 260612-e9t (#245): dashboard urgency card data source. Returns the active
+// clients who have NOTHING assigned in the next 4 days — no upcoming workout
+// assignment AND no habit active in that window — so the trainer can assign
+// before the client slips through the cracks.
+//
+// BOUNDED READS (Firestore cost is an active concern — see STATE.md "Firestore
+// cost reduction"). This mirrors `getCoachPulse`'s read budget EXACTLY:
+//   - listClients() then .filter(!pendingProvisioning).slice(0, 50)
+//   - WORKOUTS: ONE windowed trainerId query (with the proven trainerId-only
+//     limit(600) fallback on index error) — NEVER a per-client assignment
+//     fan-out.
+//   - HABITS: per-client capped reads (.where(clientId).limit(50)); a habit
+//     "covers" a client when isHabitScheduledOn() is true on ANY of the 4
+//     window dates (honors startsOn/endsOn/skippedDates/cadence).
+// The whole thing is defensive: a single failing query degrades to partial /
+// empty coverage and never throws to the page (the dashboard loads it behind
+// safe(), but we also catch here so a habit-read failure can't zero the card).
+
+import { gcFitnessFirestore } from "@/lib/firebase/gc-fitness-admin";
+
+import { getCurrentTrainer } from "./auth-helpers";
+import { civilDateFormat, civilDateToday } from "./civil-date";
+import { FirestoreCollections } from "./collections";
+import { listClients } from "./client-roster";
+import { isHabitScheduledOn } from "./habit-schedule";
+import { getTrainerTimezone } from "./trainer-timezone";
+
+/** Number of days ahead (today inclusive) the urgency window spans. */
+const WINDOW_DAYS = 4;
+/** Cap on clients scanned + returned (mirrors getCoachPulse's 50). */
+const MAX_CLIENTS = 50;
+
+export interface UnassignedClientRow {
+  uid: string;
+  displayName: string;
+  photoURL: string | null;
+}
+
+/**
+ * Build the civil-date window [today, today+WINDOW_DAYS-1] in the trainer's tz.
+ * Uses noon-UTC date arithmetic like coach-pulse-actions' buildWindowDays —
+ * civil dates map to exactly one day regardless of zone, so this is DST-safe.
+ */
+function buildWindowDays(timezone: string): string[] {
+  const today = civilDateToday(timezone);
+  const todayDate = new Date(`${today}T12:00:00Z`);
+  const days: string[] = [];
+  for (let offset = 0; offset < WINDOW_DAYS; offset += 1) {
+    const day = new Date(todayDate.getTime() + offset * 24 * 60 * 60 * 1000);
+    days.push(civilDateFormat(day, timezone));
+  }
+  return days;
+}
+
+export async function listClientsWithNothingAssignedSoon(): Promise<
+  UnassignedClientRow[]
+> {
+  const trainer = await getCurrentTrainer();
+  const db = gcFitnessFirestore();
+
+  const clients = await listClients();
+  const activeClients = clients
+    .filter((c) => !c.pendingProvisioning)
+    .slice(0, MAX_CLIENTS);
+  if (activeClients.length === 0) return [];
+
+  const trainerTz = await getTrainerTimezone();
+  const windowDays = buildWindowDays(trainerTz);
+  const windowStart = windowDays[0]!;
+  const windowEnd = windowDays[windowDays.length - 1]!;
+
+  const logError = (label: string) => (err: unknown) => {
+    console.error(`[coach-attention] ${label} failed`, err);
+    return null;
+  };
+
+  // ── WORKOUTS: ONE windowed trainerId query (verbatim shape from
+  // coach-pulse-actions). Falls back to the trainerId-only limit(600) + an
+  // in-memory window filter when the (trainerId, scheduledFor) composite index
+  // is still building, so an index build can't silently mark everyone covered
+  // (false negatives) or everyone uncovered (false positives). ──────────────
+  const assignmentsPromise = db
+    .collection(FirestoreCollections.workoutAssignments)
+    .where("trainerId", "==", trainer.uid)
+    .where("scheduledFor", ">=", windowStart)
+    .where("scheduledFor", "<=", windowEnd)
+    .limit(600)
+    .get()
+    .catch(() =>
+      db
+        .collection(FirestoreCollections.workoutAssignments)
+        .where("trainerId", "==", trainer.uid)
+        .limit(600)
+        .get()
+        .catch(logError("workout_assignments")),
+    );
+
+  // ── HABITS: per-client capped reads. ─────────────────────────────────────
+  const habitsPromises = activeClients.map((client) =>
+    db
+      .collection(FirestoreCollections.habits)
+      .where("clientId", "==", client.uid)
+      .limit(50)
+      .get()
+      .catch(logError(`habits clientId=${client.uid}`)),
+  );
+
+  const [assignmentsSnap, habitsSnaps] = await Promise.all([
+    assignmentsPromise,
+    Promise.all(habitsPromises),
+  ]);
+
+  // Clients with ≥1 workout assignment landing in [windowStart, windowEnd].
+  // The in-memory window filter is a no-op for the indexed query (already
+  // windowed) and the necessary trim for the trainerId-only fallback.
+  const coveredByWorkout = new Set<string>();
+  for (const doc of assignmentsSnap?.docs ?? []) {
+    const data = doc.data() as Record<string, unknown>;
+    const scheduledFor =
+      typeof data.scheduledFor === "string" ? data.scheduledFor : "";
+    const clientId = typeof data.clientId === "string" ? data.clientId : "";
+    if (!scheduledFor || !clientId) continue;
+    if (scheduledFor < windowStart || scheduledFor > windowEnd) continue;
+    coveredByWorkout.add(clientId);
+  }
+
+  // Clients with ≥1 habit active on ANY of the window dates. Soft-deleted
+  // habits never count (the predicate ignores `deleted`, so guard here —
+  // mirrors coach-pulse's habitScheduledOn wrapper).
+  const coveredByHabit = new Set<string>();
+  habitsSnaps.forEach((snap, idx) => {
+    if (!snap) return;
+    const client = activeClients[idx]!;
+    for (const doc of snap.docs) {
+      const habit = doc.data() as Record<string, unknown>;
+      if (habit.deleted === true) continue;
+      const activeInWindow = windowDays.some((d) =>
+        isHabitScheduledOn(habit, d),
+      );
+      if (activeInWindow) {
+        coveredByHabit.add(client.uid);
+        break;
+      }
+    }
+  });
+
+  // Result = active clients covered by NEITHER a workout NOR an active habit.
+  const rows: UnassignedClientRow[] = activeClients
+    .filter(
+      (c) => !coveredByWorkout.has(c.uid) && !coveredByHabit.has(c.uid),
+    )
+    .map((c) => ({
+      uid: c.uid,
+      displayName: c.displayName,
+      photoURL: c.photoURL,
+    }));
+
+  return rows.slice(0, MAX_CLIENTS);
+}

--- a/backoffice/src/lib/gc-fitness/workout-assignment-actions.ts
+++ b/backoffice/src/lib/gc-fitness/workout-assignment-actions.ts
@@ -40,6 +40,8 @@ import {
   bulkAssignSchema,
   editAssignmentSchema,
   MAX_CLIENTS_PER_BATCH,
+  MAX_OPS_PER_BATCH,
+  OPS_PER_ASSIGNMENT,
 } from "./workout-assignment-schema";
 import { getCurrentTrainer } from "./auth-helpers";
 import {
@@ -292,6 +294,94 @@ function nextCivilForWeekdayOnOrAfter(civilDate: string, weekday: number): strin
   const delta = (weekday - currentWeekday + 7) % 7;
   return addCivilDays(civilDate, delta);
 }
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Shared recurrence date-expansion (single + bulk call sites)
+// ─────────────────────────────────────────────────────────────────────────────
+//
+// 260612-e9t (#175): `assignTemplateRecurring` and `bulkAssignTemplate` must
+// expand a `RecurrenceRule` into the SAME set of civil dates for the SAME
+// startDate/endDate — otherwise the two surfaces would silently drift. The
+// matcher + civil-day walk below is the SINGLE source of truth; both client
+// call sites invoke `expandRecurrenceDates`. (The inline matcher inside
+// `assignTemplateRecurring*ToPending` is a separate pending-mirror path; this
+// shared helper covers the canonical client paths.)
+
+type ExpandableRecurrence =
+  | { kind: "single" }
+  | { kind: "daily" }
+  | { kind: "weekly"; weekday: number }
+  | { kind: "weekly_days"; weekdays: number[] }
+  | { kind: "every_n_days"; everyN: number }
+  | { kind: "monthly"; dayOfMonth: number };
+
+/** True when `date` (a civil-date string) matches `recurrence` anchored at `startDate`. */
+function matchesRecurrence(
+  recurrence: ExpandableRecurrence,
+  startDate: string,
+  date: string,
+  dayIndex: number,
+): boolean {
+  switch (recurrence.kind) {
+    case "single":
+      return date === startDate;
+    case "daily":
+      return true;
+    case "weekly":
+      return dayIndex === recurrence.weekday;
+    case "weekly_days":
+      return recurrence.weekdays.includes(dayIndex);
+    case "every_n_days": {
+      const [y0, m0, d0] = startDate.split("-").map(Number);
+      const [y1, m1, d1] = date.split("-").map(Number);
+      const diff =
+        (Date.UTC(y1, m1 - 1, d1) - Date.UTC(y0, m0 - 1, d0)) / 86_400_000;
+      return diff >= 0 && diff % recurrence.everyN === 0;
+    }
+    case "monthly": {
+      const [y, m, d] = date.split("-").map(Number);
+      const target = recurrence.dayOfMonth;
+      const lastDayOfMonth = new Date(y, m, 0).getDate();
+      const clamped = Math.min(target, lastDayOfMonth);
+      return d === clamped;
+    }
+  }
+}
+
+/**
+ * Expand a recurrence rule into the matching civil dates in
+ * `[startDate, endDate ?? startDate + NO_END_HORIZON_DAYS]`, capped at
+ * `MAX_RECURRING_OCCURRENCES`. Returns the dates in ascending order.
+ */
+function expandRecurrenceDates(
+  recurrence: ExpandableRecurrence,
+  startDate: string,
+  endDate?: string,
+): string[] {
+  const hardWindowEnd = addCivilDays(startDate, NO_END_HORIZON_DAYS);
+  const windowEnd = endDate ?? hardWindowEnd;
+  const dates: string[] = [];
+  for (let date = startDate; date <= windowEnd; date = addCivilDays(date, 1)) {
+    if (
+      matchesRecurrence(recurrence, startDate, date, dayOfWeekFromCivil(date))
+    ) {
+      dates.push(date);
+      if (dates.length >= MAX_RECURRING_OCCURRENCES) break;
+    }
+  }
+  return dates;
+}
+
+/**
+ * Hard ceiling on total docs a single bulk-recurring submit may write
+ * (clients × dates). Mirrors the spirit of MAX_RECURRING_OCCURRENCES (the
+ * per-client cap) for the multi-client fan-out. 166 clients × 12 weekly
+ * occurrences ≈ 2000 docs is comfortably under this; an "absurd" submit
+ * (166 × daily-for-a-year capped at 104 = 17264) is rejected BEFORE any
+ * commit so we never half-write a series. Chosen as a sane operational
+ * ceiling, not a Firestore limit.
+ */
+const MAX_TOTAL_BULK_RECURRING_DOCS = 5000;
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Per-exercise weight-prefill freshness anchor (prescriptionUpdatedAtByExerciseId)
@@ -616,59 +706,176 @@ export async function bulkAssignTemplate(
     throw new Error("Not your template.");
   }
 
-  // 2) Build the batch.
-  const batch = db.batch();
-  const ids: string[] = [];
-  const ymd = parsed.scheduledFor.replace(/-/g, "");
   const templateSnapshot = applyExerciseOverrides(
     await templateSnapshotForAssignment(template),
     undefined,
   );
 
-  for (const clientId of parsed.clientIds) {
-    const docId = `asg-${clientId}-${ymd}-${randomUUID()}`;
-    const ref = db.collection(ASSIGNMENTS).doc(docId);
-    batch.set(ref, {
-      templateId: parsed.templateId,
-      templateSnapshot, // SAME REFERENCE — immutable snapshot
-      clientId,
-      trainerId: trainer.uid,
-      scheduledFor: parsed.scheduledFor,
-      scheduledTime: parsed.scheduledTime ?? null,
-      meetingNotes: parsed.meetingNotes ?? null,
-      timezone: parsed.timezone ?? null,
-      status: "scheduled" as const,
-      createdAt: FieldValue.serverTimestamp(),
-      updatedAt: FieldValue.serverTimestamp(),
-      // Prescription established now — weight-prefill freshness anchor.
-      prescriptionUpdatedAt: FieldValue.serverTimestamp(),
-    });
-    ids.push(docId);
+  // 260612-e9t (#175): decide single-date vs recurring expansion. A
+  // `{kind:"single"}` rule (or no recurrence) keeps the byte-identical
+  // single-date behavior; any other rule expands dates per the SHARED
+  // `expandRecurrenceDates` helper (same matcher assignTemplateRecurring uses).
+  const recurrence = parsed.recurrence as ExpandableRecurrence | undefined;
+  const isRecurring =
+    recurrence !== undefined && recurrence.kind !== "single";
+
+  if (!isRecurring) {
+    // ── No-recurrence path: ONE doc per client on parsed.scheduledFor in a
+    // single atomic WriteBatch (byte-identical to the pre-260612 behavior:
+    // same doc shape, singleAssignmentEvent per client, no seriesId/recurrence).
+    const batch = db.batch();
+    const ids: string[] = [];
+    const ymd = parsed.scheduledFor.replace(/-/g, "");
+
+    for (const clientId of parsed.clientIds) {
+      const docId = `asg-${clientId}-${ymd}-${randomUUID()}`;
+      const ref = db.collection(ASSIGNMENTS).doc(docId);
+      batch.set(ref, {
+        templateId: parsed.templateId,
+        templateSnapshot, // SAME REFERENCE — immutable snapshot
+        clientId,
+        trainerId: trainer.uid,
+        scheduledFor: parsed.scheduledFor,
+        scheduledTime: parsed.scheduledTime ?? null,
+        meetingNotes: parsed.meetingNotes ?? null,
+        timezone: parsed.timezone ?? null,
+        status: "scheduled" as const,
+        createdAt: FieldValue.serverTimestamp(),
+        updatedAt: FieldValue.serverTimestamp(),
+        // Prescription established now — weight-prefill freshness anchor.
+        prescriptionUpdatedAt: FieldValue.serverTimestamp(),
+      });
+      ids.push(docId);
+    }
+
+    // Atomic commit — throws on permission denial, network error, or rule
+    // violation. The verbatim error message bubbles up to the trainer toast
+    // (Pitfall 5 — no silent partial-success messaging). UID lists are never
+    // included in the error (T-04-24 — count + verbatim error string only).
+    await batch.commit();
+
+    await Promise.all(
+      parsed.clientIds.map((clientId, i) =>
+        recordCoachActivityEvent(
+          db,
+          singleAssignmentEvent({
+            trainerId: trainer.uid,
+            assignmentId: ids[i],
+            templateName: (templateSnapshot as { name?: unknown }).name,
+            clientId,
+            pendingEmail: null,
+            scheduledFor: parsed.scheduledFor,
+          }),
+        ),
+      ),
+    );
+
+    return { ids };
   }
 
-  // 3) Atomic commit — throws on permission denial, network error, or rule
-  // violation. The verbatim error message bubbles up to the trainer toast
-  // (Pitfall 5 — no silent partial-success messaging). UID lists are never
-  // included in the error (T-04-24 — count + verbatim error string only).
-  await batch.commit();
+  // ── Recurring path ──────────────────────────────────────────────────────
+  // Expand dates ONCE (same for every client — they all share scheduledFor as
+  // the anchor) then write one doc per (client × date). Each CLIENT gets its
+  // OWN seriesId so cascade-delete / series-edit scope a single client's series.
+  const dates = expandRecurrenceDates(
+    recurrence,
+    parsed.scheduledFor,
+    parsed.endDate,
+  );
+  if (dates.length === 0) {
+    throw new Error("No dates generated for that recurrence.");
+  }
 
+  // Total-ops guard: reject an absurd submit BEFORE any commit so we never
+  // half-write a series across chunked batches (no all-or-nothing per-chunk
+  // rollback). clients × dates is the doc count. The error is verbatim and
+  // carries NO UID list (T-04-24).
+  const totalDocs = parsed.clientIds.length * dates.length;
+  if (totalDocs > MAX_TOTAL_BULK_RECURRING_DOCS) {
+    throw new Error(
+      `This recurring bulk-assign would write ${totalDocs} sessions, ` +
+        `which exceeds the ${MAX_TOTAL_BULK_RECURRING_DOCS} limit. ` +
+        `Reduce the client count, the date range, or the frequency.`,
+    );
+  }
+
+  const recurrencePayload: Record<string, unknown> = recurrence;
+  // Pre-generate a per-client seriesId so the coach_activity events (recorded
+  // AFTER all commits succeed) reference the same series each client's docs
+  // carry.
+  const seriesIdByClient = new Map<string, string>(
+    parsed.clientIds.map((clientId) => [clientId, randomUUID()]),
+  );
+
+  // Chunk writes across batches: Firestore caps a batch at 500 ops and each
+  // assignment write costs OPS_PER_ASSIGNMENT(3), so flush every
+  // floor(500/3)=166 SET ops. We accumulate (client × date) docs in submit
+  // order and commit a batch whenever it fills.
+  const SETS_PER_BATCH = Math.floor(MAX_OPS_PER_BATCH / OPS_PER_ASSIGNMENT); // 166
+  const idsByClient = new Map<string, string[]>(
+    parsed.clientIds.map((clientId) => [clientId, []]),
+  );
+  const allIds: string[] = [];
+
+  let batch = db.batch();
+  let opsInBatch = 0;
+  for (const clientId of parsed.clientIds) {
+    const seriesId = seriesIdByClient.get(clientId)!;
+    for (const date of dates) {
+      const ymd = date.replace(/-/g, "");
+      const docId = `asg-${clientId}-${ymd}-${randomUUID()}`;
+      const ref = db.collection(ASSIGNMENTS).doc(docId);
+      batch.set(ref, {
+        templateId: parsed.templateId,
+        templateSnapshot, // SAME REFERENCE — immutable snapshot
+        clientId,
+        trainerId: trainer.uid,
+        scheduledFor: date,
+        scheduledTime: parsed.scheduledTime ?? null,
+        meetingNotes: parsed.meetingNotes ?? null,
+        timezone: parsed.timezone ?? null,
+        status: "scheduled" as const,
+        createdAt: FieldValue.serverTimestamp(),
+        updatedAt: FieldValue.serverTimestamp(),
+        // Prescription established now — weight-prefill freshness anchor.
+        prescriptionUpdatedAt: FieldValue.serverTimestamp(),
+        recurrence: recurrencePayload,
+        seriesId,
+      });
+      idsByClient.get(clientId)!.push(docId);
+      allIds.push(docId);
+      opsInBatch += 1;
+      if (opsInBatch >= SETS_PER_BATCH) {
+        await batch.commit();
+        batch = db.batch();
+        opsInBatch = 0;
+      }
+    }
+  }
+  if (opsInBatch > 0) {
+    await batch.commit();
+  }
+
+  // Record ONE seriesAssignmentEvent per client AFTER all commits succeed
+  // (mirrors assignTemplateRecurring + the single-path post-commit Promise.all).
   await Promise.all(
-    parsed.clientIds.map((clientId, i) =>
+    parsed.clientIds.map((clientId) =>
       recordCoachActivityEvent(
         db,
-        singleAssignmentEvent({
+        seriesAssignmentEvent({
           trainerId: trainer.uid,
-          assignmentId: ids[i],
+          seriesId: seriesIdByClient.get(clientId)!,
           templateName: (templateSnapshot as { name?: unknown }).name,
           clientId,
           pendingEmail: null,
-          scheduledFor: parsed.scheduledFor,
+          recurrence: recurrencePayload,
+          dates,
         }),
       ),
     ),
   );
 
-  return { ids };
+  return { ids: allIds };
 }
 
 export async function assignTemplateRecurring(
@@ -717,55 +924,20 @@ export async function assignTemplateRecurring(
     recurrence = { kind: "weekly", weekday: parsed.weekday! };
   }
 
-  const hardWindowEnd = addCivilDays(parsed.startDate, NO_END_HORIZON_DAYS);
-  const windowEnd = parsed.endDate ?? hardWindowEnd;
-
-  // Walk each civil day in [startDate, windowEnd]; keep dates that match the
-  // recurrence rule. Cap at MAX_RECURRING_OCCURRENCES so a "no end date +
-  // daily" submit can't write more than 104 docs.
-  function matchesRule(date: string, dayIndex: number): boolean {
-    switch (recurrence.kind) {
-      case "single":
-        return date === parsed.startDate;
-      case "daily":
-        return true;
-      case "weekly":
-        return dayIndex === recurrence.weekday;
-      case "weekly_days":
-        return recurrence.weekdays.includes(dayIndex);
-      case "every_n_days": {
-        // Whole-day delta in civil days from startDate to date.
-        const [y0, m0, d0] = parsed.startDate.split("-").map(Number);
-        const [y1, m1, d1] = date.split("-").map(Number);
-        const diff =
-          (Date.UTC(y1, m1 - 1, d1) - Date.UTC(y0, m0 - 1, d0)) / 86_400_000;
-        return diff >= 0 && diff % recurrence.everyN === 0;
-      }
-      case "monthly": {
-        const [y, m, d] = date.split("-").map(Number);
-        const target = recurrence.dayOfMonth;
-        const lastDayOfMonth = new Date(y, m, 0).getDate();
-        const clamped = Math.min(target, lastDayOfMonth);
-        return d === clamped;
-      }
-    }
-  }
-
-  const dates: string[] = [];
-  for (
-    let date = parsed.startDate;
-    date <= windowEnd;
-    date = addCivilDays(date, 1)
-  ) {
-    if (matchesRule(date, dayOfWeekFromCivil(date))) {
-      dates.push(date);
-      if (dates.length >= MAX_RECURRING_OCCURRENCES) break;
-    }
-  }
+  // 260612-e9t (#175): date expansion now flows through the SHARED
+  // `expandRecurrenceDates` helper (single source of truth with
+  // bulkAssignTemplate). Same window cap + MAX_RECURRING_OCCURRENCES behavior.
+  const dates = expandRecurrenceDates(
+    recurrence,
+    parsed.startDate,
+    parsed.endDate,
+  );
   if (dates.length === 0) {
     throw new Error("No dates generated for that recurrence.");
   }
   const windowStart = dates[0];
+  const windowEnd =
+    parsed.endDate ?? addCivilDays(parsed.startDate, NO_END_HORIZON_DAYS);
 
   const templateSnapshot = applyExerciseOverrides(
     await templateSnapshotForAssignment(template),

--- a/backoffice/src/lib/gc-fitness/workout-assignment-schema.ts
+++ b/backoffice/src/lib/gc-fitness/workout-assignment-schema.ts
@@ -125,20 +125,39 @@ export type AssignTemplateInput = z.infer<typeof assignTemplateSchema>;
  * WriteBatch. Cap is `MAX_CLIENTS_PER_BATCH` (166) per Pitfall 5; the
  * Server Action re-asserts the cap defensively after parse.
  */
-export const bulkAssignSchema = z.object({
-  templateId: z.string().min(1, "templateId is required."),
-  clientIds: z
-    .array(z.string().min(1, "clientId entries cannot be empty strings."))
-    .min(1, "Pick at least one client.")
-    .max(
-      MAX_CLIENTS_PER_BATCH,
-      `Bulk-assign supports at most ${MAX_CLIENTS_PER_BATCH} clients per submit.`,
-  ),
-  scheduledFor: civilDateSchema,
-  scheduledTime: scheduledTimeSchema,
-  meetingNotes: meetingNotesSchema,
-  timezone: ianaTimezoneSchema,
-});
+export const bulkAssignSchema = z
+  .object({
+    templateId: z.string().min(1, "templateId is required."),
+    clientIds: z
+      .array(z.string().min(1, "clientId entries cannot be empty strings."))
+      .min(1, "Pick at least one client.")
+      .max(
+        MAX_CLIENTS_PER_BATCH,
+        `Bulk-assign supports at most ${MAX_CLIENTS_PER_BATCH} clients per submit.`,
+    ),
+    scheduledFor: civilDateSchema,
+    scheduledTime: scheduledTimeSchema,
+    meetingNotes: meetingNotesSchema,
+    timezone: ianaTimezoneSchema,
+    // 260612-e9t (#175): optional recurrence. When absent or `{kind:"single"}`
+    // the Server Action writes exactly one doc per client on `scheduledFor`
+    // (byte-identical to the pre-recurrence behavior). When a real recurrence
+    // is present, the action expands dates (mirroring `assignTemplateRecurring`)
+    // and writes one doc per (client × matching date) with a per-client
+    // seriesId. `endDate` bounds the expansion window (rolling horizon cap when
+    // omitted).
+    recurrence: z.lazy(() => recurrenceSchema).optional(),
+    endDate: civilDateSchema.optional(),
+  })
+  .superRefine((data, ctx) => {
+    if (data.endDate && data.endDate < data.scheduledFor) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["endDate"],
+        message: "endDate must be on or after scheduledFor.",
+      });
+    }
+  });
 
 export type BulkAssignInput = z.infer<typeof bulkAssignSchema>;
 


### PR DESCRIPTION
## Summary

Three gc-fitness backoffice issues on one branch:

- **mdb1/gc-fitness#175 — Bulk workout assignment recurrence.** `bulkAssignTemplate` now accepts the canonical `RecurrenceRule` (daily / weekly / weekly-days / every-N / monthly) + optional end date. The date-expansion matcher was factored out of `assignTemplateRecurring` into a shared `expandRecurrenceDates` helper so single and bulk paths can't drift. Recurring submits write one `workout_assignments` doc per (client × matching date) with a per-client `seriesId` and one `seriesAssignmentEvent` per client in `coach_activity`; writes are chunked under the 500-op batch limit and submits expanding past 5000 docs are rejected before any commit. The no-recurrence path is unchanged. UI: recurrence picker in the bulk assign form + summary line in the confirm modal.
- **mdb1/gc-fitness#176 — Bulk habit assignment from the Agenda.** The existing `BulkAssignHabitDialog` (which already carries the template's recurring schedule) is now mounted in the Agenda month calendar via an "Asignar hábito" header button; assigning invalidates the `schedule` query so habits show up on the calendar immediately.
- **mdb1/gc-fitness#245 — Dashboard urgency card.** New bounded server action `listClientsWithNothingAssignedSoon()` — one windowed `trainerId` assignments query (with index-error fallback) plus capped per-client habit reads through the shared `isHabitScheduledOn` predicate, no unbounded fan-out — feeding a new `UnassignedClientsCard` on the dashboard home behind `safe()`.

## Test gate

- `npx tsc --noEmit`: clean
- `npx jest`: 517 passed; only red is the known pre-existing locale-dependent `client-activity-time` flake (green in CI). 15 new test cases (7 for #175, 8 for #245).
- No `firestore.rules` changes — recurring bulk docs reuse the exact shape `assignTemplateRecurring` already writes.

Closes mdb1/gc-fitness#175
Closes mdb1/gc-fitness#176
Closes mdb1/gc-fitness#245