### PR TITLE
fix(gc-fitness): Cancel on template edit discards the autosaved draft (+ confirm modal)

### DIFF
--- a/backoffice/messages/en.json
+++ b/backoffice/messages/en.json
@@ -696,7 +696,11 @@
       "savedToast": "Template saved.",
       "saveFailed": "Couldn't save.",
       "submitErrorsHeadline": "Fix these before saving:",
-      "submitErrorExercisePrefix": "Exercise #{index}"
+      "submitErrorExercisePrefix": "Exercise #{index}",
+      "discardDialogTitle": "Discard changes?",
+      "discardDialogBody": "If you cancel, your unsaved changes to this template will be lost.",
+      "discardDialogConfirm": "Discard changes",
+      "discardDialogKeepEditing": "Keep editing"
     }
   },
   "habits": {

--- a/backoffice/messages/es.json
+++ b/backoffice/messages/es.json
@@ -696,7 +696,11 @@
       "savedToast": "Plantilla guardada.",
       "saveFailed": "No se pudo guardar.",
       "submitErrorsHeadline": "Falta completar antes de guardar:",
-      "submitErrorExercisePrefix": "Ejercicio #{index}"
+      "submitErrorExercisePrefix": "Ejercicio #{index}",
+      "discardDialogTitle": "¿Descartar cambios?",
+      "discardDialogBody": "Si cancelás, se perderán los cambios no guardados de esta rutina.",
+      "discardDialogConfirm": "Descartar cambios",
+      "discardDialogKeepEditing": "Seguir editando"
     }
   },
   "habits": {

--- a/backoffice/src/components/gc-fitness/__tests__/template-form-cancel.test.tsx
+++ b/backoffice/src/components/gc-fitness/__tests__/template-form-cancel.test.tsx
@@ -1,0 +1,145 @@
+/**
+ * @jest-environment jsdom
+ */
+
+// template-form-cancel.test.tsx
+//
+// Regression for the "Cancel keeps my changes" bug: the edit form autosaves a
+// draft to localStorage on every change and restores it on the next mount. The
+// Cancel button used to just navigate back, leaving the draft on disk — so
+// re-opening the editor resurrected the cancelled edits.
+//
+// These tests cover the fix: explicit Cancel, when a draft was restored (or the
+// form is dirty), opens a confirm dialog; confirming DISCARDS — it removes the
+// localStorage draft and navigates back, and the navigation does not re-write
+// the draft.
+//
+// First three lines MUST stay the jsdom docblock (backoffice jest defaults to
+// testEnvironment: node).
+
+import "@testing-library/jest-dom";
+
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import React from "react";
+
+const mockBack = jest.fn();
+jest.mock("next/navigation", () => ({
+  useRouter: () => ({ back: mockBack, push: jest.fn() }),
+}));
+
+// useTranslations(ns) → t(key) returns the key verbatim so we can query by it.
+jest.mock("next-intl", () => ({
+  useTranslations: () => (key: string) => key,
+}));
+
+// Heavy data hooks — stub to safe empty shapes (no Firestore).
+jest.mock("@/lib/gc-fitness/exercises-listener", () => ({
+  useExercisesQuery: () => ({
+    data: [],
+    isLoading: false,
+    error: null,
+    hasSnapshot: true,
+  }),
+}));
+jest.mock("@/lib/gc-fitness/workout-templates-listener", () => ({
+  useWorkoutTemplates: () => ({ data: [], isLoading: false, error: null }),
+}));
+
+// Child components are exercised by their own tests — stub them out so this
+// test stays focused on the cancel/draft flow and doesn't need their providers.
+jest.mock("../exercise-picker-popover", () => ({
+  ExercisePickerPopover: () => null,
+}));
+jest.mock("../exercise-multi-add-dialog", () => ({
+  ExerciseMultiAddDialog: () => null,
+}));
+jest.mock("../template-tags-picker", () => ({
+  TemplateTagsPicker: () => null,
+}));
+
+import { TemplateForm } from "../template-form";
+
+const DRAFT_PREFIX = "gc-fitness:template-draft:";
+const TEMPLATE_ID = "tpl-1";
+const DRAFT_KEY = `edit:${TEMPLATE_ID}`;
+const STORAGE_KEY = `${DRAFT_PREFIX}${DRAFT_KEY}`;
+
+const SERVER_DEFAULTS = {
+  name: { en: "Push Day", es: "Empuje" },
+  description: { en: "", es: "" },
+  tag: "push" as const,
+  tags: ["push"],
+  exercises: [
+    {
+      exerciseId: "0025",
+      sets: 3,
+      reps: 12,
+      rest_seconds: 90,
+      transition_rest_seconds: 60,
+      order: 0,
+    },
+  ],
+};
+
+// A draft that differs from the server defaults (a swapped exercise) — this is
+// the "unsaved change" the trainer wants Cancel to throw away.
+const DRAFT_VALUE = {
+  ...SERVER_DEFAULTS,
+  exercises: [
+    {
+      exerciseId: "9999-swapped",
+      sets: 4,
+      reps: 8,
+      rest_seconds: 120,
+      transition_rest_seconds: 60,
+      order: 0,
+    },
+  ],
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  window.localStorage.clear();
+});
+
+function renderForm() {
+  return render(
+    <TemplateForm
+      mode="edit"
+      draftKey={DRAFT_KEY}
+      defaultValues={SERVER_DEFAULTS}
+      onSubmit={async () => ({ ok: true as const })}
+    />,
+  );
+}
+
+describe("TemplateForm cancel discards the autosaved draft", () => {
+  it("confirms then clears the restored draft and navigates back", async () => {
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(DRAFT_VALUE));
+    renderForm();
+
+    // The restore effect read the draft → confirm path is armed.
+    fireEvent.click(screen.getByRole("button", { name: "cancel" }));
+
+    // Confirm dialog appears (translation mock returns the key verbatim).
+    const confirm = await screen.findByText("discardDialogConfirm");
+    fireEvent.click(confirm);
+
+    await waitFor(() => {
+      expect(mockBack).toHaveBeenCalledTimes(1);
+    });
+    // The draft is gone AND was not re-written by the unmount/navigation flush.
+    expect(window.localStorage.getItem(STORAGE_KEY)).toBeNull();
+  });
+
+  it("keeps the draft when the trainer chooses 'keep editing'", async () => {
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(DRAFT_VALUE));
+    renderForm();
+
+    fireEvent.click(screen.getByRole("button", { name: "cancel" }));
+    fireEvent.click(await screen.findByText("discardDialogKeepEditing"));
+
+    expect(mockBack).not.toHaveBeenCalled();
+    expect(window.localStorage.getItem(STORAGE_KEY)).not.toBeNull();
+  });
+});

