### PR TITLE
fix(gc-fitness): normalized + ranked exercise search (issue mdb1/gc-fitness#291)

### DIFF
--- a/backoffice/src/app/gc-fitness/exercises/client.tsx
+++ b/backoffice/src/app/gc-fitness/exercises/client.tsx
@@ -54,7 +54,7 @@ import {
   EXERCISES_QUERY_KEY,
   type ExerciseRow,
 } from "@/lib/gc-fitness/exercises-listener";
-import { exerciseSearchHaystack } from "@/lib/gc-fitness/exercise-search";
+import { searchExercises } from "@/lib/gc-fitness/exercise-search";
 import {
   softDeleteExercise,
   duplicateExercise,
@@ -85,15 +85,9 @@ function matchesFilters(
   f: ExerciseFiltersState,
   trainerUid: string,
 ): boolean {
-  // Search — case-insensitive substring match on EN and ES name + EN
-  // description + keywords + tags. Trainers expect to search by either
-  // language; lower-casing both sides handles ES accents reasonably (full
-  // normalization deferred until i18n in P12).
-  if (f.search.trim().length > 0) {
-    const needle = f.search.trim().toLowerCase();
-    const hay = exerciseSearchHaystack(row).toLowerCase();
-    if (!hay.includes(needle)) return false;
-  }
+  // Search is handled SEPARATELY by searchExercises in the rows memo (issue
+  // #291) — normalized (hyphen/diacritic/plural) AND name-aware ranked. This
+  // predicate only handles the chip/select filters below.
 
   // Muscle filter — array-contains-any semantics (row matches if it contains
   // ANY of the selected groups). Mirrors Firestore `array-contains-any`,
@@ -144,7 +138,10 @@ export function ExerciseLibraryClient({
 
   const rows = useMemo(() => {
     const all = (data ?? []).filter((r) => r.deleted !== true);
-    return all.filter((r) => matchesFilters(r, filters, trainerUid));
+    // Apply the non-search chip/select filters first, THEN rank + search
+    // (issue #291): normalized, plural/hyphen-tolerant, best-match-first.
+    const filtered = all.filter((r) => matchesFilters(r, filters, trainerUid));
+    return searchExercises(filtered, filters.search);
   }, [data, filters, trainerUid]);
 
   const handleDuplicate = useCallback(

--- a/backoffice/src/components/gc-fitness/__tests__/exercise-picker-popover.test.tsx
+++ b/backoffice/src/components/gc-fitness/__tests__/exercise-picker-popover.test.tsx
@@ -327,3 +327,89 @@ describe("ExercisePickerPopover render-window cap (Task 3 Case 5, Codex MEDIUM)"
     expect(allRows.length).toBe(100);
   });
 });
+
+// ---------------------------------------------------------------------------
+// Case 6 (issue #291) — search applies BEFORE the render cap. The ONLY
+// matching row is LAST in data order (position 120 of 120), past the
+// 100-row cap. Before the fix the cap sliced it off and cmdk only filtered
+// the rendered rows, so the match was never surfaced. With search-before-cap
+// + shouldFilter={false}, typing "incline press" must surface the row.
+// ---------------------------------------------------------------------------
+
+describe("ExercisePickerPopover search-before-cap (issue #291 Case 6)", () => {
+  it("finds a matching row beyond the 100-row cap via the search input", () => {
+    const rows: ExerciseRow[] = [];
+    // 119 filler rows that do NOT match "incline press".
+    for (let i = 0; i < 119; i++) {
+      rows.push(
+        makeRow({
+          id: `filler-${i}`,
+          name: { en: `Exercise ${i}`, es: `Ejercicio ${i}` },
+        }),
+      );
+    }
+    // The ONLY match, LAST in data order (index 119).
+    rows.push(
+      makeRow({
+        id: "incline-db",
+        name: { en: "Incline Dumbbell Press", es: "Press inclinado" },
+      }),
+    );
+    mockUseExercisesQuery.mockReturnValue({
+      data: rows,
+      isLoading: false,
+      error: null,
+      hasSnapshot: true,
+    });
+
+    render(<ExercisePickerPopover value="" onChange={() => {}} />);
+    openPicker();
+
+    // Before searching, the last-in-order row is NOT rendered (capped out).
+    expect(
+      screen.queryByTestId("exercise-picker-row-incline-db"),
+    ).not.toBeInTheDocument();
+
+    // Type into the cmdk CommandInput.
+    const input = screen.getByPlaceholderText("Search exercises…");
+    fireEvent.change(input, { target: { value: "incline press" } });
+
+    // Search ran BEFORE the cap → the only match is now rendered.
+    expect(
+      screen.getByTestId("exercise-picker-row-incline-db"),
+    ).toBeInTheDocument();
+  });
+
+  it('ranks "Bench Press (Barbell)" above "Incline Bench Press" in DOM order', () => {
+    const rows: ExerciseRow[] = [
+      makeRow({
+        id: "incline-bench",
+        name: { en: "Incline Bench Press", es: "Press de banca inclinado" },
+      }),
+      makeRow({
+        id: "bench-barbell",
+        name: { en: "Bench Press (Barbell)", es: "Press de banca (Barra)" },
+      }),
+    ];
+    mockUseExercisesQuery.mockReturnValue({
+      data: rows,
+      isLoading: false,
+      error: null,
+      hasSnapshot: true,
+    });
+
+    render(<ExercisePickerPopover value="" onChange={() => {}} />);
+    openPicker();
+
+    const input = screen.getByPlaceholderText("Search exercises…");
+    fireEvent.change(input, { target: { value: "bench press" } });
+
+    const barbell = screen.getByTestId("exercise-picker-row-bench-barbell");
+    const incline = screen.getByTestId("exercise-picker-row-incline-bench");
+    // The barbell row must precede the incline row in document order.
+    expect(
+      barbell.compareDocumentPosition(incline) &
+        Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
+  });
+});

--- a/backoffice/src/components/gc-fitness/exercise-multi-add-dialog.tsx
+++ b/backoffice/src/components/gc-fitness/exercise-multi-add-dialog.tsx
@@ -32,13 +32,12 @@ import {
   EXERCISES_QUERY_KEY,
   type ExerciseRow,
 } from "@/lib/gc-fitness/exercises-listener";
-import { exerciseSearchHaystack } from "@/lib/gc-fitness/exercise-search";
+import { searchExercises } from "@/lib/gc-fitness/exercise-search";
 
 import {
   ChipRow,
   FilterChip,
   displayEs,
-  fuzzyTokenMatch,
 } from "./exercise-picker-popover";
 import {
   QuickCreateExercise,
@@ -126,14 +125,12 @@ export function ExerciseMultiAddDialog({
     [data],
   );
 
+  // 260612-r8l (issue #291): apply the chip filters first, THEN searchExercises
+  // (filter by relevance AND name-aware rank). Replaces the old coarse
+  // fuzzyTokenMatch pass so the multi-add list is ranked best-first and shares
+  // the exact normalization/ranking the picker + library use.
   const filtered = useMemo(() => {
-    const needle = search.trim();
-    const bySearch = needle
-      ? exercises.filter((ex) => {
-          return fuzzyTokenMatch(needle, exerciseSearchHaystack(ex));
-        })
-      : exercises;
-    return applyFilters(bySearch, filters);
+    return searchExercises(applyFilters(exercises, filters), search);
   }, [exercises, search, filters]);
 
   function toggle(id: string) {

--- a/backoffice/src/components/gc-fitness/exercise-picker-popover.tsx
+++ b/backoffice/src/components/gc-fitness/exercise-picker-popover.tsx
@@ -81,7 +81,19 @@ import {
   EXERCISES_QUERY_KEY,
   type ExerciseRow,
 } from "@/lib/gc-fitness/exercises-listener";
-import { exerciseSearchHaystack } from "@/lib/gc-fitness/exercise-search";
+import {
+  searchExercises,
+  normalizeSearchText,
+} from "@/lib/gc-fitness/exercise-search";
+// Re-export the legacy helper names so existing consumers that import them
+// from THIS component keep working (exercise-multi-add-dialog.tsx and the
+// legacy src/lib/gc-fitness/__tests__/exercise-picker-popover.test.tsx).
+// The implementations now live in exercise-search.ts (issue #291).
+export {
+  normalizeSearchText,
+  fuzzyTokenScore,
+  fuzzyTokenMatch,
+} from "@/lib/gc-fitness/exercise-search";
 import {
   useExerciseFilters,
   applyFilters,
@@ -152,104 +164,6 @@ export function displayEs(row: ExerciseRow): string {
   return es;
 }
 
-/**
- * Lowercases + strips Latin diacritics + collapses whitespace. Used both
- * inside the Command `value` prop (so the fuzzy-matcher sees normalized
- * input AND normalized haystack) and in `displayEs` to decide whether the
- * ES line is meaningfully different from EN.
- *
- * Examples:
- *   "Sentadílla"        -> "sentadilla"
- *   "Press de banca"    -> "press de banca"
- *   "  Squat  "         -> "squat"
- */
-export function normalizeSearchText(s: string): string {
-  return s
-    .toLowerCase()
-    .normalize("NFD")
-    .replace(/\p{Diacritic}/gu, "")
-    // Hyphens, underscores, slashes all behave as word separators so
-    // "Pull-Ups" matches a "pull ups" query and "wide_grip" matches
-    // "wide grip". This also fixes the case where the trainer types
-    // a hyphenated name and the haystack stores it un-hyphenated.
-    .replace(/[-_/]+/g, " ")
-    .replace(/\s+/g, " ")
-    .trim();
-}
-
-/**
- * Score how well a query matches a haystack on a 0..1 scale.
- *
- * Token-based and ORDER-INDEPENDENT: each query token is matched against
- * any haystack word (startsWith preferred, contains as a fallback). The
- * caller's typed token order is intentionally ignored so "incline bench
- * dum" surfaces "Incline Dumbbell Press" even though the query mixes a
- * non-existent middle token ("bench") and a different order than the
- * exercise name.
- *
- * Returns:
- *   - 0          → no useful match (less than 60% of query tokens land)
- *   - 0 < s ≤ 1  → matched. Score = matchedTokens / totalTokens, with a
- *                  small bonus for exact-word startsWith hits over loose
- *                  contains-only hits.
- *
- * Threshold tuning: 60% is permissive enough to forgive one missing
- * token in a 3-token query (2/3 = 0.66 ≥ 0.6), but still rejects
- * "incline xyz xyz" (1/3 = 0.33 < 0.6) so unrelated typos don't pollute
- * the result list. Single-token queries always require a full match
- * (1/1 = 1.0).
- */
-export function fuzzyTokenScore(query: string, haystack: string): number {
-  const normalizedQuery = normalizeSearchText(query);
-  if (!normalizedQuery) return 1;
-  const tokens = normalizedQuery.split(" ").filter(Boolean);
-  if (tokens.length === 0) return 1;
-  const words = normalizeSearchText(haystack).split(" ").filter(Boolean);
-  if (words.length === 0) return 0;
-
-  let strongHits = 0;
-  let weakHits = 0;
-  for (const token of tokens) {
-    let matched: "strong" | "weak" | null = null;
-    for (const word of words) {
-      if (word.startsWith(token)) {
-        matched = "strong";
-        break;
-      }
-    }
-    if (!matched) {
-      for (const word of words) {
-        if (word.includes(token)) {
-          matched = "weak";
-          break;
-        }
-      }
-    }
-    if (matched === "strong") strongHits += 1;
-    else if (matched === "weak") weakHits += 1;
-  }
-
-  const matchedRatio = (strongHits + weakHits) / tokens.length;
-  // 60% threshold: tolerates one missing token in a 3-token query, but
-  // rejects 1-of-3 noise. Single-token queries require a full hit (1.0).
-  if (matchedRatio < 0.6) return 0;
-  // Strong matches outweigh weak ones — exact-word startsWith ranks above
-  // a mid-word contains match.
-  return Math.min(
-    1,
-    (strongHits + weakHits * 0.6) / tokens.length,
-  );
-}
-
-/**
- * Backward-compat boolean wrapper used by the multi-add dialog +
- * picker's "Exercise not found?" check. Returns true when the score is
- * above zero (i.e., the threshold-passing match in fuzzyTokenScore).
- */
-export function fuzzyTokenMatch(query: string, haystack: string): boolean {
-  return fuzzyTokenScore(query, haystack) > 0;
-}
-
 // 260522-mo2 Task D: preview source resolution now prefers gifUrl >
 // imageUrl > thumbnailURL. BOTH the inner `src=` prop AND the OUTER
 // conditional in the popover row + trigger-selected blocks reference
@@ -300,14 +214,20 @@ export function ExercisePickerPopover({
   // Codex MEDIUM render-window cap: when the filtered set exceeds 100
   // rows, render only the first 100 and surface a "+ N more — refine
   // filter" indicator so the user knows to narrow.
+  // 260612-r8l (issue #291): search now runs BEFORE the render cap. The old
+  // code sliced to RENDER_CAP first and let cmdk's internal filter match only
+  // the rendered rows, so a row past position 100 in updatedAt-desc order was
+  // never surfaced. We apply the chip filters, THEN searchExercises (filter +
+  // name-aware rank), THEN cap. The `<Command shouldFilter={false}>` below
+  // disables cmdk's internal matcher so it renders exactly the rows we pass.
   const { visible, overflow } = useMemo(() => {
     const live = (data ?? []).filter((r) => r.deleted !== true);
-    const filtered = applyFilters(live, filters);
+    const ranked = searchExercises(applyFilters(live, filters), search);
     return {
-      visible: filtered.slice(0, RENDER_CAP),
-      overflow: Math.max(0, filtered.length - RENDER_CAP),
+      visible: ranked.slice(0, RENDER_CAP),
+      overflow: Math.max(0, ranked.length - RENDER_CAP),
     };
-  }, [data, filters]);
+  }, [data, filters, search]);
 
   // Kept for the empty-state branch: distinguishes "no rows in cache" from
   // "filters narrowed to zero".
@@ -317,17 +237,13 @@ export function ExercisePickerPopover({
   );
 
   // Whether the trainer's search yields ZERO matches — drives the inline
-  // "Exercise not found. Quick create" panel below. We re-run fuzzy match
-  // ourselves so it stays in sync with what cmdk's internal matcher
-  // produces (both go through normalizeSearchText so a hyphenated needle
-  // like "pull up" matches "Pull-Ups").
+  // "Exercise not found. Quick create" panel below. Search is now applied to
+  // `visible` upstream (via searchExercises), so an empty `visible` with a
+  // non-blank needle IS the no-match signal — no per-row re-check needed.
   const noMatches = useMemo(() => {
     const needle = search.trim();
     if (!needle) return false;
-    if (visible.length === 0) return true;
-    return !visible.some((ex) =>
-      fuzzyTokenMatch(needle, exerciseSearchHaystack(ex)),
-    );
+    return visible.length === 0;
   }, [search, visible]);
 
   const selected = useMemo(
@@ -465,13 +381,13 @@ export function ExercisePickerPopover({
           onClear={clearFilters}
         />
         <Command
-          // 260527-is1 — override cmdk's default character-subsequence
-          // scorer with our token-based, order-independent fuzzy match.
-          // Without this, typing "incline bench dum" failed to surface
-          // "Incline Dumbbell Press" because cmdk requires the typed
-          // characters to appear as an in-order subsequence of the value
-          // and "bench" never appears in that exercise's value at all.
-          filter={(value, search) => fuzzyTokenScore(search, value)}
+          // 260612-r8l (issue #291) — filtering + ranking now happen
+          // EXTERNALLY (searchExercises, applied before the render cap in the
+          // `visible` memo). cmdk must NOT re-filter the rows we pass, or it
+          // would (a) re-apply its own character-subsequence matcher and (b)
+          // only ever see the capped 100 rows. `shouldFilter={false}` makes
+          // cmdk render exactly `visible`.
+          shouldFilter={false}
         >
           <div className="flex items-center border-b px-3">
             <Search className="mr-2 h-4 w-4 shrink-0 opacity-50" />

--- a/backoffice/src/lib/gc-fitness/__tests__/exercise-search.test.ts
+++ b/backoffice/src/lib/gc-fitness/__tests__/exercise-search.test.ts
@@ -3,8 +3,18 @@
 // Covers the shared exercise discovery haystack used by the library view and
 // the picker/multi-add flows. The synonym mapping is the core of issue #180:
 // a trainer should find "Military Standing Press" by typing "shoulder press".
+//
+// Issue #291 additions (A–D): normalization + name-aware RANKING in
+// `searchExercises` / `scoreExercise`. A coach typing a partial / hyphenated /
+// pluralized name should find the right exercise AND see the best match first.
 
-import { exerciseSearchHaystack } from "../exercise-search";
+import {
+  exerciseSearchHaystack,
+  normalizeSearchText,
+  scoreExercise,
+  searchExercises,
+} from "../exercise-search";
+import type { ExerciseRow } from "../exercises-listener";
 
 describe("exerciseSearchHaystack", () => {
   it("includes keywords and variations for synonym search", () => {
@@ -21,5 +31,187 @@ describe("exerciseSearchHaystack", () => {
     expect(haystack.toLowerCase()).toContain("shoulder press");
     expect(haystack.toLowerCase()).toContain("seated shoulder press");
     expect(haystack.toLowerCase()).toContain("standard-library");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Issue #291 — normalization edge cases.
+// ---------------------------------------------------------------------------
+
+describe("normalizeSearchText (issue #291 punctuation)", () => {
+  it("treats parentheses as a word separator", () => {
+    expect(normalizeSearchText("Bench Press (Barbell)")).toBe(
+      "bench press barbell",
+    );
+  });
+
+  it("treats hyphens as a word separator and strips diacritics", () => {
+    expect(normalizeSearchText("Pull-Ups")).toBe("pull ups");
+    expect(normalizeSearchText("Sentadílla")).toBe("sentadilla");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Shared fixture helper — one local makeRow, override per case.
+// Mirrors the field set from the component test's makeRow.
+// ---------------------------------------------------------------------------
+
+function makeRow(overrides: Partial<ExerciseRow> = {}): ExerciseRow {
+  return {
+    id: overrides.id ?? "row",
+    name: { en: "Test Exercise", es: "Ejercicio", ...(overrides.name ?? {}) },
+    description: { en: "", es: "" },
+    muscleGroups: ["chest"],
+    equipment: ["barbell"],
+    mediaURL: null,
+    thumbnailURL: null,
+    youtubeURL: null,
+    source: "free-exercise-db",
+    ownerId: null,
+    version: 1,
+    updatedAt: "2026-05-25T00:00:00.000Z",
+    createdAt: "2026-05-25T00:00:00.000Z",
+    deleted: false,
+    deletedAt: null,
+    mergedInto: null,
+    imageUrl: null,
+    endImageUrl: null,
+    gifUrl: null,
+    instructions: null,
+    deletedReason: null,
+    primaryMuscles: ["chest"],
+    secondaryMuscles: [],
+    mechanic: "compound",
+    level: "intermediate",
+    category: "strength",
+    force: "push",
+    metric: "reps",
+    ...overrides,
+  } as ExerciseRow;
+}
+
+// ---------------------------------------------------------------------------
+// Test A — hyphen + plural tolerance.
+// ---------------------------------------------------------------------------
+
+describe("searchExercises Test A — hyphen + plural (#291)", () => {
+  const pullUps = makeRow({
+    id: "pull-ups",
+    name: { en: "Pull-Ups", es: "Dominadas" },
+  });
+  const pushUps = makeRow({
+    id: "push-ups",
+    name: { en: "Push-Ups", es: "Flexiones" },
+  });
+
+  it('"pull up" surfaces "Pull-Ups" and ranks it first', () => {
+    const result = searchExercises([pullUps, pushUps], "pull up");
+    expect(result.map((r) => r.id)).toContain("pull-ups");
+    expect(result[0].id).toBe("pull-ups");
+  });
+
+  it('"pull ups" surfaces the "Pull-Up" stored singular too', () => {
+    const pullUp = makeRow({ id: "pull-up", name: { en: "Pull-Up", es: "" } });
+    const result = searchExercises([pullUp, pushUps], "pull ups");
+    expect(result.map((r) => r.id)).toContain("pull-up");
+    expect(result[0].id).toBe("pull-up");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Test B — name-aware ranking.
+// ---------------------------------------------------------------------------
+
+describe("searchExercises Test B — ranking (#291)", () => {
+  const benchBarbell = makeRow({
+    id: "bench-barbell",
+    name: { en: "Bench Press (Barbell)", es: "Press de banca (Barra)" },
+  });
+  const inclineBench = makeRow({
+    id: "incline-bench",
+    name: { en: "Incline Bench Press", es: "Press de banca inclinado" },
+  });
+  const keywordOnly = makeRow({
+    id: "floor-fly",
+    name: { en: "Floor Fly", es: "Aperturas en el suelo" },
+    keywords: ["bench press"],
+  });
+
+  it('"bench press" puts "Bench Press (Barbell)" first', () => {
+    const result = searchExercises(
+      [inclineBench, keywordOnly, benchBarbell],
+      "bench press",
+    );
+    expect(result[0].id).toBe("bench-barbell");
+  });
+
+  it('"Incline Bench Press" ranks above the keyword-only match', () => {
+    const result = searchExercises(
+      [keywordOnly, inclineBench, benchBarbell],
+      "bench press",
+    );
+    const inclineIdx = result.findIndex((r) => r.id === "incline-bench");
+    const keywordIdx = result.findIndex((r) => r.id === "floor-fly");
+    expect(inclineIdx).toBeGreaterThanOrEqual(0);
+    expect(keywordIdx).toBeGreaterThanOrEqual(0);
+    expect(inclineIdx).toBeLessThan(keywordIdx);
+  });
+
+  it("scores a tighter name above a longer one", () => {
+    expect(scoreExercise("bench press", benchBarbell)).toBeGreaterThan(
+      scoreExercise("bench press", inclineBench),
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Test C — order-independent multi-token.
+// ---------------------------------------------------------------------------
+
+describe("searchExercises Test C — order-independent (#291)", () => {
+  const inclineDbPress = makeRow({
+    id: "incline-db-press",
+    name: { en: "Incline Dumbbell Press", es: "Press inclinado con mancuernas" },
+  });
+  const squat = makeRow({ id: "squat", name: { en: "Squat", es: "Sentadilla" } });
+
+  it('"incline press" matches "Incline Dumbbell Press"', () => {
+    const result = searchExercises([squat, inclineDbPress], "incline press");
+    expect(result.map((r) => r.id)).toContain("incline-db-press");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Test D — empty query passthrough.
+// ---------------------------------------------------------------------------
+
+describe("searchExercises Test D — empty passthrough (#291)", () => {
+  const rows = [
+    makeRow({ id: "a", name: { en: "Alpha", es: "" } }),
+    makeRow({ id: "b", name: { en: "Beta", es: "" } }),
+    makeRow({ id: "c", name: { en: "Gamma", es: "" } }),
+  ];
+
+  it("empty query returns rows unchanged (same order)", () => {
+    expect(searchExercises(rows, "")).toEqual(rows);
+  });
+
+  it("whitespace-only query returns rows unchanged (same order)", () => {
+    expect(searchExercises(rows, "   ")).toEqual(rows);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Test E (bonus) — diacritic-insensitive ES name match.
+// ---------------------------------------------------------------------------
+
+describe("searchExercises diacritics (#291)", () => {
+  it('"sentadilla" finds a row whose ES name is "Sentadílla"', () => {
+    const accented = makeRow({
+      id: "sentadilla",
+      name: { en: "Squat", es: "Sentadílla" },
+    });
+    const result = searchExercises([accented], "sentadilla");
+    expect(result.map((r) => r.id)).toContain("sentadilla");
   });
 });

--- a/backoffice/src/lib/gc-fitness/exercise-search.ts
+++ b/backoffice/src/lib/gc-fitness/exercise-search.ts
@@ -31,3 +31,258 @@ export function exerciseSearchHaystack(
     .filter((value): value is string => typeof value === "string" && value.trim().length > 0)
     .join(" ");
 }
+
+/**
+ * Lowercases + strips Latin diacritics + collapses whitespace, treating a set
+ * of separators/punctuation as word boundaries. Used both inside the search
+ * matcher (so the matcher sees normalized input AND normalized haystack) and
+ * in `displayEs` to decide whether the ES line is meaningfully different from
+ * EN.
+ *
+ * Word separators: hyphen/underscore/slash AND the punctuation set
+ * `()[]{},.:;"'`. This makes "Pull-Ups" match a "pull ups" query and
+ * "Bench Press (Barbell)" expose "barbell" as its own searchable word so the
+ * query "bench press barbell" strong-matches every name word.
+ *
+ * Examples:
+ *   "Sentadílla"          -> "sentadilla"
+ *   "Press de banca"      -> "press de banca"
+ *   "  Squat  "           -> "squat"
+ *   "Pull-Ups"            -> "pull ups"
+ *   "Bench Press (Barbell)" -> "bench press barbell"
+ */
+export function normalizeSearchText(s: string): string {
+  return s
+    .toLowerCase()
+    .normalize("NFD")
+    .replace(/\p{Diacritic}/gu, "")
+    // Hyphens, underscores, slashes AND the punctuation set ()[]{},.:;"'
+    // all behave as word separators so "Pull-Ups" matches a "pull ups"
+    // query and "(Barbell)" becomes a standalone "barbell" word.
+    .replace(/[-_/()[\]{},.:;"']+/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+/**
+ * Strips a single trailing "s" when the word is long enough to keep a
+ * meaningful stem. Both the query token and the haystack word are stemmed so
+ * "ups" vs "up" and "up" vs "ups" both match; "press" -> "pres" stays
+ * symmetric. Guard `length > 1` so a bare "s" doesn't collapse to "".
+ */
+function singularStem(w: string): string {
+  if (w.length > 1 && w.endsWith("s")) return w.slice(0, -1);
+  return w;
+}
+
+/**
+ * True when a query token strong-matches a haystack word: either the word
+ * starts with the token verbatim, or the singular stems align by startsWith.
+ * The stem comparison gives plural/singular tolerance in both directions.
+ */
+function tokenStrongMatchesWord(token: string, word: string): boolean {
+  if (word.startsWith(token)) return true;
+  const stemToken = singularStem(token);
+  const stemWord = singularStem(word);
+  return stemWord.startsWith(stemToken) || stemToken.startsWith(stemWord);
+}
+
+/**
+ * Score how well a query matches a haystack on a 0..1 scale.
+ *
+ * Token-based and ORDER-INDEPENDENT: each query token is matched against
+ * any haystack word (strong startsWith / plural-stem match preferred, loose
+ * contains as a fallback). The caller's typed token order is intentionally
+ * ignored so "incline bench dum" surfaces "Incline Dumbbell Press" even
+ * though the query mixes a non-existent middle token ("bench") and a
+ * different order than the exercise name.
+ *
+ * Returns:
+ *   - 0          → no useful match (less than 60% of query tokens land)
+ *   - 0 < s ≤ 1  → matched. Score = matchedTokens / totalTokens, with a
+ *                  bonus for strong (startsWith / plural-stem) hits over
+ *                  loose contains-only hits.
+ *
+ * Threshold tuning: 60% is permissive enough to forgive one missing token in
+ * a 3-token query (2/3 = 0.66 ≥ 0.6), but still rejects "incline xyz xyz"
+ * (1/3 = 0.33 < 0.6). Single-token queries always require a full match.
+ */
+export function fuzzyTokenScore(query: string, haystack: string): number {
+  const normalizedQuery = normalizeSearchText(query);
+  if (!normalizedQuery) return 1;
+  const tokens = normalizedQuery.split(" ").filter(Boolean);
+  if (tokens.length === 0) return 1;
+  const words = normalizeSearchText(haystack).split(" ").filter(Boolean);
+  if (words.length === 0) return 0;
+
+  let strongHits = 0;
+  let weakHits = 0;
+  for (const token of tokens) {
+    let matched: "strong" | "weak" | null = null;
+    for (const word of words) {
+      if (tokenStrongMatchesWord(token, word)) {
+        matched = "strong";
+        break;
+      }
+    }
+    if (!matched) {
+      for (const word of words) {
+        if (word.includes(token)) {
+          matched = "weak";
+          break;
+        }
+      }
+    }
+    if (matched === "strong") strongHits += 1;
+    else if (matched === "weak") weakHits += 1;
+  }
+
+  const matchedRatio = (strongHits + weakHits) / tokens.length;
+  // 60% threshold: tolerates one missing token in a 3-token query, but
+  // rejects 1-of-3 noise. Single-token queries require a full hit (1.0).
+  if (matchedRatio < 0.6) return 0;
+  // Strong matches outweigh weak ones — exact-word startsWith ranks above
+  // a mid-word contains match.
+  return Math.min(1, (strongHits + weakHits * 0.6) / tokens.length);
+}
+
+/**
+ * Backward-compat boolean wrapper used by the multi-add dialog +
+ * picker's "Exercise not found?" check. Returns true when the score is
+ * above zero (i.e., the threshold-passing match in fuzzyTokenScore).
+ */
+export function fuzzyTokenMatch(query: string, haystack: string): boolean {
+  return fuzzyTokenScore(query, haystack) > 0;
+}
+
+// ---------------------------------------------------------------------------
+// Name-aware ranking (issue #291).
+//
+// scoreExercise returns a score in clearly-separated numeric BANDS so the tier
+// ordering can never be inverted by the within-tier fraction:
+//
+//   exact name match            -> 5.x   (highest)
+//   name phrase-prefix          -> 4.x
+//   all tokens strong-match name-> 3.x   (minus a small per-extra-word penalty)
+//   name partial / contains     -> 2.x
+//   haystack-only (kw/tags/...)  -> 1.x   (lowest non-zero)
+//   no match                    -> 0
+//
+// The fractional part within a band is always < 1 so cross-band ordering holds.
+// ---------------------------------------------------------------------------
+
+const BAND_EXACT = 5;
+const BAND_PREFIX = 4;
+const BAND_ALL_TOKENS = 3;
+const BAND_PARTIAL = 2;
+const BAND_HAYSTACK = 1;
+
+/**
+ * Per-extra-name-word penalty so a tighter name beats a longer one within the
+ * all-tokens-strong-match band: "Bench Press (Barbell)" (3 name words, 1 extra
+ * over the 2-token query) ranks above "Incline Bench Press" (3 name words but
+ * the query tokens land on the trailing two, leaving "incline" as the extra).
+ * Kept small (< the band gap / max-extra-words) so it never crosses bands.
+ */
+const EXTRA_WORD_PENALTY = 0.02;
+
+function allTokensStrongMatchWords(tokens: string[], words: string[]): boolean {
+  if (tokens.length === 0 || words.length === 0) return false;
+  return tokens.every((token) =>
+    words.some((word) => tokenStrongMatchesWord(token, word)),
+  );
+}
+
+/**
+ * Name-aware ranked score for a single row against a query. Higher is better.
+ * Computed against the EN+ES NAME first, with the broader haystack
+ * (keywords/tags/muscles/variations) as the lowest-band fallback.
+ */
+export function scoreExercise(query: string, row: ExerciseRow): number {
+  const normQuery = normalizeSearchText(query);
+  if (!normQuery) return 0;
+  const tokens = normQuery.split(" ").filter(Boolean);
+
+  const nameEn = normalizeSearchText(row.name.en ?? "");
+  const nameEs = normalizeSearchText(row.name.es ?? "");
+
+  // Tier 1 — exact normalized name match (EN or ES).
+  if (normQuery === nameEn || normQuery === nameEs) {
+    return BAND_EXACT;
+  }
+
+  // Tier 2 — name phrase-prefix (normalized name startsWith normalized query).
+  // Require a word-boundary so "press" doesn't prefix-"pressure"; the
+  // normalized query already ends mid-word only if the user typed a partial.
+  const prefixEn = nameEn === normQuery || nameEn.startsWith(`${normQuery} `);
+  const prefixEs = nameEs === normQuery || nameEs.startsWith(`${normQuery} `);
+  if (prefixEn || prefixEs) {
+    return BAND_PREFIX;
+  }
+
+  // Tier 3 — all query tokens strong-match the name words (order-independent),
+  // with a per-extra-name-word penalty so the tighter name ranks higher.
+  const enWords = nameEn.split(" ").filter(Boolean);
+  const esWords = nameEs.split(" ").filter(Boolean);
+  const matchesEn = allTokensStrongMatchWords(tokens, enWords);
+  const matchesEs = allTokensStrongMatchWords(tokens, esWords);
+  if (matchesEn || matchesEs) {
+    // Use the side that matched with the FEWEST words (tightest name).
+    const candidateWordCounts: number[] = [];
+    if (matchesEn) candidateWordCounts.push(enWords.length);
+    if (matchesEs) candidateWordCounts.push(esWords.length);
+    const nameWordCount = Math.min(...candidateWordCounts);
+    const extraWords = Math.max(0, nameWordCount - tokens.length);
+    return BAND_ALL_TOKENS - extraWords * EXTRA_WORD_PENALTY;
+  }
+
+  // Tier 4 — name partial / contains (normalized name contains the query, or a
+  // looser fuzzy match against the name only).
+  if (nameEn.includes(normQuery) || nameEs.includes(normQuery)) {
+    return BAND_PARTIAL;
+  }
+  const nameFuzzy = Math.max(
+    fuzzyTokenScore(query, row.name.en ?? ""),
+    fuzzyTokenScore(query, row.name.es ?? ""),
+  );
+  if (nameFuzzy > 0) {
+    // Keep the fraction strictly < 1 so it stays inside the partial band.
+    return BAND_PARTIAL - 0.5 + nameFuzzy * 0.5;
+  }
+
+  // Tier 5 — haystack-only match (keywords/tags/muscles/variations).
+  const haystackScore = fuzzyTokenScore(query, exerciseSearchHaystack(row));
+  if (haystackScore > 0) {
+    return BAND_HAYSTACK + haystackScore * 0.5;
+  }
+
+  return 0;
+}
+
+/**
+ * Filter + name-aware stable rank. Empty/whitespace query returns the rows
+ * unchanged (same order, same elements) so callers can pass the raw list
+ * through without a re-sort. Otherwise keeps only rows with a positive score
+ * and STABLE-sorts by score desc, tie-break alphabetical by normalized EN
+ * name (then original index for full determinism).
+ */
+export function searchExercises<T extends ExerciseRow>(
+  rows: T[],
+  query: string,
+): T[] {
+  if (!query || !query.trim()) return [...rows];
+
+  const decorated = rows
+    .map((row, index) => ({ row, index, score: scoreExercise(query, row) }))
+    .filter((d) => d.score > 0);
+
+  decorated.sort((a, b) => {
+    if (b.score !== a.score) return b.score - a.score;
+    const nameA = normalizeSearchText(a.row.name.en ?? "");
+    const nameB = normalizeSearchText(b.row.name.en ?? "");
+    if (nameA !== nameB) return nameA < nameB ? -1 : 1;
+    return a.index - b.index;
+  });
+
+  return decorated.map((d) => d.row);
+}


### PR DESCRIPTION
Fixes the three exercise-search defects reported in mdb1/gc-fitness#291.

## Defects fixed

1. **"pull up" didn't match "Pull-Ups"** — the library page used a raw lowercase substring match with no hyphen/diacritic/plural normalization.
2. **Closest match didn't rank first** — "bench press" buried "Bench Press (Barbell)" because the old fuzzy score was coarse (every match ≈ 1.0) and two surfaces didn't rank at all (data order = `updatedAt desc`).
3. **Picker search missed results past the 100-row render cap** — `ExercisePickerPopover` sliced to `RENDER_CAP` *before* searching, and cmdk only filters rendered rows. Searching "Incline Press" only matched within the first 100 rows; ticking the Dumbbell chip shrank the pre-cap set, which is why *more* results appeared with a filter active.

## Changes

- **`lib/gc-fitness/exercise-search.ts`** is now the single search module: `normalizeSearchText` (lowercase, diacritics, hyphens/underscores/slashes AND `()[]{},.:;"'` as word separators), `fuzzyTokenScore`/`fuzzyTokenMatch` with singular/plural stem tolerance, and new `scoreExercise` + `searchExercises` with banded name-aware ranking (exact name ≫ name prefix ≫ all tokens in name, penalizing extra words ≫ name partial ≫ keyword/tag-only), stable sort with alphabetical tie-break.
- **Picker popover**: search+rank now run BEFORE the render cap; `<Command shouldFilter={false}>` replaces the custom `filter` prop. Legacy helper names re-exported from the component for back-compat.
- **Multi-add dialog** and **exercise library table** route through the same `searchExercises`, so all three surfaces match and rank identically.

## Tests

- `exercise-search.test.ts`: hyphen/plural ("pull up" ↔ "Pull-Ups"), ranking ("bench press" → "Bench Press (Barbell)" first), order-independent tokens ("incline press" → "Incline Dumbbell Press"), diacritics, empty-query passthrough.
- `exercise-picker-popover.test.tsx`: regression test proving a match at position 120 of 120 (past the cap) is surfaced by typing in the search input; DOM-order ranking assertion.

## Test gate

- Targeted suites: 45/45 green. `npx tsc --noEmit` clean.
- Full `npx jest`: 539/541 — the 2 failures (`client-activity-time` locale flake, `workout-assignment-actions`) were baselined against a fresh `origin/main` worktree and fail identically there (pre-existing, not regressions).