### PR TITLE
fix(gc-fitness): standard-template edit crash — don't write endsOn:undefined on fork/duplicate

### DIFF
--- a/backoffice/src/lib/gc-fitness/__tests__/workout-template-actions.test.ts
+++ b/backoffice/src/lib/gc-fitness/__tests__/workout-template-actions.test.ts
@@ -99,6 +99,7 @@ import {
   updateWorkoutTemplate,
   softDeleteWorkoutTemplate,
   listWorkoutTemplates,
+  forkStandardWorkoutTemplate,
 } from "../workout-template-actions";
 import { getTokens } from "next-firebase-auth-edge";
 
@@ -357,6 +358,64 @@ describe("updateWorkoutTemplate", () => {
     // T-04-14 / 15: immutable fields never echoed in the patch.
     expect(patch.trainerId).toBeUndefined();
     expect(patch.createdAt).toBeUndefined();
+  });
+});
+
+// Standard-template fork. Regression: the Admin SDK rejects an explicit
+// `undefined` value, so forking a standard template that lacks `endsOn`
+// (every standard template does) crashed with "Cannot use 'undefined' as a
+// Firestore value". The fork must OMIT the `endsOn` key entirely when the
+// source has none, and copy it through when present.
+describe("forkStandardWorkoutTemplate", () => {
+  function fakeStandardSnapshot(opts: { endsOn?: string }) {
+    return {
+      exists: true,
+      id: "tpl-kXZSqc-std-resistance-b",
+      data: () => ({
+        trainerId: "__standard__",
+        isStandard: true,
+        version: 2,
+        deleted: false,
+        name: { en: "RESISTANCE B", es: "RESISTANCE B" },
+        tag: "custom",
+        exercises: [
+          { exerciseId: "0157", sets: 3, reps: 0, rest_seconds: 30, order: 0, metric: "time", durationSeconds: 40 },
+        ],
+        ...(opts.endsOn ? { endsOn: opts.endsOn } : {}),
+        createdAt: { toDate: () => new Date("2026-01-01T00:00:00Z") },
+        updatedAt: { toDate: () => new Date("2026-01-01T00:00:00Z") },
+      }),
+    } as unknown as DocumentSnapshot;
+  }
+
+  it("forks an endsOn-less standard template WITHOUT writing endsOn: undefined", async () => {
+    mockedGetTokens.mockResolvedValue(fakeTokens({ role: "trainer" }));
+    mockGet.mockResolvedValue(fakeStandardSnapshot({}));
+    mockSet.mockResolvedValue(undefined);
+
+    const result = await forkStandardWorkoutTemplate("tpl-kXZSqc-std-resistance-b");
+
+    expect(mockSet).toHaveBeenCalledTimes(1);
+    const payload = mockSet.mock.calls[0][0];
+    // The key must be ABSENT — not present-with-undefined (which the Admin
+    // SDK rejects). Time-based exercises copy through verbatim.
+    expect(Object.prototype.hasOwnProperty.call(payload, "endsOn")).toBe(false);
+    expect(payload.trainerId).toBe(ALLOWED_UID);
+    expect(payload.isStandard).toBe(false);
+    expect(payload.sourceTemplateId).toBe("tpl-kXZSqc-std-resistance-b");
+    expect(payload.exercises[0].metric).toBe("time");
+    expect(result.id).toContain(`tpl-${ALLOWED_UID}-`);
+  });
+
+  it("copies endsOn through when the standard source has one", async () => {
+    mockedGetTokens.mockResolvedValue(fakeTokens({ role: "trainer" }));
+    mockGet.mockResolvedValue(fakeStandardSnapshot({ endsOn: "2026-12-31" }));
+    mockSet.mockResolvedValue(undefined);
+
+    await forkStandardWorkoutTemplate("tpl-kXZSqc-std-resistance-b");
+
+    const payload = mockSet.mock.calls[0][0];
+    expect(payload.endsOn).toBe("2026-12-31");
   });
 });
 

--- a/backoffice/src/lib/gc-fitness/workout-template-actions.ts
+++ b/backoffice/src/lib/gc-fitness/workout-template-actions.ts
@@ -245,7 +245,12 @@ export async function forkStandardWorkoutTemplate(
   await docRef.set({
     name: source.name ?? { en: "", es: "" },
     description: source.description ?? { en: "", es: "" },
-    endsOn: typeof source.endsOn === "string" ? source.endsOn : undefined,
+    // `endsOn` is OPTIONAL — most templates (incl. every standard template)
+    // don't carry it. The Admin SDK rejects an explicit `undefined` value
+    // ("Cannot use 'undefined' as a Firestore value"), so include the key
+    // ONLY when the source actually has a string. Writing `endsOn: undefined`
+    // unconditionally crashed forking any endsOn-less standard template.
+    ...(typeof source.endsOn === "string" ? { endsOn: source.endsOn } : {}),
     tag: sourceTags[0] ?? "custom",
     tags: sourceTags,
     exercises: Array.isArray(source.exercises) ? source.exercises : [],
@@ -299,7 +304,9 @@ export async function duplicateWorkoutTemplate(
   await docRef.set({
     name: suffixedName,
     description: source.description ?? { en: "", es: "" },
-    endsOn: typeof source.endsOn === "string" ? source.endsOn : undefined,
+    // See forkStandardWorkoutTemplate — omit `endsOn` entirely when the
+    // source lacks it; the Admin SDK rejects an explicit `undefined`.
+    ...(typeof source.endsOn === "string" ? { endsOn: source.endsOn } : {}),
     tag: sourceTags[0] ?? "custom",
     tags: sourceTags,
     exercises: Array.isArray(source.exercises) ? source.exercises : [],


### PR DESCRIPTION
## Blocker — fixes the "Algo salió mal" crash when opening a standard template's edit page

Opening `/gc-fitness/templates/<std-template>/edit` forks the standard template to the trainer (`forkStandardWorkoutTemplate`), then redirects to the fork's edit page. The fork wrote:

```ts
endsOn: typeof source.endsOn === "string" ? source.endsOn : undefined,
```

The Firestore **Admin SDK rejects an explicit `undefined`** value (`Cannot use "undefined" as a Firestore value (found in field "endsOn")`) — `ignoreUndefinedProperties` is not enabled. **Every** standard template lacks `endsOn`, so the fork always threw → the page hit its error boundary and showed *"Algo salió mal"* (reproduced on `std-resistance-b/edit`).

This is a **pre-existing latent bug** (standard-template editing was never exercised until the standard routines were rebuilt to be worth opening, PR #160), not caused by the time-based template data — the fork copies `exercises[]` verbatim with no validation.

## Fix

Include the `endsOn` key **only when the source has a string** (conditional spread), in both `forkStandardWorkoutTemplate` and `duplicateWorkoutTemplate` (same pattern, same latent bug).

## Tests

`workout-template-actions.test.ts` — new `forkStandardWorkoutTemplate` describe:
- forks an `endsOn`-less standard template and asserts the set payload **omits** the `endsOn` key (not present-with-undefined), copies time-based exercises through, sets `isStandard:false` + `sourceTemplateId`.
- copies `endsOn` through when the source has one.

Repro confirmed against the live Admin SDK (a `.set({ endsOn: undefined })` throws); fix verified by the payload-shape assertions.

## Gate

`npx tsc --noEmit` clean; `workout-template-actions` 17/17 green; full `npx jest` 552/554 (the 2 reds are the pre-existing `client-activity-time` locale flake + `workout-assignment-actions`, unrelated).

> ⚠️ Production is currently blocked from editing/forking standard templates until this deploys (backoffice auto-deploys `main` on merge).