--- a/backoffice/src/components/gc-fitness/template-form.tsx
+++ b/backoffice/src/components/gc-fitness/template-form.tsx
@@ -79,6 +79,16 @@ import {
   TooltipProvider,
   TooltipTrigger,
 } from "@/components/ui/tooltip";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
 import { cn } from "@/lib/utils";
 
 import {
@@ -362,9 +372,15 @@ export function TemplateForm({
   }, [draftKey]);
 
   const draftTimerRef = useRef<number | null>(null);
+  // Set when the trainer explicitly Cancels (Discard). It short-circuits the
+  // unmount + pagehide draft flushes below so an explicit discard isn't
+  // immediately re-persisted by the navigation that follows it — that
+  // re-write was the bug where Cancel left the changes for the next edit.
+  const cancellingRef = useRef(false);
   useEffect(() => {
     if (!draftKey) return;
     const subscription = form.watch((value) => {
+      if (cancellingRef.current) return;
       if (draftTimerRef.current !== null) {
         window.clearTimeout(draftTimerRef.current);
       }
@@ -376,13 +392,17 @@ export function TemplateForm({
     // If the trainer navigates away within DRAFT_DEBOUNCE_MS of the last
     // keystroke, the pending timer is cancelled by cleanup and the draft is
     // lost. FLUSH the latest snapshot synchronously on unmount so the
-    // /templates list can surface the draft on the next visit.
+    // /templates list can surface the draft on the next visit — UNLESS the
+    // trainer explicitly Cancelled (then the draft was just cleared and must
+    // stay cleared).
     return () => {
       subscription.unsubscribe();
       if (draftTimerRef.current !== null) {
         window.clearTimeout(draftTimerRef.current);
         draftTimerRef.current = null;
-        writeDraft(draftKey, form.getValues());
+        if (!cancellingRef.current) {
+          writeDraft(draftKey, form.getValues());
+        }
       }
     };
   }, [draftKey, form]);
@@ -394,6 +414,7 @@ export function TemplateForm({
     if (!draftKey) return;
     const key = draftKey; // capture for closure (TS narrowing lost in nested fn)
     function flush() {
+      if (cancellingRef.current) return;
       if (draftTimerRef.current !== null) {
         window.clearTimeout(draftTimerRef.current);
         draftTimerRef.current = null;
@@ -413,6 +434,31 @@ export function TemplateForm({
     clearDraft(draftKey);
     form.reset(buildDefaults(defaultValues, mode));
     setDraftRestored(false);
+  }
+
+  // Cancel flow. Explicit Cancel DISCARDS — clears any autosaved draft and
+  // navigates away. When there are unsaved changes (dirty this session OR a
+  // draft was restored from a prior session) we confirm first so the trainer
+  // doesn't lose work by accident.
+  const [showCancelConfirm, setShowCancelConfirm] = useState(false);
+
+  function performCancel() {
+    cancellingRef.current = true;
+    if (draftTimerRef.current !== null) {
+      window.clearTimeout(draftTimerRef.current);
+      draftTimerRef.current = null;
+    }
+    if (draftKey) clearDraft(draftKey);
+    setShowCancelConfirm(false);
+    router.back();
+  }
+
+  function handleCancelClick() {
+    if (form.formState.isDirty || draftRestored) {
+      setShowCancelConfirm(true);
+      return;
+    }
+    performCancel();
   }
   // ------------------------------------------------------------------------
 
@@ -2209,7 +2255,7 @@ export function TemplateForm({
           <Button
             type="button"
             variant="ghost"
-            onClick={() => router.back()}
+            onClick={handleCancelClick}
             disabled={pending}
           >
             {t("cancel")}
@@ -2219,6 +2265,28 @@ export function TemplateForm({
           </Button>
         </div>
       </form>
+
+      {/* Unsaved-changes guard — explicit Cancel discards the autosaved draft,
+          so confirm before throwing away in-progress edits. */}
+      <AlertDialog open={showCancelConfirm} onOpenChange={setShowCancelConfirm}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>{t("discardDialogTitle")}</AlertDialogTitle>
+            <AlertDialogDescription>
+              {t("discardDialogBody")}
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>{t("discardDialogKeepEditing")}</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={performCancel}
+              className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+            >
+              {t("discardDialogConfirm")}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
     </Form>
   );
 }


### PR DESCRIPTION
Fixes the two issues reported on the template edit flow:

1. **No "you'll lose your changes" warning on Cancel.**
2. **Cancelled changes came back.** Re-opening the editor showed the edits the trainer had just cancelled.

## Root cause

The editor autosaves a draft to `localStorage` (`gc-fitness:template-draft:edit:<id>`) on every change (debounced) and **restores it on the next mount**. The draft was only cleared on a successful save — Cancel just called `router.back()`, leaving the draft on disk. Worse, the unmount + `pagehide` flush handlers would *re-write* the draft during the navigation, so even clearing it naively wasn't enough.

## Fix

`template-form.tsx`:
- **Cancel now discards.** When the form is dirty or a draft was restored, Cancel opens a confirm `AlertDialog` ("¿Descartar cambios?" / "Discard changes?"). Confirming clears the draft and navigates back; "Seguir editando" keeps the trainer in the form.
- A `cancellingRef` short-circuits the **unmount** and **pagehide/visibilitychange** draft flushes, so the post-Cancel navigation can't resurrect the just-cleared draft.
- New i18n strings `discardDialog*` (en + es).

The accidental-close safety net is unchanged: closing the tab or hitting the browser back button still preserves an in-progress draft. Only the explicit **Cancel** button is treated as "throw these away".

## Tests

`template-form-cancel.test.tsx` (jsdom): seeds a draft in localStorage, mounts the editor, clicks Cancel → Discard, and asserts the draft key is **removed** and `router.back()` fired (proving no re-write); plus a "keep editing" case that leaves the draft intact and doesn't navigate.

## Gate

`npx tsc --noEmit` clean; new suite 2/2 green; full `npx jest` 554/556 — the 2 reds are the pre-existing `client-activity-time` locale flake + `workout-assignment-actions`, unrelated.