### PR TITLE
feat(gc-fitness): read-only VIEW mode for templates — stop auto-fork (duplicates) on open

### DIFF
--- a/backoffice/messages/en.json
+++ b/backoffice/messages/en.json
@@ -547,12 +547,24 @@
       "untitled": "(untitled)",
       "actionsAria": "Actions",
       "edit": "Edit",
+      "view": "View",
       "duplicate": "Duplicate",
       "delete": "Delete",
       "draftUntitled": "(untitled draft)",
       "draftBadgeTooltip": "Incomplete draft — cannot be assigned until completed",
       "draftResumeCta": "Continue draft",
       "draftPendingLabel": "Draft"
+    },
+    "viewPage": {
+      "standardBadge": "Standard",
+      "exercisesHeading": "Exercises",
+      "restLabel": "rest {seconds}s",
+      "setsRepsLabel": "{sets} × {reps}",
+      "setsTimeLabel": "{sets} × {seconds}s",
+      "backCta": "Back",
+      "duplicateCta": "Duplicate",
+      "duplicatedToast": "Template duplicated.",
+      "duplicateFailedToast": "Couldn't duplicate. Please try again."
     },
     "editPage": {
       "title": "Edit template",

--- a/backoffice/messages/es.json
+++ b/backoffice/messages/es.json
@@ -547,12 +547,24 @@
       "untitled": "(sin título)",
       "actionsAria": "Acciones",
       "edit": "Editar",
+      "view": "Ver",
       "duplicate": "Duplicar",
       "delete": "Eliminar",
       "draftUntitled": "(borrador sin título)",
       "draftBadgeTooltip": "Borrador incompleto — no se puede asignar hasta completarse",
       "draftResumeCta": "Continuar borrador",
       "draftPendingLabel": "Borrador"
+    },
+    "viewPage": {
+      "standardBadge": "Standard",
+      "exercisesHeading": "Ejercicios",
+      "restLabel": "descanso {seconds}s",
+      "setsRepsLabel": "{sets} × {reps}",
+      "setsTimeLabel": "{sets} × {seconds}s",
+      "backCta": "Volver",
+      "duplicateCta": "Duplicar",
+      "duplicatedToast": "Plantilla duplicada.",
+      "duplicateFailedToast": "No se pudo duplicar. Intentá de nuevo."
     },
     "editPage": {
       "title": "Editar plantilla",

--- a/backoffice/src/app/gc-fitness/templates/[id]/edit/page.tsx
+++ b/backoffice/src/app/gc-fitness/templates/[id]/edit/page.tsx
@@ -19,7 +19,6 @@ import {
 import { gcFitnessFirestore } from "@/lib/firebase/gc-fitness-admin";
 import { FirestoreCollections } from "@/lib/gc-fitness/collections";
 import type { WorkoutTemplateInput } from "@/lib/gc-fitness/workout-template-schema";
-import { forkStandardWorkoutTemplate } from "@/lib/gc-fitness/workout-template-actions";
 import { ExerciseQueryProvider } from "../../../exercises/providers";
 import { TemplatesQueryProvider } from "../../providers";
 import { EditTemplateClient } from "./client";
@@ -74,8 +73,11 @@ export default async function EditTemplatePage({ params }: PageParams) {
   const isStandardLike = data.isStandard === true || ownerId.length === 0;
 
   if (isStandardLike && ownerId !== trainer.uid) {
-    const fork = await forkStandardWorkoutTemplate(id);
-    redirect(`/gc-fitness/templates/${fork.id}/edit`);
+    // Standard/library templates are read-only for non-owners. Send them to
+    // the VIEW page instead of auto-forking — the trainer forks explicitly
+    // via the "Duplicate" button there. This prevents accidental duplication
+    // from a direct /edit URL (the original auto-fork created silent copies).
+    redirect(`/gc-fitness/templates/${id}/view`);
   }
   if (ownerId !== trainer.uid) {
     redirect("/gc-fitness/forbidden");

--- a/backoffice/src/app/gc-fitness/templates/[id]/view/__tests__/actions.test.tsx
+++ b/backoffice/src/app/gc-fitness/templates/[id]/view/__tests__/actions.test.tsx
@@ -1,0 +1,92 @@
+/**
+ * @jest-environment jsdom
+ */
+
+// view/__tests__/actions.test.tsx
+//
+// Covers the read-only template VIEW action bar (the fix for the silent
+// auto-fork-on-open bug). Asserts:
+//   - Duplicate calls the existing `duplicateWorkoutTemplate` server action
+//     with the templateId, then navigates into the NEW copy's /edit page.
+//   - Back navigates to the templates list.
+//   - A failed duplicate surfaces a toast and does NOT navigate.
+//
+// First three lines MUST stay the jsdom docblock (backoffice jest defaults to
+// testEnvironment: node).
+
+import "@testing-library/jest-dom";
+
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import React from "react";
+
+const mockPush = jest.fn();
+jest.mock("next/navigation", () => ({
+  useRouter: () => ({ push: mockPush, back: jest.fn() }),
+}));
+
+// useTranslations(ns) → t(key) returns the key verbatim so we can query by it.
+jest.mock("next-intl", () => ({
+  useTranslations: () => (key: string) => key,
+}));
+
+const mockToastSuccess = jest.fn();
+const mockToastError = jest.fn();
+jest.mock("sonner", () => ({
+  toast: {
+    success: (...args: unknown[]) => mockToastSuccess(...args),
+    error: (...args: unknown[]) => mockToastError(...args),
+  },
+}));
+
+const mockDuplicate = jest.fn();
+jest.mock("@/lib/gc-fitness/workout-template-actions", () => ({
+  duplicateWorkoutTemplate: (...args: unknown[]) => mockDuplicate(...args),
+}));
+
+import { ViewTemplateActions } from "../actions";
+
+const TEMPLATE_ID = "tpl-standard-1";
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe("ViewTemplateActions", () => {
+  it("duplicates and navigates into the new copy's editor", async () => {
+    mockDuplicate.mockResolvedValueOnce({ id: "tpl-copy-99" });
+    render(<ViewTemplateActions templateId={TEMPLATE_ID} />);
+
+    fireEvent.click(screen.getByText("duplicateCta"));
+
+    await waitFor(() => {
+      expect(mockDuplicate).toHaveBeenCalledWith(TEMPLATE_ID);
+    });
+    await waitFor(() => {
+      expect(mockPush).toHaveBeenCalledWith(
+        "/gc-fitness/templates/tpl-copy-99/edit",
+      );
+    });
+    expect(mockToastSuccess).toHaveBeenCalledWith("duplicatedToast");
+    expect(mockToastError).not.toHaveBeenCalled();
+  });
+
+  it("toasts and does not navigate when duplicate fails", async () => {
+    mockDuplicate.mockRejectedValueOnce(new Error("boom"));
+    render(<ViewTemplateActions templateId={TEMPLATE_ID} />);
+
+    fireEvent.click(screen.getByText("duplicateCta"));
+
+    await waitFor(() => {
+      expect(mockToastError).toHaveBeenCalledWith("boom");
+    });
+    expect(mockPush).not.toHaveBeenCalled();
+  });
+
+  it("Back navigates to the templates list", () => {
+    render(<ViewTemplateActions templateId={TEMPLATE_ID} />);
+
+    fireEvent.click(screen.getByText("backCta"));
+
+    expect(mockPush).toHaveBeenCalledWith("/gc-fitness/templates");
+  });
+});

--- a/backoffice/src/app/gc-fitness/templates/[id]/view/actions.tsx
+++ b/backoffice/src/app/gc-fitness/templates/[id]/view/actions.tsx
@@ -1,0 +1,74 @@
+"use client";
+
+// templates/[id]/view/actions.tsx
+//
+// Client action bar for the read-only template VIEW page. A Standard
+// (library) template opens here instead of auto-forking on /edit, so the
+// trainer forks *only* when they explicitly hit Duplicate.
+//
+// - Duplicate → existing `duplicateWorkoutTemplate` server action (which
+//   already behaves like a fork for standard templates and suffixes the
+//   name with " (copia)"/" (copy)"), then navigates into the new copy's
+//   editor. Matches the iOS "duplicate then refine" UX.
+// - Back → returns to the templates list.
+
+import { useTransition } from "react";
+import { useRouter } from "next/navigation";
+import { ArrowLeft, Copy } from "lucide-react";
+import { useTranslations } from "next-intl";
+import { toast } from "sonner";
+
+import { Button } from "@/components/ui/button";
+import { duplicateWorkoutTemplate } from "@/lib/gc-fitness/workout-template-actions";
+
+interface ViewTemplateActionsProps {
+  templateId: string;
+}
+
+export function ViewTemplateActions({ templateId }: ViewTemplateActionsProps) {
+  const router = useRouter();
+  const t = useTranslations("templates.viewPage");
+  const [pending, startTransition] = useTransition();
+
+  function handleDuplicate() {
+    startTransition(async () => {
+      try {
+        const result = await duplicateWorkoutTemplate(templateId);
+        toast.success(t("duplicatedToast"));
+        router.push(`/gc-fitness/templates/${result.id}/edit`);
+      } catch (err) {
+        const message =
+          err instanceof Error ? err.message : t("duplicateFailedToast");
+        toast.error(message);
+      }
+    });
+  }
+
+  function handleBack() {
+    router.push("/gc-fitness/templates");
+  }
+
+  return (
+    <div className="flex flex-wrap items-center gap-3">
+      <Button
+        type="button"
+        onClick={handleDuplicate}
+        disabled={pending}
+        className="gap-2 rounded-full"
+      >
+        <Copy className="h-4 w-4" />
+        {t("duplicateCta")}
+      </Button>
+      <Button
+        type="button"
+        variant="ghost"
+        onClick={handleBack}
+        disabled={pending}
+        className="gap-2 rounded-full"
+      >
+        <ArrowLeft className="h-4 w-4" />
+        {t("backCta")}
+      </Button>
+    </div>
+  );
+}

--- a/backoffice/src/app/gc-fitness/templates/[id]/view/page.tsx
+++ b/backoffice/src/app/gc-fitness/templates/[id]/view/page.tsx
@@ -1,0 +1,206 @@
+// /gc-fitness/templates/[id]/view/page.tsx — read-only template VIEW (Server Component)
+//
+// A Standard (library) template (`isStandard:true`, trainerId "__standard__")
+// opens here instead of routing straight to /edit, which would auto-FORK it
+// into a trainer-owned copy and silently create duplicates. From here the
+// trainer explicitly hits "Duplicate" to fork (via ViewTemplateActions).
+//
+// Auth/redirect preamble mirrors the edit page. The template payload comes
+// from the existing `getWorkoutTemplateForAssignment` resolver (it authorizes
+// owned OR standard and pre-resolves exerciseName / previewUrl / metric). The
+// raw doc is fetched alongside (like the edit page) for the display-only
+// `isStandard` / tags / description fields.
+
+import { redirect } from "next/navigation";
+import { getTranslations } from "next-intl/server";
+
+import {
+  getCurrentTrainer,
+  type CurrentTrainer,
+} from "@/lib/gc-fitness/auth-helpers";
+import { gcFitnessFirestore } from "@/lib/firebase/gc-fitness-admin";
+import { FirestoreCollections } from "@/lib/gc-fitness/collections";
+import { getWorkoutTemplateForAssignment } from "@/lib/gc-fitness/workout-template-actions";
+import { Badge } from "@/components/ui/badge";
+import { Card, CardContent } from "@/components/ui/card";
+import { ExercisePreviewThumb } from "@/components/gc-fitness/exercise-preview-thumb";
+import { sectionMetadata } from "@/lib/gc-fitness/page-metadata";
+import { ViewTemplateActions } from "./actions";
+
+// Tab title: "GC Fitness - <workouts>" (issue #170).
+export const generateMetadata = () => sectionMetadata("workouts");
+
+export const dynamic = "force-dynamic";
+
+interface PageParams {
+  params: Promise<{ id: string }>;
+}
+
+// Difficulty-ish tag → semantic Badge variant, mirroring the list view.
+function tagBadgeVariant(
+  raw: string,
+): "success" | "brand" | "violet" | "secondary" {
+  const v = raw.toLowerCase();
+  if (/(principiante|beginner|f[aá]cil|easy)/.test(v)) return "success";
+  if (/(intermedio|intermediate|medio)/.test(v)) return "brand";
+  if (/(avanzado|advanced|expert|dif[ií]cil|hard)/.test(v)) return "violet";
+  return "secondary";
+}
+
+function readTags(data: Record<string, unknown>): string[] {
+  const tags = data.tags;
+  if (Array.isArray(tags)) {
+    return tags.filter((t): t is string => typeof t === "string" && t.length > 0);
+  }
+  const tag = data.tag;
+  return typeof tag === "string" && tag.length > 0 ? [tag] : [];
+}
+
+export default async function ViewTemplatePage({ params }: PageParams) {
+  const t = await getTranslations("templates.viewPage");
+  let _trainer: CurrentTrainer;
+  try {
+    _trainer = await getCurrentTrainer();
+  } catch (err) {
+    const message = err instanceof Error ? err.message : "Forbidden";
+    if (message === "Forbidden") {
+      redirect("/gc-fitness/login");
+    }
+    throw err;
+  }
+  void _trainer;
+
+  const { id } = await params;
+
+  // Resolve the template via the existing assignment resolver — it authorizes
+  // (owned OR standard) and pre-resolves exerciseName / previewUrl / metric.
+  // "Template not found." / "Not your template." → bounce to the list (these
+  // are the deliberate auth/404 branches). Transient Firestore failures bubble
+  // to the route error boundary, like the edit page.
+  let template: Awaited<ReturnType<typeof getWorkoutTemplateForAssignment>>;
+  try {
+    template = await getWorkoutTemplateForAssignment(id);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : "";
+    if (message === "Template not found." || message === "Not your template.") {
+      redirect("/gc-fitness/templates");
+    }
+    throw err;
+  }
+
+  // Fetch the raw doc for display-only metadata (isStandard, tags, description).
+  const db = gcFitnessFirestore();
+  const snap = await db
+    .collection(FirestoreCollections.workoutTemplates)
+    .doc(id)
+    .get();
+  const data = (snap.exists ? snap.data() : {}) as Record<string, unknown>;
+
+  const isStandard = data.isStandard === true;
+  const tags = readTags(data);
+  const description = data.description as
+    | { en?: string; es?: string }
+    | undefined;
+
+  const nameEn = template.name.en?.trim() ?? "";
+  const nameEs = template.name.es?.trim() ?? "";
+  const primaryName = nameEn || nameEs || id;
+  const secondaryName = nameEs && nameEs !== nameEn ? nameEs : null;
+
+  const descriptionText =
+    description?.en?.trim() || description?.es?.trim() || null;
+
+  return (
+    <div className="mx-auto flex w-full min-w-0 max-w-4xl flex-col gap-6 px-4 py-8 sm:px-6">
+      <div className="flex flex-col gap-3">
+        <div className="flex flex-col gap-1">
+          <div className="flex flex-wrap items-center gap-2">
+            <h1 className="font-heading text-2xl font-semibold tracking-tight">
+              {primaryName}
+            </h1>
+            {isStandard ? (
+              <Badge variant="outline" className="capitalize">
+                {t("standardBadge")}
+              </Badge>
+            ) : null}
+          </div>
+          {secondaryName ? (
+            <p className="text-sm text-muted-foreground">{secondaryName}</p>
+          ) : null}
+          {descriptionText ? (
+            <p className="text-sm text-muted-foreground">{descriptionText}</p>
+          ) : null}
+          {tags.length > 0 ? (
+            <div className="mt-1 flex flex-wrap gap-1.5">
+              {tags.map((raw) => (
+                <Badge
+                  key={raw}
+                  variant={tagBadgeVariant(raw)}
+                  className="capitalize"
+                >
+                  {raw}
+                </Badge>
+              ))}
+            </div>
+          ) : null}
+        </div>
+        <ViewTemplateActions templateId={id} />
+      </div>
+
+      <section className="flex flex-col gap-3">
+        <h2 className="font-heading text-lg font-semibold tracking-tight">
+          {t("exercisesHeading")}
+        </h2>
+        <Card>
+          <CardContent className="divide-y divide-border p-0">
+            {template.exercises.map((exercise) => {
+              const effectiveMetric: "reps" | "time" =
+                exercise.metric ?? exercise.sourceMetric ?? "reps";
+              const prescription =
+                effectiveMetric === "time"
+                  ? t("setsTimeLabel", {
+                      sets: exercise.sets,
+                      seconds: exercise.durationSeconds ?? 0,
+                    })
+                  : t("setsRepsLabel", {
+                      sets: exercise.sets,
+                      reps: exercise.reps,
+                    });
+              const rest = t("restLabel", { seconds: exercise.rest_seconds });
+              return (
+                <div
+                  key={`${exercise.index}-${exercise.exerciseId}`}
+                  className="flex items-center gap-3 px-4 py-3.5 sm:px-5"
+                >
+                  <span className="w-5 shrink-0 text-sm font-medium text-muted-foreground">
+                    {exercise.index + 1}
+                  </span>
+                  <ExercisePreviewThumb
+                    src={exercise.previewUrl}
+                    alt={exercise.exerciseName}
+                  />
+                  <div className="flex min-w-0 flex-1 flex-col gap-0.5">
+                    <h3 className="truncate text-base font-medium text-foreground">
+                      {exercise.exerciseName}
+                    </h3>
+                    {exercise.notes ? (
+                      <p className="truncate text-xs text-muted-foreground">
+                        {exercise.notes}
+                      </p>
+                    ) : null}
+                  </div>
+                  <p className="shrink-0 text-right text-sm text-muted-foreground">
+                    <span className="font-medium text-foreground">
+                      {prescription}
+                    </span>
+                    <span className="ml-2">· {rest}</span>
+                  </p>
+                </div>
+              );
+            })}
+          </CardContent>
+        </Card>
+      </section>
+    </div>
+  );
+}

--- a/backoffice/src/app/gc-fitness/templates/client.tsx
+++ b/backoffice/src/app/gc-fitness/templates/client.tsx
@@ -17,6 +17,7 @@ import {
   AlertCircle,
   Copy,
   Dumbbell,
+  Eye,
   Pencil,
   Plus,
   Search,
@@ -229,6 +230,11 @@ export function TemplatesLibraryClient({
     () => ({
       onEdit: (row: WorkoutTemplateRow) =>
         router.push(`/gc-fitness/templates/${row.id}/edit`),
+      // Standard/library templates open a read-only VIEW instead of /edit —
+      // /edit on a non-owned standard template would auto-fork and silently
+      // create duplicates. The trainer forks explicitly from the view page.
+      onView: (row: WorkoutTemplateRow) =>
+        router.push(`/gc-fitness/templates/${row.id}/view`),
       onDelete: (row: WorkoutTemplateRow) => setConfirmDelete(row),
       onResumeDraft: () => router.push("/gc-fitness/templates/new"),
       // P21 — duplicate trainer-owned template. Triggers a Server Action
@@ -410,14 +416,18 @@ export function TemplatesLibraryClient({
                     onClick={() =>
                       row.__isDraft
                         ? handlers.onResumeDraft()
-                        : handlers.onEdit(row)
+                        : row.isStandard
+                          ? handlers.onView(row)
+                          : handlers.onEdit(row)
                     }
                     onKeyDown={(e) => {
                       if (e.key === "Enter" || e.key === " ") {
                         e.preventDefault();
                         row.__isDraft
                           ? handlers.onResumeDraft()
-                          : handlers.onEdit(row);
+                          : row.isStandard
+                            ? handlers.onView(row)
+                            : handlers.onEdit(row);
                       }
                     }}
                     className={cn(
@@ -490,14 +500,29 @@ export function TemplatesLibraryClient({
                             </Button>
                           </DropdownMenuTrigger>
                           <DropdownMenuContent align="end">
-                            <DropdownMenuItem onClick={() => handlers.onEdit(row)}>
-                              <Pencil className="mr-2 h-4 w-4" />
-                              {row.isStandard
-                                ? columnsT("duplicate")
-                                : columnsT("edit")}
-                            </DropdownMenuItem>
-                            {!row.isStandard ? (
+                            {row.isStandard ? (
                               <>
+                                <DropdownMenuItem
+                                  onClick={() => handlers.onView(row)}
+                                >
+                                  <Eye className="mr-2 h-4 w-4" />
+                                  {columnsT("view")}
+                                </DropdownMenuItem>
+                                <DropdownMenuItem
+                                  onClick={() => handlers.onDuplicate(row)}
+                                >
+                                  <Copy className="mr-2 h-4 w-4" />
+                                  {columnsT("duplicate")}
+                                </DropdownMenuItem>
+                              </>
+                            ) : (
+                              <>
+                                <DropdownMenuItem
+                                  onClick={() => handlers.onEdit(row)}
+                                >
+                                  <Pencil className="mr-2 h-4 w-4" />
+                                  {columnsT("edit")}
+                                </DropdownMenuItem>
                                 <DropdownMenuItem
                                   onClick={() => handlers.onDuplicate(row)}
                                 >
@@ -512,7 +537,7 @@ export function TemplatesLibraryClient({
                                   {columnsT("delete")}
                                 </DropdownMenuItem>
                               </>
-                            ) : null}
+                            )}
                           </DropdownMenuContent>
                         </DropdownMenu>
                       </div>


### PR DESCRIPTION
Fixes: tapping a **Standard/library** template (e.g. RESISTANCE D) went straight to `/edit`, which auto-**forked** it into a trainer-owned copy — so every open silently created a duplicate (the user accumulated several "RESISTANCE D" copies).

## New UX

- **Standard templates open a read-only VIEW** (`/gc-fitness/templates/<id>/view`) showing the name, Standard badge, tags, description, and the full exercise list (name + thumbnail + `sets × reps` or `sets × Ns` for time-based + rest). From there an explicit **Duplicate** button forks it (and lands the trainer in the new copy's editor); a **Back** button returns to the list.
- **Owned templates** still open `/edit` directly (unchanged).
- **`/edit` of a non-owned Standard template now redirects to `/view`** instead of auto-forking — kills accidental duplication from direct URLs too.
- List dropdown for Standard rows now shows **View** + **Duplicate** (was a single item mislabeled "Duplicate" that actually opened the auto-forking edit).

## Reuse / safety

- The view resolves the template via the existing `getWorkoutTemplateForAssignment` resolver (authorizes owned-or-standard, pre-resolves exercise names / preview / metric / duration), and renders with the existing design-system primitives (`Card`, `Badge`, `ExercisePreviewThumb`). Not-found / not-yours → redirect to the list; transient Firestore errors bubble to the route error boundary (same as edit).
- Duplicate uses the existing `duplicateWorkoutTemplate` action (already forks standard templates and suffixes the name " (copia)"/" (copy)" so copies are distinguishable).

## Tests / gate

- `view/__tests__/actions.test.tsx` (jsdom): Duplicate → action called with the templateId + `router.push` to the new `/edit` + success toast; failure → error toast, no nav; Back → push to list. 3/3 green.
- `npx tsc --noEmit` clean; full `npx jest` 557 pass — only the 2 pre-existing baselined reds (`client-activity-time` locale flake, `workout-assignment-actions`).

## Data note

The 2 spurious "RESISTANCE D" forked copies that the old auto-fork created in prod were already cleaned up out-of-band (soft-deleted, backup retained).