### PR TITLE
feat(gc-fitness): only the new standard library + coach-authored exercises are pickable

### DIFF
--- a/backoffice/docs/legacy-exercise-retirement.md
+++ b/backoffice/docs/legacy-exercise-retirement.md
@@ -1,0 +1,115 @@
+# Legacy Exercise Retirement
+
+**Status:** active (code-side hiding shipped 2026-06-12 — "legacy exercise retirement")
+**Single source of truth:** [`src/lib/gc-fitness/exercise-visibility.ts`](../src/lib/gc-fitness/exercise-visibility.ts) (`isPickableExercise`)
+
+## What this is
+
+The shared `exercises` Firestore collection accumulated three generations of
+catalog seeds (wger, free-exercise-db, alias dedupe docs) plus a NEW curated
+"standard library". Coaches were seeing 400+ legacy duplicates in every
+exercise-choice surface. This change hides the legacy catalog from the choice
+surfaces **without deleting any data**, so the new standard library and
+coach-authored exercises are the only pickable options, while every historical
+routine that references a legacy id keeps resolving.
+
+## Classification rule
+
+An exercise is **pickable** if and only if:
+
+1. it is NOT soft-deleted (`deleted !== true`), AND
+2. its `tags` contains `"standard-library"` (the new curated library), **OR**
+   its `source === "trainer"` AND `ownerId != null` (a genuine coach-authored
+   exercise).
+
+Everything else is **hidden** from the choice surfaces.
+
+> ⚠️ **The `ownerId != null` guard is load-bearing.** `snapToRow`
+> (`exercises-listener.ts`) coerces ANY unknown wire `source` — including the 24
+> `"standard_alias"` docs — to `"trainer"`. A bare `source === "trainer"` check
+> would therefore wrongly keep alias docs pickable. All 24 alias docs have
+> `ownerId: null`; all 38 genuine trainer docs have `ownerId` set, so the guard
+> is what separates them after snapToRow normalization.
+
+The predicate is wired into the three choice surfaces via `.filter(isPickableExercise)`:
+
+- `src/components/gc-fitness/exercise-picker-popover.tsx` — `visible` + `liveCount` memos
+- `src/components/gc-fitness/exercise-multi-add-dialog.tsx` — `exercises` memo
+- `src/app/gc-fitness/exercises/client.tsx` — `rows` memo
+
+The library page "Standard" / "Custom" source filter keeps working unchanged —
+with legacy hidden, "Standard" now means the new curated library and "Custom"
+means trainer-authored.
+
+## Audited prod counts (2026-06-12, project `gcfitness-3476b`)
+
+| Bucket | Count | Disposition |
+|--------|-------|-------------|
+| **Total docs** | **871** | — |
+| New standard library (`tags: ["standard-library"]`; 257 numeric-ID + 15 `std-*`) | 272 | **Pickable** |
+| Trainer-authored (live, `source: "trainer"`, `ownerId` set) | 38 | **Pickable** |
+| Legacy free-exercise-db (`fexd-*`, `source: "free-exercise-db"`, no tag) | 237 | Hidden code-side |
+| Legacy wger (`wger-*`, live, `source: "wger"`, no tag) | 139 | Hidden code-side |
+| Legacy alias (`alias-*`, `source: "standard_alias"` → coerced to `"trainer"`, `ownerId: null`) | 24 | Hidden code-side |
+| wger docs already `deletedAt`-filtered server-side | 161 | Already filtered |
+
+Pickable = 272 + 38 = **310**. Hidden live legacy = 237 + 139 + 24 = **400**.
+(310 + 400 + 161 ≈ 871; small rounding from concurrent edits during the audit.)
+
+## Why hiding is CODE-SIDE only (never `deleted:true` / `mergedInto`)
+
+We deliberately do NOT mutate Firestore to hide legacy docs.
+
+- Setting `deleted: true` breaks the **iOS exercise-detail screen**, which
+  filters on `deleted` to decide whether an exercise `isLive` — a referenced-but-
+  deleted exercise would vanish from a client's existing routine detail.
+- Writing `mergedInto` to redirect a legacy id caused the **2026-06-12 dangling-
+  mergedInto incident**: a `mergedInto` pointing at a non-existent canonical id
+  broke detail screens in prod. See
+  `.planning/quick/260612-urgent-dangling-mergedinto/INCIDENT.md`.
+
+Code-side hiding keeps every legacy doc alive and resolvable while removing it
+from the curated picker. No wire payload changes; no security-rule changes.
+
+## What still references legacy ids (must keep resolving)
+
+Legacy exercise ids remain referenced by historical data. These must keep
+resolving names + thumbnails — which is why the picker's `selected` memo
+resolves over the FULL unfiltered query, NOT the filtered list:
+
+- `workout_templates` — `exercises[].exerciseId`
+- `workout_assignments` — per-assignment exercise snapshots
+- `workout_logs` / set logs — logged exercise ids
+- progress charts — per-exercise volume/PR series keyed by exercise id
+
+## DELIBERATE mobile gap (cross-platform parity)
+
+This filter ships **backoffice-only**. The iOS and Android Library tabs still
+browse the full legacy catalog (browse-only) until a twin `isPickableExercise`
+filter ships on each native surface. This is acceptable for now because coaches
+author/pick exercises in the backoffice, not on mobile.
+
+> **TODO (parity):** port `isPickableExercise` to the iOS `GCFitnessCore`
+> exercise list and the Android `core` exercise list so the mobile Library tabs
+> hide legacy exercises identically. Track per the cross-platform parity rule in
+> `gc-fitness/CLAUDE.md`. Strings: none added here (no user-facing copy change).
+
+## Safe hard-removal checklist (FUTURE — not done here)
+
+When we decide to physically delete legacy docs from Firestore:
+
+1. **Per-id reference audit.** For EACH legacy id, scan every referencing
+   collection — `workout_templates.exercises[].exerciseId`,
+   `workout_assignments` snapshots, `workout_logs` / set logs, and progress
+   chart series — and either migrate the reference to a canonical
+   standard-library id or accept the data loss.
+2. **Beta-only safety.** All current users are beta testers, so accepting loss
+   for orphaned references is tolerable — but confirm the count first.
+3. **Delete Storage media too.** Remove the exercise's Firebase Storage assets
+   (`gifUrl` / `imageUrl` / `endImageUrl` / `thumbnailURL`) so the bucket
+   doesn't keep dangling media.
+4. **Remove `alias-*` docs LAST.** Alias docs may back-reference canonical ids;
+   deleting them before the docs they point at can strand resolution paths.
+5. **Mobile twins first.** Ship the iOS/Android `isPickableExercise` filter
+   before hard-removal so the mobile Library tabs don't 404 on freshly-deleted
+   ids.

