### PR TITLE
feat(backoffice): recurrence selector in bulk habit assignment (#176 round 2)

### DIFF
--- a/backoffice/messages/en.json
+++ b/backoffice/messages/en.json
@@ -815,7 +815,28 @@
       "assigning": "Assigning…",
       "cancel": "Cancel",
       "assignedToast": "{count} assigned.",
-      "assignFailed": "Assignment failed."
+      "assignFailed": "Assignment failed.",
+      "scheduleLabel": "Recurrence",
+      "scheduleHint": "Defaults to the habit's saved schedule. Change it to assign a different recurrence to every selected client.",
+      "scheduleTypeLabel": "Type",
+      "scheduleTypeRecurring": "Recurring",
+      "scheduleTypeOneTime": "One-time",
+      "cadenceLabel": "Cadence",
+      "cadenceDaily": "Daily",
+      "cadenceWeekly": "Weekly",
+      "cadenceMonthly": "Monthly",
+      "weekdaysLabel": "Weekdays",
+      "monthDaysLabel": "Days of month",
+      "monthDaysHint": "Select one or more days (example: 12 and 25).",
+      "weekdayShort": {
+        "mon": "Mon",
+        "tue": "Tue",
+        "wed": "Wed",
+        "thu": "Thu",
+        "fri": "Fri",
+        "sat": "Sat",
+        "sun": "Sun"
+      }
     },
     "compliance": {
       "scheduledInfo": "Percentage of scheduled days completed since the habit started (days before the start date and non-scheduled days don't count).",

--- a/backoffice/messages/es.json
+++ b/backoffice/messages/es.json
@@ -815,7 +815,28 @@
       "assigning": "Asignando…",
       "cancel": "Cancelar",
       "assignedToast": "{count} asignados.",
-      "assignFailed": "Falló la asignación."
+      "assignFailed": "Falló la asignación.",
+      "scheduleLabel": "Recurrencia",
+      "scheduleHint": "Por defecto usa la programación guardada del hábito. Cambiala para asignar una recurrencia distinta a cada cliente seleccionado.",
+      "scheduleTypeLabel": "Tipo",
+      "scheduleTypeRecurring": "Recurrente",
+      "scheduleTypeOneTime": "Una sola vez",
+      "cadenceLabel": "Frecuencia",
+      "cadenceDaily": "Diario",
+      "cadenceWeekly": "Semanal",
+      "cadenceMonthly": "Mensual",
+      "weekdaysLabel": "Días de la semana",
+      "monthDaysLabel": "Días del mes",
+      "monthDaysHint": "Seleccioná uno o más días (ejemplo: 12 y 25).",
+      "weekdayShort": {
+        "mon": "Lun",
+        "tue": "Mar",
+        "wed": "Mié",
+        "thu": "Jue",
+        "fri": "Vie",
+        "sat": "Sáb",
+        "sun": "Dom"
+      }
     },
     "compliance": {
       "scheduledInfo": "Porcentaje de días programados completados desde que empezó el hábito (los días anteriores a la fecha de inicio y los días no programados no cuentan).",

--- a/backoffice/src/components/gc-fitness/schedule/bulk-assign-habit-dialog.tsx
+++ b/backoffice/src/components/gc-fitness/schedule/bulk-assign-habit-dialog.tsx
@@ -19,8 +19,17 @@
 // The server action `assignHabitTemplate` already creates one per-client
 // /habits doc per clientId, copying the template (description/photoUrl/
 // youtubeUrl/sourceTemplateId/schedule). This dialog is the UI entry point.
+//
+// #176 (Round 2): the dialog now also exposes an explicit RECURRENCE selector
+// (mirrors the single-client HabitForm schedule UI). It is seeded from the
+// picked template's schedule, so the prior behavior is the default; the trainer
+// can override the recurrence (one-time / daily / weekly weekdays / monthly
+// days) before assigning, and the chosen schedule flows through
+// `assignHabitTemplate({ schedule })` into every created habit doc in the exact
+// wire format iOS/Android consume (scheduleType / scheduleCadence /
+// scheduleWeekdays / scheduleMonthDays / scheduleDayOfMonth / endsOn).
 
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { ChevronLeft, Search } from "lucide-react";
 import { useQuery } from "@tanstack/react-query";
 import { toast } from "sonner";
@@ -46,6 +55,54 @@ import {
 export interface BulkAssignClient {
   uid: string;
   displayName: string;
+}
+
+type ScheduleCadence = "daily" | "weekly" | "monthly";
+
+// Mirrors HabitForm's WEEKDAY_KEYS — 1=Mon … 7=Sun (the wire values iOS/Android
+// expect in scheduleWeekdays).
+const WEEKDAY_KEYS = [
+  { value: 1, key: "mon" },
+  { value: 2, key: "tue" },
+  { value: 3, key: "wed" },
+  { value: 4, key: "thu" },
+  { value: 5, key: "fri" },
+  { value: 6, key: "sat" },
+  { value: 7, key: "sun" },
+] as const;
+const MONTH_DAY_OPTIONS = Array.from({ length: 31 }, (_, index) => index + 1);
+
+/**
+ * The schedule the bulk dialog will send. Seeded from the picked template, then
+ * editable. Sent to `assignHabitTemplate` as the `schedule` override.
+ */
+interface BulkSchedule {
+  scheduleType: "recurring" | "one-time";
+  scheduleCadence: ScheduleCadence;
+  scheduleWeekdays: number[];
+  scheduleMonthDays: number[];
+  endsOn?: string;
+}
+
+function scheduleFromTemplate(tpl: HabitTemplateRow): BulkSchedule {
+  const scheduleType = tpl.scheduleType === "one-time" ? "one-time" : "recurring";
+  const scheduleCadence: ScheduleCadence =
+    tpl.scheduleCadence === "weekly" || tpl.scheduleCadence === "monthly"
+      ? tpl.scheduleCadence
+      : "daily";
+  return {
+    scheduleType,
+    scheduleCadence,
+    scheduleWeekdays: Array.isArray(tpl.scheduleWeekdays)
+      ? [...tpl.scheduleWeekdays]
+      : [],
+    scheduleMonthDays: Array.isArray(tpl.scheduleMonthDays)
+      ? [...tpl.scheduleMonthDays]
+      : typeof tpl.scheduleDayOfMonth === "number"
+        ? [tpl.scheduleDayOfMonth]
+        : [],
+    endsOn: tpl.endsOn,
+  };
 }
 
 interface BulkAssignHabitDialogProps {
@@ -78,12 +135,24 @@ export function BulkAssignHabitDialog({
     () => new Set(),
   );
   const [startsOn, setStartsOn] = useState<string>(() => todayCivilDate());
+  const [schedule, setSchedule] = useState<BulkSchedule | null>(null);
   const [submitting, setSubmitting] = useState(false);
+
+  // Seed the recurrence selector from the picked template's schedule, so the
+  // current "inherit the template" behavior is the default. Re-seeds whenever
+  // the trainer picks a different template (and clears when they go back to the
+  // picker). Trainer edits then live in `schedule` until the next template swap.
+  useEffect(() => {
+    setSchedule(
+      selectedTemplate ? scheduleFromTemplate(selectedTemplate) : null,
+    );
+  }, [selectedTemplate]);
 
   function reset() {
     setSelectedTemplate(null);
     setSelectedClientIds(new Set());
     setStartsOn(todayCivilDate());
+    setSchedule(null);
     setSubmitting(false);
   }
 
@@ -121,6 +190,25 @@ export function BulkAssignHabitDialog({
         templateId: selectedTemplate.id,
         clientIds: Array.from(selectedClientIds),
         startsOn,
+        ...(schedule
+          ? {
+              schedule: {
+                scheduleType: schedule.scheduleType,
+                ...(schedule.scheduleType === "recurring"
+                  ? {
+                      scheduleCadence: schedule.scheduleCadence,
+                      ...(schedule.scheduleCadence === "weekly"
+                        ? { scheduleWeekdays: schedule.scheduleWeekdays }
+                        : {}),
+                      ...(schedule.scheduleCadence === "monthly"
+                        ? { scheduleMonthDays: schedule.scheduleMonthDays }
+                        : {}),
+                    }
+                  : {}),
+                ...(schedule.endsOn ? { endsOn: schedule.endsOn } : {}),
+              },
+            }
+          : {}),
       });
       toast.success(t("assignedToast", { count: result.created }));
       onAssigned();
@@ -236,6 +324,184 @@ export function BulkAssignHabitDialog({
             />
             <p className="text-xs text-muted-foreground">{t("startsOnHint")}</p>
           </div>
+
+          {/* Step 4 — recurrence (#176). Seeded from the template; editable. */}
+          {selectedTemplate && schedule ? (
+            <div className="flex flex-col gap-3 rounded-md border p-3">
+              <div className="flex flex-col gap-1.5">
+                <p className="text-sm font-medium">{t("scheduleLabel")}</p>
+                <p className="text-xs text-muted-foreground">
+                  {t("scheduleHint")}
+                </p>
+              </div>
+
+              {/* Type: recurring vs one-time */}
+              <div className="flex flex-col gap-1.5">
+                <span className="text-xs font-medium text-muted-foreground">
+                  {t("scheduleTypeLabel")}
+                </span>
+                <div className="flex flex-wrap gap-2">
+                  {(["recurring", "one-time"] as const).map((value) => {
+                    const active = schedule.scheduleType === value;
+                    return (
+                      <Button
+                        key={value}
+                        type="button"
+                        variant={active ? "default" : "outline"}
+                        size="sm"
+                        aria-pressed={active}
+                        onClick={() =>
+                          setSchedule((prev) =>
+                            prev ? { ...prev, scheduleType: value } : prev,
+                          )
+                        }
+                      >
+                        {value === "recurring"
+                          ? t("scheduleTypeRecurring")
+                          : t("scheduleTypeOneTime")}
+                      </Button>
+                    );
+                  })}
+                </div>
+              </div>
+
+              {schedule.scheduleType === "recurring" ? (
+                <>
+                  {/* Cadence */}
+                  <div className="flex flex-col gap-1.5">
+                    <span className="text-xs font-medium text-muted-foreground">
+                      {t("cadenceLabel")}
+                    </span>
+                    <div className="flex flex-wrap gap-2">
+                      {(["daily", "weekly", "monthly"] as const).map(
+                        (cadence) => {
+                          const active = schedule.scheduleCadence === cadence;
+                          return (
+                            <Button
+                              key={cadence}
+                              type="button"
+                              variant={active ? "default" : "outline"}
+                              size="sm"
+                              aria-pressed={active}
+                              onClick={() =>
+                                setSchedule((prev) => {
+                                  if (!prev) return prev;
+                                  const next: BulkSchedule = {
+                                    ...prev,
+                                    scheduleCadence: cadence,
+                                  };
+                                  // Seed a sensible default day when switching
+                                  // to monthly with nothing chosen yet.
+                                  if (
+                                    cadence === "monthly" &&
+                                    next.scheduleMonthDays.length === 0
+                                  ) {
+                                    next.scheduleMonthDays = [1];
+                                  }
+                                  return next;
+                                })
+                              }
+                            >
+                              {cadence === "daily"
+                                ? t("cadenceDaily")
+                                : cadence === "weekly"
+                                  ? t("cadenceWeekly")
+                                  : t("cadenceMonthly")}
+                            </Button>
+                          );
+                        },
+                      )}
+                    </div>
+                  </div>
+
+                  {/* Weekly → weekday chips */}
+                  {schedule.scheduleCadence === "weekly" ? (
+                    <div className="flex flex-col gap-1.5">
+                      <span className="text-xs font-medium text-muted-foreground">
+                        {t("weekdaysLabel")}
+                      </span>
+                      <div className="flex flex-wrap gap-2">
+                        {WEEKDAY_KEYS.map((weekday) => {
+                          const active = schedule.scheduleWeekdays.includes(
+                            weekday.value,
+                          );
+                          return (
+                            <Button
+                              key={weekday.value}
+                              type="button"
+                              variant={active ? "default" : "outline"}
+                              size="sm"
+                              aria-pressed={active}
+                              onClick={() =>
+                                setSchedule((prev) => {
+                                  if (!prev) return prev;
+                                  const set = new Set(prev.scheduleWeekdays);
+                                  if (set.has(weekday.value))
+                                    set.delete(weekday.value);
+                                  else set.add(weekday.value);
+                                  return {
+                                    ...prev,
+                                    scheduleWeekdays: Array.from(set).sort(
+                                      (a, b) => a - b,
+                                    ),
+                                  };
+                                })
+                              }
+                            >
+                              {t(`weekdayShort.${weekday.key}`)}
+                            </Button>
+                          );
+                        })}
+                      </div>
+                    </div>
+                  ) : null}
+
+                  {/* Monthly → day-of-month chips */}
+                  {schedule.scheduleCadence === "monthly" ? (
+                    <div className="flex flex-col gap-1.5">
+                      <span className="text-xs font-medium text-muted-foreground">
+                        {t("monthDaysLabel")}
+                      </span>
+                      <div className="flex flex-wrap gap-2">
+                        {MONTH_DAY_OPTIONS.map((monthDay) => {
+                          const active =
+                            schedule.scheduleMonthDays.includes(monthDay);
+                          return (
+                            <Button
+                              key={monthDay}
+                              type="button"
+                              variant={active ? "default" : "outline"}
+                              size="sm"
+                              aria-pressed={active}
+                              onClick={() =>
+                                setSchedule((prev) => {
+                                  if (!prev) return prev;
+                                  const set = new Set(prev.scheduleMonthDays);
+                                  if (set.has(monthDay)) set.delete(monthDay);
+                                  else set.add(monthDay);
+                                  return {
+                                    ...prev,
+                                    scheduleMonthDays: Array.from(set).sort(
+                                      (a, b) => a - b,
+                                    ),
+                                  };
+                                })
+                              }
+                            >
+                              {monthDay}
+                            </Button>
+                          );
+                        })}
+                      </div>
+                      <p className="text-xs text-muted-foreground">
+                        {t("monthDaysHint")}
+                      </p>
+                    </div>
+                  ) : null}
+                </>
+              ) : null}
+            </div>
+          ) : null}
         </div>
 
         <DialogFooter>

--- a/backoffice/src/lib/gc-fitness/__tests__/habit-actions.test.ts
+++ b/backoffice/src/lib/gc-fitness/__tests__/habit-actions.test.ts
@@ -69,10 +69,27 @@ const mockCollection = jest.fn(() => ({
   get: () => mockQueryGet(),
 }));
 
+// batch().set(...).commit() — captures every set payload for assignHabitTemplate.
+const mockBatchSet = jest.fn();
+const mockBatchCommit = jest.fn().mockResolvedValue(undefined);
+const mockBatch = jest.fn(() => ({
+  set: mockBatchSet,
+  commit: mockBatchCommit,
+}));
+
 jest.mock("@/lib/firebase/gc-fitness-admin", () => ({
   gcFitnessFirestore: jest.fn(() => ({
     collection: mockCollection,
+    batch: mockBatch,
   })),
+}));
+
+// coach-activity-log is a side-effect logger here — stub it so assign tests
+// don't hit Firestore writes through it. habitAssignedEvent is a pure builder.
+jest.mock("../coach-activity-log", () => ({
+  recordCoachActivityEvent: jest.fn().mockResolvedValue(undefined),
+  markCoachActivityDeleted: jest.fn().mockResolvedValue(undefined),
+  habitAssignedEvent: jest.fn((args: unknown) => args),
 }));
 
 jest.mock("firebase-admin/firestore", () => ({
@@ -95,6 +112,7 @@ import {
   getHabit,
   listHabitsForTrainer,
   listHabitsForClient,
+  assignHabitTemplate,
 } from "../habit-actions";
 import { getTokens } from "next-firebase-auth-edge";
 
@@ -191,6 +209,46 @@ function fakeQuerySnapshot(
       }),
     })),
   } as unknown as QuerySnapshot;
+}
+
+// A habit_templates doc snapshot for the assign tests. Defaults to a
+// trainer-owned, daily, recurring binary template.
+function fakeTemplateSnapshot(opts: {
+  exists: boolean;
+  id?: string;
+  scope?: "global" | "trainer";
+  trainerId?: string | null;
+  deleted?: boolean;
+  scheduleType?: "recurring" | "one-time";
+  scheduleCadence?: "daily" | "weekly" | "monthly";
+  scheduleWeekdays?: number[];
+  scheduleMonthDays?: number[];
+  startsOn?: string;
+}) {
+  const data = {
+    id: opts.id ?? "habit-template-trainer-A-x",
+    scope: opts.scope ?? "trainer",
+    trainerId: opts.trainerId ?? ALLOWED_UID,
+    type: "binary",
+    name: { en: "Stretch", es: "Estirar" },
+    reminderEnabled: false,
+    deleted: opts.deleted ?? false,
+    scheduleType: opts.scheduleType ?? "recurring",
+    scheduleCadence: opts.scheduleCadence ?? "daily",
+    ...(opts.scheduleWeekdays ? { scheduleWeekdays: opts.scheduleWeekdays } : {}),
+    ...(opts.scheduleMonthDays
+      ? { scheduleMonthDays: opts.scheduleMonthDays }
+      : {}),
+    startsOn: opts.startsOn ?? "2026-05-01",
+    createdAt: { toDate: () => new Date("2026-05-01T00:00:00Z") },
+    updatedAt: { toDate: () => new Date("2026-05-01T00:00:00Z") },
+  };
+  return {
+    exists: opts.exists,
+    id: data.id,
+    data: () => data,
+    get: (field: string) => (data as Record<string, unknown>)[field],
+  } as unknown as DocumentSnapshot;
 }
 
 const VALID_BINARY_HABIT_INPUT = {
@@ -615,5 +673,171 @@ describe("getHabit", () => {
 
     expect(result.id).toBe("hab-abc");
     expect(result.trainerId).toBe("previous-coach");
+  });
+});
+
+describe("assignHabitTemplate — recurrence override (#176)", () => {
+  // Each assign: mockGet resolves the TEMPLATE first, then one user doc per
+  // client (assertTrainerOwnsClient). Helper wires those resolves in order.
+  function wireTemplateAndClients(
+    template: DocumentSnapshot,
+    clientCount: number,
+  ) {
+    mockGet.mockResolvedValueOnce(template);
+    for (let i = 0; i < clientCount; i += 1) {
+      mockGet.mockResolvedValueOnce(
+        fakeUserSnapshot({ exists: true, coachId: ALLOWED_UID }),
+      );
+    }
+  }
+
+  // A1 — NO override → habit inherits the template's schedule (prior behavior).
+  it("A1 — inherits the template schedule when no override is sent", async () => {
+    mockedGetTokens.mockResolvedValue(fakeTokens({ role: "trainer" }));
+    wireTemplateAndClients(
+      fakeTemplateSnapshot({
+        exists: true,
+        scheduleType: "recurring",
+        scheduleCadence: "weekly",
+        scheduleWeekdays: [1, 3, 5],
+      }),
+      1,
+    );
+
+    const result = await assignHabitTemplate({
+      templateId: "habit-template-trainer-A-x",
+      clientIds: ["uid-client-1"],
+      startsOn: "2026-06-15",
+    });
+
+    expect(result.created).toBe(1);
+    expect(mockBatchSet).toHaveBeenCalledTimes(1);
+    const payload = mockBatchSet.mock.calls[0][1] as Record<string, unknown>;
+    expect(payload.scheduleType).toBe("recurring");
+    expect(payload.scheduleCadence).toBe("weekly");
+    expect(payload.scheduleWeekdays).toEqual([1, 3, 5]);
+    expect(payload.startsOn).toBe("2026-06-15");
+    expect(payload.sourceTemplateId).toBe("habit-template-trainer-A-x");
+  });
+
+  // A2 — weekly override beats a daily template; weekdays written verbatim.
+  it("A2 — applies a weekly override to every created habit doc", async () => {
+    mockedGetTokens.mockResolvedValue(fakeTokens({ role: "trainer" }));
+    wireTemplateAndClients(
+      fakeTemplateSnapshot({ exists: true, scheduleCadence: "daily" }),
+      2,
+    );
+
+    await assignHabitTemplate({
+      templateId: "habit-template-trainer-A-x",
+      clientIds: ["uid-client-1", "uid-client-2"],
+      startsOn: "2026-06-15",
+      schedule: {
+        scheduleType: "recurring",
+        scheduleCadence: "weekly",
+        scheduleWeekdays: [2, 4],
+      },
+    });
+
+    expect(mockBatchSet).toHaveBeenCalledTimes(2);
+    for (const call of mockBatchSet.mock.calls) {
+      const payload = call[1] as Record<string, unknown>;
+      expect(payload.scheduleType).toBe("recurring");
+      expect(payload.scheduleCadence).toBe("weekly");
+      expect(payload.scheduleWeekdays).toEqual([2, 4]);
+      // The template was daily; the override must NOT leak a daily cadence.
+      expect(payload.scheduleMonthDays).toBeUndefined();
+    }
+  });
+
+  // A3 — monthly override writes scheduleMonthDays AND mirrors the first day
+  // into scheduleDayOfMonth (iOS/Android read whichever exists).
+  it("A3 — monthly override writes month days and mirrors scheduleDayOfMonth", async () => {
+    mockedGetTokens.mockResolvedValue(fakeTokens({ role: "trainer" }));
+    wireTemplateAndClients(fakeTemplateSnapshot({ exists: true }), 1);
+
+    await assignHabitTemplate({
+      templateId: "habit-template-trainer-A-x",
+      clientIds: ["uid-client-1"],
+      startsOn: "2026-06-15",
+      schedule: {
+        scheduleType: "recurring",
+        scheduleCadence: "monthly",
+        scheduleMonthDays: [12, 25],
+      },
+    });
+
+    const payload = mockBatchSet.mock.calls[0][1] as Record<string, unknown>;
+    expect(payload.scheduleCadence).toBe("monthly");
+    expect(payload.scheduleMonthDays).toEqual([12, 25]);
+    expect(payload.scheduleDayOfMonth).toBe(12);
+    expect(payload.scheduleWeekdays).toBeUndefined();
+  });
+
+  // A4 — one-time override drops all recurrence fields.
+  it("A4 — one-time override drops cadence/weekday/monthday fields", async () => {
+    mockedGetTokens.mockResolvedValue(fakeTokens({ role: "trainer" }));
+    wireTemplateAndClients(
+      fakeTemplateSnapshot({
+        exists: true,
+        scheduleCadence: "weekly",
+        scheduleWeekdays: [1, 2, 3],
+      }),
+      1,
+    );
+
+    await assignHabitTemplate({
+      templateId: "habit-template-trainer-A-x",
+      clientIds: ["uid-client-1"],
+      startsOn: "2026-06-15",
+      schedule: { scheduleType: "one-time" },
+    });
+
+    const payload = mockBatchSet.mock.calls[0][1] as Record<string, unknown>;
+    expect(payload.scheduleType).toBe("one-time");
+    expect(payload.scheduleCadence).toBeUndefined();
+    expect(payload.scheduleWeekdays).toBeUndefined();
+    expect(payload.scheduleMonthDays).toBeUndefined();
+  });
+
+  // A5 — endsOn override flows onto the habit doc.
+  it("A5 — carries an endsOn override onto the habit doc", async () => {
+    mockedGetTokens.mockResolvedValue(fakeTokens({ role: "trainer" }));
+    wireTemplateAndClients(fakeTemplateSnapshot({ exists: true }), 1);
+
+    await assignHabitTemplate({
+      templateId: "habit-template-trainer-A-x",
+      clientIds: ["uid-client-1"],
+      startsOn: "2026-06-15",
+      schedule: {
+        scheduleType: "recurring",
+        scheduleCadence: "daily",
+        endsOn: "2026-09-15",
+      },
+    });
+
+    const payload = mockBatchSet.mock.calls[0][1] as Record<string, unknown>;
+    expect(payload.endsOn).toBe("2026-09-15");
+  });
+
+  // A6 — a cross-trainer / deleted template is refused before any write.
+  it("A6 — refuses a template owned by another trainer", async () => {
+    mockedGetTokens.mockResolvedValue(fakeTokens({ role: "trainer" }));
+    mockGet.mockResolvedValueOnce(
+      fakeTemplateSnapshot({
+        exists: true,
+        scope: "trainer",
+        trainerId: "other-trainer",
+      }),
+    );
+
+    await expect(
+      assignHabitTemplate({
+        templateId: "habit-template-other-x",
+        clientIds: ["uid-client-1"],
+        schedule: { scheduleType: "recurring", scheduleCadence: "daily" },
+      }),
+    ).rejects.toThrow(/not available/i);
+    expect(mockBatchSet).not.toHaveBeenCalled();
   });
 });

--- a/backoffice/src/lib/gc-fitness/habit-actions.ts
+++ b/backoffice/src/lib/gc-fitness/habit-actions.ts
@@ -1595,6 +1595,27 @@ export async function assignHabitTemplate(input: unknown): Promise<{
       // cell, the habit should begin on that cell's day rather than inheriting
       // the template's own startsOn.
       startsOn: z.string().trim().min(1).optional(),
+      // Optional RECURRENCE override (#176). When present, the chosen schedule
+      // replaces the template's own schedule fields on every created habit doc
+      // — same wire shape the single-client HabitForm writes (and iOS/Android
+      // already consume via the HabitSchedule / isHabitScheduledOn predicate).
+      // When absent, behavior is unchanged: each habit inherits the template's
+      // schedule. The selector in BulkAssignHabitDialog defaults to the
+      // template's schedule, so "no override" and "override == template" both
+      // yield the previous output.
+      schedule: z
+        .object({
+          scheduleType: z.enum(["recurring", "one-time"]),
+          scheduleCadence: z.enum(["daily", "weekly", "monthly"]).optional(),
+          scheduleWeekdays: z
+            .array(z.number().int().min(1).max(7))
+            .optional(),
+          scheduleMonthDays: z
+            .array(z.number().int().min(1).max(31))
+            .optional(),
+          endsOn: z.string().trim().min(1).optional(),
+        })
+        .optional(),
     })
     .parse(input);
 
@@ -1618,6 +1639,61 @@ export async function assignHabitTemplate(input: unknown): Promise<{
   for (const clientId of parsed.clientIds) {
     await assertTrainerOwnsClient(trainer.uid, clientId);
   }
+
+  // Resolve the schedule fields ONCE (identical for every client in the batch).
+  // If an override is supplied, normalize it the same way HabitForm.onSubmit
+  // does — only carry the cadence-relevant arrays, drop empties, mirror the
+  // first monthDay into scheduleDayOfMonth (iOS/Android read whichever exists).
+  const scheduleFields: Record<string, unknown> = (() => {
+    const override = parsed.schedule;
+    if (!override) {
+      // No override → inherit the template's schedule (previous behavior).
+      return {
+        scheduleType: template.scheduleType ?? "recurring",
+        ...(template.endsOn ? { endsOn: template.endsOn } : {}),
+        ...(template.scheduleCadence
+          ? { scheduleCadence: template.scheduleCadence }
+          : { scheduleCadence: "daily" }),
+        ...(template.scheduleWeekdays
+          ? { scheduleWeekdays: template.scheduleWeekdays }
+          : {}),
+        ...(template.scheduleDayOfMonth !== undefined
+          ? { scheduleDayOfMonth: template.scheduleDayOfMonth }
+          : {}),
+        ...(template.scheduleMonthDays
+          ? { scheduleMonthDays: template.scheduleMonthDays }
+          : {}),
+      };
+    }
+    if (override.scheduleType === "one-time") {
+      // One-time habits carry no cadence/weekday/monthday recurrence fields.
+      return {
+        scheduleType: "one-time",
+        ...(override.endsOn ? { endsOn: override.endsOn } : {}),
+      };
+    }
+    const cadence = override.scheduleCadence ?? "daily";
+    const out: Record<string, unknown> = {
+      scheduleType: "recurring",
+      scheduleCadence: cadence,
+      ...(override.endsOn ? { endsOn: override.endsOn } : {}),
+    };
+    if (cadence === "weekly") {
+      const weekdays = (override.scheduleWeekdays ?? []).filter(
+        (d) => Number.isInteger(d) && d >= 1 && d <= 7,
+      );
+      if (weekdays.length > 0) out.scheduleWeekdays = weekdays;
+    } else if (cadence === "monthly") {
+      const monthDays = (override.scheduleMonthDays ?? []).filter(
+        (d) => Number.isInteger(d) && d >= 1 && d <= 31,
+      );
+      if (monthDays.length > 0) {
+        out.scheduleMonthDays = monthDays;
+        out.scheduleDayOfMonth = monthDays[0];
+      }
+    }
+    return out;
+  })();
 
   const batch = db.batch();
   const assignedHabits: Array<{ docId: string; clientId: string }> = [];
@@ -1647,21 +1723,8 @@ export async function assignHabitTemplate(input: unknown): Promise<{
       ...(template.reminderMonthDays
         ? { reminderMonthDays: template.reminderMonthDays }
         : {}),
-      scheduleType: template.scheduleType ?? "recurring",
       startsOn: parsed.startsOn ?? template.startsOn ?? todayCivilDateUTC(),
-      ...(template.endsOn ? { endsOn: template.endsOn } : {}),
-      ...(template.scheduleCadence
-        ? { scheduleCadence: template.scheduleCadence }
-        : { scheduleCadence: "daily" }),
-      ...(template.scheduleWeekdays
-        ? { scheduleWeekdays: template.scheduleWeekdays }
-        : {}),
-      ...(template.scheduleDayOfMonth !== undefined
-        ? { scheduleDayOfMonth: template.scheduleDayOfMonth }
-        : {}),
-      ...(template.scheduleMonthDays
-        ? { scheduleMonthDays: template.scheduleMonthDays }
-        : {}),
+      ...scheduleFields,
       reminderEnabled: template.reminderEnabled,
       sourceTemplateId: template.id,
       deleted: false,


### PR DESCRIPTION
## Summary

Follow-up to #154: the bulk habit dialog (reached from the Agenda) silently inherited the template's schedule — mdb1/gc-fitness#176 asked for explicit recurrence in the bulk flow.

- `BulkAssignHabitDialog` now has a Recurrence block mirroring the single-client `HabitForm` schedule editor: type (recurring / one-time), cadence (daily / weekly / monthly), weekday chips (Mon–Sun), day-of-month chips. It seeds from the picked template's schedule (re-seeds on template swap) so the previous inherit-the-template behavior remains the default; the trainer can override before assigning.
- `assignHabitTemplate` gained an optional `schedule` override: normalized (one-time strips recurrence fields; weekly keeps valid weekdays; monthly writes `scheduleMonthDays` + mirrors first day into `scheduleDayOfMonth`) and written onto every created `/habits` doc. Absent → behavior unchanged.
- Wire fields are the exact shape iOS/Android already consume via the shared `HabitSchedule`/`isHabitScheduledOn` predicate (`scheduleType`, `scheduleCadence`, `scheduleWeekdays`, `scheduleMonthDays`, `scheduleDayOfMonth`, `endsOn`). No new fields, no rules change.
- Strings added to both `messages/en.json` and `messages/es.json`, reusing `habits.form` wording.

## Test gate

- `npx tsc --noEmit`: clean
- `npx jest`: 523 passed; only red is the known pre-existing locale `client-activity-time` flake (green in CI). 6 new assign tests; `habit-actions` suite 28/28 green.

Refs mdb1/gc-fitness#176