--- a/backoffice/src/app/gc-fitness/exercises/client.tsx
+++ b/backoffice/src/app/gc-fitness/exercises/client.tsx
@@ -55,6 +55,7 @@ import {
   type ExerciseRow,
 } from "@/lib/gc-fitness/exercises-listener";
 import { searchExercises } from "@/lib/gc-fitness/exercise-search";
+import { isPickableExercise } from "@/lib/gc-fitness/exercise-visibility";
 import {
   softDeleteExercise,
   duplicateExercise,
@@ -137,7 +138,7 @@ export function ExerciseLibraryClient({
   const [deletePending, setDeletePending] = useState(false);
 
   const rows = useMemo(() => {
-    const all = (data ?? []).filter((r) => r.deleted !== true);
+    const all = (data ?? []).filter(isPickableExercise);
     // Apply the non-search chip/select filters first, THEN rank + search
     // (issue #291): normalized, plural/hyphen-tolerant, best-match-first.
     const filtered = all.filter((r) => matchesFilters(r, filters, trainerUid));

--- a/backoffice/src/components/gc-fitness/__tests__/exercise-picker-popover.test.tsx
+++ b/backoffice/src/components/gc-fitness/__tests__/exercise-picker-popover.test.tsx
@@ -71,6 +71,12 @@ function makeRow(overrides: Partial<ExerciseRow> = {}): ExerciseRow {
     thumbnailURL: null,
     youtubeURL: null,
     source: "free-exercise-db",
+    // Legacy exercise retirement: isPickableExercise now hides non-trainer rows
+    // that lack the standard-library tag. The pre-existing picker smoke tests
+    // (chips / cap / search) seed rows that should remain VISIBLE, so the
+    // fixture default now carries the tag. Tests asserting legacy-hidden
+    // behavior override `tags` (and `source`/`ownerId`) explicitly.
+    tags: ["standard-library"],
     ownerId: null,
     version: 1,
     updatedAt: "2026-05-25T00:00:00.000Z",
@@ -411,5 +417,80 @@ describe("ExercisePickerPopover search-before-cap (issue #291 Case 6)", () => {
       barbell.compareDocumentPosition(incline) &
         Node.DOCUMENT_POSITION_FOLLOWING,
     ).toBeTruthy();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Legacy exercise retirement — isPickableExercise filter.
+//
+// (A) A legacy catalog row (source "wger", no standard-library tag) must NOT
+//     appear in the open picker list, while a standard-library row does.
+// (B) Selected-resolution invariant: rendering the picker with `value` set to a
+//     legacy row's id must STILL show that legacy row's name in the trigger,
+//     because the `selected` memo resolves over the FULL unfiltered data so
+//     existing template/assignment rows that reference a now-hidden exercise
+//     keep rendering its name + thumbnail.
+// ---------------------------------------------------------------------------
+
+describe("ExercisePickerPopover legacy retirement filter", () => {
+  it("hides a legacy wger row but shows a standard-library row in the list", () => {
+    const legacy = makeRow({
+      id: "wger-legacy",
+      name: { en: "Legacy Wger Curl", es: "Curl Wger Legado" },
+      source: "wger",
+      ownerId: null,
+      tags: [],
+    });
+    const library = makeRow({
+      id: "std-bench",
+      name: { en: "Standard Bench Press", es: "Press de banca estándar" },
+      source: "wger",
+      ownerId: null,
+      tags: ["standard-library"],
+    });
+    mockUseExercisesQuery.mockReturnValue({
+      data: [legacy, library],
+      isLoading: false,
+      error: null,
+      hasSnapshot: true,
+    });
+
+    render(<ExercisePickerPopover value="" onChange={() => {}} />);
+    openPicker();
+
+    // Standard-library row is pickable.
+    expect(
+      screen.getByTestId("exercise-picker-row-std-bench"),
+    ).toBeInTheDocument();
+    // Legacy row is filtered out of the choice list.
+    expect(
+      screen.queryByTestId("exercise-picker-row-wger-legacy"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("still renders a hidden legacy exercise's name in the trigger when it is the selected value", () => {
+    const legacy = makeRow({
+      id: "wger-legacy",
+      name: { en: "Legacy Wger Curl", es: "Curl Wger Legado" },
+      source: "wger",
+      ownerId: null,
+      tags: [],
+    });
+    mockUseExercisesQuery.mockReturnValue({
+      data: [legacy],
+      isLoading: false,
+      error: null,
+      hasSnapshot: true,
+    });
+
+    // value points at the legacy id — mirrors an existing template row that
+    // references a now-hidden exercise.
+    render(
+      <ExercisePickerPopover value="wger-legacy" onChange={() => {}} />,
+    );
+
+    // The trigger resolves the legacy row over the FULL unfiltered data, so its
+    // name still renders even though it is hidden from the pickable list.
+    expect(screen.getByText("Legacy Wger Curl")).toBeInTheDocument();
   });
 });

--- a/backoffice/src/components/gc-fitness/exercise-multi-add-dialog.tsx
+++ b/backoffice/src/components/gc-fitness/exercise-multi-add-dialog.tsx
@@ -33,6 +33,7 @@ import {
   type ExerciseRow,
 } from "@/lib/gc-fitness/exercises-listener";
 import { searchExercises } from "@/lib/gc-fitness/exercise-search";
+import { isPickableExercise } from "@/lib/gc-fitness/exercise-visibility";
 
 import {
   ChipRow,
@@ -121,7 +122,7 @@ export function ExerciseMultiAddDialog({
   }
 
   const exercises = useMemo(
-    () => (data ?? []).filter((r) => r.deleted !== true),
+    () => (data ?? []).filter(isPickableExercise),
     [data],
   );
 

--- a/backoffice/src/components/gc-fitness/exercise-picker-popover.tsx
+++ b/backoffice/src/components/gc-fitness/exercise-picker-popover.tsx
@@ -85,6 +85,7 @@ import {
   searchExercises,
   normalizeSearchText,
 } from "@/lib/gc-fitness/exercise-search";
+import { isPickableExercise } from "@/lib/gc-fitness/exercise-visibility";
 // Re-export the legacy helper names so existing consumers that import them
 // from THIS component keep working (exercise-multi-add-dialog.tsx and the
 // legacy src/lib/gc-fitness/__tests__/exercise-picker-popover.test.tsx).
@@ -221,7 +222,7 @@ export function ExercisePickerPopover({
   // name-aware rank), THEN cap. The `<Command shouldFilter={false}>` below
   // disables cmdk's internal matcher so it renders exactly the rows we pass.
   const { visible, overflow } = useMemo(() => {
-    const live = (data ?? []).filter((r) => r.deleted !== true);
+    const live = (data ?? []).filter(isPickableExercise);
     const ranked = searchExercises(applyFilters(live, filters), search);
     return {
       visible: ranked.slice(0, RENDER_CAP),
@@ -232,7 +233,7 @@ export function ExercisePickerPopover({
   // Kept for the empty-state branch: distinguishes "no rows in cache" from
   // "filters narrowed to zero".
   const liveCount = useMemo(
-    () => (data ?? []).filter((r) => r.deleted !== true).length,
+    () => (data ?? []).filter(isPickableExercise).length,
     [data],
   );
 

--- a/backoffice/src/lib/gc-fitness/__tests__/exercise-visibility.test.ts
+++ b/backoffice/src/lib/gc-fitness/__tests__/exercise-visibility.test.ts
@@ -1,0 +1,112 @@
+// exercise-visibility.test.ts (legacy exercise retirement)
+//
+// Unit coverage for `isPickableExercise` — the single source of truth for
+// which exercises appear in the backoffice choice surfaces (picker,
+// multi-add dialog, library page).
+//
+// The CRITICAL case is the `standard_alias` shape: snapToRow maps ANY unknown
+// wire `source` (including `"standard_alias"`, 24 such alias docs in prod) to
+// `"trainer"`. A bare `source === "trainer"` branch would WRONGLY keep those
+// alias docs pickable. All 24 alias docs have `ownerId: null`; all 38 genuine
+// trainer-authored docs have `ownerId` set — hence the `ownerId != null` guard.
+
+import {
+  isPickableExercise,
+  STANDARD_LIBRARY_TAG,
+} from "@/lib/gc-fitness/exercise-visibility";
+
+describe("isPickableExercise", () => {
+  it("exposes the standard-library tag constant", () => {
+    expect(STANDARD_LIBRARY_TAG).toBe("standard-library");
+  });
+
+  it("keeps trainer-authored exercises (source trainer, ownerId set)", () => {
+    expect(
+      isPickableExercise({
+        deleted: false,
+        source: "trainer",
+        ownerId: "uid-1",
+        tags: [],
+      }),
+    ).toBe(true);
+  });
+
+  it("keeps standard-library-tagged exercises even on a wger source", () => {
+    expect(
+      isPickableExercise({
+        deleted: false,
+        source: "wger",
+        ownerId: null,
+        tags: [STANDARD_LIBRARY_TAG],
+      }),
+    ).toBe(true);
+  });
+
+  it("hides legacy wger exercises without the standard-library tag", () => {
+    expect(
+      isPickableExercise({
+        deleted: false,
+        source: "wger",
+        ownerId: null,
+        tags: [],
+      }),
+    ).toBe(false);
+  });
+
+  it("hides legacy free-exercise-db exercises without the standard-library tag", () => {
+    expect(
+      isPickableExercise({
+        deleted: false,
+        source: "free-exercise-db",
+        ownerId: null,
+        tags: [],
+      }),
+    ).toBe(false);
+  });
+
+  it("hides standard_alias docs (snapToRow → source trainer, ownerId null)", () => {
+    // This is exactly how a `standard_alias` wire doc surfaces post-snapToRow:
+    // the unknown source coerces to "trainer" but the alias never has an owner.
+    expect(
+      isPickableExercise({
+        deleted: false,
+        source: "trainer",
+        ownerId: null,
+        tags: [],
+      }),
+    ).toBe(false);
+  });
+
+  it("hides a deleted exercise even when it carries the standard-library tag", () => {
+    expect(
+      isPickableExercise({
+        deleted: true,
+        source: "wger",
+        ownerId: null,
+        tags: [STANDARD_LIBRARY_TAG],
+      }),
+    ).toBe(false);
+  });
+
+  it("hides a deleted trainer exercise", () => {
+    expect(
+      isPickableExercise({
+        deleted: true,
+        source: "trainer",
+        ownerId: "uid-1",
+        tags: [],
+      }),
+    ).toBe(false);
+  });
+
+  it("hides a non-trainer row with undefined tags", () => {
+    expect(
+      isPickableExercise({
+        deleted: false,
+        source: "free-exercise-db",
+        ownerId: null,
+        tags: undefined,
+      }),
+    ).toBe(false);
+  });
+});

--- a/backoffice/src/lib/gc-fitness/exercise-visibility.ts
+++ b/backoffice/src/lib/gc-fitness/exercise-visibility.ts
@@ -21,7 +21,7 @@
 //   HIDDEN   = 400 legacy live docs (237 free-exercise-db + 139 wger + 24
 //   standard_alias) with no standard-library tag.
 //
-// ⚠️ THE ownerId GUARD IS LOad-bearing. `snapToRow` (exercises-listener.ts)
+// ⚠️ THE ownerId GUARD IS LOAD-BEARING. `snapToRow` (exercises-listener.ts)
 // coerces ANY unknown wire `source` — including the 24 `"standard_alias"` docs
 // — to `"trainer"`. A bare `source === "trainer"` check would therefore WRONGLY
 // keep those alias docs pickable. All 24 alias docs have `ownerId: null`; all

--- a/backoffice/src/lib/gc-fitness/exercise-visibility.ts
+++ b/backoffice/src/lib/gc-fitness/exercise-visibility.ts
@@ -1,0 +1,59 @@
+// exercise-visibility.ts
+//
+// SINGLE SOURCE OF TRUTH for which exercises are pickable in the backoffice
+// choice surfaces (the single-add picker, the multi-add dialog, and the
+// exercises library page). See `docs/legacy-exercise-retirement.md` for the
+// full decision record, audited prod counts, and the safe hard-removal
+// checklist.
+//
+// WHY A PREDICATE INSTEAD OF DATA WRITES — legacy catalog exercises (fexd-*,
+// wger-*, alias-*) are hidden CODE-SIDE only. We NEVER set `deleted: true` or
+// `mergedInto` to hide them: the 2026-06-12 dangling-mergedInto incident showed
+// that mutating those fields breaks the iOS exercise-detail screen (it filters
+// on `deleted` / chases `mergedInto`) AND broke prod. Legacy docs stay alive in
+// Firestore so ~600 historical templates / assignments / logs that reference
+// their ids keep resolving names + thumbnails.
+//
+// CLASSIFICATION (2026-06-12 audit, project gcfitness-3476b):
+//   PICKABLE = NEW standard library (`tags` contains "standard-library", 272
+//   docs) OR genuine coach-authored exercise (`source === "trainer"` AND
+//   `ownerId != null`, 38 docs).
+//   HIDDEN   = 400 legacy live docs (237 free-exercise-db + 139 wger + 24
+//   standard_alias) with no standard-library tag.
+//
+// ⚠️ THE ownerId GUARD IS LOad-bearing. `snapToRow` (exercises-listener.ts)
+// coerces ANY unknown wire `source` — including the 24 `"standard_alias"` docs
+// — to `"trainer"`. A bare `source === "trainer"` check would therefore WRONGLY
+// keep those alias docs pickable. All 24 alias docs have `ownerId: null`; all
+// 38 genuine trainer docs have `ownerId` set. The `ownerId != null` guard is
+// what separates them post-snapToRow.
+
+import type { ExerciseRow } from "./exercises-listener";
+
+/**
+ * Semantic tag marking a doc as part of the NEW curated standard library.
+ *
+ * Declared LOCALLY (not imported from exercise-standard-library.ts) on purpose:
+ * importing from that module would pull the whole generated exercise array into
+ * every client bundle that consumes the predicate. The literal lives here as
+ * the wire contract; the seeded docs carry the matching `tags` entry.
+ */
+export const STANDARD_LIBRARY_TAG = "standard-library";
+
+/**
+ * Whether an exercise row should appear in a choice surface.
+ *
+ * Precedence (deleted → standard-library tag → trainer-with-owner → hidden):
+ *   1. `deleted === true` → never pickable (even if standard-library-tagged).
+ *   2. carries the standard-library tag → pickable (the new curated library).
+ *   3. `source === "trainer"` AND `ownerId != null` → pickable (coach-authored;
+ *      the ownerId guard rejects snapToRow-coerced `standard_alias` docs).
+ *   4. otherwise hidden (legacy fexd / wger / alias catalog docs).
+ */
+export function isPickableExercise(
+  row: Pick<ExerciseRow, "deleted" | "source" | "tags" | "ownerId">,
+): boolean {
+  if (row.deleted === true) return false;
+  if (row.tags?.includes(STANDARD_LIBRARY_TAG)) return true;
+  return row.source === "trainer" && row.ownerId != null;
+}


### PR DESCRIPTION
Retires the legacy exercise catalog from every **choice** surface while keeping every doc alive and resolvable for existing routines, per the beta-stage decision (2026-06-12). (The exercise-search fix from #158 is already merged into `main`; this builds on it.)

## Rule (code-side only — zero prod data writes)

Pickable = has `tags: ["standard-library"]` (the new "Name (Equipment)" library, **272 docs**) OR is genuinely coach-authored (`source === "trainer"` AND `ownerId != null`, **38 docs**). Hidden from choices: **400 legacy live docs** (237 free-exercise-db + 139 wger + 24 standard_alias).

⚠️ The `ownerId != null` guard is load-bearing: `snapToRow` coerces unknown wire sources (including the 24 `standard_alias` docs, all `ownerId: null`) to `"trainer"` — a bare source check would keep them pickable.

## Why a predicate instead of marking docs

The 2026-06-12 prod incident: `deleted: true` breaks the iOS detail screen (filters on it) and dangling `mergedInto` pointers broke ~307 exercise details in the production app. Hiding code-side is instantly reversible and keeps referential integrity for historical templates/assignments/logs.

## Invariants locked by tests

- Picker `selected` resolution still searches the FULL dataset → existing template/assignment rows referencing a legacy exercise keep rendering name + thumbnail (dedicated test).
- Quick-create / duplicate keep working: `createExercise` enforces `source: "trainer"` + `ownerId: uid`, so new coach exercises remain pickable; `duplicateExercise` is the escape hatch to clone a legacy exercise into an editable, pickable copy.
- Predicate unit suite covers the alias shape (`source:"trainer"`, `ownerId:null` → hidden), std-lib tag, deleted-even-with-tag, undefined tags.

## Documentation

`backoffice/docs/legacy-exercise-retirement.md` — decision record: audited prod counts, the incident lesson, what still references legacy ids, the **deliberate mobile gap** (iOS/Android Library tabs still browse legacy until a twin filter ships — coaches pick in the backoffice), and the safe hard-removal checklist for when we decide to delete the old docs (all current users are beta testers).

## Test gate

`npx tsc --noEmit` clean; `npx jest` 550/552 — only the two pre-existing baselined reds (`client-activity-time` locale flake, `workout-assignment-actions`), no new failures.