### PR TITLE
feat(gc-fitness): instructions (EN+ES) + Spanish description for standard-library exercises

### DIFF
--- a/backoffice/scripts/backfill-library-instructions.cjs
+++ b/backoffice/scripts/backfill-library-instructions.cjs
@@ -1,0 +1,152 @@
+/**
+ * backfill-library-instructions.cjs
+ *
+ * Writes step-by-step `instructions` (EN + ES) and a Spanish `description.es`
+ * onto the standard-library exercises, which shipped with NO instructions and
+ * an English-only description (description.es was a copy of the English).
+ *
+ * SOURCE / CORRECTNESS:
+ *   The instruction text lives in the committed data file
+ *   `scripts/data/library-exercise-instructions.json` keyed by the exercise
+ *   doc id. English steps come from the ExerciseDB CSV; Spanish is an
+ *   Argentine-Spanish translation. CRUCIALLY, the steps are keyed to the
+ *   exercise's CORRECTED gif (`exercises/library-gifs/<csvId>.gif`) — the
+ *   seed had mapped ~77 exercises to the wrong source movement, repointed by
+ *   `fix-library-gif-mismatches.cjs`, so the instructions match what the user
+ *   actually sees. Exercises whose gif is still uncovered/wrong were left out
+ *   of the data file (no instructions rather than wrong ones).
+ *
+ * SAFETY:
+ *   - Reads the committed data file; never re-derives mappings at run time.
+ *   - Backs up each touched doc's prior instructions + description before writing.
+ *   - --dry-run prints the plan + backup, no Firestore writes.
+ *   - Idempotent: writing the same content twice is a no-op-equivalent (only
+ *     updatedAt churns). Uses field path `description.es` so `description.en`
+ *     is preserved.
+ *   - Admin SDK required (.env.local).
+ *
+ * Usage (from backoffice/):
+ *   node scripts/backfill-library-instructions.cjs --dry-run
+ *   node scripts/backfill-library-instructions.cjs
+ */
+
+const fs = require("node:fs");
+const path = require("node:path");
+
+const { initializeApp, cert, getApps } = require("firebase-admin/app");
+const { getFirestore, FieldValue } = require("firebase-admin/firestore");
+
+const EXERCISES = "exercises";
+const DATA_FILE = path.resolve(
+  process.cwd(),
+  "scripts/data/library-exercise-instructions.json",
+);
+
+function loadEnv() {
+  const envPath = path.resolve(process.cwd(), ".env.local");
+  if (!fs.existsSync(envPath)) return;
+  for (const line of fs.readFileSync(envPath, "utf8").split(/\r?\n/)) {
+    const match = line.match(/^([A-Z0-9_]+)=(.*)$/);
+    if (match && process.env[match[1]] === undefined) {
+      process.env[match[1]] = match[2];
+    }
+  }
+}
+
+function initAdmin() {
+  const projectId = process.env.NEXT_PUBLIC_GC_FITNESS_FIREBASE_PROJECT_ID;
+  const clientEmail = process.env.GC_FITNESS_FIREBASE_ADMIN_CLIENT_EMAIL;
+  const privateKeyB64 = process.env.GC_FITNESS_FIREBASE_ADMIN_PRIVATE_KEY;
+  if (!projectId || !clientEmail || !privateKeyB64) {
+    throw new Error("Missing GC Fitness Firebase Admin env vars in .env.local.");
+  }
+  if (getApps()[0]) return getApps()[0];
+  return initializeApp({
+    credential: cert({
+      projectId,
+      clientEmail,
+      privateKey: Buffer.from(privateKeyB64, "base64").toString("utf8"),
+    }),
+  });
+}
+
+function isStepArray(v) {
+  return Array.isArray(v) && v.length > 0 && v.every((s) => typeof s === "string" && s.trim());
+}
+
+async function main() {
+  const dryRun = process.argv.slice(2).includes("--dry-run");
+  loadEnv();
+  initAdmin();
+  const db = getFirestore();
+
+  const data = JSON.parse(fs.readFileSync(DATA_FILE, "utf8"));
+  const ids = Object.keys(data);
+  console.log(
+    `\nBackfilling instructions + description.es on ${ids.length} exercises${dryRun ? "  [DRY RUN]" : ""}\n`,
+  );
+
+  // Validate the data file up front (fail loud).
+  for (const id of ids) {
+    const e = data[id];
+    if (!isStepArray(e.en) || !isStepArray(e.es)) {
+      throw new Error(`Bad instruction data for ${id} (en/es must be non-empty string arrays).`);
+    }
+    if (e.en.length !== e.es.length) {
+      throw new Error(`Step-count mismatch for ${id}: en=${e.en.length} es=${e.es.length}.`);
+    }
+  }
+
+  // Backup prior state.
+  const refs = ids.map((id) => db.collection(EXERCISES).doc(id));
+  const snaps = await db.getAll(...refs);
+  const backup = [];
+  let missing = 0;
+  for (const snap of snaps) {
+    if (!snap.exists) {
+      missing += 1;
+      console.warn(`  ⚠ doc not found, will skip: ${snap.id}`);
+      continue;
+    }
+    const d = snap.data();
+    backup.push({ id: snap.id, instructions: d.instructions ?? null, description: d.description ?? null });
+  }
+  const backupDir = path.resolve(process.cwd(), "scripts/backups");
+  fs.mkdirSync(backupDir, { recursive: true });
+  const stamp = process.env.BACKUP_STAMP || "manual";
+  const backupPath = path.join(backupDir, `library-instructions-${stamp}.json`);
+  fs.writeFileSync(backupPath, JSON.stringify(backup, null, 2));
+  console.log(`Backup written: ${backupPath} (${backup.length} docs, ${missing} missing)\n`);
+
+  if (dryRun) {
+    const sample = ids[0];
+    console.log(`e.g. ${sample}: ${data[sample].en.length} EN steps, ${data[sample].es.length} ES steps`);
+    console.log(`   en[0]: ${data[sample].en[0]}`);
+    console.log(`   es[0]: ${data[sample].es[0]}`);
+    console.log("\n[DRY RUN] no Firestore writes performed.\n");
+    return;
+  }
+
+  const existing = new Set(backup.map((b) => b.id));
+  let written = 0;
+  const writable = ids.filter((id) => existing.has(id));
+  for (let i = 0; i < writable.length; i += 400) {
+    const batch = db.batch();
+    for (const id of writable.slice(i, i + 400)) {
+      const e = data[id];
+      batch.update(db.collection(EXERCISES).doc(id), {
+        instructions: { en: e.en, es: e.es },
+        "description.es": e.descEs ?? FieldValue.delete(),
+        updatedAt: FieldValue.serverTimestamp(),
+      });
+      written += 1;
+    }
+    await batch.commit();
+  }
+  console.log(`\n✓ Wrote instructions + description.es on ${written} exercises.\n`);
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/backoffice/scripts/data/library-exercise-instructions.json
+++ b/backoffice/scripts/data/library-exercise-instructions.json
@@ -1,0 +1,4970 @@
+{
+ "1001": {
+  "en": [
+   "Place a band around your thighs, just above your knees.",
+   "Stand facing a step or platform with your feet hip-width apart.",
+   "Step up onto the platform with your right foot, pushing through your heel.",
+   "Extend your left leg behind you, keeping it straight.",
+   "Lower your left foot back down to the ground.",
+   "Repeat with your left foot stepping up onto the platform.",
+   "Continue alternating legs for the desired number of repetitions."
+  ],
+  "es": [
+   "Colocate una banda alrededor de los muslos, justo por encima de las rodillas.",
+   "Parate frente a un escalon o plataforma con los pies separados al ancho de las caderas.",
+   "Subi a la plataforma con el pie derecho, empujando desde el talon.",
+   "Extende la pierna izquierda hacia atras, manteniendola recta.",
+   "Baja el pie izquierdo de nuevo al piso.",
+   "Repeti subiendo a la plataforma con el pie izquierdo.",
+   "Segui alternando las piernas durante la cantidad de repeticiones deseada."
+  ],
+  "descEs": "Ejercicio de cuadriceps a una pierna con empuje de rodilla."
+ },
+ "1008": {
+  "en": [
+   "Stand with your feet hip-width apart, holding a dumbbell in your right hand.",
+   "Shift your weight onto your left leg and lift your right foot slightly off the ground.",
+   "Keeping your back straight, hinge forward at the hips and lower the dumbbell towards the ground.",
+   "At the same time, extend your right leg straight behind you, maintaining a slight bend in your left knee.",
+   "Lower the dumbbell until your torso and right leg are parallel to the ground.",
+   "Pause for a moment, then engage your glutes and hamstrings to return to the starting position.",
+   "Repeat for the desired number of repetitions, then switch sides."
+  ],
+  "es": [
+   "Parate con los pies separados al ancho de las caderas, sosteniendo una mancuerna en la mano derecha.",
+   "Pasa el peso a la pierna izquierda y levanta levemente el pie derecho del piso.",
+   "Manteniendo la espalda recta, flexiona desde las caderas y baja la mancuerna hacia el piso.",
+   "Al mismo tiempo, extende la pierna derecha recta hacia atras, manteniendo una leve flexion en la rodilla izquierda.",
+   "Baja la mancuerna hasta que el torso y la pierna derecha queden paralelos al piso.",
+   "Hace una pausa y despues activa los gluteos e isquiotibiales para volver a la posicion inicial.",
+   "Repeti durante la cantidad de repeticiones deseada y despues cambia de lado."
+  ],
+  "descEs": "Bisagra de cadera a una pierna para isquiotibiales y equilibrio."
+ },
+ "1009": {
+  "en": [
+   "Stand with your feet shoulder-width apart and your toes pointing forward.",
+   "Hold the barbell with an overhand grip, hands slightly wider than shoulder-width apart.",
+   "Bend at the hips, keeping your back straight and your knees slightly bent.",
+   "Lower the barbell towards the ground, keeping it close to your body.",
+   "Feel the stretch in your hamstrings as you lower the barbell.",
+   "Once you feel a stretch in your hamstrings, push your hips forward and stand up straight.",
+   "Squeeze your glutes at the top of the movement.",
+   "Lower the barbell back down to the starting position and repeat for the desired number of repetitions."
+  ],
+  "es": [
+   "Parate con los pies separados al ancho de los hombros y las puntas de los pies hacia adelante.",
+   "Agarra la barra con un agarre prono, las manos un poco mas separadas que el ancho de los hombros.",
+   "Flexiona desde las caderas, manteniendo la espalda recta y las rodillas levemente flexionadas.",
+   "Baja la barra hacia el piso, manteniendola cerca del cuerpo.",
+   "Senti el estiramiento en los isquiotibiales a medida que bajas la barra.",
+   "Cuando sientas el estiramiento en los isquiotibiales, empuja las caderas hacia adelante y parate derecho.",
+   "Apreta los gluteos en la parte alta del movimiento.",
+   "Baja la barra de nuevo a la posicion inicial y repeti durante la cantidad de repeticiones deseada."
+  ],
+  "descEs": "Bisagra de cadera enfocada en gluteos e isquiotibiales."
+ },
+ "1014": {
+  "en": [
+   "Sit on a flat bench with your back straight and your feet flat on the ground.",
+   "Place your hands on the sides of the bench for support.",
+   "Keeping your legs straight, slowly raise them up in front of you until they are parallel to the ground.",
+   "Pause for a moment at the top, then slowly lower your legs back down to the starting position.",
+   "Repeat for the desired number of repetitions."
+  ],
+  "es": [
+   "Sentate en un banco plano con la espalda recta y los pies apoyados en el piso.",
+   "Apoya las manos a los costados del banco para sostenerte.",
+   "Manteniendo las piernas rectas, elevalas lentamente hacia adelante hasta que queden paralelas al piso.",
+   "Hace una pausa arriba y despues baja lentamente las piernas a la posicion inicial.",
+   "Repeti durante la cantidad de repeticiones deseada."
+  ],
+  "descEs": "Elevacion del abdomen bajo con control estricto."
+ },
+ "1015": {
+  "en": [
+   "Stand with your feet shoulder-width apart and wrap the band around a sturdy object at chest height.",
+   "Hold the band with both hands and step away from the anchor point, creating tension in the band.",
+   "Position yourself perpendicular to the anchor point, with your side facing the band.",
+   "Extend your arms straight out in front of you, keeping your hands at chest height.",
+   "Engage your core and press the band away from your chest, fully extending your arms.",
+   "Hold the position for a few seconds, then slowly bring the band back towards your chest.",
+   "Repeat for the desired number of repetitions, then switch sides."
+  ],
+  "es": [
+   "Pará con los pies al ancho de los hombros y enganchá la banda a un objeto firme a la altura del pecho.",
+   "Sostené la banda con ambas manos y alejate del punto de anclaje para generar tensión.",
+   "Ubicate perpendicular al anclaje, con un costado del cuerpo mirando hacia la banda.",
+   "Extendé los brazos hacia adelante, manteniendo las manos a la altura del pecho.",
+   "Activá el core y empujá la banda lejos del pecho, extendiendo los brazos por completo.",
+   "Mantené la posición unos segundos y luego volvé lentamente la banda hacia el pecho.",
+   "Repetí durante la cantidad de repeticiones deseada y luego cambiá de lado."
+  ],
+  "descEs": "Press anti-rotación para el core."
+ },
+ "1160": {
+  "en": [
+   "Start in a high plank position with your hands directly under your shoulders and your body in a straight line.",
+   "Engage your core and bring your right knee towards your chest, then quickly switch and bring your left knee towards your chest.",
+   "Continue alternating legs in a running motion, keeping your hips low and your core engaged.",
+   "Maintain a steady pace and breathe evenly throughout the exercise.",
+   "Repeat for the desired number of repetitions."
+  ],
+  "es": [
+   "Empeza en posicion de plancha alta con las manos justo debajo de los hombros y el cuerpo en linea recta.",
+   "Activa el core y lleva la rodilla derecha hacia el pecho, despues cambia rapido y lleva la rodilla izquierda hacia el pecho.",
+   "Segui alternando las piernas en un movimiento de carrera, manteniendo las caderas bajas y el core activado.",
+   "Manten un ritmo constante y respira de forma pareja durante todo el ejercicio.",
+   "Repeti durante la cantidad de repeticiones deseada."
+  ],
+  "descEs": "Ejercicio dinamico de core y acondicionamiento."
+ },
+ "1167": {
+  "en": [
+   "Stand tall with your feet shoulder-width apart.",
+   "Extend your arms straight out to the sides, parallel to the ground.",
+   "Slowly bring your arms forward, crossing them in front of your body.",
+   "Feel the stretch in your chest muscles.",
+   "Hold the stretch for 10-30 seconds.",
+   "Return to the starting position and repeat for the desired number of repetitions."
+  ],
+  "es": [
+   "Pará bien erguido con los pies al ancho de los hombros.",
+   "Extendé los brazos hacia los costados, paralelos al piso.",
+   "Llevá lentamente los brazos hacia adelante, cruzándolos por delante del cuerpo.",
+   "Sentí el estiramiento en los músculos del pecho.",
+   "Mantené el estiramiento de 10 a 30 segundos.",
+   "Volvé a la posición inicial y repetí durante la cantidad de repeticiones deseada."
+  ],
+  "descEs": "Estiramiento de apertura para los pectorales."
+ },
+ "1201": {
+  "en": [
+   "Stand with your feet shoulder-width apart, toes pointed slightly outward.",
+   "Hold the kettlebell with both hands in front of your body, arms extended.",
+   "Bend your knees slightly and hinge at the hips, pushing your butt back.",
+   "Swing the kettlebell back between your legs, keeping your arms straight and maintaining a flat back.",
+   "Drive your hips forward and swing the kettlebell up to shoulder height, using the momentum generated by your hips.",
+   "Allow the kettlebell to swing back down between your legs and repeat the movement for the desired number of repetitions."
+  ],
+  "es": [
+   "Parate con los pies separados al ancho de los hombros, las puntas de los pies levemente hacia afuera.",
+   "Sostene la kettlebell con ambas manos frente al cuerpo, con los brazos extendidos.",
+   "Flexiona levemente las rodillas y bisagra desde las caderas, llevando la cola hacia atras.",
+   "Balancea la kettlebell hacia atras entre las piernas, manteniendo los brazos rectos y la espalda plana.",
+   "Empuja las caderas hacia adelante y balancea la kettlebell hasta la altura de los hombros, usando el impulso generado por las caderas.",
+   "Deja que la kettlebell vuelva a balancearse hacia abajo entre las piernas y repeti el movimiento durante la cantidad de repeticiones deseada."
+  ],
+  "descEs": "Bisagra balistica para potencia y acondicionamiento."
+ },
+ "1253": {
+  "en": [
+   "Adjust the leverage machine to the appropriate height for your body.",
+   "Position yourself facing the machine, with your toes on the foot platform and your heels hanging off the edge.",
+   "Place your hands on the handles or the support bars for stability.",
+   "Engage your calves and lift your heels as high as possible, using the balls of your feet.",
+   "Pause for a moment at the top, then slowly lower your heels back down to the starting position.",
+   "Repeat for the desired number of repetitions."
+  ],
+  "es": [
+   "Ajustá la máquina a la altura adecuada para tu cuerpo.",
+   "Ubicate de frente a la máquina, con la punta de los pies en la plataforma y los talones por fuera del borde.",
+   "Apoyá las manos en las manijas o las barras de apoyo para mayor estabilidad.",
+   "Activá los gemelos y elevá los talones lo más alto posible, apoyándote en la punta de los pies.",
+   "Hacé una pausa arriba y luego bajá lentamente los talones a la posición inicial.",
+   "Repetí durante la cantidad de repeticiones deseada."
+  ],
+  "descEs": "Movimiento clásico de gemelos de pie."
+ },
+ "1259": {
+  "en": [
+   "Stand tall with your feet shoulder-width apart.",
+   "Interlace your fingers behind your head with your elbows pointing outwards.",
+   "Slowly squeeze your shoulder blades together and push your chest forward.",
+   "Hold the stretch for 15-30 seconds.",
+   "Release the stretch and repeat as desired."
+  ],
+  "es": [
+   "Pará bien erguido con los pies al ancho de los hombros.",
+   "Entrelazá los dedos detrás de la cabeza con los codos apuntando hacia afuera.",
+   "Junturá lentamente los omóplatos y llevá el pecho hacia adelante.",
+   "Mantené el estiramiento de 15 a 30 segundos.",
+   "Soltá el estiramiento y repetí las veces que quieras."
+  ],
+  "descEs": "Estiramiento de apertura para los pectorales."
+ },
+ "1262": {
+  "en": [
+   "Attach a D-handle to a low pulley cable machine and set the bench to a decline angle.",
+   "Lie down on the bench with your head towards the machine and grab the handle with your right hand.",
+   "Extend your arm straight up above your chest, keeping a slight bend in your elbow.",
+   "With a controlled motion, lower your arm out to the side until your hand is in line with your shoulder.",
+   "Pause for a moment, then reverse the motion and bring your arm back to the starting position.",
+   "Repeat for the desired number of repetitions, then switch to your left arm and repeat the exercise."
+  ],
+  "es": [
+   "Enganchá una manija tipo D a la polea baja y poné el banco en ángulo declinado.",
+   "Acostate en el banco con la cabeza hacia la máquina y agarrá la manija con la mano derecha.",
+   "Extendé el brazo hacia arriba por encima del pecho, manteniendo una leve flexión en el codo.",
+   "Con un movimiento controlado, bajá el brazo hacia el costado hasta que la mano quede a la altura del hombro.",
+   "Hacé una pausa y luego invertí el movimiento llevando el brazo a la posición inicial.",
+   "Repetí durante la cantidad de repeticiones deseada y luego cambiá al brazo izquierdo y repetí el ejercicio."
+  ],
+  "descEs": "Movimiento de aislamiento para la aducción y el estiramiento del pecho."
+ },
+ "1286": {
+  "en": [
+   "Adjust the seat height and position yourself on the machine with your back against the pad.",
+   "Grasp the handles with a pronated grip and keep your elbows slightly bent.",
+   "Exhale and push the handles forward, bringing them together in front of your chest.",
+   "Pause for a moment, squeezing your chest muscles.",
+   "Inhale and slowly return to the starting position, allowing your chest muscles to stretch.",
+   "Repeat for the desired number of repetitions."
+  ],
+  "es": [
+   "Ajusta la altura del asiento y ubicate en la maquina con la espalda apoyada en el respaldo.",
+   "Agarra las manijas con agarre prono y manten los codos levemente flexionados.",
+   "Exhala y empuja las manijas hacia adelante, juntandolas frente al pecho.",
+   "Hace una pausa, apretando los musculos del pecho.",
+   "Inhala y volve lentamente a la posicion inicial, dejando que los musculos del pecho se estiren.",
+   "Repeti durante la cantidad de repeticiones deseada."
+  ],
+  "descEs": "Aperturas en maquina para aislar el pecho de forma estable."
+ },
+ "1299": {
+  "en": [
+   "Adjust the seat and backrest of the leverage machine to a comfortable position.",
+   "Sit on the machine with your back against the backrest and your feet flat on the floor.",
+   "Grasp the handles with an overhand grip and position your hands slightly wider than shoulder-width apart.",
+   "Push the handles forward and away from your body until your arms are fully extended.",
+   "Pause for a moment, then slowly bend your elbows and lower the handles back towards your chest.",
+   "Repeat for the desired number of repetitions."
+  ],
+  "es": [
+   "Ajustá el asiento y el respaldo de la máquina a una posición cómoda.",
+   "Sentate en la máquina con la espalda contra el respaldo y los pies apoyados en el piso.",
+   "Agarrá las manijas con un agarre prono y ubicá las manos un poco más anchas que el ancho de los hombros.",
+   "Empujá las manijas hacia adelante y lejos del cuerpo hasta extender los brazos por completo.",
+   "Hacé una pausa y luego flexioná lentamente los codos para volver las manijas hacia el pecho.",
+   "Repetí durante la cantidad de repeticiones deseada."
+  ],
+  "descEs": "Variante de press inclinado que enfatiza la parte alta del pecho."
+ },
+ "1300": {
+  "en": [
+   "Adjust the seat height and backrest of the leverage machine to a comfortable position.",
+   "Sit on the machine with your back against the backrest and your feet flat on the floor.",
+   "Grasp the handles with an overhand grip and position your hands slightly wider than shoulder-width apart.",
+   "Push the handles forward and away from your body until your arms are fully extended.",
+   "Slowly lower the handles back towards your chest, keeping your elbows slightly bent.",
+   "Pause for a moment at the bottom, then push the handles back to the starting position.",
+   "Repeat for the desired number of repetitions."
+  ],
+  "es": [
+   "Ajustá la altura del asiento y el respaldo de la máquina a una posición cómoda.",
+   "Sentate en la máquina con la espalda contra el respaldo y los pies apoyados en el piso.",
+   "Agarrá las manijas con un agarre prono y ubicá las manos un poco más anchas que el ancho de los hombros.",
+   "Empujá las manijas hacia adelante y lejos del cuerpo hasta extender los brazos por completo.",
+   "Bajá lentamente las manijas hacia el pecho, manteniendo los codos levemente flexionados.",
+   "Hacé una pausa abajo y luego empujá las manijas de nuevo a la posición inicial.",
+   "Repetí durante la cantidad de repeticiones deseada."
+  ],
+  "descEs": "Variante de press declinado que enfatiza la parte baja del pecho."
+ },
+ "1308": {
+  "en": [
+   "Lie flat on your back on the floor with your knees bent and feet flat on the ground.",
+   "Hold the barbell with one hand, palm facing up, and extend your arm straight up over your chest.",
+   "Slowly lower the barbell towards your chest, keeping your elbow close to your body.",
+   "Pause for a moment at the bottom, then push the barbell back up to the starting position.",
+   "Repeat for the desired number of repetitions, then switch arms."
+  ],
+  "es": [
+   "Acostate boca arriba en el piso con las rodillas flexionadas y los pies apoyados.",
+   "Sostene la barra con una mano, la palma hacia arriba, y extende el brazo recto hacia arriba sobre el pecho.",
+   "Baja lentamente la barra hacia el pecho, manteniendo el codo cerca del cuerpo.",
+   "Hace una pausa abajo y despues empuja la barra de nuevo hacia arriba a la posicion inicial.",
+   "Repeti durante la cantidad de repeticiones deseada y despues cambia de brazo."
+  ],
+  "descEs": "Variante de press con recorrido acortado."
+ },
+ "1326": {
+  "en": [
+   "Hang from a pull-up bar with your palms facing away from you and your arms fully extended.",
+   "Engage your core and squeeze your shoulder blades together.",
+   "Pull your body up towards the bar by bending your elbows and bringing your chest towards the bar.",
+   "Pause at the top of the movement, then slowly lower your body back down to the starting position.",
+   "Repeat for the desired number of repetitions."
+  ],
+  "es": [
+   "Colgate de una barra de dominadas con las palmas hacia adelante y los brazos completamente extendidos.",
+   "Activa el core y junta las escapulas.",
+   "Tira del cuerpo hacia arriba flexionando los codos y llevando el pecho hacia la barra.",
+   "Hace una pausa en la parte alta y despues baja lentamente el cuerpo a la posicion inicial.",
+   "Repeti durante la cantidad de repeticiones deseada."
+  ],
+  "descEs": "Tiron vertical para dorsales y espalda alta."
+ },
+ "1350": {
+  "en": [
+   "Adjust the seat height and footrests to a comfortable position.",
+   "Sit on the machine with your chest against the pad and your feet on the footrests.",
+   "Grasp the handles with an overhand grip, shoulder-width apart.",
+   "Keep your back straight and your core engaged.",
+   "Pull the handles towards your body, squeezing your shoulder blades together.",
+   "Pause for a moment at the peak of the movement.",
+   "Slowly release the handles and return to the starting position.",
+   "Repeat for the desired number of repetitions."
+  ],
+  "es": [
+   "Ajustá la altura del asiento y los apoyapiés a una posición cómoda.",
+   "Sentate en la máquina con el pecho contra la pechera y los pies en los apoyapiés.",
+   "Agarrá las manijas con un agarre prono, al ancho de los hombros.",
+   "Mantené la espalda recta y el core activo.",
+   "Traccioná las manijas hacia el cuerpo, juntando los omóplatos.",
+   "Hacé una pausa en el punto máximo del movimiento.",
+   "Soltá lentamente las manijas y volvé a la posición inicial.",
+   "Repetí durante la cantidad de repeticiones deseada."
+  ],
+  "descEs": "Tracción horizontal para dorsales y espalda media."
+ },
+ "1354": {
+  "en": [
+   "Stand with your feet shoulder-width apart, holding a medicine ball with both hands above your head.",
+   "Engage your core and keep your back straight.",
+   "Bend your knees slightly and forcefully slam the medicine ball down to the ground in front of you.",
+   "As you slam the ball down, use your entire body to generate power, including your shoulders and core.",
+   "Catch the ball on the bounce and repeat for the desired number of repetitions."
+  ],
+  "es": [
+   "Pará con los pies al ancho de los hombros, sosteniendo un balón medicinal con ambas manos por encima de la cabeza.",
+   "Activá el core y mantené la espalda recta.",
+   "Flexioná levemente las rodillas y estrellá con fuerza el balón medicinal contra el piso por delante tuyo.",
+   "Mientras estrellás el balón, usá todo el cuerpo para generar potencia, incluyendo hombros y core.",
+   "Atajá el balón en el rebote y repetí durante la cantidad de repeticiones deseada."
+  ],
+  "descEs": "Lanzamiento explosivo de acondicionamiento para todo el cuerpo."
+ },
+ "1359": {
+  "en": [
+   "Set up the smith machine with the bar at hip height.",
+   "Stand facing the bar with your feet shoulder-width apart.",
+   "Bend your knees slightly and hinge forward at the hips, keeping your back straight.",
+   "Grasp the bar with an overhand grip, hands slightly wider than shoulder-width apart.",
+   "Pull the bar towards your lower chest, squeezing your shoulder blades together.",
+   "Pause for a moment at the top, then slowly lower the bar back down to the starting position.",
+   "Repeat for the desired number of repetitions."
+  ],
+  "es": [
+   "Configurá la máquina smith con la barra a la altura de las caderas.",
+   "Pará de frente a la barra con los pies al ancho de los hombros.",
+   "Flexioná levemente las rodillas y hacé una bisagra hacia adelante desde las caderas, manteniendo la espalda recta.",
+   "Agarrá la barra con un agarre prono, con las manos un poco más anchas que el ancho de los hombros.",
+   "Traccioná la barra hacia la parte baja del pecho, juntando los omóplatos.",
+   "Hacé una pausa arriba y luego bajá lentamente la barra a la posición inicial.",
+   "Repetí durante la cantidad de repeticiones deseada."
+  ],
+  "descEs": "Tracción horizontal pesada para grosor de espalda."
+ },
+ "1366": {
+  "en": [
+   "Lie face down on the floor with your legs extended behind you.",
+   "Place your hands on the floor next to your lower ribs, fingers pointing forward.",
+   "Press your hands firmly into the floor and straighten your arms, lifting your torso and thighs off the ground.",
+   "Roll your shoulders back and down, opening your chest and lifting your gaze towards the ceiling.",
+   "Hold this position for a few breaths, then slowly lower your body back down to the starting position.",
+   "Repeat for the desired number of repetitions."
+  ],
+  "es": [
+   "Acostate boca abajo en el piso con las piernas extendidas hacia atrás.",
+   "Apoyá las manos en el piso al costado de las costillas bajas, con los dedos apuntando hacia adelante.",
+   "Presioná firme las manos contra el piso y estirá los brazos, levantando el torso y los muslos del suelo.",
+   "Llevá los hombros hacia atrás y abajo, abriendo el pecho y elevando la mirada hacia el techo.",
+   "Mantené esta posición durante unas respiraciones y luego bajá lentamente el cuerpo a la posición inicial.",
+   "Repetí durante la cantidad de repeticiones deseada."
+  ],
+  "descEs": "Apertura del frente del cuerpo y extensión de la columna."
+ },
+ "1373": {
+  "en": [
+   "Stand with your feet shoulder-width apart, toes pointing forward.",
+   "Place your hands on a wall or stable surface for balance.",
+   "Slowly raise your heels off the ground, lifting your body weight onto the balls of your feet.",
+   "Pause for a moment at the top, then slowly lower your heels back down to the starting position.",
+   "Repeat for the desired number of repetitions."
+  ],
+  "es": [
+   "Pará con los pies al ancho de los hombros, con la punta de los pies hacia adelante.",
+   "Apoyá las manos en una pared o superficie estable para mantener el equilibrio.",
+   "Elevá lentamente los talones del piso, llevando el peso del cuerpo a la punta de los pies.",
+   "Hacé una pausa arriba y luego bajá lentamente los talones a la posición inicial.",
+   "Repetí durante la cantidad de repeticiones deseada."
+  ],
+  "descEs": "Fuerza de gemelos y estabilidad de tobillo."
+ },
+ "1385": {
+  "en": [
+   "Adjust the seat of the leg press machine so that your knees are slightly bent when your feet are on the footplate.",
+   "Sit on the machine with your back against the backrest and your feet flat on the footplate, shoulder-width apart.",
+   "Place your toes and the balls of your feet on the footplate, keeping your heels off the edge.",
+   "Release the safety handles and push the footplate away from you by extending your knees.",
+   "Once your knees are fully extended, slowly lower your heels by flexing your calves.",
+   "Pause for a moment at the bottom, then push the footplate back up by extending your calves.",
+   "Repeat for the desired number of repetitions."
+  ],
+  "es": [
+   "Ajustá el asiento de la prensa para que las rodillas queden levemente flexionadas con los pies en la plataforma.",
+   "Sentate en la máquina con la espalda contra el respaldo y los pies apoyados en la plataforma, al ancho de los hombros.",
+   "Apoyá la punta de los pies en la plataforma, dejando los talones por fuera del borde.",
+   "Soltá los seguros y empujá la plataforma lejos tuyo extendiendo las rodillas.",
+   "Una vez con las rodillas extendidas por completo, bajá lentamente los talones flexionando los gemelos.",
+   "Hacé una pausa abajo y luego empujá la plataforma de nuevo extendiendo los gemelos.",
+   "Repetí durante la cantidad de repeticiones deseada."
+  ],
+  "descEs": "Press enfocado en cuádriceps con soporte estable del torso."
+ },
+ "1386": {
+  "en": [
+   "Stand with your feet shoulder-width apart, toes pointing forward.",
+   "Place your hands on a stable surface for support, such as a wall or a bar.",
+   "Lift one leg off the ground, keeping your knee slightly bent.",
+   "Raise your heel as high as possible, using your calf muscles.",
+   "Pause for a moment at the top, then slowly lower your heel back down.",
+   "Repeat for the desired number of repetitions, then switch legs."
+  ],
+  "es": [
+   "Pará con los pies al ancho de los hombros, con la punta de los pies hacia adelante.",
+   "Apoyá las manos en una superficie estable para sostenerte, como una pared o una barra.",
+   "Levantá una pierna del piso, manteniendo la rodilla levemente flexionada.",
+   "Elevá el talón lo más alto posible, usando los músculos del gemelo.",
+   "Hacé una pausa arriba y luego bajá lentamente el talón.",
+   "Repetí durante la cantidad de repeticiones deseada y luego cambiá de pierna."
+  ],
+  "descEs": "Movimiento clásico de gemelos de pie."
+ },
+ "1393": {
+  "en": [
+   "Position yourself on the floor under the smith machine bar, facing away from the machine.",
+   "Place the balls of your feet on a raised surface, such as a weight plate or block.",
+   "Position the smith machine bar across your lower legs, just above your ankles.",
+   "Hold onto the bar with your hands for stability.",
+   "Raise your heels off the ground by extending your ankles, lifting your body up.",
+   "Pause at the top of the movement, then slowly lower your heels back down to the starting position.",
+   "Repeat for the desired number of repetitions."
+  ],
+  "es": [
+   "Ubicate en el piso debajo de la barra de la máquina smith, de espaldas a la máquina.",
+   "Apoyá la punta de los pies sobre una superficie elevada, como un disco o un step.",
+   "Ubicá la barra de la smith sobre la parte baja de las piernas, justo por encima de los tobillos.",
+   "Sostenete de la barra con las manos para mayor estabilidad.",
+   "Elevá los talones del piso extendiendo los tobillos, levantando el cuerpo.",
+   "Hacé una pausa arriba del movimiento y luego bajá lentamente los talones a la posición inicial.",
+   "Repetí durante la cantidad de repeticiones deseada."
+  ],
+  "descEs": "Movimiento clásico de gemelos de pie."
+ },
+ "1409": {
+  "en": [
+   "Start by lying flat on your back on the ground with your knees bent and feet flat on the floor.",
+   "Place a barbell across your hips, holding it securely with both hands.",
+   "Engage your glutes and core muscles, then lift your hips off the ground until your body forms a straight line from your knees to your shoulders.",
+   "Pause for a moment at the top, squeezing your glutes.",
+   "Slowly lower your hips back down to the starting position.",
+   "Repeat for the desired number of repetitions."
+  ],
+  "es": [
+   "Empezá acostado boca arriba en el piso con las rodillas flexionadas y los pies apoyados en el suelo.",
+   "Colocá una barra sobre las caderas, sosteniéndola firme con ambas manos.",
+   "Activá glúteos y core, y luego elevá las caderas del piso hasta que el cuerpo forme una línea recta desde las rodillas hasta los hombros.",
+   "Hacé una pausa arriba, apretando los glúteos.",
+   "Bajá lentamente las caderas a la posición inicial.",
+   "Repetí durante la cantidad de repeticiones deseada."
+  ],
+  "descEs": "Ejercicio fundamental de extensión de cadera dominante de glúteos."
+ },
+ "1410": {
+  "en": [
+   "Start by standing with your feet shoulder-width apart and a barbell resting on your upper back.",
+   "Take a step backward with your right foot, landing on the ball of your foot.",
+   "Bend both knees to lower your body until your left thigh is parallel to the ground.",
+   "Push through your left heel to return to the starting position.",
+   "Repeat with the other leg."
+  ],
+  "es": [
+   "Empeza parado con los pies separados al ancho de los hombros y una barra apoyada en la parte alta de la espalda.",
+   "Da un paso hacia atras con el pie derecho, apoyando la punta del pie.",
+   "Flexiona ambas rodillas para bajar el cuerpo hasta que el muslo izquierdo quede paralelo al piso.",
+   "Empuja desde el talon izquierdo para volver a la posicion inicial.",
+   "Repeti con la otra pierna."
+  ],
+  "descEs": "Variante de zancada que mantiene la tension en los gluteos."
+ },
+ "1422": {
+  "en": [
+   "Start by lying flat on your back on the ground with your knees bent and feet flat on the floor.",
+   "Place a barbell across your hips, holding it securely with both hands.",
+   "Engage your glutes and core muscles, then lift your hips off the ground until your body forms a straight line from your knees to your shoulders.",
+   "Pause for a moment at the top, squeezing your glutes.",
+   "Slowly lower your hips back down to the starting position.",
+   "Repeat for the desired number of repetitions."
+  ],
+  "es": [
+   "Empeza acostado boca arriba en el piso con las rodillas flexionadas y los pies apoyados.",
+   "Coloca una mancuerna sobre las caderas, sosteniendola firme con ambas manos.",
+   "Activa los gluteos y el core, despues elevá las caderas del piso hasta que el cuerpo forme una linea recta desde las rodillas hasta los hombros.",
+   "Hace una pausa arriba, apretando los gluteos.",
+   "Baja lentamente las caderas a la posicion inicial.",
+   "Repeti durante la cantidad de repeticiones deseada."
+  ],
+  "descEs": "Puente de gluteos en el piso con carga facil de escalar."
+ },
+ "1431": {
+  "en": [
+   "Adjust the machine to your desired assistance level.",
+   "Stand on the foot platform and grip the handles with an overhand grip, slightly wider than shoulder-width apart.",
+   "Keep your chest up and shoulders back, engage your core, and slightly bend your knees.",
+   "Pull your body up by flexing your elbows and driving your elbows down towards your sides.",
+   "Continue pulling until your chin is above the bar.",
+   "Pause for a moment at the top, then slowly lower your body back down to the starting position.",
+   "Repeat for the desired number of repetitions."
+  ],
+  "es": [
+   "Ajustá la máquina al nivel de asistencia que quieras.",
+   "Pará sobre la plataforma y agarrá las manijas con un agarre prono, un poco más anchas que el ancho de los hombros.",
+   "Mantené el pecho arriba y los hombros hacia atrás, activá el core y flexioná levemente las rodillas.",
+   "Traccioná el cuerpo hacia arriba flexionando los codos y llevándolos hacia abajo a los costados.",
+   "Seguí traccionando hasta que el mentón quede por encima de la barra.",
+   "Hacé una pausa arriba y luego bajá lentamente el cuerpo a la posición inicial.",
+   "Repetí durante la cantidad de repeticiones deseada."
+  ],
+  "descEs": "Tracción vertical con agarre supino."
+ },
+ "1433": {
+  "en": [
+   "Set up the smith machine with the barbell at shoulder height.",
+   "Stand facing the barbell with your feet shoulder-width apart.",
+   "Grasp the barbell with an overhand grip, slightly wider than shoulder-width apart.",
+   "Step back and position the barbell on your front shoulders, resting it on your collarbone and deltoids.",
+   "Keep your chest up, back straight, and core engaged.",
+   "Lower your body by bending at the knees and hips, as if sitting back into a chair.",
+   "Continue lowering until your thighs are parallel to the ground or slightly below.",
+   "Pause for a moment, then push through your heels to return to the starting position.",
+   "Repeat for the desired number of repetitions."
+  ],
+  "es": [
+   "Acomodá el smith con la barra a la altura de los hombros.",
+   "Parate de frente a la barra con los pies al ancho de los hombros.",
+   "Agarrá la barra con agarre pronado, un poco más abierto que el ancho de los hombros.",
+   "Dá un paso atrás y apoyá la barra sobre los hombros, descansándola sobre la clavícula y los deltoides.",
+   "Mantené el pecho arriba, la espalda recta y el core activado.",
+   "Bajá flexionando rodillas y caderas, como si te sentaras en una silla.",
+   "Seguí bajando hasta que los muslos queden paralelos al piso o un poco por debajo.",
+   "Hacé una pausa y empujá con los talones para volver a la posición inicial.",
+   "Repetí la cantidad de repeticiones deseada."
+  ],
+  "descEs": "Sentadilla dominante de cuádriceps con el torso erguido."
+ },
+ "1434": {
+  "en": [
+   "Set up the smith machine with the barbell at a height that allows you to comfortably rest it on your upper back.",
+   "Stand with your feet shoulder-width apart, toes slightly turned outwards.",
+   "Step under the bar and position it across your upper back, resting it on your traps.",
+   "Grip the bar with your hands slightly wider than shoulder-width apart.",
+   "Unrack the bar by straightening your legs and stepping back from the rack.",
+   "Take a deep breath and brace your core.",
+   "Initiate the squat by pushing your hips back and bending your knees.",
+   "Lower your body until your thighs are parallel to the ground or slightly below.",
+   "Keep your chest up and your back straight throughout the movement.",
+   "Drive through your heels to stand back up, extending your hips and knees.",
+   "Repeat for the desired number of repetitions."
+  ],
+  "es": [
+   "Acomodá el smith con la barra a una altura que te permita apoyarla cómodamente sobre la espalda alta.",
+   "Parate con los pies al ancho de los hombros y las puntas levemente hacia afuera.",
+   "Metete debajo de la barra y apoyala sobre la espalda alta, descansándola sobre los trapecios.",
+   "Agarrá la barra con las manos un poco más abiertas que el ancho de los hombros.",
+   "Sacá la barra del soporte estirando las piernas y dando un paso atrás.",
+   "Tomá aire profundo y activá el core.",
+   "Iniciá la sentadilla llevando la cadera hacia atrás y flexionando las rodillas.",
+   "Bajá hasta que los muslos queden paralelos al piso o un poco por debajo.",
+   "Mantené el pecho arriba y la espalda recta durante todo el movimiento.",
+   "Empujá con los talones para volver a pararte, extendiendo cadera y rodillas.",
+   "Repetí la cantidad de repeticiones deseada."
+  ],
+  "descEs": "Patrón fundamental de sentadilla para la fuerza del tren inferior."
+ },
+ "1435": {
+  "en": [
+   "Stand with your feet shoulder-width apart and the barbell resting on your upper back.",
+   "Keeping your chest up and core engaged, slowly lower your body by bending your knees and pushing your hips back.",
+   "Continue lowering until your thighs are parallel to the ground or slightly below.",
+   "Pause for a moment, then push through your heels to return to the starting position.",
+   "Repeat for the desired number of repetitions."
+  ],
+  "es": [
+   "Parate con los pies al ancho de los hombros y la barra apoyada sobre la espalda alta.",
+   "Con el pecho arriba y el core activado, bajá despacio flexionando las rodillas y llevando la cadera hacia atrás.",
+   "Seguí bajando hasta que los muslos queden paralelos al piso o un poco por debajo.",
+   "Hacé una pausa y empujá con los talones para volver a la posición inicial.",
+   "Repetí la cantidad de repeticiones deseada."
+  ],
+  "descEs": "Patrón fundamental de sentadilla para la fuerza del tren inferior."
+ },
+ "1436": {
+  "en": [
+   "Stand with your feet shoulder-width apart, toes slightly turned out.",
+   "Place the barbell on your upper back, resting it on your traps.",
+   "Engage your core and keep your chest up as you begin to squat down, pushing your hips back and bending your knees.",
+   "Lower yourself until your thighs are parallel to the ground, or as low as you can comfortably go.",
+   "Drive through your heels to stand back up, extending your hips and knees.",
+   "Repeat for the desired number of repetitions."
+  ],
+  "es": [
+   "Parate con los pies al ancho de los hombros y las puntas levemente hacia afuera.",
+   "Apoyá la barra sobre la espalda alta, descansándola sobre los trapecios.",
+   "Activá el core y mantené el pecho arriba mientras empezás a bajar, llevando la cadera hacia atrás y flexionando las rodillas.",
+   "Bajá hasta que los muslos queden paralelos al piso, o tan abajo como puedas cómodamente.",
+   "Empujá con los talones para volver a pararte, extendiendo cadera y rodillas.",
+   "Repetí la cantidad de repeticiones deseada."
+  ],
+  "descEs": "Patrón fundamental de sentadilla para la fuerza del tren inferior."
+ },
+ "1456": {
+  "en": [
+   "Stand with your feet shoulder-width apart, holding a dumbbell in each hand at shoulder level.",
+   "Bend your knees slightly and dip your body down, then explosively extend your legs and press the dumbbells overhead.",
+   "Lock out your arms at the top of the movement, then lower the dumbbells back to shoulder level.",
+   "Repeat for the desired number of repetitions."
+  ],
+  "es": [
+   "Parate con los pies separados al ancho de los hombros, sosteniendo una mancuerna en cada mano a la altura de los hombros.",
+   "Flexiona levemente las rodillas y baja el cuerpo, despues extende las piernas de forma explosiva y empuja las mancuernas por encima de la cabeza.",
+   "Bloquea los brazos en la parte alta del movimiento, despues baja las mancuernas de nuevo a la altura de los hombros.",
+   "Repeti durante la cantidad de repeticiones deseada."
+  ],
+  "descEs": "Press de hombros explosivo con impulso de piernas."
+ },
+ "1459": {
+  "en": [
+   "Stand with your feet shoulder-width apart, holding a dumbbell in each hand with an overhand grip.",
+   "Keeping your back straight and your core engaged, hinge at the hips and lower the dumbbells towards the ground, allowing your knees to bend slightly.",
+   "Lower the dumbbells until you feel a stretch in your hamstrings, then push through your heels and engage your glutes to return to the starting position.",
+   "Repeat for the desired number of repetitions."
+  ],
+  "es": [
+   "Parate con los pies al ancho de los hombros, sosteniendo una mancuerna en cada mano con agarre pronado.",
+   "Manteniendo la espalda recta y el core activado, hacé una bisagra de cadera y bajá las mancuernas hacia el piso, dejando que las rodillas se flexionen levemente.",
+   "Bajá las mancuernas hasta sentir un estiramiento en los isquiotibiales, después empujá con los talones y activá los glúteos para volver a la posición inicial.",
+   "Repetí la cantidad de repeticiones deseada."
+  ],
+  "descEs": "Bisagra de cadera enfocada en glúteos e isquiotibiales."
+ },
+ "1460": {
+  "en": [
+   "Stand with your feet shoulder-width apart.",
+   "Take a step forward with your right leg, lowering your body into a lunge position.",
+   "Keep your torso upright and your front knee aligned with your ankle.",
+   "Push off with your right foot and bring your left foot forward, stepping into a lunge position with your left leg.",
+   "Continue alternating legs and walking forward, maintaining a controlled and steady pace.",
+   "Repeat for the desired number of repetitions."
+  ],
+  "es": [
+   "Parate con los pies al ancho de los hombros.",
+   "Dá un paso hacia adelante con la pierna derecha, bajando el cuerpo a la posición de zancada.",
+   "Mantené el torso erguido y la rodilla de adelante alineada con el tobillo.",
+   "Empujá con el pie derecho y llevá el pie izquierdo hacia adelante, entrando en una zancada con la pierna izquierda.",
+   "Seguí alternando piernas y caminando hacia adelante, manteniendo un ritmo controlado y constante.",
+   "Repetí la cantidad de repeticiones deseada."
+  ],
+  "descEs": "Ejercicio básico unilateral para el tren inferior."
+ },
+ "1489": {
+  "en": [
+   "Stand with your feet shoulder-width apart and your toes pointing slightly outward.",
+   "Hold onto a stable object for balance if needed.",
+   "Slowly lower your body by bending your knees and leaning back, keeping your torso upright.",
+   "Continue lowering until your thighs are parallel to the ground or as far as you can comfortably go.",
+   "Pause for a moment, then push through your heels to return to the starting position.",
+   "Repeat for the desired number of repetitions."
+  ],
+  "es": [
+   "Parate con los pies al ancho de los hombros y las puntas levemente hacia afuera.",
+   "Sujetate de un objeto firme para mantener el equilibrio si lo necesitás.",
+   "Bajá despacio flexionando las rodillas e inclinándote hacia atrás, manteniendo el torso erguido.",
+   "Seguí bajando hasta que los muslos queden paralelos al piso o tan abajo como puedas cómodamente.",
+   "Hacé una pausa y empujá con los talones para volver a la posición inicial.",
+   "Repetí la cantidad de repeticiones deseada."
+  ],
+  "descEs": "Patrón de aislamiento de cuádriceps con gran recorrido de rodilla."
+ },
+ "1490": {
+  "en": [
+   "Stand on the edge of a step or a sturdy platform with your heels hanging off and your toes on the step.",
+   "Hold onto a railing or wall for balance if needed.",
+   "Slowly raise your heels as high as possible, lifting your body weight onto the balls of your feet.",
+   "Pause for a moment at the top, then slowly lower your heels back down to the starting position.",
+   "Repeat for the desired number of repetitions."
+  ],
+  "es": [
+   "Parate en el borde de un escalón o plataforma firme con los talones colgando y las puntas de los pies sobre el escalón.",
+   "Sujetate de una baranda o pared para mantener el equilibrio si lo necesitás.",
+   "Elevá despacio los talones lo más alto posible, llevando el peso del cuerpo a la punta de los pies.",
+   "Hacé una pausa arriba y bajá despacio los talones hasta la posición inicial.",
+   "Repetí la cantidad de repeticiones deseada."
+  ],
+  "descEs": "Trabajo de gemelos con carga y el torso inclinado."
+ },
+ "1511": {
+  "en": [
+   "Stand with your feet shoulder-width apart.",
+   "Step forward with your right foot and shift your weight onto your right leg.",
+   "Keeping your back straight, slowly bend forward at the hips, reaching towards your right foot with both hands.",
+   "Hold the stretch for 20-30 seconds, then return to the starting position.",
+   "Repeat on the other side."
+  ],
+  "es": [
+   "Parate con los pies al ancho de los hombros.",
+   "Dá un paso hacia adelante con el pie derecho y pasá el peso a la pierna derecha.",
+   "Manteniendo la espalda recta, inclinate despacio hacia adelante desde la cadera, llevando ambas manos hacia el pie derecho.",
+   "Mantené el estiramiento durante 20 a 30 segundos y volvé a la posición inicial.",
+   "Repetí del otro lado."
+  ],
+  "descEs": "Ejercicio clásico de flexibilidad para la cadena posterior."
+ },
+ "1560": {
+  "en": [
+   "Sit on the stability ball with your feet flat on the ground and your knees bent at a 90-degree angle.",
+   "Slowly roll the ball forward, walking your feet out until your upper back is resting on the ball and your legs are extended straight in front of you.",
+   "Place your hands on your hips for support.",
+   "Engage your core and slowly lower your upper body towards the ground, keeping your back straight and your chest lifted.",
+   "Stop when you feel a stretch in your hamstrings, and hold the position for 20-30 seconds.",
+   "Slowly return to the starting position by pushing through your heels and using your hamstrings to pull yourself back up.",
+   "Repeat for the desired number of repetitions."
+  ],
+  "es": [
+   "Sentate sobre la pelota de estabilidad con los pies apoyados en el piso y las rodillas flexionadas a 90 grados.",
+   "Rodá despacio la pelota hacia adelante, caminando con los pies hasta que la espalda alta quede apoyada sobre la pelota y las piernas extendidas al frente.",
+   "Apoyá las manos sobre la cadera para sostenerte.",
+   "Activá el core y bajá despacio el torso hacia el piso, manteniendo la espalda recta y el pecho elevado.",
+   "Detente cuando sientas un estiramiento en los isquiotibiales y mantené la posición durante 20 a 30 segundos.",
+   "Volvé despacio a la posición inicial empujando con los talones y usando los isquiotibiales para subir.",
+   "Repetí la cantidad de repeticiones deseada."
+  ],
+  "descEs": "Ejercicio clásico de flexibilidad para la cadena posterior."
+ },
+ "1576": {
+  "en": [
+   "Lie on your side with your legs straight.",
+   "Bend your top leg and grab your ankle or foot with your hand.",
+   "Gently pull your ankle or foot towards your glutes until you feel a stretch in your quads.",
+   "Hold the stretch for 20-30 seconds.",
+   "Release the stretch and repeat on the other side."
+  ],
+  "es": [
+   "Acostate de lado con las piernas rectas.",
+   "Flexiona la pierna de arriba y agarra el tobillo o el pie con la mano.",
+   "Tira suavemente el tobillo o el pie hacia los gluteos hasta sentir un estiramiento en los cuadriceps.",
+   "Manten el estiramiento durante 20 a 30 segundos.",
+   "Solta el estiramiento y repeti del otro lado."
+  ],
+  "descEs": "Ejercicio de flexibilidad para la parte frontal del muslo."
+ },
+ "1624": {
+  "en": [
+   "Lie flat on your back on the floor with your knees bent and feet flat on the ground.",
+   "Hold the barbell with one hand, palm facing up, and extend your arm straight up over your chest.",
+   "Slowly lower the barbell towards your chest, keeping your elbow close to your body.",
+   "Pause for a moment at the bottom, then push the barbell back up to the starting position.",
+   "Repeat for the desired number of repetitions, then switch arms."
+  ],
+  "es": [
+   "Acostate boca arriba en el piso con las rodillas flexionadas y los pies apoyados.",
+   "Sostene la mancuerna con una mano, la palma hacia arriba, y extende el brazo recto hacia arriba sobre el pecho.",
+   "Baja lentamente la mancuerna hacia el pecho, manteniendo el codo cerca del cuerpo.",
+   "Hace una pausa abajo y despues empuja la mancuerna de nuevo hacia arriba a la posicion inicial.",
+   "Repeti durante la cantidad de repeticiones deseada y despues cambia de brazo."
+  ],
+  "descEs": "Variante de press con recorrido acortado."
+ },
+ "1625": {
+  "en": [
+   "Lie flat on a bench with your feet flat on the ground and your back pressed against the bench.",
+   "Grasp the barbell with an overhand grip, slightly wider than shoulder-width apart.",
+   "Lower the barbell to your chest, keeping your elbows tucked in close to your body.",
+   "Push the barbell back up to the starting position, fully extending your arms.",
+   "Repeat for the desired number of repetitions."
+  ],
+  "es": [
+   "Acostate boca arriba en un banco con los pies apoyados en el piso y la espalda pegada al banco.",
+   "Agarra la barra con un agarre prono, un poco mas separado que el ancho de los hombros.",
+   "Baja la barra hacia el pecho, manteniendo los codos cerca del cuerpo.",
+   "Empuja la barra de nuevo hacia arriba a la posicion inicial, extendiendo completamente los brazos.",
+   "Repeti durante la cantidad de repeticiones deseada."
+  ],
+  "descEs": "Press-extension hibrido para cargar pesado los triceps."
+ },
+ "1639": {
+  "en": [
+   "Attach a rope attachment to a low pulley cable machine.",
+   "Stand facing the machine with your feet shoulder-width apart.",
+   "Grasp the rope with a neutral grip (palms facing each other).",
+   "Position your upper arms against the preacher bench pad, keeping your elbows slightly bent.",
+   "Keeping your upper arms stationary, exhale and curl the rope towards your shoulders by contracting your biceps.",
+   "Hold the contracted position for a brief pause as you squeeze your biceps.",
+   "Inhale and slowly lower the rope back to the starting position.",
+   "Repeat for the desired number of repetitions."
+  ],
+  "es": [
+   "Enganchá una cuerda en la polea baja de la máquina.",
+   "Parate de frente a la máquina con los pies al ancho de los hombros.",
+   "Agarrá la cuerda con agarre neutro (las palmas enfrentadas).",
+   "Apoyá los brazos contra el respaldo del banco predicador, manteniendo los codos levemente flexionados.",
+   "Manteniendo los brazos quietos, exhalá y hacé el curl llevando la cuerda hacia los hombros al contraer los bíceps.",
+   "Mantené la posición contraída una breve pausa mientras apretás los bíceps.",
+   "Inhalá y bajá despacio la cuerda a la posición inicial.",
+   "Repetí la cantidad de repeticiones deseada."
+  ],
+  "descEs": "Curl con agarre neutro para el braquial y los antebrazos."
+ },
+ "1674": {
+  "en": [
+   "Adjust the bench to a 45-degree incline.",
+   "Lie face down on the bench with a dumbbell in each hand, palms facing each other.",
+   "Allow your arms to hang straight down towards the floor, keeping your elbows slightly bent.",
+   "Keeping your upper arms stationary, exhale and curl the weights while contracting your biceps.",
+   "Continue to raise the dumbbells until your biceps are fully contracted and the dumbbells are at shoulder level.",
+   "Hold the contracted position for a brief pause as you squeeze your biceps.",
+   "Inhale and slowly begin to lower the dumbbells back to the starting position.",
+   "Repeat for the desired number of repetitions."
+  ],
+  "es": [
+   "Ajustá el banco a una inclinación de 45 grados.",
+   "Acostate boca abajo en el banco con una mancuerna en cada mano, las palmas enfrentadas.",
+   "Dejá que los brazos cuelguen rectos hacia el piso, manteniendo los codos levemente flexionados.",
+   "Manteniendo los brazos quietos, exhalá y hacé el curl mientras contraés los bíceps.",
+   "Seguí subiendo las mancuernas hasta que los bíceps queden completamente contraídos y las mancuernas a la altura de los hombros.",
+   "Mantené la posición contraída una breve pausa mientras apretás los bíceps.",
+   "Inhalá y empezá a bajar despacio las mancuernas a la posición inicial.",
+   "Repetí la cantidad de repeticiones deseada."
+  ],
+  "descEs": "Curl martillo en estiramiento largo para hipertrofia del brazo."
+ },
+ "1675": {
+  "en": [
+   "Stand up straight with your feet shoulder-width apart and hold the ez barbell with an underhand grip, palms facing up.",
+   "Keep your elbows close to your torso and your upper arms stationary throughout the movement.",
+   "Exhale as you curl the barbell up towards your shoulders, contracting your biceps.",
+   "Pause for a moment at the top, then inhale as you slowly lower the barbell back down to the starting position.",
+   "Repeat for the desired number of repetitions."
+  ],
+  "es": [
+   "Parate derecho con los pies separados al ancho de los hombros y sostene la barra EZ con un agarre supino, las palmas hacia arriba.",
+   "Manten los codos cerca del torso y los brazos superiores quietos durante todo el movimiento.",
+   "Exhala mientras curlas la barra hacia los hombros, contrayendo los biceps.",
+   "Hace una pausa arriba, despues inhala mientras bajas lentamente la barra a la posicion inicial.",
+   "Repeti durante la cantidad de repeticiones deseada."
+  ],
+  "descEs": "Curl amigable con las munecas para biceps y antebrazos."
+ },
+ "1678": {
+  "en": [
+   "Sit on a bench with a dumbbell in each hand, palms facing your torso and arms extended straight down.",
+   "Keeping your upper arms stationary, exhale and curl the weights while contracting your biceps.",
+   "Continue to raise the dumbbells until your biceps are fully contracted and the dumbbells are at shoulder level.",
+   "Hold the contracted position for a brief pause as you squeeze your biceps.",
+   "Inhale and slowly begin to lower the dumbbells back to the starting position.",
+   "Repeat for the desired number of repetitions."
+  ],
+  "es": [
+   "Sentate en un banco con una mancuerna en cada mano, las palmas mirando el torso y los brazos extendidos hacia abajo.",
+   "Manteniendo los brazos quietos, exhalá y hacé el curl mientras contraés los bíceps.",
+   "Seguí subiendo las mancuernas hasta que los bíceps queden completamente contraídos y las mancuernas a la altura de los hombros.",
+   "Mantené la posición contraída una breve pausa mientras apretás los bíceps.",
+   "Inhalá y empezá a bajar despacio las mancuernas a la posición inicial.",
+   "Repetí la cantidad de repeticiones deseada."
+  ],
+  "descEs": "Patrón general de curl para desarrollar los brazos."
+ },
+ "1684": {
+  "en": [
+   "Stand in front of a step or platform with a dumbbell in each hand, palms facing your body.",
+   "Place your right foot on the step, ensuring your entire foot is in contact with the surface.",
+   "Engage your core and push through your right heel to lift your body up onto the step, bringing your left knee up towards your chest.",
+   "At the top of the movement, perform a bicep curl by bending your elbows and bringing the dumbbells towards your shoulders.",
+   "Lower the dumbbells back down and simultaneously lower your left foot back to the ground.",
+   "Repeat the movement on the opposite side, stepping up with your left foot and curling the dumbbells.",
+   "Continue alternating sides for the desired number of repetitions."
+  ],
+  "es": [
+   "Parate frente a un escalón o plataforma con una mancuerna en cada mano, las palmas mirando el cuerpo.",
+   "Apoyá el pie derecho sobre el escalón, asegurándote de que todo el pie esté en contacto con la superficie.",
+   "Activá el core y empujá con el talón derecho para subir el cuerpo al escalón, llevando la rodilla izquierda hacia el pecho.",
+   "Arriba del movimiento, hacé un curl de bíceps flexionando los codos y llevando las mancuernas hacia los hombros.",
+   "Bajá las mancuernas y al mismo tiempo bajá el pie izquierdo de vuelta al piso.",
+   "Repetí el movimiento del lado opuesto, subiendo con el pie izquierdo y haciendo el curl.",
+   "Seguí alternando lados la cantidad de repeticiones deseada."
+  ],
+  "descEs": "Ejercicio de cuádriceps a una pierna con elevación de rodilla."
+ },
+ "1700": {
+  "en": [
+   "Stand with your feet shoulder-width apart, holding a dumbbell in each hand at shoulder level.",
+   "Bend your knees slightly and dip your body down, then explosively extend your legs and press the dumbbells overhead.",
+   "Lock out your arms at the top of the movement, then lower the dumbbells back to shoulder level.",
+   "Repeat for the desired number of repetitions."
+  ],
+  "es": [
+   "Parate con los pies al ancho de los hombros, sosteniendo una mancuerna en cada mano a la altura de los hombros.",
+   "Flexioná un poco las rodillas y bajá el cuerpo, después extendé las piernas de forma explosiva y empujá las mancuernas por encima de la cabeza.",
+   "Bloqueá los brazos arriba del movimiento y bajá las mancuernas a la altura de los hombros.",
+   "Repetí la cantidad de repeticiones deseada."
+  ],
+  "descEs": "Press de hombros explosivo por encima de la cabeza con impulso de piernas."
+ },
+ "1719": {
+  "en": [
+   "Lie flat on a bench with your feet flat on the ground and your back pressed against the bench.",
+   "Grasp the barbell with an overhand grip, slightly wider than shoulder-width apart.",
+   "Lower the barbell to your chest, keeping your elbows tucked in close to your body.",
+   "Push the barbell back up to the starting position, fully extending your arms.",
+   "Repeat for the desired number of repetitions."
+  ],
+  "es": [
+   "Acostate boca arriba en un banco con los pies apoyados en el piso y la espalda pegada al banco.",
+   "Agarra la barra con un agarre prono, un poco mas separado que el ancho de los hombros.",
+   "Baja la barra hacia el pecho, manteniendo los codos cerca del cuerpo.",
+   "Empuja la barra de nuevo hacia arriba a la posicion inicial, extendiendo completamente los brazos.",
+   "Repeti durante la cantidad de repeticiones deseada."
+  ],
+  "descEs": "Press-extension hibrido para cargar pesado los triceps."
+ },
+ "1723": {
+  "en": [
+   "Stand facing a cable machine with your feet shoulder-width apart.",
+   "Hold the cable handle with your right hand and step back to create tension in the cable.",
+   "Bend your knees slightly and hinge forward at the hips, keeping your back straight.",
+   "Keep your upper arm close to your body and your elbow bent at a 90-degree angle.",
+   "Extend your forearm backward, straightening your arm fully.",
+   "Pause for a moment, then slowly return to the starting position.",
+   "Repeat for the desired number of repetitions, then switch sides."
+  ],
+  "es": [
+   "Parate frente a una polea con los pies separados al ancho de los hombros.",
+   "Sostene la manija de la polea con la mano derecha y da un paso atras para crear tension en el cable.",
+   "Flexiona levemente las rodillas y bisagra hacia adelante desde las caderas, manteniendo la espalda recta.",
+   "Manten el brazo superior cerca del cuerpo y el codo flexionado a 90 grados.",
+   "Extende el antebrazo hacia atras, estirando completamente el brazo.",
+   "Hace una pausa y despues volve lentamente a la posicion inicial.",
+   "Repeti durante la cantidad de repeticiones deseada y despues cambia de lado."
+  ],
+  "descEs": "Aislamiento liviano con apriete para finalizar los triceps."
+ },
+ "1731": {
+  "en": [
+   "Sit on a flat bench with a dumbbell in each hand, resting on your thighs.",
+   "Using your thighs to help raise the dumbbells, lift the dumbbells one at a time so that you can hold them in front of you at shoulder width.",
+   "Once at shoulder width, rotate your wrists forward so that the palms of your hands are facing away from you. This will be your starting position.",
+   "As you breathe in, slowly lower the dumbbells to your side until they are about level with your chest.",
+   "As you exhale, use your triceps to lift the dumbbells back to the starting position. Make sure to use only your triceps and do not use your forearms or biceps to help lift the dumbbells.",
+   "After a second pause at the contracted position, repeat the movement for the prescribed amount of repetitions."
+  ],
+  "es": [
+   "Sentate en un banco plano con una mancuerna en cada mano, apoyadas sobre los muslos.",
+   "Ayudándote con los muslos, subí las mancuernas de a una hasta sostenerlas frente a vos al ancho de los hombros.",
+   "Una vez al ancho de los hombros, girá las muñecas hacia adelante de modo que las palmas miren hacia afuera. Esta es la posición inicial.",
+   "Mientras inhalás, bajá despacio las mancuernas hacia los costados hasta que queden a la altura del pecho.",
+   "Mientras exhalás, usá los tríceps para subir las mancuernas a la posición inicial. Asegurate de usar solo los tríceps y no los antebrazos ni los bíceps.",
+   "Después de una pausa de un segundo en la contracción, repetí el movimiento la cantidad de repeticiones indicada."
+  ],
+  "descEs": "Press pesado de tríceps con apoyo del pecho."
+ },
+ "1733": {
+  "en": [
+   "Sit on an incline bench with a dumbbell in each hand, resting on your thighs.",
+   "Slowly lie back on the bench, keeping the dumbbells close to your chest.",
+   "Once you are fully lying down, extend your arms straight up towards the ceiling, keeping your elbows slightly bent.",
+   "Pause for a moment at the top, then slowly lower the dumbbells back down to the starting position.",
+   "Repeat for the desired number of repetitions."
+  ],
+  "es": [
+   "Sentate en un banco inclinado con una mancuerna en cada mano, apoyadas sobre los muslos.",
+   "Recostate despacio en el banco, manteniendo las mancuernas cerca del pecho.",
+   "Una vez acostado por completo, extendé los brazos rectos hacia el techo, manteniendo los codos levemente flexionados.",
+   "Hacé una pausa arriba y bajá despacio las mancuernas a la posición inicial.",
+   "Repetí la cantidad de repeticiones deseada."
+  ],
+  "descEs": "Patrón general de extensión para los brazos."
+ },
+ "1736": {
+  "en": [
+   "Sit on an exercise ball with your feet flat on the ground and your back straight.",
+   "Hold a dumbbell in one hand with your palm facing up and your elbow bent at a 90-degree angle.",
+   "Extend your arm straight up towards the ceiling, keeping your elbow stationary.",
+   "Slowly lower the dumbbell back down to the starting position.",
+   "Repeat for the desired number of repetitions, then switch arms."
+  ],
+  "es": [
+   "Sentate en una pelota de ejercicio con los pies apoyados en el piso y la espalda recta.",
+   "Sostené una mancuerna en una mano con la palma hacia arriba y el codo flexionado a 90 grados.",
+   "Extendé el brazo recto hacia el techo, manteniendo el codo quieto.",
+   "Bajá despacio la mancuerna a la posición inicial.",
+   "Repetí la cantidad de repeticiones deseada y después cambiá de brazo."
+  ],
+  "descEs": "Patrón de estiramiento y bloqueo para los tríceps."
+ },
+ "1756": {
+  "en": [
+   "Stand with your feet hip-width apart, holding a barbell in front of your thighs with an overhand grip.",
+   "Shift your weight onto your left foot and lift your right foot slightly off the ground.",
+   "Hinge forward at the hips, keeping your back straight and your right leg extended behind you for balance.",
+   "Lower the barbell towards the ground, keeping it close to your body and your left leg slightly bent.",
+   "Pause for a moment at the bottom, then engage your glutes and hamstrings to lift your torso back up to the starting position.",
+   "Repeat for the desired number of repetitions, then switch sides."
+  ],
+  "es": [
+   "Parate con los pies al ancho de la cadera, sosteniendo una barra frente a los muslos con agarre pronado.",
+   "Pasá el peso al pie izquierdo y levantá apenas el pie derecho del piso.",
+   "Hacé una bisagra hacia adelante desde la cadera, manteniendo la espalda recta y la pierna derecha extendida atrás para equilibrar.",
+   "Bajá la barra hacia el piso, manteniéndola cerca del cuerpo y la pierna izquierda levemente flexionada.",
+   "Hacé una pausa abajo y activá glúteos e isquiotibiales para subir el torso a la posición inicial.",
+   "Repetí la cantidad de repeticiones deseada y después cambiá de lado."
+  ],
+  "descEs": "Bisagra unilateral para isquiotibiales y equilibrio."
+ },
+ "1758": {
+  "en": [
+   "Sit on the leverage machine with your back against the pad and your feet flat on the floor.",
+   "Grasp the handles or place your hands on the side pads for support.",
+   "Engage your abs and slowly lean back, allowing the pad to move with you.",
+   "Once your upper body is at a 45-degree angle, contract your abs and crunch forward, bringing your chest towards your knees.",
+   "Pause for a moment at the top, then slowly release and return to the starting position.",
+   "Repeat for the desired number of repetitions."
+  ],
+  "es": [
+   "Sentate en la maquina con la espalda apoyada en el respaldo y los pies apoyados en el piso.",
+   "Agarra las manijas o apoya las manos en las almohadillas laterales para sostenerte.",
+   "Activa los abdominales y echate lentamente hacia atras, dejando que la almohadilla se mueva con vos.",
+   "Cuando la parte superior del cuerpo este a 45 grados, contrae los abdominales y crunch hacia adelante, llevando el pecho hacia las rodillas.",
+   "Hace una pausa arriba y despues solta lentamente y volve a la posicion inicial.",
+   "Repeti durante la cantidad de repeticiones deseada."
+  ],
+  "descEs": "Movimiento abdominal clasico de flexion de columna."
+ },
+ "1760": {
+  "en": [
+   "Stand with your feet shoulder-width apart, holding a dumbbell vertically against your chest with both hands.",
+   "Keeping your chest up and core engaged, lower your body down into a squat position by pushing your hips back and bending your knees.",
+   "Continue lowering until your thighs are parallel to the ground, or as low as you can comfortably go.",
+   "Pause for a moment at the bottom, then push through your heels to return to the starting position.",
+   "Repeat for the desired number of repetitions."
+  ],
+  "es": [
+   "Parate con los pies al ancho de los hombros, sosteniendo una mancuerna en vertical contra el pecho con ambas manos.",
+   "Con el pecho arriba y el core activado, bajá a la posición de sentadilla llevando la cadera hacia atrás y flexionando las rodillas.",
+   "Seguí bajando hasta que los muslos queden paralelos al piso, o tan abajo como puedas cómodamente.",
+   "Hacé una pausa abajo y empujá con los talones para volver a la posición inicial.",
+   "Repetí la cantidad de repeticiones deseada."
+  ],
+  "descEs": "Sentadilla dominante de cuádriceps con el torso erguido."
+ },
+ "1774": {
+  "en": [
+   "Start by lying flat on your back on the ground with your knees bent and feet flat on the floor.",
+   "Place a barbell across your hips, holding it securely with both hands.",
+   "Engage your glutes and core muscles, then lift your hips off the ground until your body forms a straight line from your knees to your shoulders.",
+   "Pause for a moment at the top, squeezing your glutes.",
+   "Slowly lower your hips back down to the starting position.",
+   "Repeat for the desired number of repetitions."
+  ],
+  "es": [
+   "Empeza acostado boca arriba en el piso con las rodillas flexionadas y los pies apoyados.",
+   "Coloca la barra sobre las caderas, sosteniendola firme con ambas manos.",
+   "Activa los gluteos y el core, despues elevá las caderas del piso hasta que el cuerpo forme una linea recta desde las rodillas hasta los hombros.",
+   "Hace una pausa arriba, apretando los gluteos.",
+   "Baja lentamente las caderas a la posicion inicial.",
+   "Repeti durante la cantidad de repeticiones deseada."
+  ],
+  "descEs": "Puente de gluteos en el piso con carga facil de escalar."
+ },
+ "2135": {
+  "en": [
+   "Start by lying face down on the floor.",
+   "Place your forearms on the ground, with your elbows directly under your shoulders.",
+   "Extend your legs straight out behind you, with your toes on the ground.",
+   "Engage your core and lift your body off the ground, balancing on your forearms and toes.",
+   "Keep your body in a straight line from your head to your heels.",
+   "Hold this position for the desired amount of time.",
+   "Lower your body back down to the starting position.",
+   "Repeat for the desired number of repetitions."
+  ],
+  "es": [
+   "Empezá acostado boca abajo en el piso.",
+   "Apoyá los antebrazos en el suelo, con los codos justo debajo de los hombros.",
+   "Estirá las piernas hacia atras, con las puntas de los pies en el piso.",
+   "Activá el core y elevá el cuerpo del piso, equilibrandote sobre los antebrazos y las puntas de los pies.",
+   "Mantené el cuerpo en linea recta desde la cabeza hasta los talones.",
+   "Sostené esta posicion durante el tiempo deseado.",
+   "Bajá el cuerpo de nuevo a la posicion inicial.",
+   "Repetí la cantidad de repeticiones deseada."
+  ],
+  "descEs": "Sosten basico del core contra la extension."
+ },
+ "2137": {
+  "en": [
+   "Sit on a bench with a dumbbell in each hand, resting on your thighs.",
+   "Raise the dumbbells to shoulder height, palms facing forward.",
+   "Press the dumbbells upward until your arms are fully extended overhead.",
+   "Pause for a moment at the top, then slowly lower the dumbbells back to shoulder height.",
+   "Repeat for the desired number of repetitions."
+  ],
+  "es": [
+   "Sentate en un banco con una mancuerna en cada mano, apoyadas sobre los muslos.",
+   "Elevá las mancuernas a la altura de los hombros, las palmas hacia adelante.",
+   "Empuja las mancuernas hacia arriba hasta que los brazos queden completamente extendidos por encima de la cabeza.",
+   "Hace una pausa arriba y despues baja lentamente las mancuernas a la altura de los hombros.",
+   "Repeti durante la cantidad de repeticiones deseada."
+  ],
+  "descEs": "Patron de press estable con menos demanda del tren inferior."
+ },
+ "2287": {
+  "en": [
+   "Adjust the sled machine to a comfortable position for your height.",
+   "Stand with your feet shoulder-width apart on the platform, toes slightly pointed outwards.",
+   "Hold onto the handles or bars for stability.",
+   "Lower your body by bending your knees and hips, keeping your back straight and chest up.",
+   "Continue lowering until your thighs are parallel to the ground or slightly below.",
+   "Pause for a moment, then push through your heels to raise your body back up to the starting position.",
+   "Repeat for the desired number of repetitions."
+  ],
+  "es": [
+   "Ajusta la maquina a una posicion comoda para tu altura.",
+   "Parate con los pies separados al ancho de los hombros sobre la plataforma, las puntas de los pies levemente hacia afuera.",
+   "Agarrate de las manijas o barras para mayor estabilidad.",
+   "Baja el cuerpo flexionando las rodillas y las caderas, manteniendo la espalda recta y el pecho arriba.",
+   "Segui bajando hasta que los muslos queden paralelos al piso o un poco por debajo.",
+   "Hace una pausa y despues empuja desde los talones para subir el cuerpo a la posicion inicial.",
+   "Repeti durante la cantidad de repeticiones deseada."
+  ],
+  "descEs": "Sentadilla guiada con enfasis en los cuadriceps."
+ },
+ "2289": {
+  "en": [
+   "Adjust the seat of the leverage machine so that your shoulders are aligned with the lever pad.",
+   "Place your toes on the lever pad, with your heels hanging off the edge.",
+   "Grasp the handles or side supports for stability.",
+   "Push the lever pad down by extending your ankles, contracting your calf muscles.",
+   "Pause for a moment at the bottom of the movement.",
+   "Slowly return to the starting position by allowing your heels to rise back up.",
+   "Repeat for the desired number of repetitions."
+  ],
+  "es": [
+   "Ajustá el asiento de la maquina para que los hombros queden alineados con la almohadilla de apoyo.",
+   "Apoyá las puntas de los pies en la almohadilla, con los talones colgando del borde.",
+   "Agarrá las manijas o los apoyos laterales para estabilizarte.",
+   "Empujá la almohadilla hacia abajo estirando los tobillos, contrayendo los gemelos.",
+   "Hacé una pausa abajo del movimiento.",
+   "Volvé lentamente a la posicion inicial dejando que los talones suban de nuevo.",
+   "Repetí la cantidad de repeticiones deseada."
+  ],
+  "descEs": "Elevacion de gemelos realizada sobre la plataforma de la prensa."
+ },
+ "2405": {
+  "en": [
+   "Attach a rope attachment to a high pulley on a cable machine.",
+   "Stand facing the machine with your feet shoulder-width apart and a slight bend in your knees.",
+   "Grasp the rope with an overhand grip, palms facing each other.",
+   "Keep your elbows close to your sides and your upper arms stationary throughout the exercise.",
+   "Exhale and push the rope downward by extending your elbows until your arms are fully extended.",
+   "Pause for a moment, then inhale and slowly return to the starting position by allowing your elbows to flex.",
+   "Repeat for the desired number of repetitions."
+  ],
+  "es": [
+   "Engancha una cuerda a una polea alta de la maquina.",
+   "Parate frente a la maquina con los pies separados al ancho de los hombros y una leve flexion en las rodillas.",
+   "Agarra la cuerda con un agarre prono, las palmas enfrentadas.",
+   "Manten los codos cerca de los costados y los brazos superiores quietos durante todo el ejercicio.",
+   "Exhala y empuja la cuerda hacia abajo extendiendo los codos hasta que los brazos queden completamente extendidos.",
+   "Hace una pausa y despues inhala y volve lentamente a la posicion inicial dejando que los codos se flexionen.",
+   "Repeti durante la cantidad de repeticiones deseada."
+  ],
+  "descEs": "Accesorio de brazo con fuerte bloqueo de triceps."
+ },
+ "2611": {
+  "en": [
+   "Adjust the sled machine to a comfortable position for your height.",
+   "Stand with your feet shoulder-width apart on the platform, toes slightly pointed outwards.",
+   "Hold onto the handles or bars for stability.",
+   "Lower your body by bending your knees and hips, keeping your back straight and chest up.",
+   "Continue lowering until your thighs are parallel to the ground or slightly below.",
+   "Pause for a moment, then push through your heels to raise your body back up to the starting position.",
+   "Repeat for the desired number of repetitions."
+  ],
+  "es": [
+   "Ajusta la maquina a una posicion comoda para tu altura.",
+   "Parate con los pies separados al ancho de los hombros sobre la plataforma, las puntas de los pies levemente hacia afuera.",
+   "Agarrate de las manijas o barras para mayor estabilidad.",
+   "Baja el cuerpo flexionando las rodillas y las caderas, manteniendo la espalda recta y el pecho arriba.",
+   "Segui bajando hasta que los muslos queden paralelos al piso o un poco por debajo.",
+   "Hace una pausa y despues empuja desde los talones para subir el cuerpo a la posicion inicial.",
+   "Repeti durante la cantidad de repeticiones deseada."
+  ],
+  "descEs": "Sentadilla guiada para cargar pesado los cuadriceps."
+ },
+ "2796": {
+  "en": [
+   "Stand with your feet hip-width apart, holding a dumbbell in your right hand.",
+   "Shift your weight onto your left leg and lift your right foot slightly off the ground.",
+   "Keeping your back straight, hinge forward at the hips and lower the dumbbell towards the ground.",
+   "At the same time, extend your right leg straight behind you, maintaining a slight bend in your left knee.",
+   "Lower the dumbbell until your torso and right leg are parallel to the ground.",
+   "Pause for a moment, then engage your glutes and hamstrings to return to the starting position.",
+   "Repeat for the desired number of repetitions, then switch sides."
+  ],
+  "es": [
+   "Parate con los pies separados al ancho de las caderas, sosteniendo una mancuerna en la mano derecha.",
+   "Pasa el peso a la pierna izquierda y levanta levemente el pie derecho del piso.",
+   "Manteniendo la espalda recta, flexiona desde las caderas y baja la mancuerna hacia el piso.",
+   "Al mismo tiempo, extende la pierna derecha recta hacia atras, manteniendo una leve flexion en la rodilla izquierda.",
+   "Baja la mancuerna hasta que el torso y la pierna derecha queden paralelos al piso.",
+   "Hace una pausa y despues activa los gluteos e isquiotibiales para volver a la posicion inicial.",
+   "Repeti durante la cantidad de repeticiones deseada y despues cambia de lado."
+  ],
+  "descEs": "Bisagra de cadera a una pierna para isquiotibiales y equilibrio."
+ },
+ "2802": {
+  "en": [
+   "Lie flat on your back with your legs extended and your arms overhead.",
+   "Engage your core and lift your legs and upper body simultaneously, reaching your hands towards your toes.",
+   "Pause for a moment at the top, then slowly lower your legs and upper body back down to the starting position.",
+   "Repeat for the desired number of repetitions."
+  ],
+  "es": [
+   "Acostate boca arriba con las piernas extendidas y los brazos por encima de la cabeza.",
+   "Activa el core y elevá las piernas y la parte superior del cuerpo en simultaneo, llevando las manos hacia los pies.",
+   "Hace una pausa arriba y despues baja lentamente las piernas y la parte superior del cuerpo a la posicion inicial.",
+   "Repeti durante la cantidad de repeticiones deseada."
+  ],
+  "descEs": "Movimiento abdominal avanzado con peso corporal."
+ },
+ "2810": {
+  "en": [
+   "Stand in front of a bench or step with a barbell resting on your upper back.",
+   "Place one foot on the bench or step, ensuring your entire foot is in contact with the surface.",
+   "Push through your heel and step up onto the bench or step, fully extending your hip and knee.",
+   "Pause briefly at the top, then lower yourself back down to the starting position.",
+   "Repeat with the opposite leg.",
+   "Continue alternating legs for the desired number of repetitions."
+  ],
+  "es": [
+   "Parate frente a un banco o cajón con una barra apoyada en la parte alta de la espalda.",
+   "Apoyá un pie sobre el banco o cajón, asegurándote de que toda la planta haga contacto con la superficie.",
+   "Empujá con el talón y subí al banco o cajón, extendiendo por completo la cadera y la rodilla.",
+   "Hacé una pausa breve arriba y después bajá controlado a la posición inicial.",
+   "Repetí con la pierna contraria.",
+   "Seguí alternando las piernas durante las repeticiones deseadas."
+  ],
+  "descEs": "Ejercicio de cuádriceps a una pierna con empuje de rodilla."
+ },
+ "2812": {
+  "en": [
+   "Stand in front of a bench or step with a dumbbell in each hand, palms facing your body.",
+   "Place your right foot on the bench or step, ensuring your entire foot is in contact with the surface.",
+   "Step up onto the bench or step with your right foot, pushing through your heel to lift your body up.",
+   "As you step up, simultaneously lift your left knee towards your chest.",
+   "Pause at the top of the movement, then slowly lower your left foot back to the ground while keeping your right foot on the bench or step.",
+   "Repeat the movement with your left foot on the bench or step.",
+   "Continue alternating between your right and left foot for the desired number of repetitions."
+  ],
+  "es": [
+   "Parate frente a un banco o step con una mancuerna en cada mano, palmas hacia el cuerpo.",
+   "Apoyá el pie derecho en el banco o step, asegurando que todo el pie quede en contacto con la superficie.",
+   "Subi al banco o step con el pie derecho, empujando con el talon para elevar el cuerpo.",
+   "Mientras subis, simultaneamente llevá la rodilla izquierda hacia el pecho.",
+   "Hacé una pausa arriba del movimiento y despues bajá lentamente el pie izquierdo al piso manteniendo el derecho en el banco o step.",
+   "Repetí el movimiento con el pie izquierdo en el banco o step.",
+   "Segui alternando entre el pie derecho y el izquierdo durante la cantidad de repeticiones deseada."
+  ],
+  "descEs": "Constructor de gluteos y cuadriceps a una pierna."
+ },
+ "3013": {
+  "en": [
+   "Position yourself on the smith machine with your back against the pad and your feet shoulder-width apart.",
+   "Place your hands on the barbell, slightly wider than shoulder-width apart.",
+   "Engage your core and glutes, then push through your heels to raise your hips off the ground.",
+   "Continue lifting until your body forms a straight line from your knees to your shoulders.",
+   "Hold for a moment at the top, then slowly lower your hips back down to the starting position.",
+   "Repeat for the desired number of repetitions."
+  ],
+  "es": [
+   "Ubicate en el smith con la espalda apoyada contra el banco y los pies separados al ancho de los hombros.",
+   "Tomá la barra con las manos algo más abiertas que el ancho de los hombros.",
+   "Activá el core y los glúteos, después empujá con los talones para levantar la cadera del suelo.",
+   "Seguí elevando hasta que el cuerpo forme una línea recta desde las rodillas hasta los hombros.",
+   "Mantené un instante arriba y después bajá la cadera despacio a la posición inicial.",
+   "Repetí durante las repeticiones deseadas."
+  ],
+  "descEs": "Ejercicio clásico de extensión de cadera dominante de glúteo."
+ },
+ "3193": {
+  "en": [
+   "Adjust the glute-ham raise machine to fit your body.",
+   "Position yourself face down on the machine with your ankles secured.",
+   "Place your hands on your chest or cross them over your chest.",
+   "Engage your hamstrings and glutes to lift your upper body up towards the ceiling.",
+   "Continue lifting until your body is in a straight line from your head to your heels.",
+   "Pause for a moment at the top, then slowly lower your body back down to the starting position.",
+   "Repeat for the desired number of repetitions."
+  ],
+  "es": [
+   "Ajustá la maquina de glute-ham raise a tu cuerpo.",
+   "Ubicate boca abajo en la maquina con los tobillos sujetos.",
+   "Colocá las manos sobre el pecho o cruzalas sobre el pecho.",
+   "Activá isquiotibiales y gluteos para elevar el torso hacia el techo.",
+   "Segui elevando hasta que el cuerpo quede en linea recta desde la cabeza hasta los talones.",
+   "Hacé una pausa arriba y despues bajá el cuerpo lentamente a la posicion inicial.",
+   "Repetí la cantidad de repeticiones deseada."
+  ],
+  "descEs": "Movimiento excentrico de alta intensidad para isquiotibiales."
+ },
+ "3195": {
+  "en": [
+   "Adjust the glute-ham raise machine to fit your body.",
+   "Position yourself face down on the machine with your ankles secured.",
+   "Place your hands on your chest or cross them over your chest.",
+   "Engage your hamstrings and glutes to lift your upper body up towards the ceiling.",
+   "Continue lifting until your body is in a straight line from your head to your heels.",
+   "Pause for a moment at the top, then slowly lower your body back down to the starting position.",
+   "Repeat for the desired number of repetitions."
+  ],
+  "es": [
+   "Ajustá la máquina de elevación de glúteo-femoral a tu cuerpo.",
+   "Ubicate boca abajo en la máquina con los tobillos asegurados.",
+   "Apoyá las manos sobre el pecho o cruzalas por delante del pecho.",
+   "Activá los isquiotibiales y los glúteos para elevar el tronco hacia arriba.",
+   "Seguí elevando hasta que el cuerpo quede en línea recta desde la cabeza hasta los talones.",
+   "Hacé una pausa arriba y después bajá el cuerpo despacio a la posición inicial.",
+   "Repetí durante las repeticiones deseadas."
+  ],
+  "descEs": "Fuerza de cadena posterior con gran demanda de isquiotibiales."
+ },
+ "3234": {
+  "en": [
+   "Adjust the seat height and position yourself on the machine with your back against the pad.",
+   "Grasp the handles with a pronated grip and keep your elbows slightly bent.",
+   "Exhale and push the handles forward, bringing them together in front of your chest.",
+   "Pause for a moment, squeezing your chest muscles.",
+   "Inhale and slowly return to the starting position, allowing your chest muscles to stretch.",
+   "Repeat for the desired number of repetitions."
+  ],
+  "es": [
+   "Ajustá la altura del asiento y ubicate en la máquina con la espalda apoyada contra el respaldo.",
+   "Agarrá las manijas con agarre pronado y mantené los codos levemente flexionados.",
+   "Exhalá y empujá las manijas hacia adelante, juntándolas frente al pecho.",
+   "Hacé una pausa y apretá los músculos del pecho.",
+   "Inhalá y volvé despacio a la posición inicial, dejando que el pecho se estire.",
+   "Repetí durante las repeticiones deseadas."
+  ],
+  "descEs": "Movimiento de aislamiento para la aducción y el estiramiento del pecho."
+ },
+ "3305": {
+  "en": [
+   "Start by standing with your feet shoulder-width apart, holding a barbell at shoulder height with an overhand grip.",
+   "Lower into a squat position by bending your knees and pushing your hips back.",
+   "As you reach the bottom of the squat, explosively drive through your heels to stand up, simultaneously pressing the barbell overhead.",
+   "Lower the barbell back to shoulder height as you lower back into the squat position.",
+   "Repeat for the desired number of repetitions."
+  ],
+  "es": [
+   "Empezá parado con los pies a la altura de los hombros, sosteniendo una barra a la altura de los hombros con agarre pronado.",
+   "Bajá a posicion de sentadilla flexionando las rodillas y llevando la cadera hacia atras.",
+   "Al llegar al fondo de la sentadilla, empujá explosivamente con los talones para pararte, presionando simultaneamente la barra por encima de la cabeza.",
+   "Bajá la barra de vuelta a la altura de los hombros mientras volves a la posicion de sentadilla.",
+   "Repetí la cantidad de repeticiones deseada."
+  ],
+  "descEs": "Sentadilla mas press por encima de la cabeza para potencia de cuerpo completo."
+ },
+ "3360": {
+  "en": [
+   "Start on all fours with your hands directly under your shoulders and your knees directly under your hips.",
+   "Lift your knees slightly off the ground, keeping your back flat and your core engaged.",
+   "Move your right hand and left foot forward simultaneously, followed by your left hand and right foot.",
+   "Continue crawling forward, alternating your hand and foot movements.",
+   "Maintain a steady pace and keep your core tight throughout the exercise.",
+   "Continue for the desired distance or time."
+  ],
+  "es": [
+   "Empezá en cuatro apoyos con las manos justo debajo de los hombros y las rodillas justo debajo de la cadera.",
+   "Elevá levemente las rodillas del piso, manteniendo la espalda plana y el core activado.",
+   "Movés la mano derecha y el pie izquierdo hacia adelante simultaneamente, seguidos de la mano izquierda y el pie derecho.",
+   "Segui avanzando, alternando los movimientos de manos y pies.",
+   "Mantené un ritmo constante y el core firme durante todo el ejercicio.",
+   "Continuá durante la distancia o el tiempo deseado."
+  ],
+  "descEs": "Ejercicio de desplazamiento para hombros, core y piernas."
+ },
+ "3470": {
+  "en": [
+   "Stand in front of a bench or step with a dumbbell in each hand, palms facing your body.",
+   "Place your right foot on the bench or step, ensuring your entire foot is in contact with the surface.",
+   "Push through your right heel and lift your body up onto the bench or step, straightening your right leg.",
+   "Bring your left foot up onto the bench or step, standing fully upright.",
+   "Step back down with your left foot, followed by your right foot, returning to the starting position.",
+   "Repeat for the desired number of repetitions, then switch legs."
+  ],
+  "es": [
+   "Parate frente a un banco o cajón con una mancuerna en cada mano y las palmas mirando al cuerpo.",
+   "Apoyá el pie derecho sobre el banco o cajón, asegurándote de que toda la planta haga contacto con la superficie.",
+   "Empujá con el talón derecho y subí el cuerpo al banco o cajón, estirando la pierna derecha.",
+   "Subí el pie izquierdo al banco o cajón hasta quedar completamente erguido.",
+   "Bajá con el pie izquierdo y después con el derecho, volviendo a la posición inicial.",
+   "Repetí durante las repeticiones deseadas y después cambiá de pierna."
+  ],
+  "descEs": "Empuje a una pierna con demanda de equilibrio."
+ },
+ "3523": {
+  "en": [
+   "Sit on the edge of a bench with your back against it and your feet flat on the ground.",
+   "Place your hands on the bench beside your hips for support.",
+   "Engage your glutes and hamstrings, then lift your hips off the bench until your body forms a straight line from your knees to your shoulders.",
+   "Pause for a moment at the top, then slowly lower your hips back down to the starting position.",
+   "Repeat for the desired number of repetitions."
+  ],
+  "es": [
+   "Sentate en el borde de un banco con la espalda contra el y los pies apoyados en el piso.",
+   "Apoyá las manos en el banco al lado de la cadera para sostenerte.",
+   "Activá gluteos e isquiotibiales, despues elevá la cadera del banco hasta que el cuerpo forme una linea recta desde las rodillas hasta los hombros.",
+   "Hacé una pausa arriba y despues bajá la cadera lentamente a la posicion inicial.",
+   "Repetí la cantidad de repeticiones deseada."
+  ],
+  "descEs": "Ejercicio basico de extension de cadera dominante de gluteo."
+ },
+ "3544": {
+  "en": [
+   "Start by lying on your side with your legs extended and stacked on top of each other.",
+   "Place your forearm on the ground directly below your shoulder, with your elbow bent at a 90-degree angle.",
+   "Engage your core and lift your hips off the ground, creating a straight line from your head to your feet.",
+   "Hold this position for the desired amount of time.",
+   "Lower your hips back down to the ground and repeat on the other side."
+  ],
+  "es": [
+   "Empezá acostado de costado con las piernas estiradas y una arriba de la otra.",
+   "Apoyá el antebrazo en el piso justo debajo del hombro, con el codo flexionado a 90 grados.",
+   "Activá el core y elevá la cadera del piso, formando una linea recta desde la cabeza hasta los pies.",
+   "Sostené esta posicion durante el tiempo deseado.",
+   "Bajá la cadera de nuevo al piso y repetí del otro lado."
+  ],
+  "descEs": "Sosten basico del core contra la extension."
+ },
+ "3548": {
+  "en": [
+   "Stand up straight with a dumbbell in each hand, palms facing your sides.",
+   "Keep your back straight and your shoulders back.",
+   "Take small, controlled steps forward, maintaining an upright posture.",
+   "Continue walking for the desired distance or time.",
+   "To finish, stop walking and carefully lower the dumbbells to your sides."
+  ],
+  "es": [
+   "Parate erguido con una mancuerna en cada mano y las palmas mirando a los costados.",
+   "Mantené la espalda recta y los hombros hacia atrás.",
+   "Da pasos cortos y controlados hacia adelante, conservando una postura erguida.",
+   "Seguí caminando durante la distancia o el tiempo deseado.",
+   "Para terminar, frená y bajá con cuidado las mancuernas a los costados."
+  ],
+  "descEs": "Caminata con carga para el agarre y la rigidez del tronco."
+ },
+ "3561": {
+  "en": [
+   "Sit on the edge of a bench with your back against it and your feet flat on the ground.",
+   "Place your hands on the bench beside your hips for support.",
+   "Engage your glutes and hamstrings, then lift your hips off the bench until your body forms a straight line from your knees to your shoulders.",
+   "Pause for a moment at the top, then slowly lower your hips back down to the starting position.",
+   "Repeat for the desired number of repetitions."
+  ],
+  "es": [
+   "Sentate en el borde de un banco con la espalda apoyada contra él y los pies bien apoyados en el suelo.",
+   "Apoyá las manos sobre el banco al lado de la cadera para sostenerte.",
+   "Activá glúteos e isquiotibiales y después elevá la cadera del banco hasta que el cuerpo forme una línea recta desde las rodillas hasta los hombros.",
+   "Hacé una pausa arriba y después bajá la cadera despacio a la posición inicial.",
+   "Repetí durante las repeticiones deseadas."
+  ],
+  "descEs": "Ejercicio clásico de extensión de cadera dominante de glúteo."
+ },
+ "3562": {
+  "en": [
+   "Start by sitting on the edge of a bench with your upper back resting against it and your feet flat on the ground, hip-width apart.",
+   "Place a barbell across your hips, holding it securely with both hands.",
+   "Engage your glutes and core muscles, then press through your heels to lift your hips off the bench, creating a straight line from your knees to your shoulders.",
+   "Pause for a moment at the top, squeezing your glutes.",
+   "Slowly lower your hips back down to the starting position.",
+   "Repeat for the desired number of repetitions."
+  ],
+  "es": [
+   "Empezá sentado en el borde de un banco con la parte alta de la espalda apoyada contra el y los pies en el piso, al ancho de la cadera.",
+   "Colocá una barra sobre la cadera, sosteniendola firme con ambas manos.",
+   "Activá gluteos y core, despues empujá con los talones para elevar la cadera del banco, formando una linea recta desde las rodillas hasta los hombros.",
+   "Hacé una pausa arriba, apretando los gluteos.",
+   "Bajá la cadera lentamente a la posicion inicial.",
+   "Repetí la cantidad de repeticiones deseada."
+  ],
+  "descEs": "Puente de gluteos en el piso con carga facil de regular."
+ },
+ "3582": {
+  "en": [
+   "Stand facing away from a suspension trainer with your feet shoulder-width apart.",
+   "Extend one leg forward and place the top of your foot in the foot cradle of the suspension trainer.",
+   "Bend your standing leg and lower your body down into a lunge position, keeping your chest up and your knee in line with your toes.",
+   "Push through your heel to return to the starting position.",
+   "Repeat for the desired number of repetitions, then switch legs."
+  ],
+  "es": [
+   "Parate de espaldas a un entrenador de suspensión con los pies separados al ancho de los hombros.",
+   "Extendé una pierna hacia atrás y apoyá el empeine en el estribo del entrenador de suspensión.",
+   "Flexioná la pierna de apoyo y bajá el cuerpo a una posición de zancada, manteniendo el pecho alto y la rodilla alineada con la punta del pie.",
+   "Empujá con el talón para volver a la posición inicial.",
+   "Repetí durante las repeticiones deseadas y después cambiá de pierna."
+  ],
+  "descEs": "Ejercicio a una pierna para glúteos y cuádriceps."
+ },
+ "3635": {
+  "en": [
+   "Stand facing away from a suspension trainer with your feet shoulder-width apart.",
+   "Extend one leg forward and place the top of your foot in the foot cradle of the suspension trainer.",
+   "Bend your standing leg and lower your body down into a lunge position, keeping your chest up and your knee in line with your toes.",
+   "Push through your heel to return to the starting position.",
+   "Repeat for the desired number of repetitions, then switch legs."
+  ],
+  "es": [
+   "Parate de espaldas a un entrenador de suspensión con los pies separados al ancho de los hombros.",
+   "Extendé una pierna hacia atrás y apoyá el empeine en el estribo del entrenador de suspensión.",
+   "Flexioná la pierna de apoyo y bajá el cuerpo a una posición de zancada, manteniendo el pecho alto y la rodilla alineada con la punta del pie.",
+   "Empujá con el talón para volver a la posición inicial.",
+   "Repetí durante las repeticiones deseadas y después cambiá de pierna."
+  ],
+  "descEs": "Ejercicio a una pierna que carga fuertemente los cuádriceps."
+ },
+ "3655": {
+  "en": [
+   "Stand with your feet hip-width apart.",
+   "Lift your right knee up towards your chest as high as you can while balancing on your left leg.",
+   "Step forward with your right foot and lower your body into a lunge position, bending both knees to a 90-degree angle.",
+   "Push off with your right foot and bring your left knee up towards your chest.",
+   "Step forward with your left foot and lower your body into a lunge position.",
+   "Continue alternating legs and lunging forward, keeping your core engaged and maintaining a steady pace.",
+   "Repeat for the desired number of repetitions."
+  ],
+  "es": [
+   "Parate con los pies al ancho de la cadera.",
+   "Elevá la rodilla derecha hacia el pecho lo mas alto posible mientras te equilibras sobre la pierna izquierda.",
+   "Dá un paso hacia adelante con el pie derecho y bajá el cuerpo a posicion de zancada, flexionando ambas rodillas a 90 grados.",
+   "Empujá con el pie derecho y elevá la rodilla izquierda hacia el pecho.",
+   "Dá un paso hacia adelante con el pie izquierdo y bajá el cuerpo a posicion de zancada.",
+   "Segui alternando las piernas y avanzando con zancadas, manteniendo el core activado y un ritmo constante.",
+   "Repetí la cantidad de repeticiones deseada."
+  ],
+  "descEs": "Cuadriceps y gluteos con avance constante hacia adelante."
+ },
+ "3665": {
+  "en": [
+   "Start by lying on your side with your legs extended and stacked on top of each other.",
+   "Place your forearm on the ground directly below your shoulder, with your elbow bent at a 90-degree angle.",
+   "Engage your core and lift your hips off the ground, creating a straight line from your head to your feet.",
+   "Hold this position for the desired amount of time.",
+   "Lower your hips back down to the ground and repeat on the other side."
+  ],
+  "es": [
+   "Empezá recostado de lado con las piernas extendidas y apoyadas una sobre la otra.",
+   "Apoyá el antebrazo en el suelo justo debajo del hombro, con el codo flexionado a 90 grados.",
+   "Activá el core y elevá la cadera del suelo, formando una línea recta desde la cabeza hasta los pies.",
+   "Mantené esta posición durante el tiempo deseado.",
+   "Bajá la cadera al suelo y repetí del otro lado."
+  ],
+  "descEs": "Sostén de tronco anti-flexión lateral."
+ },
+ "0003": {
+  "en": [
+   "Lie flat on your back with your hands placed behind your head.",
+   "Lift your legs off the ground and bend your knees at a 90-degree angle.",
+   "Bring your right elbow towards your left knee while simultaneously straightening your right leg.",
+   "Return to the starting position and repeat the movement on the opposite side, bringing your left elbow towards your right knee while straightening your left leg.",
+   "Continue alternating sides in a pedaling motion for the desired number of repetitions."
+  ],
+  "es": [
+   "Acostate boca arriba con las manos detras de la cabeza.",
+   "Elevá las piernas del piso y flexioná las rodillas a 90 grados.",
+   "Llevá el codo derecho hacia la rodilla izquierda mientras simultaneamente estiras la pierna derecha.",
+   "Volvé a la posicion inicial y repetí el movimiento del lado opuesto, llevando el codo izquierdo hacia la rodilla derecha mientras estiras la pierna izquierda.",
+   "Segui alternando lados en un movimiento de pedaleo durante la cantidad de repeticiones deseada."
+  ],
+  "descEs": "Maquina de cardio de intervalos de alta intensidad."
+ },
+ "0009": {
+  "en": [
+   "Adjust the machine to your desired height and secure your knees on the pad.",
+   "Grasp the handles with your palms facing down and your arms fully extended.",
+   "Lower your body by bending your elbows until your upper arms are parallel to the floor.",
+   "Pause for a moment, then push yourself back up to the starting position.",
+   "Repeat for the desired number of repetitions."
+  ],
+  "es": [
+   "Ajustá la maquina a la altura deseada y apoyá las rodillas en la almohadilla.",
+   "Agarrá las manijas con las palmas hacia abajo y los brazos completamente estirados.",
+   "Bajá el cuerpo flexionando los codos hasta que los brazos queden paralelos al piso.",
+   "Hacé una pausa y despues empujá para volver a la posicion inicial.",
+   "Repetí la cantidad de repeticiones deseada."
+  ],
+  "descEs": "Fondo enfocado en pecho con fuerte demanda de pecho inferior y triceps."
+ },
+ "0014": {
+  "en": [
+   "Sit on the ground with your knees bent and feet flat on the floor.",
+   "Hold the medicine ball with both hands in front of your chest.",
+   "Lean back slightly, engaging your abs and keeping your back straight.",
+   "Slowly twist your torso to the right, bringing the medicine ball towards the right side of your body.",
+   "Pause for a moment, then twist your torso to the left, bringing the medicine ball towards the left side of your body.",
+   "Continue alternating sides for the desired number of repetitions."
+  ],
+  "es": [
+   "Sentate en el piso con las rodillas flexionadas y los pies apoyados.",
+   "Sostené el balón medicinal con ambas manos frente al pecho.",
+   "Inclinate ligeramente hacia atrás, activando los abdominales y manteniendo la espalda recta.",
+   "Girá despacio el torso hacia la derecha, llevando el balón hacia el costado derecho del cuerpo.",
+   "Hacé una pausa y después girá el torso hacia la izquierda, llevando el balón hacia el costado izquierdo del cuerpo.",
+   "Seguí alternando los lados durante las repeticiones deseadas."
+  ],
+  "descEs": "Control rotacional del tronco y trabajo de oblicuos."
+ },
+ "0017": {
+  "en": [
+   "Adjust the machine to your desired weight and height settings.",
+   "Grasp the handles with an overhand grip, slightly wider than shoulder-width apart.",
+   "Hang with your arms fully extended and your feet off the ground.",
+   "Engage your back muscles and pull your body up towards the handles, keeping your elbows close to your body.",
+   "Continue pulling until your chin is above the handles.",
+   "Pause for a moment at the top, then slowly lower your body back down to the starting position.",
+   "Repeat for the desired number of repetitions."
+  ],
+  "es": [
+   "Ajustá la máquina al peso y la altura que prefieras.",
+   "Agarrá las manijas con un agarre prono, un poco más abierto que el ancho de los hombros.",
+   "Colgate con los brazos completamente extendidos y los pies sin tocar el piso.",
+   "Activá los músculos de la espalda y traccioná el cuerpo hacia arriba hacia las manijas, manteniendo los codos cerca del cuerpo.",
+   "Seguí traccionando hasta que el mentón quede por encima de las manijas.",
+   "Hacé una pausa arriba y después bajá despacio el cuerpo hasta la posición inicial.",
+   "Repetí durante las repeticiones deseadas."
+  ],
+  "descEs": "Tracción vertical para dorsales y espalda alta."
+ },
+ "0019": {
+  "en": [
+   "Adjust the machine to your desired weight and height.",
+   "Kneel down on the pad facing the machine, with your hands gripping the handles.",
+   "Lower your body by bending your elbows, keeping your back straight and close to the machine.",
+   "Pause for a moment at the bottom, then push yourself back up to the starting position.",
+   "Repeat for the desired number of repetitions."
+  ],
+  "es": [
+   "Ajustá la máquina al peso y la altura que prefieras.",
+   "Arrodillate sobre la almohadilla mirando hacia la máquina, con las manos agarrando las manijas.",
+   "Bajá el cuerpo flexionando los codos, manteniendo la espalda recta y cerca de la máquina.",
+   "Hacé una pausa abajo y después empujá para volver a la posición inicial.",
+   "Repetí durante las repeticiones deseadas."
+  ],
+  "descEs": "Movimiento compuesto de tríceps con asistencia del pecho."
+ },
+ "0024": {
+  "en": [
+   "Start by standing with your feet shoulder-width apart and the barbell resting on your upper chest, just below your collarbone.",
+   "Hold the barbell with an overhand grip, keeping your elbows up and your upper arms parallel to the ground.",
+   "Lower your body down into a squat position by bending at the knees and hips, keeping your back straight and your chest up.",
+   "Pause for a moment at the bottom of the squat, then push through your heels to return to the starting position.",
+   "Repeat for the desired number of repetitions."
+  ],
+  "es": [
+   "Empezá parado con los pies al ancho de los hombros y la barra apoyada sobre la parte alta del pecho, justo debajo de la clavícula.",
+   "Sostené la barra con un agarre prono, manteniendo los codos arriba y los brazos paralelos al piso.",
+   "Bajá el cuerpo hasta la posición de sentadilla flexionando las rodillas y las caderas, manteniendo la espalda recta y el pecho arriba.",
+   "Hacé una pausa abajo de la sentadilla y después empujá con los talones para volver a la posición inicial.",
+   "Repetí durante las repeticiones deseadas."
+  ],
+  "descEs": "Patrón de sentadilla erguido con mayor énfasis en los cuádriceps."
+ },
+ "0025": {
+  "en": [
+   "Lie flat on a bench with your feet flat on the ground and your back pressed against the bench.",
+   "Grasp the barbell with an overhand grip slightly wider than shoulder-width apart.",
+   "Lift the barbell off the rack and hold it directly above your chest with your arms fully extended.",
+   "Lower the barbell slowly towards your chest, keeping your elbows tucked in.",
+   "Pause for a moment when the barbell touches your chest.",
+   "Push the barbell back up to the starting position by extending your arms.",
+   "Repeat for the desired number of repetitions."
+  ],
+  "es": [
+   "Acostate sobre el banco con los pies apoyados en el piso y la espalda pegada al banco.",
+   "Agarrá la barra con un agarre prono un poco más abierto que el ancho de los hombros.",
+   "Sacá la barra del soporte y sostenela directamente sobre el pecho con los brazos completamente extendidos.",
+   "Bajá la barra despacio hacia el pecho, manteniendo los codos recogidos.",
+   "Hacé una pausa cuando la barra toque el pecho.",
+   "Empujá la barra de vuelta hacia arriba a la posición inicial extendiendo los brazos.",
+   "Repetí durante las repeticiones deseadas."
+  ],
+  "descEs": "Press horizontal estándar para fuerza de pecho."
+ },
+ "0027": {
+  "en": [
+   "Stand with your feet shoulder-width apart and knees slightly bent.",
+   "Bend forward at the hips while keeping your back straight and chest up.",
+   "Grasp the barbell with an overhand grip, hands slightly wider than shoulder-width apart.",
+   "Pull the barbell towards your lower chest by retracting your shoulder blades and squeezing your back muscles.",
+   "Pause for a moment at the top, then slowly lower the barbell back to the starting position.",
+   "Repeat for the desired number of repetitions."
+  ],
+  "es": [
+   "Parate con los pies al ancho de los hombros y las rodillas ligeramente flexionadas.",
+   "Inclinate hacia adelante desde las caderas manteniendo la espalda recta y el pecho arriba.",
+   "Agarrá la barra con un agarre prono, con las manos un poco más abiertas que el ancho de los hombros.",
+   "Traccioná la barra hacia la parte baja del pecho retrayendo las escápulas y apretando los músculos de la espalda.",
+   "Hacé una pausa arriba y después bajá despacio la barra hasta la posición inicial.",
+   "Repetí durante las repeticiones deseadas."
+  ],
+  "descEs": "Tracción horizontal pesada para grosor de espalda."
+ },
+ "0028": {
+  "en": [
+   "Start by standing with your feet shoulder-width apart, holding a barbell at shoulder height with an overhand grip.",
+   "Lower into a squat position by bending your knees and pushing your hips back.",
+   "As you reach the bottom of the squat, explosively drive through your heels to stand up, simultaneously pressing the barbell overhead.",
+   "Lower the barbell back to shoulder height as you lower back into the squat position.",
+   "Repeat for the desired number of repetitions."
+  ],
+  "es": [
+   "Empezá parado con los pies separados al ancho de los hombros, sosteniendo una barra a la altura de los hombros con agarre pronado.",
+   "Bajá a una posición de sentadilla flexionando las rodillas y llevando la cadera hacia atrás.",
+   "Al llegar al fondo de la sentadilla, empujá explosivamente con los talones para pararte y al mismo tiempo presioná la barra por encima de la cabeza.",
+   "Bajá la barra de vuelta a la altura de los hombros mientras volvés a bajar a la sentadilla.",
+   "Repetí durante las repeticiones deseadas."
+  ],
+  "descEs": "Sentadilla más press por encima de la cabeza para potencia de cuerpo entero."
+ },
+ "0030": {
+  "en": [
+   "Lie flat on a bench with your feet flat on the ground and your back pressed against the bench.",
+   "Grasp the barbell with a close grip, slightly narrower than shoulder-width apart.",
+   "Unrack the barbell and lower it slowly towards your chest, keeping your elbows close to your body.",
+   "Pause for a moment when the barbell touches your chest.",
+   "Push the barbell back up to the starting position, fully extending your arms.",
+   "Repeat for the desired number of repetitions."
+  ],
+  "es": [
+   "Acostate sobre el banco con los pies apoyados en el piso y la espalda pegada al banco.",
+   "Agarrá la barra con un agarre cerrado, un poco más angosto que el ancho de los hombros.",
+   "Sacá la barra del soporte y bajala despacio hacia el pecho, manteniendo los codos cerca del cuerpo.",
+   "Hacé una pausa cuando la barra toque el pecho.",
+   "Empujá la barra de vuelta hacia arriba a la posición inicial, extendiendo completamente los brazos.",
+   "Repetí durante las repeticiones deseadas."
+  ],
+  "descEs": "Press pesado de tríceps con apoyo del pecho."
+ },
+ "0031": {
+  "en": [
+   "Stand up straight with your feet shoulder-width apart and hold a barbell with an underhand grip, palms facing forward.",
+   "Keep your elbows close to your torso and exhale as you curl the weights while contracting your biceps.",
+   "Continue to raise the bar until your biceps are fully contracted and the bar is at shoulder level.",
+   "Hold the contracted position for a brief pause as you squeeze your biceps.",
+   "Inhale as you slowly begin to lower the bar back to the starting position.",
+   "Repeat for the desired number of repetitions."
+  ],
+  "es": [
+   "Parate derecho con los pies al ancho de los hombros y sostené una barra con un agarre supino, con las palmas hacia adelante.",
+   "Mantené los codos cerca del torso y exhalá mientras flexionás contrayendo los bíceps.",
+   "Seguí subiendo la barra hasta que los bíceps estén completamente contraídos y la barra quede a la altura de los hombros.",
+   "Mantené la posición contraída una breve pausa apretando los bíceps.",
+   "Inhalá mientras empezás a bajar despacio la barra hasta la posición inicial.",
+   "Repetí durante las repeticiones deseadas."
+  ],
+  "descEs": "Curl clásico de bíceps con agarre fijo."
+ },
+ "0032": {
+  "en": [
+   "Stand with your feet shoulder-width apart and the barbell on the ground in front of you.",
+   "Bend your knees and hinge at the hips to lower your torso and grip the barbell with an overhand grip, hands slightly wider than shoulder-width apart.",
+   "Keep your back straight and chest lifted as you drive through your heels to lift the barbell off the ground, extending your hips and knees.",
+   "As you stand up straight, squeeze your glutes and keep your core engaged.",
+   "Lower the barbell back down to the ground by bending at the hips and knees, keeping your back straight.",
+   "Repeat for the desired number of repetitions."
+  ],
+  "es": [
+   "Parate con los pies al ancho de los hombros y la barra en el piso frente a vos.",
+   "Flexioná las rodillas y hacé bisagra en las caderas para bajar el torso y agarrar la barra con un agarre prono, con las manos un poco más abiertas que el ancho de los hombros.",
+   "Mantené la espalda recta y el pecho elevado mientras empujás con los talones para levantar la barra del piso, extendiendo las caderas y las rodillas.",
+   "Al pararte derecho, apretá los glúteos y mantené el core activado.",
+   "Bajá la barra de vuelta al piso flexionando las caderas y las rodillas, manteniendo la espalda recta.",
+   "Repetí durante las repeticiones deseadas."
+  ],
+  "descEs": "Tracción completa de cadena posterior y patrón de bisagra de cadera."
+ },
+ "0033": {
+  "en": [
+   "Lie on a decline bench with your feet secured and your head lower than your hips.",
+   "Grasp the barbell with an overhand grip slightly wider than shoulder-width apart.",
+   "Unrack the barbell and lower it slowly towards your chest, keeping your elbows tucked in.",
+   "Pause for a moment at the bottom, then push the barbell back up to the starting position.",
+   "Repeat for the desired number of repetitions."
+  ],
+  "es": [
+   "Acostate en un banco declinado con los pies sujetos y la cabeza más abajo que las caderas.",
+   "Agarrá la barra con un agarre prono un poco más abierto que el ancho de los hombros.",
+   "Sacá la barra del soporte y bajala despacio hacia el pecho, manteniendo los codos recogidos.",
+   "Hacé una pausa abajo y después empujá la barra de vuelta hacia arriba a la posición inicial.",
+   "Repetí durante las repeticiones deseadas."
+  ],
+  "descEs": "Variante de press declinado que enfatiza la parte baja del pecho."
+ },
+ "0042": {
+  "en": [
+   "Start by standing with your feet shoulder-width apart, toes slightly turned out.",
+   "Hold the barbell in front of your shoulders, resting it on your collarbone and shoulders.",
+   "Engage your core and keep your chest up as you lower your body down into a squat position, pushing your hips back and bending your knees.",
+   "Lower until your thighs are parallel to the ground, or as low as you can comfortably go.",
+   "Pause for a moment at the bottom, then push through your heels to return to the starting position.",
+   "Repeat for the desired number of repetitions."
+  ],
+  "es": [
+   "Empezá parado con los pies al ancho de los hombros y las puntas ligeramente hacia afuera.",
+   "Sostené la barra al frente de los hombros, apoyándola sobre la clavícula y los hombros.",
+   "Activá el core y mantené el pecho arriba mientras bajás el cuerpo hasta la posición de sentadilla, llevando las caderas hacia atrás y flexionando las rodillas.",
+   "Bajá hasta que los muslos queden paralelos al piso, o tan bajo como puedas cómodamente.",
+   "Hacé una pausa abajo y después empujá con los talones para volver a la posición inicial.",
+   "Repetí durante las repeticiones deseadas."
+  ],
+  "descEs": "Sentadilla dominante de cuádriceps con el torso erguido."
+ },
+ "0044": {
+  "en": [
+   "Start by standing with your feet shoulder-width apart and the barbell resting on your upper back.",
+   "Keeping your back straight and your core engaged, hinge forward at the hips, pushing your buttocks back as if you were trying to touch the wall behind you with your glutes.",
+   "Lower your torso until it is parallel to the ground, feeling a stretch in your hamstrings.",
+   "Pause for a moment, then return to the starting position by squeezing your glutes and pushing your hips forward.",
+   "Repeat for the desired number of repetitions."
+  ],
+  "es": [
+   "Empezá parado con los pies al ancho de los hombros y la barra apoyada sobre la parte alta de la espalda.",
+   "Manteniendo la espalda recta y el core activado, hacé bisagra hacia adelante desde las caderas, llevando los glúteos hacia atrás como si quisieras tocar la pared de atrás con ellos.",
+   "Bajá el torso hasta que quede paralelo al piso, sintiendo un estiramiento en los isquiotibiales.",
+   "Hacé una pausa y después volvé a la posición inicial apretando los glúteos y empujando las caderas hacia adelante.",
+   "Repetí durante las repeticiones deseadas."
+  ],
+  "descEs": "Bisagra de cadera que carga fuertemente los isquiotibiales."
+ },
+ "0045": {
+  "en": [
+   "Lie flat on your back on the floor with your knees bent and feet flat on the ground.",
+   "Hold the barbell with one hand, palm facing up, and extend your arm straight up over your chest.",
+   "Slowly lower the barbell towards your chest, keeping your elbow close to your body.",
+   "Pause for a moment at the bottom, then push the barbell back up to the starting position.",
+   "Repeat for the desired number of repetitions, then switch arms."
+  ],
+  "es": [
+   "Recostate de espaldas en el suelo con las rodillas flexionadas y los pies bien apoyados.",
+   "Sostené la barra con una mano, la palma hacia arriba, y extendé el brazo recto por encima del pecho.",
+   "Bajá la barra despacio hacia el pecho, manteniendo el codo cerca del cuerpo.",
+   "Hacé una pausa abajo y después empujá la barra de vuelta a la posición inicial.",
+   "Repetí durante las repeticiones deseadas y después cambiá de brazo."
+  ],
+  "descEs": "Variante de press con rango de movimiento reducido."
+ },
+ "0046": {
+  "en": [
+   "Adjust the seat height and backrest of the machine to fit your body.",
+   "Sit on the machine with your back against the backrest and your feet on the footpad.",
+   "Grasp the handles or sidebars for stability.",
+   "Extend your legs forward by straightening your knees, lifting the weight.",
+   "Pause for a moment at the top, then slowly lower the weight back to the starting position.",
+   "Repeat for the desired number of repetitions."
+  ],
+  "es": [
+   "Ajustá la altura del asiento y el respaldo de la máquina a tu cuerpo.",
+   "Sentate en la máquina con la espalda apoyada contra el respaldo y los pies sobre el rodillo.",
+   "Agarrá las manijas o los laterales para estabilizarte.",
+   "Extendé las piernas hacia adelante estirando las rodillas, levantando el peso.",
+   "Hacé una pausa arriba y después bajá el peso despacio a la posición inicial.",
+   "Repetí durante las repeticiones deseadas."
+  ],
+  "descEs": "Aislamiento de cuádriceps en máquina."
+ },
+ "0047": {
+  "en": [
+   "Set up an incline bench at a 45-degree angle.",
+   "Lie down on the bench with your feet flat on the ground.",
+   "Grasp the barbell with an overhand grip, slightly wider than shoulder-width apart.",
+   "Unrack the barbell and lower it slowly towards your chest, keeping your elbows at a 45-degree angle.",
+   "Pause for a moment at the bottom, then push the barbell back up to the starting position.",
+   "Repeat for the desired number of repetitions."
+  ],
+  "es": [
+   "Preparate con un banco inclinado a 45 grados.",
+   "Acostate en el banco con los pies apoyados en el piso.",
+   "Agarrá la barra con un agarre prono, un poco más abierto que el ancho de los hombros.",
+   "Sacá la barra del soporte y bajala despacio hacia el pecho, manteniendo los codos a 45 grados.",
+   "Hacé una pausa abajo y después empujá la barra de vuelta hacia arriba a la posición inicial.",
+   "Repetí durante las repeticiones deseadas."
+  ],
+  "descEs": "Variante de press inclinado que enfatiza la parte alta del pecho."
+ },
+ "0054": {
+  "en": [
+   "Start by standing with your feet shoulder-width apart and a barbell resting on your upper back.",
+   "Take a step forward with your right foot, keeping your torso upright.",
+   "Lower your body by bending your right knee until your thigh is parallel to the ground.",
+   "Push through your right heel to return to the starting position.",
+   "Repeat with your left leg, alternating legs for the desired number of repetitions."
+  ],
+  "es": [
+   "Empezá parado con los pies al ancho de los hombros y una barra apoyada sobre la parte alta de la espalda.",
+   "Dá un paso hacia adelante con el pie derecho, manteniendo el torso erguido.",
+   "Bajá el cuerpo flexionando la rodilla derecha hasta que el muslo quede paralelo al piso.",
+   "Empujá con el talón derecho para volver a la posición inicial.",
+   "Repetí con la pierna izquierda, alternando las piernas durante las repeticiones deseadas."
+  ],
+  "descEs": "Ejercicio fundamental unilateral de tren inferior."
+ },
+ "0060": {
+  "en": [
+   "Lie flat on a bench with your feet flat on the ground and your head at the end of the bench.",
+   "Hold the barbell with an overhand grip, hands shoulder-width apart, and extend your arms straight up over your chest.",
+   "Keeping your upper arms stationary, slowly lower the barbell towards your forehead by bending your elbows.",
+   "Pause for a moment when the barbell is just above your forehead, then extend your arms back up to the starting position.",
+   "Repeat for the desired number of repetitions."
+  ],
+  "es": [
+   "Acostate sobre el banco con los pies apoyados en el piso y la cabeza al borde del banco.",
+   "Sostené la barra con un agarre prono, con las manos al ancho de los hombros, y extendé los brazos rectos hacia arriba por encima del pecho.",
+   "Manteniendo los brazos fijos, bajá despacio la barra hacia la frente flexionando los codos.",
+   "Hacé una pausa cuando la barra quede justo por encima de la frente y después extendé los brazos de vuelta a la posición inicial.",
+   "Repetí durante las repeticiones deseadas."
+  ],
+  "descEs": "Aislamiento de extensión de codo desde posición acostada."
+ },
+ "0061": {
+  "en": [
+   "Lie flat on a bench with your feet flat on the ground and your head at the end of the bench.",
+   "Hold the barbell with an overhand grip, hands shoulder-width apart, and extend your arms straight up over your chest.",
+   "Keeping your upper arms stationary, slowly lower the barbell towards your forehead by bending your elbows.",
+   "Pause for a moment at the bottom, then extend your arms back up to the starting position.",
+   "Repeat for the desired number of repetitions."
+  ],
+  "es": [
+   "Acostate sobre el banco con los pies apoyados en el piso y la cabeza al borde del banco.",
+   "Sostené la barra con un agarre prono, con las manos al ancho de los hombros, y extendé los brazos rectos hacia arriba por encima del pecho.",
+   "Manteniendo los brazos fijos, bajá despacio la barra hacia la frente flexionando los codos.",
+   "Hacé una pausa abajo y después extendé los brazos de vuelta a la posición inicial.",
+   "Repetí durante las repeticiones deseadas."
+  ],
+  "descEs": "Aislamiento de extensión de codo desde posición acostada."
+ },
+ "0070": {
+  "en": [
+   "Sit on a preacher bench with your upper arms resting on the pad and your chest against the support.",
+   "Grasp the barbell with an underhand grip, slightly wider than shoulder-width apart.",
+   "Keeping your upper arms stationary, exhale and curl the barbell up towards your shoulders.",
+   "Pause for a moment at the top, squeezing your biceps.",
+   "Inhale and slowly lower the barbell back down to the starting position.",
+   "Repeat for the desired number of repetitions."
+  ],
+  "es": [
+   "Sentate en un banco predicador con los brazos apoyados sobre la almohadilla y el pecho contra el soporte.",
+   "Agarrá la barra con un agarre supino, un poco más abierto que el ancho de los hombros.",
+   "Manteniendo los brazos fijos, exhalá y flexioná la barra hacia los hombros.",
+   "Hacé una pausa arriba apretando los bíceps.",
+   "Inhalá y bajá despacio la barra de vuelta a la posición inicial.",
+   "Repetí durante las repeticiones deseadas."
+  ],
+  "descEs": "Curl con apoyo que aísla los bíceps."
+ },
+ "0078": {
+  "en": [
+   "Stand facing away from a suspension trainer with your feet shoulder-width apart.",
+   "Extend one leg forward and place the top of your foot in the foot cradle of the suspension trainer.",
+   "Bend your standing leg and lower your body down into a lunge position, keeping your chest up and your knee in line with your toes.",
+   "Push through your heel to return to the starting position.",
+   "Repeat for the desired number of repetitions, then switch legs."
+  ],
+  "es": [
+   "Parate de espaldas a un entrenador de suspensión con los pies separados al ancho de los hombros.",
+   "Extendé una pierna hacia atrás y apoyá el empeine en el estribo del entrenador de suspensión.",
+   "Flexioná la pierna de apoyo y bajá el cuerpo a una posición de zancada, manteniendo el pecho alto y la rodilla alineada con la punta del pie.",
+   "Empujá con el talón para volver a la posición inicial.",
+   "Repetí durante las repeticiones deseadas y después cambiá de pierna."
+  ],
+  "descEs": "Ejercicio a una pierna que carga fuertemente los cuádriceps."
+ },
+ "0080": {
+  "en": [
+   "Stand up straight with your feet shoulder-width apart and hold a barbell with an overhand grip, palms facing down.",
+   "Keep your upper arms stationary and exhale as you curl the barbell upward, contracting your biceps.",
+   "Continue to raise the barbell until your biceps are fully contracted and the barbell is at shoulder level.",
+   "Hold the contracted position for a brief pause as you squeeze your biceps.",
+   "Inhale as you slowly lower the barbell back to the starting position, keeping your upper arms stationary.",
+   "Repeat for the desired number of repetitions."
+  ],
+  "es": [
+   "Parate derecho con los pies al ancho de los hombros y sostené una barra con un agarre prono, con las palmas hacia abajo.",
+   "Mantené los brazos fijos y exhalá mientras flexionás la barra hacia arriba, contrayendo los bíceps.",
+   "Seguí subiendo la barra hasta que los bíceps estén completamente contraídos y la barra quede a la altura de los hombros.",
+   "Mantené la posición contraída una breve pausa apretando los bíceps.",
+   "Inhalá mientras bajás despacio la barra de vuelta a la posición inicial, manteniendo los brazos fijos.",
+   "Repetí durante las repeticiones deseadas."
+  ],
+  "descEs": "Curl con agarre pronado para antebrazos y braquial."
+ },
+ "0082": {
+  "en": [
+   "Sit on a bench with your feet flat on the ground and hold a barbell with an overhand grip, palms facing down.",
+   "Rest your forearms on your thighs, allowing your wrists to hang off the edge.",
+   "Slowly curl your wrists upward, bringing the barbell towards your body.",
+   "Pause for a moment at the top, then slowly lower the barbell back down to the starting position.",
+   "Repeat for the desired number of repetitions."
+  ],
+  "es": [
+   "Sentate en un banco con los pies apoyados en el piso y sostené una barra con un agarre prono, con las palmas hacia abajo.",
+   "Apoyá los antebrazos sobre los muslos, dejando que las muñecas queden colgando del borde.",
+   "Flexioná despacio las muñecas hacia arriba, llevando la barra hacia el cuerpo.",
+   "Hacé una pausa arriba y después bajá despacio la barra de vuelta a la posición inicial.",
+   "Repetí durante las repeticiones deseadas."
+  ],
+  "descEs": "Aislamiento de los extensores del antebrazo."
+ },
+ "0085": {
+  "en": [
+   "Stand with your feet shoulder-width apart and your toes pointing forward.",
+   "Hold the barbell with an overhand grip, hands slightly wider than shoulder-width apart.",
+   "Bend at the hips, keeping your back straight and your knees slightly bent.",
+   "Lower the barbell towards the ground, keeping it close to your body.",
+   "Feel the stretch in your hamstrings as you lower the barbell.",
+   "Once you feel a stretch in your hamstrings, push your hips forward and stand up straight.",
+   "Squeeze your glutes at the top of the movement.",
+   "Lower the barbell back down to the starting position and repeat for the desired number of repetitions."
+  ],
+  "es": [
+   "Parate con los pies al ancho de los hombros y las puntas hacia adelante.",
+   "Sostené la barra con un agarre prono, con las manos un poco más abiertas que el ancho de los hombros.",
+   "Hacé bisagra en las caderas, manteniendo la espalda recta y las rodillas ligeramente flexionadas.",
+   "Bajá la barra hacia el piso, manteniéndola cerca del cuerpo.",
+   "Sentí el estiramiento en los isquiotibiales mientras bajás la barra.",
+   "Cuando sientas el estiramiento en los isquiotibiales, empujá las caderas hacia adelante y parate derecho.",
+   "Apretá los glúteos en la parte alta del movimiento.",
+   "Bajá la barra de vuelta a la posición inicial y repetí durante las repeticiones deseadas."
+  ],
+  "descEs": "Bisagra de cadera enfocada en glúteos e isquiotibiales."
+ },
+ "0088": {
+  "en": [
+   "Sit on a bench with your feet flat on the floor and a barbell resting on your thighs.",
+   "Place the balls of your feet on a raised platform, such as a block or step.",
+   "Position the barbell across your thighs and hold it securely with your hands.",
+   "Keeping your back straight and your core engaged, lift your heels off the ground by extending your ankles.",
+   "Pause for a moment at the top, then slowly lower your heels back down to the starting position.",
+   "Repeat for the desired number of repetitions."
+  ],
+  "es": [
+   "Sentate en un banco con los pies apoyados en el piso y una barra apoyada sobre los muslos.",
+   "Colocá la punta de los pies sobre una plataforma elevada, como un bloque o escalón.",
+   "Posicioná la barra sobre los muslos y sostenela firme con las manos.",
+   "Manteniendo la espalda recta y el core activado, levantá los talones del piso extendiendo los tobillos.",
+   "Hacé una pausa arriba y después bajá despacio los talones de vuelta a la posición inicial.",
+   "Repetí durante las repeticiones deseadas."
+  ],
+  "descEs": "Trabajo de gemelos con rodilla flexionada que enfatiza el sóleo."
+ },
+ "0091": {
+  "en": [
+   "Stand with your feet shoulder-width apart and hold the barbell with an overhand grip, slightly wider than shoulder-width.",
+   "Lift the barbell to shoulder height, keeping your elbows slightly in front of the bar.",
+   "Press the barbell overhead, extending your arms fully.",
+   "Lower the barbell back to shoulder height and repeat for the desired number of repetitions."
+  ],
+  "es": [
+   "Parate con los pies separados al ancho de los hombros y sostené la barra con agarre pronado, algo más abierto que el ancho de los hombros.",
+   "Llevá la barra a la altura de los hombros, manteniendo los codos levemente por delante de la barra.",
+   "Presioná la barra por encima de la cabeza, extendiendo los brazos por completo.",
+   "Bajá la barra de vuelta a la altura de los hombros y repetí durante las repeticiones deseadas."
+  ],
+  "descEs": "Press por encima de la cabeza clásico para deltoides y tríceps."
+ },
+ "0092": {
+  "en": [
+   "Sit on a bench with your back straight and feet flat on the ground.",
+   "Hold a barbell with an overhand grip, hands shoulder-width apart, and raise it overhead.",
+   "Lower the barbell behind your head by bending your elbows, keeping your upper arms close to your head.",
+   "Pause for a moment, then extend your arms to raise the barbell back to the starting position.",
+   "Repeat for the desired number of repetitions."
+  ],
+  "es": [
+   "Sentate en un banco con la espalda recta y los pies apoyados en el piso.",
+   "Sostené una barra con un agarre prono, con las manos al ancho de los hombros, y levantala por encima de la cabeza.",
+   "Bajá la barra por detrás de la cabeza flexionando los codos, manteniendo los brazos cerca de la cabeza.",
+   "Hacé una pausa y después extendé los brazos para subir la barra de vuelta a la posición inicial.",
+   "Repetí durante las repeticiones deseadas."
+  ],
+  "descEs": "Patrón de estiramiento y bloqueo de tríceps."
+ },
+ "0097": {
+  "en": [
+   "Stand with your feet wider than shoulder-width apart, toes pointing slightly outwards.",
+   "Hold a barbell across your upper back, resting it on your shoulders.",
+   "Take a big step to the side with your right foot, keeping your left foot planted.",
+   "Bend your right knee and lower your body down into a squat position, keeping your chest up and your back straight.",
+   "Push through your right heel to return to the starting position.",
+   "Repeat on the other side, stepping out with your left foot.",
+   "Continue alternating sides for the desired number of repetitions."
+  ],
+  "es": [
+   "Parate con los pies más abiertos que el ancho de los hombros, con las puntas ligeramente hacia afuera.",
+   "Sostené una barra sobre la parte alta de la espalda, apoyándola en los hombros.",
+   "Dá un paso grande hacia el costado con el pie derecho, manteniendo el pie izquierdo plantado.",
+   "Flexioná la rodilla derecha y bajá el cuerpo hasta la posición de sentadilla, manteniendo el pecho arriba y la espalda recta.",
+   "Empujá con el talón derecho para volver a la posición inicial.",
+   "Repetí del otro lado, dando el paso con el pie izquierdo.",
+   "Seguí alternando los lados durante las repeticiones deseadas."
+  ],
+  "descEs": "Ejercicio a una pierna que carga fuertemente los cuádriceps."
+ },
+ "0098": {
+  "en": [
+   "Stand with your feet shoulder-width apart.",
+   "Take a step forward with your right leg, lowering your body into a lunge position.",
+   "Keep your torso upright and your front knee aligned with your ankle.",
+   "Push off with your right foot and bring your left foot forward, stepping into a lunge position with your left leg.",
+   "Continue alternating legs and walking forward, maintaining a controlled and steady pace.",
+   "Repeat for the desired number of repetitions."
+  ],
+  "es": [
+   "Parate con los pies separados al ancho de los hombros.",
+   "Da un paso adelante con la pierna derecha, bajando el cuerpo a una posición de zancada.",
+   "Mantené el torso erguido y la rodilla delantera alineada con el tobillo.",
+   "Empujá con el pie derecho y llevá el pie izquierdo hacia adelante, entrando en una zancada con la pierna izquierda.",
+   "Seguí alternando las piernas y caminando hacia adelante, manteniendo un ritmo controlado y estable.",
+   "Repetí durante las repeticiones deseadas."
+  ],
+  "descEs": "Cuádriceps y glúteos con avance constante hacia adelante."
+ },
+ "0099": {
+  "en": [
+   "Stand with your feet shoulder-width apart.",
+   "Take a step forward with your right leg, lowering your body into a lunge position.",
+   "Keep your torso upright and your front knee aligned with your ankle.",
+   "Push off with your right foot and bring your left foot forward, stepping into a lunge position with your left leg.",
+   "Continue alternating legs and walking forward, maintaining a controlled and steady pace.",
+   "Repeat for the desired number of repetitions."
+  ],
+  "es": [
+   "Parate con los pies separados al ancho de los hombros.",
+   "Da un paso adelante con la pierna derecha, bajando el cuerpo a una posición de zancada.",
+   "Mantené el torso erguido y la rodilla delantera alineada con el tobillo.",
+   "Empujá con el pie derecho y llevá el pie izquierdo hacia adelante, entrando en una zancada con la pierna izquierda.",
+   "Seguí alternando las piernas y caminando hacia adelante, manteniendo un ritmo controlado y estable.",
+   "Repetí durante las repeticiones deseadas."
+  ],
+  "descEs": "Cuádriceps y glúteos con avance constante hacia adelante."
+ },
+ "0104": {
+  "en": [
+   "Attach a weight to one end of a rope or bar.",
+   "Hold the other end of the rope or bar with both hands, palms facing down.",
+   "Stand with your feet shoulder-width apart and your arms fully extended in front of you.",
+   "Slowly roll the weight up towards your hands by flexing your wrists.",
+   "Pause for a moment at the top, then slowly lower the weight back down to the starting position.",
+   "Repeat for the desired number of repetitions."
+  ],
+  "es": [
+   "Sujetá un disco a un extremo de una cuerda atada a una barra.",
+   "Sostené la barra con ambas manos, las palmas hacia abajo.",
+   "Parate con los pies separados al ancho de los hombros y los brazos extendidos por completo al frente.",
+   "Enrollá el peso hacia arriba despacio flexionando las muñecas.",
+   "Hacé una pausa arriba y después desenrollá el peso despacio de vuelta a la posición inicial.",
+   "Repetí durante las repeticiones deseadas."
+  ],
+  "descEs": "Resistencia de antebrazo con flexión repetida de muñeca."
+ },
+ "0114": {
+  "en": [
+   "Stand in front of a bench or step with a barbell resting on your upper back.",
+   "Place one foot on the bench or step, ensuring your entire foot is in contact with the surface.",
+   "Push through your heel and step up onto the bench or step, fully extending your hip and knee.",
+   "Pause briefly at the top, then lower yourself back down to the starting position.",
+   "Repeat with the opposite leg.",
+   "Continue alternating legs for the desired number of repetitions."
+  ],
+  "es": [
+   "Parate frente a un banco o cajón con una barra apoyada sobre la parte alta de la espalda.",
+   "Apoyá un pie sobre el banco o cajón, asegurándote de que toda la planta haga contacto con la superficie.",
+   "Empujá con el talón y subí al banco o cajón, extendiendo por completo la cadera y la rodilla.",
+   "Hacé una pausa breve arriba y después bajá de nuevo a la posición inicial.",
+   "Repetí con la pierna contraria.",
+   "Seguí alternando las piernas la cantidad de repeticiones que quieras."
+  ],
+  "descEs": "Empuje a una sola pierna con demanda de equilibrio."
+ },
+ "0116": {
+  "en": [
+   "Stand with your feet shoulder-width apart and your toes pointing forward.",
+   "Hold the barbell with an overhand grip, hands slightly wider than shoulder-width apart.",
+   "Bend at your hips and lower the barbell towards the ground, keeping your back straight and your knees slightly bent.",
+   "Lower the barbell until you feel a stretch in your hamstrings.",
+   "Engage your hamstrings and glutes to lift the barbell back up to the starting position.",
+   "Repeat for the desired number of repetitions."
+  ],
+  "es": [
+   "Parate con los pies a la altura de los hombros y las puntas de los pies hacia adelante.",
+   "Agarrá la barra con agarre prono, las manos un poco más anchas que los hombros.",
+   "Flexioná desde la cadera y bajá la barra hacia el piso, manteniendo la espalda recta y las rodillas levemente flexionadas.",
+   "Bajá la barra hasta sentir un estiramiento en los isquiotibiales.",
+   "Activá los isquiotibiales y los glúteos para subir la barra de nuevo a la posición inicial.",
+   "Repetí la cantidad de repeticiones que quieras."
+  ],
+  "descEs": "Bisagra de cadera enfocada en los isquiotibiales con flexión mínima de rodilla."
+ },
+ "0120": {
+  "en": [
+   "Stand with your feet shoulder-width apart and hold a barbell with an overhand grip, hands slightly wider than shoulder-width apart.",
+   "Let the barbell hang in front of your thighs, arms fully extended.",
+   "Keeping your back straight and core engaged, exhale and lift the barbell straight up towards your chin, leading with your elbows.",
+   "Pause for a moment at the top, then inhale and slowly lower the barbell back down to the starting position.",
+   "Repeat for the desired number of repetitions."
+  ],
+  "es": [
+   "Parate con los pies a la altura de los hombros y sostené una barra con agarre prono, las manos un poco más anchas que los hombros.",
+   "Dejá colgar la barra frente a los muslos, con los brazos extendidos por completo.",
+   "Manteniendo la espalda recta y el core activo, exhalá y subí la barra en línea recta hacia el mentón, guiando con los codos.",
+   "Hacé una pausa arriba y después inhalá y bajá lentamente la barra a la posición inicial.",
+   "Repetí la cantidad de repeticiones que quieras."
+  ],
+  "descEs": "Tracción vertical que trabaja los deltoides laterales y los trapecios."
+ },
+ "0126": {
+  "en": [
+   "Sit on a bench with your feet flat on the ground and your forearms resting on your thighs, holding a barbell with an underhand grip.",
+   "Allow the barbell to roll down to your fingertips, keeping your wrists straight.",
+   "Slowly curl the barbell up towards your forearms by flexing your wrists.",
+   "Pause for a moment at the top, then slowly lower the barbell back down to the starting position.",
+   "Repeat for the desired number of repetitions."
+  ],
+  "es": [
+   "Sentate en un banco con los pies apoyados en el piso y los antebrazos sobre los muslos, sosteniendo una barra con agarre supino.",
+   "Dejá que la barra ruede hacia la punta de los dedos, manteniendo las muñecas rectas.",
+   "Enrollá lentamente la barra hacia los antebrazos flexionando las muñecas.",
+   "Hacé una pausa arriba y después bajá lentamente la barra a la posición inicial.",
+   "Repetí la cantidad de repeticiones que quieras."
+  ],
+  "descEs": "Aislamiento de los flexores del antebrazo."
+ },
+ "0157": {
+  "en": [
+   "Stand with your feet shoulder-width apart, toes pointed slightly outward.",
+   "Hold the kettlebell with both hands in front of your body, arms extended.",
+   "Bend your knees slightly and hinge at the hips, pushing your butt back.",
+   "Swing the kettlebell back between your legs, keeping your arms straight and maintaining a flat back.",
+   "Drive your hips forward and swing the kettlebell up to shoulder height, using the momentum generated by your hips.",
+   "Allow the kettlebell to swing back down between your legs and repeat the movement for the desired number of repetitions."
+  ],
+  "es": [
+   "Parate con los pies separados al ancho de los hombros y las puntas levemente hacia afuera.",
+   "Sostené la kettlebell con ambas manos frente al cuerpo, los brazos extendidos.",
+   "Flexioná un poco las rodillas y hacé bisagra en la cadera, llevando la cola hacia atrás.",
+   "Balanceá la kettlebell hacia atrás entre las piernas, manteniendo los brazos rectos y la espalda plana.",
+   "Empujá la cadera hacia adelante y balanceá la kettlebell hasta la altura de los hombros, usando el impulso de la cadera.",
+   "Dejá que la kettlebell vuelva a balancearse entre las piernas y repetí el movimiento durante las repeticiones deseadas."
+  ],
+  "descEs": "Bisagra explosiva que entrena los isquiotibiales de forma dinámica."
+ },
+ "0162": {
+  "en": [
+   "Stand with your feet shoulder-width apart and grasp the cable handle with an overhand grip.",
+   "Keep your back straight and your core engaged.",
+   "Raise the cable handle in front of you, keeping your arms straight and your palms facing down.",
+   "Continue lifting until your arms are parallel to the floor.",
+   "Pause for a moment at the top, then slowly lower the cable handle back to the starting position.",
+   "Repeat for the desired number of repetitions."
+  ],
+  "es": [
+   "Parate con los pies a la altura de los hombros y agarrá la manija de la polea con agarre prono.",
+   "Mantené la espalda recta y el core activo.",
+   "Elevá la manija hacia adelante, manteniendo los brazos rectos y las palmas hacia abajo.",
+   "Seguí subiendo hasta que los brazos queden paralelos al piso.",
+   "Hacé una pausa arriba y después bajá lentamente la manija a la posición inicial.",
+   "Repetí la cantidad de repeticiones que quieras."
+  ],
+  "descEs": "Ejercicio accesorio para el deltoides anterior."
+ },
+ "0164": {
+  "en": [
+   "Stand with your feet shoulder-width apart and grasp the cable handle with an overhand grip.",
+   "Keep your back straight and your core engaged.",
+   "Raise the cable handle in front of you, keeping your arms straight and your palms facing down.",
+   "Continue lifting until your arms are parallel to the floor.",
+   "Pause for a moment at the top, then slowly lower the cable handle back to the starting position.",
+   "Repeat for the desired number of repetitions."
+  ],
+  "es": [
+   "Parate con los pies a la altura de los hombros y agarrá la manija de la polea con agarre prono.",
+   "Mantené la espalda recta y el core activo.",
+   "Elevá la manija hacia adelante, manteniendo los brazos rectos y las palmas hacia abajo.",
+   "Seguí subiendo hasta que los brazos queden paralelos al piso.",
+   "Hacé una pausa arriba y después bajá lentamente la manija a la posición inicial.",
+   "Repetí la cantidad de repeticiones que quieras."
+  ],
+  "descEs": "Ejercicio accesorio para el deltoides anterior."
+ },
+ "0165": {
+  "en": [
+   "Stand up straight with a dumbbell in each hand, palms facing forward and arms fully extended.",
+   "Keeping your upper arms stationary, exhale and curl the weights while contracting your biceps.",
+   "Continue to raise the weights until your biceps are fully contracted and the dumbbells are at shoulder level.",
+   "Hold the contracted position for a brief pause as you squeeze your biceps.",
+   "Inhale and slowly begin to lower the dumbbells back to the starting position.",
+   "Repeat for the desired number of repetitions."
+  ],
+  "es": [
+   "Parate erguido con una mancuerna en cada mano, las palmas hacia adelante y los brazos extendidos por completo.",
+   "Manteniendo los brazos pegados al cuerpo, exhalá y curlá los pesos contrayendo los bíceps.",
+   "Seguí elevando los pesos hasta que los bíceps estén completamente contraídos y las mancuernas a la altura de los hombros.",
+   "Mantené la posición contraída una pausa breve apretando los bíceps.",
+   "Inhalá y empezá a bajar despacio las mancuernas a la posición inicial.",
+   "Repetí durante las repeticiones deseadas."
+  ],
+  "descEs": "Curl versátil para la simetría y el rango de los brazos."
+ },
+ "0167": {
+  "en": [
+   "Attach a rope handle to a low pulley cable machine.",
+   "Stand facing the machine with your feet shoulder-width apart.",
+   "Grasp the rope handle with an overhand grip, palms facing each other.",
+   "Bend your knees slightly and hinge forward at the hips, keeping your back straight.",
+   "Keep your elbows slightly bent and pull the rope towards your chest, squeezing your shoulder blades together.",
+   "Pause for a moment at the top of the movement, then slowly release the tension and return to the starting position.",
+   "Repeat for the desired number of repetitions."
+  ],
+  "es": [
+   "Sujetá una cuerda a la polea baja de una máquina de cable.",
+   "Parate de frente a la máquina con los pies separados al ancho de los hombros.",
+   "Agarrá la cuerda con agarre pronado, las palmas enfrentadas.",
+   "Flexioná un poco las rodillas y hacé bisagra en la cadera hacia adelante, manteniendo la espalda recta.",
+   "Con los codos levemente flexionados, traccioná la cuerda hacia el pecho, juntando las escápulas.",
+   "Hacé una pausa al final del movimiento y después soltá la tensión despacio volviendo a la posición inicial.",
+   "Repetí durante las repeticiones deseadas."
+  ],
+  "descEs": "Tracción accesoria para la espalda alta y los deltoides posteriores."
+ },
+ "0178": {
+  "en": [
+   "Stand with your feet shoulder-width apart and grasp the cable handles with an overhand grip.",
+   "Keep your arms straight and your core engaged.",
+   "Raise your arms out to the sides until they are parallel to the floor.",
+   "Pause for a moment at the top, then slowly lower your arms back down to the starting position.",
+   "Repeat for the desired number of repetitions."
+  ],
+  "es": [
+   "Parate con los pies a la altura de los hombros y agarrá las manijas de la polea con agarre prono.",
+   "Mantené los brazos rectos y el core activo.",
+   "Elevá los brazos hacia los costados hasta que queden paralelos al piso.",
+   "Hacé una pausa arriba y después bajá lentamente los brazos a la posición inicial.",
+   "Repetí la cantidad de repeticiones que quieras."
+  ],
+  "descEs": "Ejercicio clásico de aislamiento del deltoides medio."
+ },
+ "0186": {
+  "en": [
+   "Attach a rope handle to a low pulley cable machine.",
+   "Lie down on a flat bench facing up, with your head towards the cable machine.",
+   "Grasp the rope handle with both hands, palms facing each other, and extend your arms straight up over your chest.",
+   "Keeping your upper arms stationary, slowly lower the rope handle towards your forehead by bending your elbows.",
+   "Pause for a moment at the bottom, then extend your arms back up to the starting position.",
+   "Repeat for the desired number of repetitions."
+  ],
+  "es": [
+   "Enganchá una cuerda a la polea baja de la máquina.",
+   "Acostate boca arriba en un banco plano, con la cabeza hacia la máquina.",
+   "Agarrá la cuerda con ambas manos, las palmas enfrentadas, y extendé los brazos hacia arriba por encima del pecho.",
+   "Manteniendo los brazos superiores quietos, bajá lentamente la cuerda hacia la frente flexionando los codos.",
+   "Hacé una pausa abajo y después extendé los brazos de nuevo a la posición inicial.",
+   "Repetí la cantidad de repeticiones que quieras."
+  ],
+  "descEs": "Aislamiento de extensión de codo desde posición acostada."
+ },
+ "0190": {
+  "en": [
+   "Stand facing the cable machine with your feet shoulder-width apart.",
+   "Grasp the cable handle with an underhand grip, palm facing up.",
+   "Keep your elbow close to your side and slowly curl your forearm up towards your shoulder.",
+   "Pause for a moment at the top, then slowly lower your forearm back down to the starting position.",
+   "Repeat for the desired number of repetitions."
+  ],
+  "es": [
+   "Parate de frente a la polea con los pies a la altura de los hombros.",
+   "Agarrá la manija de la polea con agarre supino, la palma hacia arriba.",
+   "Mantené el codo pegado al costado y enrollá lentamente el antebrazo hacia el hombro.",
+   "Hacé una pausa arriba y después bajá lentamente el antebrazo a la posición inicial.",
+   "Repetí la cantidad de repeticiones que quieras."
+  ],
+  "descEs": "Patrón de curl para desarrollo general del brazo."
+ },
+ "0194": {
+  "en": [
+   "Attach a rope to a cable machine at a high position.",
+   "Stand facing away from the machine with your feet shoulder-width apart.",
+   "Grasp the rope with both hands, palms facing each other, and bring your hands above your head.",
+   "Keep your upper arms close to your head and your elbows pointing forward.",
+   "Slowly lower the rope behind your head by bending your elbows.",
+   "Pause for a moment, then extend your arms back up to the starting position.",
+   "Repeat for the desired number of repetitions."
+  ],
+  "es": [
+   "Enganchá una cuerda a la polea en una posición alta.",
+   "Parate de espaldas a la máquina con los pies a la altura de los hombros.",
+   "Agarrá la cuerda con ambas manos, las palmas enfrentadas, y llevá las manos por encima de la cabeza.",
+   "Mantené los brazos superiores pegados a la cabeza y los codos apuntando hacia adelante.",
+   "Bajá lentamente la cuerda por detrás de la cabeza flexionando los codos.",
+   "Hacé una pausa y después extendé los brazos de nuevo a la posición inicial.",
+   "Repetí la cantidad de repeticiones que quieras."
+  ],
+  "descEs": "Patrón de estiramiento y bloqueo final del tríceps."
+ },
+ "0195": {
+  "en": [
+   "Adjust the cable machine so that the preacher curl pad is at chest height.",
+   "Sit on the preacher curl bench and place your upper arms on the pad, gripping the cable attachment with an underhand grip.",
+   "Keep your back straight and your elbows tucked in at your sides.",
+   "Slowly curl the cable attachment up towards your shoulders, squeezing your biceps at the top of the movement.",
+   "Pause for a moment, then slowly lower the cable attachment back down to the starting position.",
+   "Repeat for the desired number of repetitions."
+  ],
+  "es": [
+   "Ajustá la polea para que la almohadilla del banco scott quede a la altura del pecho.",
+   "Sentate en el banco scott y apoyá los brazos superiores sobre la almohadilla, agarrando el accesorio de la polea con agarre supino.",
+   "Mantené la espalda recta y los codos pegados a los costados.",
+   "Enrollá lentamente el accesorio hacia los hombros, apretando los bíceps en el punto máximo del movimiento.",
+   "Hacé una pausa y después bajá lentamente el accesorio a la posición inicial.",
+   "Repetí la cantidad de repeticiones que quieras."
+  ],
+  "descEs": "Curl de tensión constante mediante la torre de poleas."
+ },
+ "0198": {
+  "en": [
+   "Adjust the cable pulldown machine so that the seat is at a comfortable height and the knee pad is secured.",
+   "Sit on the seat with your back straight and your feet flat on the ground.",
+   "Grasp the cable bar with an overhand grip, slightly wider than shoulder-width apart.",
+   "Lean back slightly and engage your core.",
+   "Pull the cable bar down towards your chest, squeezing your shoulder blades together.",
+   "Pause for a moment at the bottom of the movement, then slowly release the bar back to the starting position.",
+   "Repeat for the desired number of repetitions."
+  ],
+  "es": [
+   "Ajustá la máquina de jalón para que el asiento quede a una altura cómoda y la almohadilla de las rodillas esté asegurada.",
+   "Sentate en el asiento con la espalda recta y los pies apoyados en el piso.",
+   "Agarrá la barra de la polea con agarre prono, un poco más ancho que los hombros.",
+   "Inclinate levemente hacia atrás y activá el core.",
+   "Traccioná la barra hacia el pecho, juntando los omóplatos.",
+   "Hacé una pausa abajo del movimiento y después soltá lentamente la barra a la posición inicial.",
+   "Repetí la cantidad de repeticiones que quieras."
+  ],
+  "descEs": "Tracción vertical en máquina cuando las dominadas no son el objetivo."
+ },
+ "0200": {
+  "en": [
+   "Attach a rope attachment to a high pulley on a cable machine.",
+   "Stand facing the machine with your feet shoulder-width apart and a slight bend in your knees.",
+   "Grasp the rope with an overhand grip, palms facing each other.",
+   "Keep your elbows close to your sides and your upper arms stationary throughout the exercise.",
+   "Exhale and push the rope downward by extending your elbows until your arms are fully extended.",
+   "Pause for a moment, then inhale and slowly return to the starting position by allowing your elbows to flex.",
+   "Repeat for the desired number of repetitions."
+  ],
+  "es": [
+   "Enganchá una cuerda a la polea alta de la máquina.",
+   "Parate de frente a la máquina con los pies a la altura de los hombros y una leve flexión en las rodillas.",
+   "Agarrá la cuerda con agarre prono, las palmas enfrentadas.",
+   "Mantené los codos pegados a los costados y los brazos superiores quietos durante todo el ejercicio.",
+   "Exhalá y empujá la cuerda hacia abajo extendiendo los codos hasta que los brazos queden extendidos por completo.",
+   "Hacé una pausa y después inhalá y volvé lentamente a la posición inicial dejando que los codos se flexionen.",
+   "Repetí la cantidad de repeticiones que quieras."
+  ],
+  "descEs": "Patrón general de extensión de brazos para el tríceps."
+ },
+ "0201": {
+  "en": [
+   "Attach a straight bar to a high pulley cable machine.",
+   "Stand facing the machine with your feet shoulder-width apart and a slight bend in your knees.",
+   "Grasp the bar with an overhand grip, hands shoulder-width apart.",
+   "Keep your elbows close to your sides and your upper arms stationary.",
+   "Exhale and push the bar down until your elbows are fully extended.",
+   "Pause for a moment, then inhale and slowly return the bar to the starting position.",
+   "Repeat for the desired number of repetitions."
+  ],
+  "es": [
+   "Enganchá una barra recta a la polea alta de la máquina.",
+   "Parate de frente a la máquina con los pies a la altura de los hombros y una leve flexión en las rodillas.",
+   "Agarrá la barra con agarre prono, las manos a la altura de los hombros.",
+   "Mantené los codos pegados a los costados y los brazos superiores quietos.",
+   "Exhalá y empujá la barra hacia abajo hasta que los codos queden extendidos por completo.",
+   "Hacé una pausa y después inhalá y volvé lentamente la barra a la posición inicial.",
+   "Repetí la cantidad de repeticiones que quieras."
+  ],
+  "descEs": "Aislamiento de tríceps en polea con el torso estable."
+ },
+ "0206": {
+  "en": [
+   "Attach a straight bar to a low pulley cable machine.",
+   "Stand facing the machine with your feet shoulder-width apart and your knees slightly bent.",
+   "Grasp the bar with an underhand grip, hands shoulder-width apart.",
+   "Keep your elbows close to your sides and your upper arms stationary throughout the exercise.",
+   "Exhale and curl the bar up towards your shoulders, contracting your biceps.",
+   "Pause for a moment at the top, squeezing your biceps.",
+   "Inhale and slowly lower the bar back to the starting position, fully extending your arms.",
+   "Repeat for the desired number of repetitions."
+  ],
+  "es": [
+   "Enganchá una barra recta a la polea baja de la máquina.",
+   "Parate de frente a la máquina con los pies a la altura de los hombros y las rodillas levemente flexionadas.",
+   "Agarrá la barra con agarre supino, las manos a la altura de los hombros.",
+   "Mantené los codos pegados a los costados y los brazos superiores quietos durante todo el ejercicio.",
+   "Exhalá y enrollá la barra hacia los hombros, contrayendo los bíceps.",
+   "Hacé una pausa arriba, apretando los bíceps.",
+   "Inhalá y bajá lentamente la barra a la posición inicial, extendiendo por completo los brazos.",
+   "Repetí la cantidad de repeticiones que quieras."
+  ],
+  "descEs": "Curl con agarre pronado para los antebrazos y el braquial."
+ },
+ "0207": {
+  "en": [
+   "Attach a straight bar to a high pulley cable machine.",
+   "Stand facing the machine with your feet shoulder-width apart.",
+   "Grasp the bar with an underhand grip, palms facing up, and your hands shoulder-width apart.",
+   "Keep your elbows close to your sides and your upper arms stationary throughout the exercise.",
+   "Using your triceps, push the bar down until your arms are fully extended and your triceps are contracted.",
+   "Pause for a moment, then slowly return the bar to the starting position.",
+   "Repeat for the desired number of repetitions."
+  ],
+  "es": [
+   "Enganchá una barra recta a la polea alta de la máquina.",
+   "Parate de frente a la máquina con los pies a la altura de los hombros.",
+   "Agarrá la barra con agarre supino, las palmas hacia arriba, y las manos a la altura de los hombros.",
+   "Mantené los codos pegados a los costados y los brazos superiores quietos durante todo el ejercicio.",
+   "Con el tríceps, empujá la barra hacia abajo hasta que los brazos queden extendidos por completo y el tríceps contraído.",
+   "Hacé una pausa y después volvé lentamente la barra a la posición inicial.",
+   "Repetí la cantidad de repeticiones que quieras."
+  ],
+  "descEs": "Aislamiento de tríceps en polea con el torso estable."
+ },
+ "0210": {
+  "en": [
+   "Attach a cable to a low pulley and sit on a bench facing the cable machine.",
+   "Grasp the cable handle with an overhand grip, palms facing down.",
+   "Rest your forearms on your thighs, with your wrists hanging off the edge.",
+   "Keeping your forearms stationary, exhale and curl your wrists upward as far as possible.",
+   "Pause for a moment at the top, then inhale and slowly lower your wrists back down to the starting position.",
+   "Repeat for the desired number of repetitions."
+  ],
+  "es": [
+   "Enganchá una polea baja y sentate en un banco de frente a la máquina.",
+   "Agarrá la manija de la polea con agarre prono, las palmas hacia abajo.",
+   "Apoyá los antebrazos sobre los muslos, con las muñecas colgando del borde.",
+   "Manteniendo los antebrazos quietos, exhalá y enrollá las muñecas hacia arriba lo más posible.",
+   "Hacé una pausa arriba y después inhalá y bajá lentamente las muñecas a la posición inicial.",
+   "Repetí la cantidad de repeticiones que quieras."
+  ],
+  "descEs": "Aislamiento de los extensores del antebrazo."
+ },
+ "0213": {
+  "en": [
+   "Attach a rope handle to a low pulley cable machine.",
+   "Stand facing the machine with your feet shoulder-width apart.",
+   "Grasp the rope handle with an overhand grip, palms facing each other.",
+   "Bend your knees slightly and hinge forward at the hips, keeping your back straight.",
+   "Keep your elbows slightly bent and pull the rope towards your chest, squeezing your shoulder blades together.",
+   "Pause for a moment at the top of the movement, then slowly release the tension and return to the starting position.",
+   "Repeat for the desired number of repetitions."
+  ],
+  "es": [
+   "Sujetá una cuerda a la polea baja de una máquina de cable.",
+   "Parate de frente a la máquina con los pies separados al ancho de los hombros.",
+   "Agarrá la cuerda con agarre pronado, las palmas enfrentadas.",
+   "Flexioná un poco las rodillas y hacé bisagra en la cadera hacia adelante, manteniendo la espalda recta.",
+   "Con los codos levemente flexionados, traccioná la cuerda hacia el pecho, juntando las escápulas.",
+   "Hacé una pausa al final del movimiento y después soltá la tensión despacio volviendo a la posición inicial.",
+   "Repetí durante las repeticiones deseadas."
+  ],
+  "descEs": "Tracción accesoria para la espalda alta y los deltoides posteriores."
+ },
+ "0227": {
+  "en": [
+   "Attach the handles to the cables at chest height.",
+   "Stand with your feet shoulder-width apart, facing away from the cable machine.",
+   "Grasp the handles with an overhand grip, palms facing forward.",
+   "Step forward slightly to create tension in the cables.",
+   "Keep your core engaged and your back straight throughout the exercise.",
+   "With a slight bend in your elbows, slowly bring your arms forward and together in front of your chest.",
+   "Squeeze your chest muscles at the peak of the movement.",
+   "Slowly reverse the movement, returning your arms to the starting position.",
+   "Repeat for the desired number of repetitions."
+  ],
+  "es": [
+   "Enganchá las manijas a las poleas a la altura del pecho.",
+   "Parate con los pies a la altura de los hombros, de espaldas a la máquina.",
+   "Agarrá las manijas con agarre prono, las palmas hacia adelante.",
+   "Dá un paso adelante para generar tensión en las poleas.",
+   "Mantené el core activo y la espalda recta durante todo el ejercicio.",
+   "Con una leve flexión en los codos, llevá lentamente los brazos hacia adelante y juntos frente al pecho.",
+   "Apretá los pectorales en el pico del movimiento.",
+   "Revertí lentamente el movimiento, llevando los brazos de nuevo a la posición inicial.",
+   "Repetí la cantidad de repeticiones que quieras."
+  ],
+  "descEs": "Aducción de pecho en polea con tensión constante."
+ },
+ "0238": {
+  "en": [
+   "Attach a straight bar to the high pulley of a cable machine.",
+   "Stand facing the machine with your feet shoulder-width apart.",
+   "Grasp the bar with an overhand grip, keeping your arms straight and your palms facing down.",
+   "Engage your lats and pull the bar down towards your thighs, keeping your arms straight throughout the movement.",
+   "Pause for a moment at the bottom, then slowly return the bar to the starting position.",
+   "Repeat for the desired number of repetitions."
+  ],
+  "es": [
+   "Enganchá una barra recta a la polea alta de la máquina.",
+   "Parate de frente a la máquina con los pies a la altura de los hombros.",
+   "Agarrá la barra con agarre prono, manteniendo los brazos rectos y las palmas hacia abajo.",
+   "Activá los dorsales y traccioná la barra hacia los muslos, manteniendo los brazos rectos durante todo el movimiento.",
+   "Hacé una pausa abajo y después volvé lentamente la barra a la posición inicial.",
+   "Repetí la cantidad de repeticiones que quieras."
+  ],
+  "descEs": "Aislamiento de dorsales con los codos bloqueados."
+ },
+ "0240": {
+  "en": [
+   "Attach a D-handle to a low pulley cable machine and lie face down on a flat bench.",
+   "Grasp the D-handle with each hand, palms facing down, and extend your arms straight out in front of you.",
+   "Keeping your arms straight, raise them out to the sides until they are parallel to the floor.",
+   "Pause for a moment at the top, then slowly lower your arms back down to the starting position.",
+   "Repeat for the desired number of repetitions."
+  ],
+  "es": [
+   "Enganchá una manija en D a la polea baja de la máquina y acostate boca abajo en un banco plano.",
+   "Agarrá una manija en D con cada mano, las palmas hacia abajo, y extendé los brazos rectos hacia adelante.",
+   "Manteniendo los brazos rectos, elevalos hacia los costados hasta que queden paralelos al piso.",
+   "Hacé una pausa arriba y después bajá lentamente los brazos a la posición inicial.",
+   "Repetí la cantidad de repeticiones que quieras."
+  ],
+  "descEs": "Trabajo de aislamiento para los deltoides posteriores y la espalda alta."
+ },
+ "0241": {
+  "en": [
+   "Attach a rope attachment to a high pulley on a cable machine.",
+   "Stand facing the machine with your feet shoulder-width apart and a slight bend in your knees.",
+   "Grasp the rope with an overhand grip, palms facing each other.",
+   "Keep your elbows close to your sides and your upper arms stationary throughout the exercise.",
+   "Exhale and push the rope downward by extending your elbows until your arms are fully extended.",
+   "Pause for a moment, then inhale and slowly return to the starting position by allowing your elbows to flex.",
+   "Repeat for the desired number of repetitions."
+  ],
+  "es": [
+   "Sujetá una cuerda a la polea alta de una máquina de cable.",
+   "Parate de frente a la máquina con los pies separados al ancho de los hombros y una leve flexión en las rodillas.",
+   "Agarrá la cuerda con agarre pronado, las palmas enfrentadas.",
+   "Mantené los codos pegados a los costados y los brazos quietos durante todo el ejercicio.",
+   "Exhalá y empujá la cuerda hacia abajo extendiendo los codos hasta que los brazos queden completamente extendidos.",
+   "Hacé una pausa y después inhalá y volvé despacio a la posición inicial dejando que los codos se flexionen.",
+   "Repetí durante las repeticiones deseadas."
+  ],
+  "descEs": "Accesorio de brazo con fuerte bloqueo final de tríceps."
+ },
+ "0246": {
+  "en": [
+   "Stand with your feet shoulder-width apart, knees slightly bent, and hold the cable attachment with an overhand grip.",
+   "Keep your back straight and your core engaged throughout the exercise.",
+   "Pull the cable attachment straight up towards your chin, leading with your elbows.",
+   "Pause for a moment at the top, squeezing your shoulder blades together.",
+   "Slowly lower the cable attachment back down to the starting position.",
+   "Repeat for the desired number of repetitions."
+  ],
+  "es": [
+   "Parate con los pies a la altura de los hombros, las rodillas levemente flexionadas, y sostené el accesorio de la polea con agarre prono.",
+   "Mantené la espalda recta y el core activo durante todo el ejercicio.",
+   "Traccioná el accesorio en línea recta hacia el mentón, guiando con los codos.",
+   "Hacé una pausa arriba, juntando los omóplatos.",
+   "Bajá lentamente el accesorio a la posición inicial.",
+   "Repetí la cantidad de repeticiones que quieras."
+  ],
+  "descEs": "Tracción vertical que trabaja los deltoides laterales y los trapecios."
+ },
+ "0247": {
+  "en": [
+   "Attach a straight bar to a low pulley cable machine.",
+   "Stand facing the machine with your feet shoulder-width apart.",
+   "Grasp the bar with an underhand grip, palms facing up, and your hands shoulder-width apart.",
+   "Rest your forearms on a bench or pad, with your wrists hanging off the edge.",
+   "Keeping your forearms stationary, exhale and curl your wrists upward as far as possible.",
+   "Pause for a moment at the top, then inhale and slowly lower the bar back to the starting position.",
+   "Repeat for the desired number of repetitions."
+  ],
+  "es": [
+   "Enganchá una barra recta a la polea baja de la máquina.",
+   "Parate de frente a la máquina con los pies a la altura de los hombros.",
+   "Agarrá la barra con agarre supino, las palmas hacia arriba, y las manos a la altura de los hombros.",
+   "Apoyá los antebrazos sobre un banco o almohadilla, con las muñecas colgando del borde.",
+   "Manteniendo los antebrazos quietos, exhalá y enrollá las muñecas hacia arriba lo más posible.",
+   "Hacé una pausa arriba y después inhalá y bajá lentamente la barra a la posición inicial.",
+   "Repetí la cantidad de repeticiones que quieras."
+  ],
+  "descEs": "Aislamiento de los flexores del antebrazo."
+ },
+ "0251": {
+  "en": [
+   "Position yourself on parallel bars with your arms fully extended and your body straight.",
+   "Lower your body by bending your elbows until your shoulders are below your elbows.",
+   "Push yourself back up to the starting position by straightening your arms.",
+   "Repeat for the desired number of repetitions."
+  ],
+  "es": [
+   "Ubicate en las barras paralelas con los brazos extendidos por completo y el cuerpo recto.",
+   "Bajá el cuerpo flexionando los codos hasta que los hombros queden por debajo de los codos.",
+   "Empujá de nuevo hacia arriba a la posición inicial estirando los brazos.",
+   "Repetí la cantidad de repeticiones que quieras."
+  ],
+  "descEs": "Fondo enfocado en el pecho con fuerte demanda de pectoral inferior y tríceps."
+ },
+ "0259": {
+  "en": [
+   "Sit on the edge of a bench or chair with your hands gripping the edge next to your hips.",
+   "Slide your butt off the bench and straighten your legs in front of you, keeping your heels on the ground.",
+   "Bend your elbows and lower your body towards the ground, keeping your back close to the bench.",
+   "Pause for a moment at the bottom, then push yourself back up to the starting position.",
+   "Repeat for the desired number of repetitions."
+  ],
+  "es": [
+   "Sentate en el borde de un banco o silla con las manos agarrando el borde al lado de la cadera.",
+   "Deslizá la cola fuera del banco y estirá las piernas al frente, manteniendo los talones en el suelo.",
+   "Flexioná los codos y bajá el cuerpo hacia el suelo, manteniendo la espalda cerca del banco.",
+   "Hacé una pausa abajo y después empujá para volver a la posición inicial.",
+   "Repetí durante las repeticiones deseadas."
+  ],
+  "descEs": "Movimiento simple de tríceps con peso corporal."
+ },
+ "0262": {
+  "en": [
+   "Lie flat on your back with your knees bent and feet flat on the ground.",
+   "Place your hands behind your head with your elbows pointing outwards.",
+   "Engaging your abs, lift your upper body off the ground and twist to bring your right elbow towards your left knee.",
+   "Pause for a moment at the top, then slowly lower your upper body back down to the starting position.",
+   "Repeat on the other side, bringing your left elbow towards your right knee.",
+   "Repeat for the desired number of repetitions."
+  ],
+  "es": [
+   "Acostate boca arriba con las rodillas flexionadas y los pies apoyados en el piso.",
+   "Colocá las manos detrás de la cabeza con los codos apuntando hacia afuera.",
+   "Activando los abdominales, levantá el torso del piso y girá para llevar el codo derecho hacia la rodilla izquierda.",
+   "Hacé una pausa arriba y después bajá lentamente el torso a la posición inicial.",
+   "Repetí del otro lado, llevando el codo izquierdo hacia la rodilla derecha.",
+   "Repetí la cantidad de repeticiones que quieras."
+  ],
+  "descEs": "Rotación dinámica del tronco con flexión abdominal."
+ },
+ "0271": {
+  "en": [
+   "Lie flat on your back with your arms extended along your sides.",
+   "Bend your knees and lift your feet off the ground, bringing your thighs perpendicular to the floor.",
+   "Contract your abs and curl your hips off the floor, bringing your knees towards your chest.",
+   "Pause for a moment at the top, then slowly lower your hips back down to the starting position.",
+   "Repeat for the desired number of repetitions."
+  ],
+  "es": [
+   "Recostate de espaldas con los brazos extendidos a los costados.",
+   "Flexioná las rodillas y levantá los pies del suelo, llevando los muslos perpendiculares al piso.",
+   "Contraé los abdominales y elevá la cadera del suelo, llevando las rodillas hacia el pecho.",
+   "Hacé una pausa arriba y después bajá la cadera despacio a la posición inicial.",
+   "Repetí durante las repeticiones deseadas."
+  ],
+  "descEs": "Ejercicio de bascula pélvica posterior enfocado en el abdomen bajo."
+ },
+ "0276": {
+  "en": [
+   "Lie flat on your back with your arms extended towards the ceiling.",
+   "Bend your knees and lift your legs off the ground, creating a 90-degree angle at your hips and knees.",
+   "Engage your core and lower back to press your lower back into the ground.",
+   "Slowly lower your right arm and left leg towards the ground, keeping them straight and hovering just above the floor.",
+   "Pause for a moment, then return to the starting position.",
+   "Repeat the movement with your left arm and right leg.",
+   "Continue alternating sides for the desired number of repetitions."
+  ],
+  "es": [
+   "Acostate boca arriba con los brazos extendidos hacia el techo.",
+   "Flexioná las rodillas y elevá las piernas formando un ángulo de 90 grados en caderas y rodillas.",
+   "Activá el core y presioná la zona lumbar contra el piso.",
+   "Bajá lentamente el brazo derecho y la pierna izquierda hacia el piso, manteniéndolos rectos y flotando justo por encima del suelo.",
+   "Hacé una pausa y después volvé a la posición inicial.",
+   "Repetí el movimiento con el brazo izquierdo y la pierna derecha.",
+   "Seguí alternando lados por la cantidad de repeticiones deseada."
+  ],
+  "descEs": "Ejercicio de coordinación del core amigable con la zona lumbar."
+ },
+ "0279": {
+  "en": [
+   "Start in a high plank position with your hands slightly wider than shoulder-width apart and your feet together.",
+   "Engage your core and lower your body towards the ground by bending your elbows, keeping your body in a straight line.",
+   "Pause for a moment when your chest is just above the ground, then push yourself back up to the starting position by straightening your arms.",
+   "Repeat for the desired number of repetitions."
+  ],
+  "es": [
+   "Empezá en posición de plancha alta con las manos algo más abiertas que el ancho de los hombros y los pies juntos.",
+   "Activá el core y bajá el cuerpo hacia el suelo flexionando los codos, manteniendo el cuerpo en línea recta.",
+   "Hacé una pausa cuando el pecho esté justo por encima del suelo y después empujá para volver a la posición inicial estirando los brazos.",
+   "Repetí durante las repeticiones deseadas."
+  ],
+  "descEs": "Press clásico con peso corporal para pecho y tríceps."
+ },
+ "0282": {
+  "en": [
+   "Lie on a decline bench with your feet secured and your knees bent.",
+   "Place your hands behind your head or across your chest.",
+   "Engage your abs and lift your upper body off the bench, curling forward towards your knees.",
+   "Pause for a moment at the top, then slowly lower your upper body back down to the starting position.",
+   "Repeat for the desired number of repetitions."
+  ],
+  "es": [
+   "Acostate en un banco declinado con los pies sujetos y las rodillas flexionadas.",
+   "Colocá las manos detrás de la cabeza o cruzadas sobre el pecho.",
+   "Activá los abdominales y elevá el tronco del banco, enrollándote hacia las rodillas.",
+   "Hacé una pausa arriba y después bajá lentamente el tronco hasta la posición inicial.",
+   "Repetí la cantidad de repeticiones deseada."
+  ],
+  "descEs": "Flexión completa del tronco en todo el rango."
+ },
+ "0283": {
+  "en": [
+   "Start in a high plank position with your hands close together, forming a diamond shape with your thumbs and index fingers.",
+   "Keep your body in a straight line from head to toe, engaging your core and glutes.",
+   "Lower your chest towards the diamond shape formed by your hands, keeping your elbows close to your body.",
+   "Pause for a moment at the bottom, then push yourself back up to the starting position.",
+   "Repeat for the desired number of repetitions."
+  ],
+  "es": [
+   "Empezá en posición de plancha alta con las manos juntas, formando un rombo con los pulgares y los índices.",
+   "Mantené el cuerpo en línea recta de la cabeza a los pies, activando el core y los glúteos.",
+   "Bajá el pecho hacia el rombo que forman tus manos, manteniendo los codos cerca del cuerpo.",
+   "Hacé una pausa abajo y después empujá para volver a la posición inicial.",
+   "Repetí la cantidad de repeticiones deseada."
+  ],
+  "descEs": "Press con peso corporal para tríceps y pecho."
+ },
+ "0284": {
+  "en": [
+   "Stand with your toes on an elevated surface, such as a step or block.",
+   "Place your hands on a stable support, such as a wall or railing, for balance.",
+   "Raise your heels as high as possible, lifting your body weight onto the balls of your feet.",
+   "Pause for a moment at the top, then slowly lower your heels back down to the starting position.",
+   "Repeat for the desired number of repetitions."
+  ],
+  "es": [
+   "Pará con las puntas de los pies sobre una superficie elevada, como un escalón o un cajón.",
+   "Apoyá las manos en un soporte estable, como una pared o un pasamanos, para mantener el equilibrio.",
+   "Elevá los talones lo más alto posible, llevando el peso del cuerpo a las puntas de los pies.",
+   "Hacé una pausa arriba y después bajá lentamente los talones hasta la posición inicial.",
+   "Repetí la cantidad de repeticiones deseada."
+  ],
+  "descEs": "Fuerza de gemelos y estabilidad de tobillo."
+ },
+ "0287": {
+  "en": [
+   "Sit on a bench with back support and hold a dumbbell in each hand at shoulder level, palms facing your body and elbows bent.",
+   "Press the dumbbells upward until your arms are fully extended and your palms are facing forward.",
+   "Rotate your wrists as you lift, so that your palms end up facing forward at the top of the movement.",
+   "Pause for a moment at the top, then slowly lower the dumbbells back to the starting position.",
+   "Repeat for the desired number of repetitions."
+  ],
+  "es": [
+   "Sentate en un banco con respaldo y sostené una mancuerna en cada mano a la altura de los hombros, palmas hacia el cuerpo y codos flexionados.",
+   "Presioná las mancuernas hacia arriba hasta extender por completo los brazos, con las palmas mirando al frente.",
+   "Rotá las muñecas a medida que subís, de modo que las palmas terminen mirando hacia adelante arriba del movimiento.",
+   "Hacé una pausa arriba y después bajá lentamente las mancuernas hasta la posición inicial.",
+   "Repetí la cantidad de repeticiones deseada."
+  ],
+  "descEs": "Press rotacional con mancuernas para el desarrollo completo del deltoides."
+ },
+ "0289": {
+  "en": [
+   "Lie flat on a bench with your feet flat on the ground and your back pressed against the bench.",
+   "Hold a dumbbell in each hand, with your palms facing forward and your arms extended above your chest.",
+   "Lower the dumbbells slowly to the sides of your chest, keeping your elbows at a 90-degree angle.",
+   "Pause for a moment, then push the dumbbells back up to the starting position, fully extending your arms.",
+   "Repeat for the desired number of repetitions."
+  ],
+  "es": [
+   "Acostate boca arriba en un banco con los pies apoyados en el piso y la espalda pegada al banco.",
+   "Sostené una mancuerna en cada mano, con las palmas hacia adelante y los brazos extendidos por encima del pecho.",
+   "Bajá lentamente las mancuernas hacia los costados del pecho, manteniendo los codos a 90 grados.",
+   "Hacé una pausa y después empujá las mancuernas de nuevo hacia arriba hasta la posición inicial, extendiendo por completo los brazos.",
+   "Repetí la cantidad de repeticiones deseada."
+  ],
+  "descEs": "Press horizontal estándar para la fuerza del pecho."
+ },
+ "0297": {
+  "en": [
+   "Sit on a bench with your legs spread apart and a dumbbell in one hand, resting your elbow on the inside of your thigh.",
+   "Fully extend your arm and hold the dumbbell with an underhand grip.",
+   "Keeping your upper arm stationary, exhale and curl the weight up towards your shoulder while contracting your biceps.",
+   "Continue to raise the dumbbell until your biceps are fully contracted and the dumbbell is at shoulder level.",
+   "Hold the contracted position for a brief pause as you squeeze your biceps.",
+   "Inhale and slowly lower the dumbbell back to the starting position.",
+   "Repeat for the desired number of repetitions, then switch arms."
+  ],
+  "es": [
+   "Sentate en un banco con las piernas separadas y una mancuerna en una mano, apoyando el codo en la cara interna del muslo.",
+   "Extendé por completo el brazo y sostené la mancuerna con agarre supino.",
+   "Manteniendo el brazo superior quieto, exhalá y subí el peso hacia el hombro contrayendo el bíceps.",
+   "Seguí elevando la mancuerna hasta contraer por completo el bíceps, con la mancuerna a la altura del hombro.",
+   "Mantené la contracción una breve pausa apretando el bíceps.",
+   "Inhalá y bajá lentamente la mancuerna hasta la posición inicial.",
+   "Repetí la cantidad de repeticiones deseada y después cambiá de brazo."
+  ],
+  "descEs": "Curl estricto con máximo foco en el bíceps."
+ },
+ "0298": {
+  "en": [
+   "Stand up straight with a dumbbell in each hand, palms facing your body.",
+   "Keep your elbows close to your torso and your upper arms stationary.",
+   "Exhale and curl the weights while contracting your biceps, bringing the dumbbells across your body towards your opposite shoulder.",
+   "Continue to raise the dumbbells until your biceps are fully contracted and the dumbbells are at shoulder level.",
+   "Hold the contracted position for a brief pause as you squeeze your biceps.",
+   "Inhale and slowly begin to lower the dumbbells back to the starting position.",
+   "Repeat for the desired number of repetitions."
+  ],
+  "es": [
+   "Pará derecho con una mancuerna en cada mano, palmas hacia el cuerpo.",
+   "Mantené los codos cerca del torso y los brazos superiores quietos.",
+   "Exhalá y subí los pesos contrayendo el bíceps, llevando las mancuernas a través del cuerpo hacia el hombro opuesto.",
+   "Seguí elevando las mancuernas hasta contraer por completo el bíceps, con las mancuernas a la altura del hombro.",
+   "Mantené la contracción una breve pausa apretando el bíceps.",
+   "Inhalá y empezá a bajar lentamente las mancuernas hasta la posición inicial.",
+   "Repetí la cantidad de repeticiones deseada."
+  ],
+  "descEs": "Curl con agarre neutro para el braquial y los antebrazos."
+ },
+ "0300": {
+  "en": [
+   "Stand with your feet shoulder-width apart, toes pointing forward.",
+   "Hold a dumbbell in each hand, palms facing your body, arms extended downwards.",
+   "Bend at your hips and knees, lowering the dumbbells towards the ground while keeping your back straight.",
+   "Push through your heels and extend your hips and knees, lifting the dumbbells back up to the starting position.",
+   "Repeat for the desired number of repetitions."
+  ],
+  "es": [
+   "Pará con los pies al ancho de los hombros y las puntas apuntando hacia adelante.",
+   "Sostené una mancuerna en cada mano, palmas hacia el cuerpo y brazos extendidos hacia abajo.",
+   "Flexioná caderas y rodillas, bajando las mancuernas hacia el piso mientras mantenés la espalda recta.",
+   "Empujá con los talones y extendé caderas y rodillas, subiendo las mancuernas de nuevo hasta la posición inicial.",
+   "Repetí la cantidad de repeticiones deseada."
+  ],
+  "descEs": "Patrón completo de tracción y bisagra de la cadena posterior."
+ },
+ "0301": {
+  "en": [
+   "Lie down on a decline bench with your feet secured and your head lower than your hips.",
+   "Hold a dumbbell in each hand and extend your arms straight up above your chest, palms facing forward.",
+   "Lower the dumbbells slowly to the sides of your chest, keeping your elbows at a 90-degree angle.",
+   "Push the dumbbells back up to the starting position, fully extending your arms.",
+   "Repeat for the desired number of repetitions."
+  ],
+  "es": [
+   "Acostate en un banco declinado con los pies sujetos y la cabeza más abajo que las caderas.",
+   "Sostené una mancuerna en cada mano y extendé los brazos hacia arriba por encima del pecho, palmas hacia adelante.",
+   "Bajá lentamente las mancuernas hacia los costados del pecho, manteniendo los codos a 90 grados.",
+   "Empujá las mancuernas de nuevo hacia arriba hasta la posición inicial, extendiendo por completo los brazos.",
+   "Repetí la cantidad de repeticiones deseada."
+  ],
+  "descEs": "Variante de press declinado que enfatiza la parte baja del pecho."
+ },
+ "0308": {
+  "en": [
+   "Lie flat on a bench with a dumbbell in each hand, palms facing each other.",
+   "Extend your arms straight up over your chest, with a slight bend in your elbows.",
+   "Keeping a slight bend in your elbows, lower your arms out to the sides in a wide arc until you feel a stretch in your chest.",
+   "Pause for a moment, then reverse the movement and bring the dumbbells back up to the starting position.",
+   "Repeat for the desired number of repetitions."
+  ],
+  "es": [
+   "Acostate boca arriba en un banco con una mancuerna en cada mano, palmas enfrentadas.",
+   "Extendé los brazos hacia arriba por encima del pecho, con una leve flexión en los codos.",
+   "Manteniendo esa leve flexión en los codos, bajá los brazos hacia los costados en un arco amplio hasta sentir un estiramiento en el pecho.",
+   "Hacé una pausa y después invertí el movimiento y subí de nuevo las mancuernas hasta la posición inicial.",
+   "Repetí la cantidad de repeticiones deseada."
+  ],
+  "descEs": "Movimiento de aislamiento para la aducción y el estiramiento del pecho."
+ },
+ "0310": {
+  "en": [
+   "Stand with your feet shoulder-width apart, holding a dumbbell in each hand with your palms facing your thighs.",
+   "Keeping your arms straight, exhale and lift the dumbbells in front of you until they are at shoulder level.",
+   "Pause for a moment at the top, then inhale and slowly lower the dumbbells back down to the starting position.",
+   "Repeat for the desired number of repetitions."
+  ],
+  "es": [
+   "Pará con los pies al ancho de los hombros, sosteniendo una mancuerna en cada mano con las palmas hacia los muslos.",
+   "Manteniendo los brazos rectos, exhalá y elevá las mancuernas al frente hasta la altura de los hombros.",
+   "Hacé una pausa arriba y después inhalá y bajá lentamente las mancuernas hasta la posición inicial.",
+   "Repetí la cantidad de repeticiones deseada."
+  ],
+  "descEs": "Ejercicio accesorio para el deltoides anterior."
+ },
+ "0313": {
+  "en": [
+   "Stand up straight with a dumbbell in each hand, palms facing your torso.",
+   "Keep your elbows close to your torso and rotate the palms of your hands until they are facing forward.",
+   "This will be your starting position.",
+   "Now, keeping the upper arms stationary, exhale and curl the weights while contracting your biceps.",
+   "Continue to raise the weights until your biceps are fully contracted and the dumbbells are at shoulder level.",
+   "Hold the contracted position for a brief pause as you squeeze your biceps.",
+   "Then, inhale and slowly begin to lower the dumbbells back to the starting position.",
+   "Repeat for the recommended amount of repetitions."
+  ],
+  "es": [
+   "Pará derecho con una mancuerna en cada mano, palmas hacia el torso.",
+   "Mantené los codos cerca del torso y rotá las palmas hasta que miren hacia adelante.",
+   "Esta será tu posición inicial.",
+   "Ahora, manteniendo los brazos superiores quietos, exhalá y subí los pesos contrayendo el bíceps.",
+   "Seguí elevando los pesos hasta contraer por completo el bíceps, con las mancuernas a la altura del hombro.",
+   "Mantené la contracción una breve pausa apretando el bíceps.",
+   "Después inhalá y empezá a bajar lentamente las mancuernas hasta la posición inicial.",
+   "Repetí la cantidad de repeticiones recomendada."
+  ],
+  "descEs": "Curl versátil para la simetría y el rango del brazo."
+ },
+ "0314": {
+  "en": [
+   "Set up an incline bench at a 45-degree angle.",
+   "Sit on the bench with your feet flat on the ground and your back pressed firmly against the bench.",
+   "Hold a dumbbell in each hand, palms facing forward, and lift them to shoulder height.",
+   "Slowly lower the dumbbells to the sides of your chest, keeping your elbows at a 90-degree angle.",
+   "Push the dumbbells back up to the starting position, fully extending your arms.",
+   "Repeat for the desired number of repetitions."
+  ],
+  "es": [
+   "Configurá un banco inclinado a 45 grados.",
+   "Sentate en el banco con los pies apoyados en el piso y la espalda bien pegada al banco.",
+   "Sostené una mancuerna en cada mano, palmas hacia adelante, y subilas a la altura de los hombros.",
+   "Bajá lentamente las mancuernas hacia los costados del pecho, manteniendo los codos a 90 grados.",
+   "Empujá las mancuernas de nuevo hacia arriba hasta la posición inicial, extendiendo por completo los brazos.",
+   "Repetí la cantidad de repeticiones deseada."
+  ],
+  "descEs": "Variante de press inclinado que enfatiza la parte alta del pecho."
+ },
+ "0318": {
+  "en": [
+   "Set an incline bench to a 45-degree angle and sit on it with a dumbbell in each hand, palms facing forward.",
+   "Rest your upper arms on the incline bench and let your elbows hang down, fully extending your arms.",
+   "Keeping your upper arms stationary, exhale and curl the weights while contracting your biceps.",
+   "Continue to raise the dumbbells until your biceps are fully contracted and the dumbbells are at shoulder level.",
+   "Hold the contracted position for a brief pause as you squeeze your biceps.",
+   "Inhale and slowly begin to lower the dumbbells back to the starting position.",
+   "Repeat for the desired number of repetitions."
+  ],
+  "es": [
+   "Configurá un banco inclinado a 45 grados y sentate con una mancuerna en cada mano, palmas hacia adelante.",
+   "Apoyá los brazos superiores sobre el banco inclinado y dejá colgar los codos, extendiendo por completo los brazos.",
+   "Manteniendo los brazos superiores quietos, exhalá y subí los pesos contrayendo el bíceps.",
+   "Seguí elevando las mancuernas hasta contraer por completo el bíceps, con las mancuernas a la altura del hombro.",
+   "Mantené la contracción una breve pausa apretando el bíceps.",
+   "Inhalá y empezá a bajar lentamente las mancuernas hasta la posición inicial.",
+   "Repetí la cantidad de repeticiones deseada."
+  ],
+  "descEs": "Curl de bíceps realizado en banco inclinado."
+ },
+ "0320": {
+  "en": [
+   "Sit on an incline bench with a dumbbell in each hand, palms facing your torso and arms fully extended.",
+   "Keep your back against the bench and your feet flat on the floor.",
+   "While keeping your upper arms stationary, exhale and curl the weights while contracting your biceps.",
+   "Continue to raise the weights until your biceps are fully contracted and the dumbbells are at shoulder level.",
+   "Hold the contracted position for a brief pause as you squeeze your biceps.",
+   "Inhale and slowly begin to lower the dumbbells back to the starting position.",
+   "Repeat for the desired number of repetitions."
+  ],
+  "es": [
+   "Sentate en un banco inclinado con una mancuerna en cada mano, palmas hacia el torso y brazos extendidos por completo.",
+   "Mantené la espalda contra el banco y los pies apoyados en el piso.",
+   "Manteniendo los brazos superiores quietos, exhalá y subí los pesos contrayendo el bíceps.",
+   "Seguí elevando los pesos hasta contraer por completo el bíceps, con las mancuernas a la altura del hombro.",
+   "Mantené la contracción una breve pausa apretando el bíceps.",
+   "Inhalá y empezá a bajar lentamente las mancuernas hasta la posición inicial.",
+   "Repetí la cantidad de repeticiones deseada."
+  ],
+  "descEs": "Curl con agarre neutro para el braquial y los antebrazos."
+ },
+ "0327": {
+  "en": [
+   "Set up an incline bench at a 45-degree angle.",
+   "Grab a dumbbell in each hand and sit on the bench with your chest against the incline.",
+   "Extend your arms fully, allowing the dumbbells to hang straight down from your shoulders.",
+   "Pull the dumbbells up towards your chest, squeezing your shoulder blades together.",
+   "Pause for a moment at the top, then slowly lower the dumbbells back to the starting position.",
+   "Repeat for the desired number of repetitions."
+  ],
+  "es": [
+   "Configurá un banco inclinado a 45 grados.",
+   "Agarrá una mancuerna en cada mano y sentate en el banco con el pecho apoyado contra la inclinación.",
+   "Extendé por completo los brazos, dejando que las mancuernas cuelguen rectas desde los hombros.",
+   "Tirá de las mancuernas hacia el pecho, juntando las escápulas.",
+   "Hacé una pausa arriba y después bajá lentamente las mancuernas hasta la posición inicial.",
+   "Repetí la cantidad de repeticiones deseada."
+  ],
+  "descEs": "Remo con soporte para reducir la fatiga de la zona lumbar."
+ },
+ "0333": {
+  "en": [
+   "Stand with your feet shoulder-width apart and hold a dumbbell in each hand.",
+   "Bend your knees slightly and hinge forward at the hips, keeping your back straight.",
+   "Bring your upper arms close to your sides, with your elbows bent at a 90-degree angle.",
+   "Extend your arms straight back, squeezing your triceps at the top of the movement.",
+   "Pause for a moment, then slowly lower the dumbbells back to the starting position.",
+   "Repeat for the desired number of repetitions."
+  ],
+  "es": [
+   "Pará con los pies al ancho de los hombros y sostené una mancuerna en cada mano.",
+   "Flexioná levemente las rodillas y hacé bisagra hacia adelante desde las caderas, manteniendo la espalda recta.",
+   "Llevá los brazos superiores pegados a los costados, con los codos flexionados a 90 grados.",
+   "Extendé los brazos hacia atrás, apretando el tríceps arriba del movimiento.",
+   "Hacé una pausa y después bajá lentamente las mancuernas hasta la posición inicial.",
+   "Repetí la cantidad de repeticiones deseada."
+  ],
+  "descEs": "Aislamiento liviano y apretón para finalizadores de tríceps."
+ },
+ "0334": {
+  "en": [
+   "Stand with your feet shoulder-width apart and hold a dumbbell in each hand, palms facing your body.",
+   "Keep your back straight and engage your core.",
+   "Raise your arms out to the sides until they are parallel to the floor, keeping a slight bend in your elbows.",
+   "Pause for a moment at the top, then slowly lower your arms back down to the starting position.",
+   "Repeat for the desired number of repetitions."
+  ],
+  "es": [
+   "Pará con los pies al ancho de los hombros y sostené una mancuerna en cada mano, palmas hacia el cuerpo.",
+   "Mantené la espalda recta y activá el core.",
+   "Elevá los brazos hacia los costados hasta que queden paralelos al piso, manteniendo una leve flexión en los codos.",
+   "Hacé una pausa arriba y después bajá lentamente los brazos hasta la posición inicial.",
+   "Repetí la cantidad de repeticiones deseada."
+  ],
+  "descEs": "Ejercicio básico de aislamiento del deltoides medio."
+ },
+ "0336": {
+  "en": [
+   "Stand with your feet shoulder-width apart, holding a dumbbell in each hand.",
+   "Take a step forward with your right foot, lowering your body into a lunge position.",
+   "Keep your back straight and your chest up as you lower your body.",
+   "Push through your right heel to return to the starting position.",
+   "Repeat with your left leg.",
+   "Alternate legs for the desired number of repetitions."
+  ],
+  "es": [
+   "Pará con los pies al ancho de los hombros, sosteniendo una mancuerna en cada mano.",
+   "Dá un paso adelante con el pie derecho, bajando el cuerpo a la posición de zancada.",
+   "Mantené la espalda recta y el pecho erguido mientras bajás.",
+   "Empujá con el talón derecho para volver a la posición inicial.",
+   "Repetí con la pierna izquierda.",
+   "Alterná las piernas por la cantidad de repeticiones deseada."
+  ],
+  "descEs": "Ejercicio unilateral básico de tren inferior."
+ },
+ "0351": {
+  "en": [
+   "Lie flat on a bench with a dumbbell in each hand, palms facing each other.",
+   "Extend your arms straight up over your chest, keeping your elbows close to your body.",
+   "Lower the dumbbells down towards your forehead, bending your elbows.",
+   "Pause for a moment, then extend your arms back up to the starting position.",
+   "Repeat for the desired number of repetitions."
+  ],
+  "es": [
+   "Acostate boca arriba en un banco con una mancuerna en cada mano, palmas enfrentadas.",
+   "Extendé los brazos hacia arriba por encima del pecho, manteniendo los codos cerca del cuerpo.",
+   "Bajá las mancuernas hacia la frente, flexionando los codos.",
+   "Hacé una pausa y después extendé los brazos de nuevo hacia arriba hasta la posición inicial.",
+   "Repetí la cantidad de repeticiones deseada."
+  ],
+  "descEs": "Aislamiento de extensión de codo desde posición acostada."
+ },
+ "0358": {
+  "en": [
+   "Sit on a bench or chair with your feet flat on the ground.",
+   "Hold a dumbbell in one hand with an overhand grip, palm facing down.",
+   "Rest your forearm on your thigh, with your wrist hanging off the edge.",
+   "Slowly lower the dumbbell towards the ground by flexing your wrist.",
+   "Pause for a moment at the bottom, then slowly curl your wrist back up towards your body.",
+   "Repeat for the desired number of repetitions, then switch to the other arm."
+  ],
+  "es": [
+   "Sentate en un banco o silla con los pies apoyados en el piso.",
+   "Sostené una mancuerna en una mano con agarre prono, palma hacia abajo.",
+   "Apoyá el antebrazo sobre el muslo, con la muñeca colgando del borde.",
+   "Bajá lentamente la mancuerna hacia el piso flexionando la muñeca.",
+   "Hacé una pausa abajo y después subí lentamente la muñeca de nuevo hacia el cuerpo.",
+   "Repetí la cantidad de repeticiones deseada y después cambiá de brazo."
+  ],
+  "descEs": "Aislamiento de los extensores del antebrazo."
+ },
+ "0370": {
+  "en": [
+   "Stand up straight with your feet shoulder-width apart and hold a dumbbell in each hand, palms facing your body.",
+   "Keeping your upper arms stationary, exhale and curl the weights while contracting your biceps. Continue to raise the weights until your biceps are fully contracted and the dumbbells are at shoulder level.",
+   "Hold the contracted position for a brief pause as you squeeze your biceps.",
+   "Inhale and slowly begin to lower the dumbbells back to the starting position.",
+   "Repeat for the desired number of repetitions."
+  ],
+  "es": [
+   "Pará bien derecho con los pies a la altura de los hombros y sostené una mancuerna en cada mano, con las palmas mirando hacia tu cuerpo.",
+   "Manteniendo los brazos pegados al torso, exhalá y flexioná los codos contrayendo los bíceps. Seguí subiendo el peso hasta que los bíceps estén totalmente contraídos y las mancuernas queden a la altura de los hombros.",
+   "Mantené la posición de contracción un instante apretando los bíceps.",
+   "Inhalá y empezá a bajar las mancuernas lentamente hasta la posición inicial.",
+   "Repetí la cantidad de repeticiones deseada."
+  ],
+  "descEs": "Curl con agarre pronado para antebrazos y braquial."
+ },
+ "0372": {
+  "en": [
+   "Sit on a preacher curl bench with your upper arms resting on the pad and your chest against it.",
+   "Hold a dumbbell in each hand with your palms facing up and your arms fully extended.",
+   "Keeping your upper arms stationary, exhale and curl the weights while contracting your biceps.",
+   "Continue to raise the dumbbells until your biceps are fully contracted and the dumbbells are at shoulder level.",
+   "Hold the contracted position for a brief pause as you squeeze your biceps.",
+   "Inhale and slowly begin to lower the dumbbells back to the starting position.",
+   "Repeat for the desired number of repetitions."
+  ],
+  "es": [
+   "Sentate en un banco de curl predicador con los brazos superiores apoyados en el respaldo y el pecho contra él.",
+   "Sostené una mancuerna en cada mano con las palmas hacia arriba y los brazos extendidos por completo.",
+   "Manteniendo los brazos superiores quietos, exhalá y subí los pesos contrayendo el bíceps.",
+   "Seguí elevando las mancuernas hasta contraer por completo el bíceps, con las mancuernas a la altura del hombro.",
+   "Mantené la contracción una breve pausa apretando el bíceps.",
+   "Inhalá y empezá a bajar lentamente las mancuernas hasta la posición inicial.",
+   "Repetí la cantidad de repeticiones deseada."
+  ],
+  "descEs": "Curl con soporte que aísla el bíceps."
+ },
+ "0378": {
+  "en": [
+   "Stand with your feet shoulder-width apart and hold a dumbbell in each hand.",
+   "Bend your knees slightly and hinge forward at the hips, keeping your back straight.",
+   "Extend your arms straight down towards the ground, palms facing each other.",
+   "Keeping a slight bend in your elbows, lift your arms out to the sides and squeeze your shoulder blades together.",
+   "Pause for a moment at the top, then slowly lower your arms back down to the starting position.",
+   "Repeat for the desired number of repetitions."
+  ],
+  "es": [
+   "Pará con los pies al ancho de los hombros y sostené una mancuerna en cada mano.",
+   "Flexioná levemente las rodillas y hacé bisagra hacia adelante desde las caderas, manteniendo la espalda recta.",
+   "Extendé los brazos hacia abajo hacia el piso, palmas enfrentadas.",
+   "Manteniendo una leve flexión en los codos, elevá los brazos hacia los costados y juntá las escápulas.",
+   "Hacé una pausa arriba y después bajá lentamente los brazos hasta la posición inicial.",
+   "Repetí la cantidad de repeticiones deseada."
+  ],
+  "descEs": "Trabajo de aislamiento para deltoides posteriores y espalda alta."
+ },
+ "0381": {
+  "en": [
+   "Stand with your feet shoulder-width apart, holding a dumbbell in each hand.",
+   "Take a step backward with your right foot, lowering your body into a lunge position.",
+   "Bend your left knee and lower your body until your left thigh is parallel to the ground.",
+   "Pause for a moment, then push through your left heel to return to the starting position.",
+   "Repeat on the other side, stepping back with your left foot."
+  ],
+  "es": [
+   "Pará con los pies al ancho de los hombros, sosteniendo una mancuerna en cada mano.",
+   "Dá un paso atrás con el pie derecho, bajando el cuerpo a la posición de zancada.",
+   "Flexioná la rodilla izquierda y bajá el cuerpo hasta que el muslo izquierdo quede paralelo al piso.",
+   "Hacé una pausa y después empujá con el talón izquierdo para volver a la posición inicial.",
+   "Repetí del otro lado, dando un paso atrás con el pie izquierdo."
+  ],
+  "descEs": "Variante de zancada que mantiene la tensión en los glúteos."
+ },
+ "0385": {
+  "en": [
+   "Sit on a bench or chair with your feet flat on the ground.",
+   "Hold a dumbbell in each hand with an overhand grip, palms facing down.",
+   "Rest your forearms on your thighs, allowing your wrists to hang off the edge.",
+   "Slowly curl your wrists upward, bringing the dumbbells towards your body.",
+   "Pause for a moment at the top, then slowly lower the dumbbells back down to the starting position.",
+   "Repeat for the desired number of repetitions."
+  ],
+  "es": [
+   "Sentate en un banco o silla con los pies apoyados en el piso.",
+   "Sostené una mancuerna en cada mano con agarre prono, palmas hacia abajo.",
+   "Apoyá los antebrazos sobre los muslos, dejando que las muñecas cuelguen del borde.",
+   "Subí lentamente las muñecas, llevando las mancuernas hacia el cuerpo.",
+   "Hacé una pausa arriba y después bajá lentamente las mancuernas hasta la posición inicial.",
+   "Repetí la cantidad de repeticiones deseada."
+  ],
+  "descEs": "Aislamiento de los flexores del antebrazo."
+ },
+ "0410": {
+  "en": [
+   "Stand with your feet shoulder-width apart, holding a dumbbell in each hand.",
+   "Take a step forward with one foot and position your feet so that your front foot is flat on the ground and your back foot is elevated on a bench or step.",
+   "Lower your body by bending your front knee and hip, keeping your back knee slightly bent and your back heel off the ground.",
+   "Continue lowering until your front thigh is parallel to the ground, then push through your front heel to return to the starting position.",
+   "Repeat for the desired number of repetitions, then switch legs and repeat."
+  ],
+  "es": [
+   "Pará con los pies al ancho de los hombros, sosteniendo una mancuerna en cada mano.",
+   "Dá un paso adelante con un pie y acomodá los pies de modo que el de adelante quede apoyado en el piso y el de atrás elevado sobre un banco o escalón.",
+   "Bajá el cuerpo flexionando la rodilla y la cadera delanteras, manteniendo la rodilla trasera levemente flexionada y el talón trasero despegado del piso.",
+   "Seguí bajando hasta que el muslo delantero quede paralelo al piso, después empujá con el talón delantero para volver a la posición inicial.",
+   "Repetí la cantidad de repeticiones deseada y después cambiá de pierna."
+  ],
+  "descEs": "Constructor unilateral estacionario de cuádriceps y glúteos."
+ },
+ "0423": {
+  "en": [
+   "Stand with your feet shoulder-width apart, holding a dumbbell in one hand.",
+   "Raise the dumbbell overhead, fully extending your arm.",
+   "Keep your upper arm close to your head and perpendicular to the ground.",
+   "Slowly lower the dumbbell behind your head, bending your elbow.",
+   "Pause for a moment, then raise the dumbbell back to the starting position.",
+   "Repeat for the desired number of repetitions."
+  ],
+  "es": [
+   "Parate con los pies a la altura de los hombros, sosteniendo una mancuerna con una mano.",
+   "Levantá la mancuerna por encima de la cabeza, extendiendo el brazo por completo.",
+   "Mantené el brazo pegado a la cabeza y perpendicular al piso.",
+   "Bajá despacio la mancuerna por detrás de la cabeza, flexionando el codo.",
+   "Hacé una pausa y volvé a subir la mancuerna a la posición inicial.",
+   "Repetí la cantidad de repeticiones deseada."
+  ],
+  "descEs": "Patrón general de extensión de brazos para tríceps."
+ },
+ "0429": {
+  "en": [
+   "Lie flat on a bench with your chest facing down and your arms extended straight down, holding a dumbbell in each hand.",
+   "Rotate your palms so they are facing up.",
+   "Keeping your upper arms stationary, exhale and curl the dumbbells as you rotate your palms to face down.",
+   "Inhale and slowly lower the dumbbells back to the starting position.",
+   "Repeat for the desired number of repetitions."
+  ],
+  "es": [
+   "Acostate boca abajo sobre un banco con los brazos extendidos hacia abajo, sosteniendo una mancuerna en cada mano.",
+   "Girá las palmas para que queden mirando hacia arriba.",
+   "Manteniendo los brazos pegados al torso, exhalá y flexioná las mancuernas mientras girás las palmas hasta que queden mirando hacia abajo.",
+   "Inhalá y bajá lentamente las mancuernas hasta la posición inicial.",
+   "Repetí la cantidad de repeticiones deseada."
+  ],
+  "descEs": "Fuerza y control rotacional del antebrazo."
+ },
+ "0431": {
+  "en": [
+   "Stand in front of a bench or step with a dumbbell in each hand, palms facing your body.",
+   "Place your right foot on the bench or step, ensuring your entire foot is in contact with the surface.",
+   "Push through your right heel and lift your body up onto the bench or step, straightening your right leg.",
+   "Bring your left foot up onto the bench or step, standing fully upright.",
+   "Step back down with your left foot, followed by your right foot, returning to the starting position.",
+   "Repeat for the desired number of repetitions, then switch legs."
+  ],
+  "es": [
+   "Parate frente a un banco o cajón con una mancuerna en cada mano, con las palmas mirando hacia el cuerpo.",
+   "Apoyá el pie derecho sobre el banco o cajón, asegurándote de que todo el pie quede en contacto con la superficie.",
+   "Empujá con el talón derecho y subí el cuerpo al banco o cajón, estirando la pierna derecha.",
+   "Subí el pie izquierdo al banco o cajón hasta quedar completamente parado.",
+   "Bajá primero con el pie izquierdo y después con el derecho, volviendo a la posición inicial.",
+   "Repetí la cantidad de repeticiones deseada y después cambiá de pierna."
+  ],
+  "descEs": "Empuje a una sola pierna con demanda de equilibrio."
+ },
+ "0432": {
+  "en": [
+   "Stand with your feet shoulder-width apart, holding a dumbbell in each hand with an overhand grip.",
+   "Keeping your back straight and your core engaged, hinge at the hips and lower the dumbbells towards the ground, allowing a slight bend in your knees.",
+   "Lower the dumbbells until you feel a stretch in your hamstrings, then squeeze your glutes and push through your heels to return to the starting position.",
+   "Repeat for the desired number of repetitions."
+  ],
+  "es": [
+   "Parate con los pies a la altura de los hombros, sosteniendo una mancuerna en cada mano con agarre prono.",
+   "Manteniendo la espalda recta y el core activado, hacé la bisagra de cadera y bajá las mancuernas hacia el piso, permitiendo una leve flexión de rodillas.",
+   "Bajá las mancuernas hasta sentir el estiramiento en los isquiotibiales, después apretá los glúteos y empujá con los talones para volver a la posición inicial.",
+   "Repetí la cantidad de repeticiones deseada."
+  ],
+  "descEs": "Bisagra con foco en isquiotibiales y mínima flexión de rodilla."
+ },
+ "0434": {
+  "en": [
+   "Stand with your feet shoulder-width apart, holding a dumbbell in each hand with an overhand grip.",
+   "Keeping your back straight and your core engaged, hinge at the hips and lower the dumbbells towards the ground, allowing your torso to lean forward.",
+   "Continue lowering the dumbbells until you feel a stretch in your hamstrings, keeping your knees slightly bent.",
+   "Pause for a moment at the bottom, then engage your glutes and hamstrings to lift your torso back up to the starting position.",
+   "Repeat for the desired number of repetitions."
+  ],
+  "es": [
+   "Parate con los pies a la altura de los hombros, sosteniendo una mancuerna en cada mano con agarre prono.",
+   "Manteniendo la espalda recta y el core activado, hacé la bisagra de cadera y bajá las mancuernas hacia el piso, dejando que el torso se incline hacia adelante.",
+   "Seguí bajando las mancuernas hasta sentir el estiramiento en los isquiotibiales, manteniendo las rodillas levemente flexionadas.",
+   "Hacé una pausa abajo, después activá glúteos e isquiotibiales para levantar el torso hasta la posición inicial.",
+   "Repetí la cantidad de repeticiones deseada."
+  ],
+  "descEs": "Bisagra con foco en isquiotibiales y mínima flexión de rodilla."
+ },
+ "0437": {
+  "en": [
+   "Stand with your feet shoulder-width apart, holding a dumbbell in each hand with an overhand grip.",
+   "Let the dumbbells hang in front of your thighs, with your arms fully extended.",
+   "Keeping your back straight and your core engaged, exhale and lift the dumbbells straight up towards your chin, leading with your elbows.",
+   "Pause for a moment at the top, then inhale and slowly lower the dumbbells back down to the starting position.",
+   "Repeat for the desired number of repetitions."
+  ],
+  "es": [
+   "Parate con los pies a la altura de los hombros, sosteniendo una mancuerna en cada mano con agarre prono.",
+   "Dejá colgar las mancuernas frente a los muslos, con los brazos completamente extendidos.",
+   "Manteniendo la espalda recta y el core activado, exhalá y levantá las mancuernas en línea recta hacia el mentón, guiando con los codos.",
+   "Hacé una pausa arriba, después inhalá y bajá despacio las mancuernas a la posición inicial.",
+   "Repetí la cantidad de repeticiones deseada."
+  ],
+  "descEs": "Tracción vertical que trabaja deltoides laterales y trapecios."
+ },
+ "0447": {
+  "en": [
+   "Stand up straight with your feet shoulder-width apart and hold the ez barbell with an underhand grip, palms facing up.",
+   "Keep your elbows close to your torso and your upper arms stationary throughout the movement.",
+   "Exhale as you curl the barbell up towards your shoulders, contracting your biceps.",
+   "Pause for a moment at the top, then inhale as you slowly lower the barbell back down to the starting position.",
+   "Repeat for the desired number of repetitions."
+  ],
+  "es": [
+   "Parate derecho con los pies a la altura de los hombros y agarrá la barra EZ con agarre supino, palmas hacia arriba.",
+   "Mantené los codos pegados al torso y los brazos quietos durante todo el movimiento.",
+   "Exhalá mientras hacés el curl de la barra hacia los hombros, contrayendo los bíceps.",
+   "Hacé una pausa arriba, después inhalá mientras bajás despacio la barra a la posición inicial.",
+   "Repetí la cantidad de repeticiones deseada."
+  ],
+  "descEs": "Curl de bíceps clásico con agarre fijo."
+ },
+ "0454": {
+  "en": [
+   "Stand with your feet shoulder-width apart and hold the ez barbell with an underhand grip, palms facing up.",
+   "Rest your upper arms on a preacher bench or stability ball, allowing your elbows to hang down.",
+   "Keeping your upper arms stationary, exhale and curl the barbell up towards your shoulders.",
+   "Pause for a moment at the top, squeezing your biceps.",
+   "Inhale and slowly lower the barbell back to the starting position.",
+   "Repeat for the desired number of repetitions."
+  ],
+  "es": [
+   "Parate con los pies a la altura de los hombros y agarrá la barra EZ con agarre supino, palmas hacia arriba.",
+   "Apoyá los brazos sobre un banco scott o pelota de estabilidad, dejando que los codos cuelguen hacia abajo.",
+   "Manteniendo los brazos quietos, exhalá y hacé el curl de la barra hacia los hombros.",
+   "Hacé una pausa arriba, apretando los bíceps.",
+   "Inhalá y bajá despacio la barra a la posición inicial.",
+   "Repetí la cantidad de repeticiones deseada."
+  ],
+  "descEs": "Curl amigable para las muñecas que trabaja bíceps y antebrazos."
+ },
+ "0464": {
+  "en": [
+   "Kneel on the floor and place the wheel roller in front of you.",
+   "Place your hands on the handles of the wheel roller and extend your arms straight out in front of you.",
+   "Engage your core muscles and slowly roll the wheel forward, keeping your back straight and your abs tight.",
+   "Continue rolling forward until your body is fully extended and your arms are overhead.",
+   "Pause for a moment, then slowly roll the wheel back towards your knees, maintaining control and keeping your abs engaged.",
+   "Repeat for the desired number of repetitions."
+  ],
+  "es": [
+   "Arrodillate en el piso y colocá la rueda abdominal frente a vos.",
+   "Apoyá las manos en las manijas de la rueda y extendé los brazos rectos hacia adelante.",
+   "Activá el core y rodá la rueda lentamente hacia adelante, manteniendo la espalda recta y los abdominales firmes.",
+   "Seguí rodando hacia adelante hasta que el cuerpo quede totalmente extendido y los brazos por encima de la cabeza.",
+   "Hacé una pausa y rodá la rueda lentamente de vuelta hacia las rodillas, manteniendo el control y los abdominales activados.",
+   "Repetí la cantidad de repeticiones deseada."
+  ],
+  "descEs": "Progresión exigente de roll-out con anti-extensión."
+ },
+ "0472": {
+  "en": [
+   "Lie flat on your back with your arms extended along your sides.",
+   "Bend your knees and lift your feet off the ground, bringing your thighs perpendicular to the floor.",
+   "Contract your abs and curl your hips off the floor, bringing your knees towards your chest.",
+   "Pause for a moment at the top, then slowly lower your hips back down to the starting position.",
+   "Repeat for the desired number of repetitions."
+  ],
+  "es": [
+   "Acostate boca arriba con los brazos extendidos a los costados del cuerpo.",
+   "Flexioná las rodillas y levantá los pies del piso, llevando los muslos perpendiculares al suelo.",
+   "Contraé los abdominales y despegá la cadera del piso, llevando las rodillas hacia el pecho.",
+   "Hacé una pausa arriba y bajá lentamente la cadera hasta la posición inicial.",
+   "Repetí la cantidad de repeticiones deseada."
+  ],
+  "descEs": "Ejercicio de báscula pélvica posterior enfocado en el abdomen bajo."
+ },
+ "0499": {
+  "en": [
+   "Hang from a pull-up bar with your palms facing away from you and your arms fully extended.",
+   "Engage your core and squeeze your shoulder blades together.",
+   "Pull your body up towards the bar by bending your elbows and bringing your chest towards the bar.",
+   "Pause at the top of the movement, then slowly lower your body back down to the starting position.",
+   "Repeat for the desired number of repetitions."
+  ],
+  "es": [
+   "Colgate de la barra de dominadas con las palmas mirando hacia adelante y los brazos totalmente extendidos.",
+   "Activá el core y juntá las escápulas.",
+   "Subí el cuerpo hacia la barra flexionando los codos y llevando el pecho hacia la barra.",
+   "Hacé una pausa arriba y bajá lentamente el cuerpo hasta la posición inicial.",
+   "Repetí la cantidad de repeticiones deseada."
+  ],
+  "descEs": "Tracción vertical para dorsales y espalda alta."
+ },
+ "0501": {
+  "en": [
+   "Hold the handles of the jump rope with your hands, palms facing inward.",
+   "Stand with your feet shoulder-width apart and knees slightly bent.",
+   "Swing the rope over your head and jump over it as it comes towards your feet.",
+   "Land softly on the balls of your feet and repeat the jump as the rope comes around again.",
+   "Continue jumping for the desired duration or number of repetitions."
+  ],
+  "es": [
+   "Sostené las manijas de la soga con las manos, con las palmas mirando hacia adentro.",
+   "Pará con los pies a la altura de los hombros y las rodillas levemente flexionadas.",
+   "Pasá la soga por encima de la cabeza y saltá por encima de ella cuando llega a tus pies.",
+   "Caé suave sobre la punta de los pies y repetí el salto cuando la soga vuelve a pasar.",
+   "Seguí saltando durante el tiempo o la cantidad de repeticiones deseada."
+  ],
+  "descEs": "Ejercicio simple de acondicionamiento con demanda de coordinación de pies."
+ },
+ "0507": {
+  "en": [
+   "Lie flat on your back with your legs extended and your arms overhead.",
+   "Engage your core and lift your legs and upper body simultaneously, reaching your hands towards your toes.",
+   "Pause for a moment at the top, then slowly lower your legs and upper body back down to the starting position.",
+   "Repeat for the desired number of repetitions."
+  ],
+  "es": [
+   "Acostate boca arriba con las piernas extendidas y los brazos por encima de la cabeza.",
+   "Activá el core y levantá las piernas y el tren superior a la vez, llevando las manos hacia los pies.",
+   "Hacé una pausa arriba, después bajá despacio las piernas y el tren superior a la posición inicial.",
+   "Repetí la cantidad de repeticiones deseada."
+  ],
+  "descEs": "Flexión de tronco en rango completo."
+ },
+ "0514": {
+  "en": [
+   "Start in a standing position with your feet shoulder-width apart.",
+   "Lower your body into a squat position by bending your knees and placing your hands on the floor in front of you.",
+   "Kick your feet back into a push-up position.",
+   "Perform a push-up, keeping your body in a straight line.",
+   "Jump your feet back into the squat position.",
+   "Jump up explosively, reaching your arms overhead.",
+   "Land softly and immediately lower back into a squat position to begin the next repetition."
+  ],
+  "es": [
+   "Empezá parado con los pies a la altura de los hombros.",
+   "Bajá el cuerpo a posición de sentadilla flexionando las rodillas y apoyando las manos en el piso frente a vos.",
+   "Llevá los pies hacia atrás de un salto hasta quedar en posición de flexión de brazos.",
+   "Hacé una flexión de brazos manteniendo el cuerpo en línea recta.",
+   "Volvé los pies de un salto a la posición de sentadilla.",
+   "Saltá hacia arriba de forma explosiva, estirando los brazos por encima de la cabeza.",
+   "Caé suave y bajá de inmediato a la posición de sentadilla para empezar la siguiente repetición."
+  ],
+  "descEs": "Clásico ejercicio de acondicionamiento de cuerpo completo."
+ },
+ "0523": {
+  "en": [
+   "Adjust the seat height and position yourself on the machine with your back against the backrest.",
+   "Grasp the handles with an overhand grip and position your hands at shoulder level.",
+   "Push the handles upward until your arms are fully extended, but do not lock your elbows.",
+   "Pause for a moment at the top, then slowly lower the handles back down to the starting position.",
+   "Repeat for the desired number of repetitions."
+  ],
+  "es": [
+   "Ajustá la altura del asiento y acomodate en la máquina con la espalda contra el respaldo.",
+   "Agarrá las manijas con agarre prono y colocá las manos a la altura de los hombros.",
+   "Empujá las manijas hacia arriba hasta extender los brazos por completo, sin trabar los codos.",
+   "Hacé una pausa arriba y bajá lentamente las manijas hasta la posición inicial.",
+   "Repetí la cantidad de repeticiones deseada."
+  ],
+  "descEs": "Patrón de empuje estable con menos demanda del tren inferior."
+ },
+ "0528": {
+  "en": [
+   "Stand with your feet shoulder-width apart and the barbell on the floor in front of you.",
+   "Bend your knees and hinge at the hips to lower down and grip the barbell with an overhand grip, hands slightly wider than shoulder-width apart.",
+   "Drive through your heels and extend your hips and knees to lift the barbell off the floor, keeping it close to your body.",
+   "As the barbell reaches your thighs, explosively extend your hips, shrug your shoulders, and pull the barbell up towards your chest.",
+   "As the barbell reaches chest height, quickly drop under it and catch it at shoulder level, with your elbows pointing forward and your palms facing up.",
+   "From the catch position, press the barbell overhead by extending your arms and pushing the barbell straight up.",
+   "Lower the barbell back down to the starting position and repeat for the desired number of repetitions."
+  ],
+  "es": [
+   "Pará con los pies a la altura de los hombros y la barra en el piso frente a vos.",
+   "Flexioná las rodillas y hacé bisagra de cadera para bajar y agarrar la barra con agarre prono, con las manos un poco más anchas que los hombros.",
+   "Empujá con los talones y extendé la cadera y las rodillas para levantar la barra del piso, manteniéndola cerca del cuerpo.",
+   "Cuando la barra llega a los muslos, extendé la cadera de forma explosiva, encogé los hombros y tirá de la barra hacia el pecho.",
+   "Cuando la barra llega a la altura del pecho, metete rápido por debajo y recibila a la altura de los hombros, con los codos hacia adelante y las palmas hacia arriba.",
+   "Desde la recepción, presioná la barra por encima de la cabeza extendiendo los brazos y empujándola recto hacia arriba.",
+   "Bajá la barra hasta la posición inicial y repetí la cantidad de repeticiones deseada."
+  ],
+  "descEs": "Levantamiento de potencia más press por encima de la cabeza para fuerza de cuerpo completo."
+ },
+ "0533": {
+  "en": [
+   "Stand with your feet shoulder-width apart, toes slightly turned out.",
+   "Hold the kettlebell with both hands in front of your chest, close to your body.",
+   "Engage your core and keep your chest up as you lower your hips down and back, as if sitting into a chair.",
+   "Lower until your thighs are parallel to the ground, or as low as you can comfortably go.",
+   "Drive through your heels to stand back up, squeezing your glutes at the top.",
+   "Repeat for the desired number of repetitions."
+  ],
+  "es": [
+   "Parate con los pies a la altura de los hombros, con las puntas levemente hacia afuera.",
+   "Sostené la pesa rusa con ambas manos frente al pecho, pegada al cuerpo.",
+   "Activá el core y mantené el pecho arriba mientras bajás la cadera abajo y atrás, como si te sentaras en una silla.",
+   "Bajá hasta que los muslos queden paralelos al piso, o tan abajo como puedas cómodamente.",
+   "Empujá con los talones para volver a pararte, apretando los glúteos arriba.",
+   "Repetí la cantidad de repeticiones deseada."
+  ],
+  "descEs": "Patrón de sentadilla erguida con foco en cuádriceps."
+ },
+ "0534": {
+  "en": [
+   "Stand with your feet shoulder-width apart, toes slightly turned out.",
+   "Hold the kettlebell with both hands in front of your chest, close to your body.",
+   "Engage your core and keep your chest up as you lower your hips down and back, as if sitting into a chair.",
+   "Lower until your thighs are parallel to the ground, or as low as you can comfortably go.",
+   "Drive through your heels to stand back up, squeezing your glutes at the top.",
+   "Repeat for the desired number of repetitions."
+  ],
+  "es": [
+   "Pará con los pies a la altura de los hombros y las puntas levemente hacia afuera.",
+   "Sostené la mancuerna con ambas manos frente al pecho, cerca del cuerpo.",
+   "Activá el core y mantené el pecho erguido mientras bajás la cadera hacia atrás y abajo, como si te sentaras en una silla.",
+   "Bajá hasta que los muslos queden paralelos al piso, o lo más bajo que puedas cómodamente.",
+   "Empujá con los talones para volver a pararte, apretando los glúteos arriba.",
+   "Repetí la cantidad de repeticiones deseada."
+  ],
+  "descEs": "Patrón de sentadilla erguida con énfasis en cuádriceps."
+ },
+ "0537": {
+  "en": [
+   "Stand with your feet shoulder-width apart, holding a kettlebell in one hand with an overhand grip.",
+   "Bend your knees slightly and hinge at the hips, lowering the kettlebell between your legs.",
+   "Explosively extend your hips, knees, and ankles, using the momentum to swing the kettlebell up to shoulder height.",
+   "As the kettlebell reaches shoulder height, rotate your wrist and punch your hand straight up, locking out your arm overhead.",
+   "Lower the kettlebell back down to the starting position and repeat for the desired number of repetitions."
+  ],
+  "es": [
+   "Parate con los pies a la altura de los hombros, sosteniendo una pesa rusa con una mano con agarre prono.",
+   "Flexioná levemente las rodillas y hacé la bisagra de cadera, bajando la pesa rusa entre las piernas.",
+   "Extendé con explosividad cadera, rodillas y tobillos, usando el impulso para llevar la pesa rusa a la altura del hombro.",
+   "Cuando la pesa rusa llega a la altura del hombro, rotá la muñeca y empujá la mano hacia arriba, bloqueando el brazo por encima de la cabeza.",
+   "Bajá la pesa rusa a la posición inicial y repetí la cantidad de repeticiones deseada."
+  ],
+  "descEs": "Levantamiento de potencia más press por encima de la cabeza para fuerza de cuerpo completo."
+ },
+ "0540": {
+  "en": [
+   "Stand with your feet shoulder-width apart and the barbell on the floor in front of you.",
+   "Bend your knees and hinge at the hips to lower down and grip the barbell with an overhand grip, hands slightly wider than shoulder-width apart.",
+   "Drive through your heels and extend your hips and knees to lift the barbell off the floor, keeping it close to your body.",
+   "As the barbell reaches your thighs, explosively extend your hips, shrug your shoulders, and pull the barbell up towards your chest.",
+   "As the barbell reaches chest height, quickly drop under it and catch it at shoulder level, with your elbows pointing forward and your palms facing up.",
+   "From the catch position, press the barbell overhead by extending your arms and pushing the barbell straight up.",
+   "Lower the barbell back down to the starting position and repeat for the desired number of repetitions."
+  ],
+  "es": [
+   "Pará con los pies a la altura de los hombros y una mancuerna en cada mano a los costados del cuerpo.",
+   "Flexioná las rodillas y hacé bisagra de cadera para bajar manteniendo la espalda recta y las mancuernas cerca del cuerpo.",
+   "Empujá con los talones y extendé la cadera y las rodillas para levantar las mancuernas, manteniéndolas cerca del cuerpo.",
+   "Cuando las mancuernas llegan a los muslos, extendé la cadera de forma explosiva, encogé los hombros y tirá de las mancuernas hacia los hombros.",
+   "Metete rápido por debajo y recibí las mancuernas a la altura de los hombros, con los codos hacia adelante y las palmas hacia adentro.",
+   "Desde la recepción, presioná las mancuernas por encima de la cabeza extendiendo los brazos hacia arriba.",
+   "Bajá las mancuernas hasta la posición inicial y repetí la cantidad de repeticiones deseada."
+  ],
+  "descEs": "Levantamiento de potencia más press por encima de la cabeza para fuerza de cuerpo completo."
+ },
+ "0549": {
+  "en": [
+   "Stand facing away from the cable machine with your feet shoulder-width apart.",
+   "Grab the rope attachment with both hands and step forward, creating tension in the cable.",
+   "Bend at the hips and lower your upper body until it is parallel to the ground, keeping your back straight.",
+   "Engage your glutes and hamstrings to pull your body back up to the starting position.",
+   "Repeat for the desired number of repetitions."
+  ],
+  "es": [
+   "Pará de espaldas a la polea con los pies a la altura de los hombros.",
+   "Agarrá la soga con ambas manos entre las piernas y dá un paso adelante para generar tensión en el cable.",
+   "Hacé bisagra de cadera y bajá el torso hasta dejarlo casi paralelo al piso, manteniendo la espalda recta.",
+   "Activá los glúteos y los isquiotibiales para llevar el cuerpo de vuelta a la posición inicial.",
+   "Repetí la cantidad de repeticiones deseada."
+  ],
+  "descEs": "Bisagra de cadera en polea para resistencia de la cadena posterior."
+ },
+ "0550": {
+  "en": [
+   "Start by standing with your feet shoulder-width apart, holding a kettlebell in front of your chest with both hands, palms facing each other.",
+   "Lower into a squat position by bending your knees and pushing your hips back, keeping your chest up and your back straight.",
+   "As you reach the bottom of the squat, explosively drive through your heels to stand up, simultaneously pressing the kettlebell overhead.",
+   "Lock out your arms at the top of the movement, fully extending your elbows.",
+   "Lower the kettlebell back to the starting position by reversing the movement, bending your elbows and lowering the weight back to your chest.",
+   "Repeat for the desired number of repetitions."
+  ],
+  "es": [
+   "Empezá parado con los pies a la altura de los hombros, sosteniendo una pesa rusa frente al pecho con ambas manos, palmas enfrentadas.",
+   "Bajá a una sentadilla flexionando las rodillas y llevando la cadera hacia atrás, manteniendo el pecho arriba y la espalda recta.",
+   "Al llegar al fondo de la sentadilla, empujá con explosividad desde los talones para pararte, presionando a la vez la pesa rusa por encima de la cabeza.",
+   "Bloqueá los brazos arriba, extendiendo por completo los codos.",
+   "Bajá la pesa rusa a la posición inicial invirtiendo el movimiento, flexionando los codos y bajando el peso de nuevo al pecho.",
+   "Repetí la cantidad de repeticiones deseada."
+  ],
+  "descEs": "Sentadilla más press por encima de la cabeza para potencia de cuerpo completo."
+ },
+ "0551": {
+  "en": [
+   "Start by lying on your back with your legs extended and the kettlebell held in your right hand, arm fully extended above your shoulder.",
+   "Bend your right knee and place your right foot flat on the ground, keeping your left leg extended.",
+   "Pressing through your right foot, lift your hips off the ground, coming into a bridge position.",
+   "Slide your left leg underneath your body, bending your left knee and placing your left foot flat on the ground.",
+   "Rotate your torso to the left, bringing your left hand to the ground for support.",
+   "Pressing through your right foot and left hand, lift your torso off the ground, coming into a kneeling position.",
+   "From the kneeling position, stand up, keeping the kettlebell extended overhead.",
+   "Reverse the movement to return to the starting position.",
+   "Repeat the exercise on the other side, starting with the kettlebell in your left hand."
+  ],
+  "es": [
+   "Empezá acostado boca arriba con las piernas extendidas y la pesa rusa sostenida en la mano derecha, con el brazo completamente extendido por encima del hombro.",
+   "Flexioná la rodilla derecha y apoyá el pie derecho plano en el piso, manteniendo la pierna izquierda extendida.",
+   "Empujando con el pie derecho, despegá la cadera del piso hasta una posición de puente.",
+   "Deslizá la pierna izquierda por debajo del cuerpo, flexionando la rodilla izquierda y apoyando el pie izquierdo plano en el piso.",
+   "Rotá el torso hacia la izquierda, llevando la mano izquierda al piso como apoyo.",
+   "Empujando con el pie derecho y la mano izquierda, despegá el torso del piso hasta una posición de rodillas.",
+   "Desde la posición de rodillas, parate manteniendo la pesa rusa extendida por encima de la cabeza.",
+   "Invertí el movimiento para volver a la posición inicial.",
+   "Repetí el ejercicio del otro lado, empezando con la pesa rusa en la mano izquierda."
+  ],
+  "descEs": "Control de cuerpo completo y estabilidad de hombro."
+ },
+ "0554": {
+  "en": [
+   "Start by lying on your back with your legs extended and the kettlebell held in your right hand, arm fully extended above your shoulder.",
+   "Bend your right knee and place your right foot flat on the ground, keeping your left leg extended.",
+   "Pressing through your right foot, lift your hips off the ground, coming into a bridge position.",
+   "Slide your left leg underneath your body, bending your left knee and placing your left foot flat on the ground.",
+   "Rotate your torso to the left, bringing your left hand to the ground for support.",
+   "Pressing through your right foot and left hand, lift your torso off the ground, coming into a kneeling position.",
+   "From the kneeling position, stand up, keeping the kettlebell extended overhead.",
+   "Reverse the movement to return to the starting position.",
+   "Repeat the exercise on the other side, starting with the kettlebell in your left hand."
+  ],
+  "es": [
+   "Empezá acostado boca arriba con las piernas extendidas y la mancuerna sostenida en la mano derecha, con el brazo totalmente extendido por encima del hombro.",
+   "Flexioná la rodilla derecha y apoyá el pie derecho plano en el piso, manteniendo la pierna izquierda extendida.",
+   "Empujando con el pie derecho, despegá la cadera del piso hasta quedar en posición de puente.",
+   "Deslizá la pierna izquierda por debajo del cuerpo, flexionando la rodilla izquierda y apoyando el pie izquierdo plano en el piso.",
+   "Rotá el torso hacia la izquierda, llevando la mano izquierda al piso para apoyarte.",
+   "Empujando con el pie derecho y la mano izquierda, despegá el torso del piso hasta quedar arrodillado.",
+   "Desde la posición de rodillas, ponete de pie manteniendo la mancuerna extendida por encima de la cabeza.",
+   "Invertí el movimiento para volver a la posición inicial.",
+   "Repetí el ejercicio del otro lado, empezando con la mancuerna en la mano izquierda."
+  ],
+  "descEs": "Control de cuerpo completo y estabilidad del hombro."
+ },
+ "0572": {
+  "en": [
+   "Adjust the leverage machine to your desired resistance level.",
+   "Stand on the foot platform and grip the handles with an overhand grip, slightly wider than shoulder-width apart.",
+   "Hang with your arms fully extended, keeping your body straight.",
+   "Engage your back muscles and pull your body up towards the handles, leading with your chest.",
+   "Continue pulling until your chin is above the handles.",
+   "Pause for a moment at the top, then slowly lower your body back down to the starting position.",
+   "Repeat for the desired number of repetitions."
+  ],
+  "es": [
+   "Ajustá la máquina de palanca al nivel de resistencia deseado.",
+   "Parate en la plataforma para los pies y agarrá las manijas con agarre prono, un poco más abiertas que el ancho de los hombros.",
+   "Colgate con los brazos completamente extendidos, manteniendo el cuerpo recto.",
+   "Activá los músculos de la espalda y tirá del cuerpo hacia las manijas, guiando con el pecho.",
+   "Seguí tirando hasta que el mentón quede por encima de las manijas.",
+   "Hacé una pausa arriba, después bajá despacio el cuerpo a la posición inicial.",
+   "Repetí la cantidad de repeticiones deseada."
+  ],
+  "descEs": "Tracción vertical con agarre supino."
+ },
+ "0577": {
+  "en": [
+   "Adjust the seat height and position yourself on the machine with your back flat against the pad.",
+   "Grasp the handles with an overhand grip and position your elbows at a 90-degree angle.",
+   "Push the handles forward until your arms are fully extended, exhaling during the movement.",
+   "Pause briefly at the end of the movement, then slowly return to the starting position, inhaling as you do so.",
+   "Repeat for the desired number of repetitions."
+  ],
+  "es": [
+   "Ajustá la altura del asiento y ubicate en la máquina con la espalda plana contra el respaldo.",
+   "Agarrá las manijas con agarre prono y posicioná los codos en un ángulo de 90 grados.",
+   "Empujá las manijas hacia adelante hasta que los brazos queden completamente extendidos, exhalando durante el movimiento.",
+   "Hacé una breve pausa al final del movimiento, después volvé despacio a la posición inicial, inhalando mientras lo hacés.",
+   "Repetí la cantidad de repeticiones deseada."
+  ],
+  "descEs": "Press horizontal estándar para fuerza de pecho."
+ },
+ "0582": {
+  "en": [
+   "Adjust the machine to fit your body and select the desired weight.",
+   "Kneel on the machine facing downwards, with your knees resting on the pad and your feet secured under the footpads.",
+   "Grasp the handles or the sides of the machine for stability.",
+   "Keeping your upper body stationary, exhale and curl your legs up towards your glutes by flexing your knees.",
+   "Pause for a moment at the top of the movement, squeezing your hamstrings.",
+   "Inhale and slowly lower your legs back to the starting position, fully extending your knees.",
+   "Repeat for the desired number of repetitions."
+  ],
+  "es": [
+   "Ajustá la máquina a tu cuerpo y seleccioná el peso deseado.",
+   "Arrodillate en la máquina mirando hacia abajo, con las rodillas apoyadas en el almohadón y los pies asegurados bajo los apoyapiés.",
+   "Agarrá las manijas o los costados de la máquina para mayor estabilidad.",
+   "Manteniendo el tren superior quieto, exhalá y hacé el curl llevando las piernas hacia los glúteos flexionando las rodillas.",
+   "Hacé una pausa arriba del movimiento, apretando los isquiotibiales.",
+   "Inhalá y bajá despacio las piernas a la posición inicial, extendiendo por completo las rodillas.",
+   "Repetí la cantidad de repeticiones deseada."
+  ],
+  "descEs": "Curl sentado que enfatiza los isquiotibiales en estiramiento."
+ },
+ "0584": {
+  "en": [
+   "Adjust the seat height and position yourself on the machine with your back against the pad.",
+   "Grasp the handles with an overhand grip and keep your arms straight.",
+   "Exhale and raise your arms out to the sides until they are parallel to the floor.",
+   "Pause for a moment at the top, then inhale and slowly lower your arms back to the starting position.",
+   "Repeat for the desired number of repetitions."
+  ],
+  "es": [
+   "Ajustá la altura del asiento y ubicate en la máquina con la espalda contra el respaldo.",
+   "Agarrá las manijas con agarre prono y mantené los brazos rectos.",
+   "Exhalá y levantá los brazos hacia los costados hasta que queden paralelos al piso.",
+   "Hacé una pausa arriba, después inhalá y bajá despacio los brazos a la posición inicial.",
+   "Repetí la cantidad de repeticiones deseada."
+  ],
+  "descEs": "Ejercicio básico de aislamiento del deltoides medio."
+ },
+ "0585": {
+  "en": [
+   "Adjust the seat height and backrest of the machine to fit your body.",
+   "Sit on the machine with your back against the backrest and your feet on the footpad.",
+   "Grasp the handles or sidebars for stability.",
+   "Extend your legs forward by straightening your knees, lifting the weight.",
+   "Pause for a moment at the top, then slowly lower the weight back to the starting position.",
+   "Repeat for the desired number of repetitions."
+  ],
+  "es": [
+   "Ajustá la altura del asiento y el respaldo de la máquina a tu cuerpo.",
+   "Sentate en la máquina con la espalda contra el respaldo y los pies sobre el apoyapiés.",
+   "Agarrá las manijas o las barras laterales para mayor estabilidad.",
+   "Extendé las piernas hacia adelante estirando las rodillas, levantando el peso.",
+   "Hacé una pausa arriba, después bajá despacio el peso a la posición inicial.",
+   "Repetí la cantidad de repeticiones deseada."
+  ],
+  "descEs": "Movimiento de aislamiento para cuádriceps."
+ },
+ "0586": {
+  "en": [
+   "Adjust the machine to fit your body and select the desired weight.",
+   "Lie face down on the machine with your legs straight and your heels against the padded lever.",
+   "Grasp the handles or the sides of the machine for stability.",
+   "Keeping your upper body stationary, exhale and curl your legs up as far as possible without lifting your hips off the pad.",
+   "Hold the contracted position for a brief pause as you squeeze your hamstrings.",
+   "Inhale and slowly lower the lever back to the starting position.",
+   "Repeat for the desired number of repetitions."
+  ],
+  "es": [
+   "Ajustá la máquina a tu cuerpo y seleccioná el peso deseado.",
+   "Acostate boca abajo en la máquina con las piernas rectas y los talones contra la palanca acolchada.",
+   "Agarrá las manijas o los costados de la máquina para mayor estabilidad.",
+   "Manteniendo el tren superior quieto, exhalá y hacé el curl llevando las piernas lo más arriba posible sin despegar la cadera del almohadón.",
+   "Mantené la posición contraída un instante mientras apretás los isquiotibiales.",
+   "Inhalá y bajá despacio la palanca a la posición inicial.",
+   "Repetí la cantidad de repeticiones deseada."
+  ],
+  "descEs": "Aislamiento de isquiotibiales en máquina."
+ },
+ "0594": {
+  "en": [
+   "Adjust the seat height so that your knees are slightly bent and your feet are flat on the footplate.",
+   "Place your toes on the footplate with your heels hanging off the edge.",
+   "Grasp the handles or the sides of the seat for stability.",
+   "Push through the balls of your feet to raise your heels as high as possible.",
+   "Pause for a moment at the top, then slowly lower your heels back down to the starting position.",
+   "Repeat for the desired number of repetitions."
+  ],
+  "es": [
+   "Ajustá la altura del asiento para que las rodillas queden levemente flexionadas y los pies planos sobre la plataforma.",
+   "Apoyá las puntas de los pies en la plataforma con los talones colgando del borde.",
+   "Agarrá las manijas o los costados del asiento para mayor estabilidad.",
+   "Empujá con la planta de los pies para elevar los talones lo más alto posible.",
+   "Hacé una pausa arriba, después bajá despacio los talones a la posición inicial.",
+   "Repetí la cantidad de repeticiones deseada."
+  ],
+  "descEs": "Trabajo de gemelos con rodilla flexionada que enfatiza el sóleo."
+ },
+ "0599": {
+  "en": [
+   "Adjust the machine to fit your body and sit on it with your back against the backrest.",
+   "Place your lower legs under the padded lever, just above your ankles.",
+   "Grasp the handles on the sides of the machine for support.",
+   "Keeping your upper legs stationary, exhale and curl your legs up as far as possible.",
+   "Hold the contracted position for a brief pause as you squeeze your hamstrings.",
+   "Inhale and slowly lower the lever back to the starting position.",
+   "Repeat for the desired number of repetitions."
+  ],
+  "es": [
+   "Ajustá la máquina a tu cuerpo y sentate con la espalda apoyada en el respaldo.",
+   "Colocá la parte baja de las piernas debajo del rodillo acolchado, justo arriba de los tobillos.",
+   "Agarrá las manijas a los costados de la máquina para sostenerte.",
+   "Manteniendo los muslos fijos, exhalá y flexioná las piernas hacia arriba lo máximo posible.",
+   "Mantené la posición contraída una breve pausa apretando los femorales.",
+   "Inhalá y bajá despacio el rodillo hasta la posición inicial.",
+   "Repetí la cantidad de repeticiones deseada."
+  ],
+  "descEs": "Curl femoral clásico para isquiotibiales en posición boca abajo."
+ },
+ "0602": {
+  "en": [
+   "Adjust the seat height and position yourself on the machine with your chest against the pad and your feet flat on the floor.",
+   "Grasp the handles with an overhand grip and keep your arms slightly bent.",
+   "Exhale and squeeze your shoulder blades together as you pull the handles back and outward, away from your body.",
+   "Pause for a moment at the peak contraction, then inhale and slowly return to the starting position.",
+   "Repeat for the desired number of repetitions."
+  ],
+  "es": [
+   "Ajustá la altura del asiento y ubicate en la máquina con el pecho contra la almohadilla y los pies apoyados en el piso.",
+   "Agarrá las manijas con agarre prono y mantené los brazos levemente flexionados.",
+   "Exhalá y juntá los omóplatos mientras llevás las manijas hacia atrás y hacia afuera, alejándolas del cuerpo.",
+   "Hacé una pausa en la máxima contracción, después inhalá y volvé despacio a la posición inicial.",
+   "Repetí la cantidad de repeticiones deseada."
+  ],
+  "descEs": "Trabajo de aislamiento para los deltoides posteriores y la espalda alta."
+ },
+ "0603": {
+  "en": [
+   "Adjust the seat height and position yourself on the machine with your back against the backrest.",
+   "Grasp the handles with an overhand grip and position your hands at shoulder level.",
+   "Push the handles upward until your arms are fully extended, but do not lock your elbows.",
+   "Pause for a moment at the top, then slowly lower the handles back down to the starting position.",
+   "Repeat for the desired number of repetitions."
+  ],
+  "es": [
+   "Ajustá la altura del asiento y ubicate en la máquina con la espalda apoyada en el respaldo.",
+   "Agarrá las manijas con agarre prono y posicioná las manos a la altura de los hombros.",
+   "Empujá las manijas hacia arriba hasta extender los brazos por completo, sin bloquear los codos.",
+   "Hacé una pausa arriba, después bajá despacio las manijas hasta la posición inicial.",
+   "Repetí la cantidad de repeticiones deseada."
+  ],
+  "descEs": "Press de hombros clásico por encima de la cabeza para deltoides y tríceps."
+ },
+ "0605": {
+  "en": [
+   "Adjust the machine to your height and stand with your feet shoulder-width apart.",
+   "Place your shoulders under the pads and hold onto the handles for stability.",
+   "Raise your heels as high as possible by extending your ankles.",
+   "Pause for a moment at the top, then slowly lower your heels back down to the starting position.",
+   "Repeat for the desired number of repetitions."
+  ],
+  "es": [
+   "Ajustá la máquina a tu altura y parate con los pies a la anchura de los hombros.",
+   "Colocá los hombros debajo de las almohadillas y agarrate de las manijas para estabilizarte.",
+   "Elevá los talones lo más alto posible extendiendo los tobillos.",
+   "Hacé una pausa arriba, después bajá despacio los talones hasta la posición inicial.",
+   "Repetí la cantidad de repeticiones deseada."
+  ],
+  "descEs": "Trabajo de gemelos con carga y el torso inclinado hacia adelante."
+ },
+ "0606": {
+  "en": [
+   "Adjust the seat height and footplate position to ensure proper alignment.",
+   "Sit on the machine with your chest against the pad and your feet flat on the footplate.",
+   "Grasp the handles with an overhand grip, slightly wider than shoulder-width apart.",
+   "Keep your back straight and engage your core.",
+   "Pull the handles towards your torso, squeezing your shoulder blades together.",
+   "Pause for a moment at the peak contraction, then slowly release the handles back to the starting position.",
+   "Repeat for the desired number of repetitions."
+  ],
+  "es": [
+   "Ajustá la altura del asiento y la posición del apoyapiés para asegurar una buena alineación.",
+   "Sentate en la máquina con el pecho contra la almohadilla y los pies apoyados en el apoyapiés.",
+   "Agarrá las manijas con agarre prono, un poco más anchas que la anchura de los hombros.",
+   "Mantené la espalda recta y activá el core.",
+   "Llevá las manijas hacia el torso, juntando los omóplatos.",
+   "Hacé una pausa en la máxima contracción, después soltá despacio las manijas hasta la posición inicial.",
+   "Repetí la cantidad de repeticiones deseada."
+  ],
+  "descEs": "Remo con apoyo de pecho para reducir la fatiga de la zona lumbar."
+ },
+ "0630": {
+  "en": [
+   "Stand facing a wall with your feet hip-width apart.",
+   "Place your hands on the wall for support.",
+   "Engage your core and lift your right knee up towards your chest, while keeping your left foot on the ground.",
+   "Quickly switch legs, bringing your left knee up towards your chest and lowering your right foot back down.",
+   "Continue alternating legs in a running motion, bringing your knees up as high as possible.",
+   "Maintain a fast pace and keep your upper body stable throughout the exercise.",
+   "Repeat for the desired duration or number of repetitions."
+  ],
+  "es": [
+   "Pará frente a una pared con los pies a la altura de la cadera.",
+   "Apoyá las manos en la pared para sostenerte.",
+   "Activá el core y subí la rodilla derecha hacia el pecho, manteniendo el pie izquierdo en el piso.",
+   "Cambiá de pierna rápido, subiendo la rodilla izquierda hacia el pecho y bajando el pie derecho.",
+   "Seguí alternando las piernas en un movimiento de carrera, subiendo las rodillas lo más alto posible.",
+   "Mantené un ritmo rápido y el torso estable durante todo el ejercicio.",
+   "Repetí durante el tiempo o la cantidad de repeticiones deseada."
+  ],
+  "descEs": "Ejercicio de acondicionamiento a peso corporal de ritmo rápido."
+ },
+ "0636": {
+  "en": [
+   "Stand up straight with your feet shoulder-width apart and hold an Olympic barbell with an overhand grip.",
+   "Let the barbell hang at arm's length in front of your thighs, with your palms facing your body.",
+   "Keeping your upper arms stationary, exhale and curl the weights while contracting your biceps.",
+   "Continue to raise the barbell until your biceps are fully contracted and the barbell is at shoulder level.",
+   "Hold the contracted position for a brief pause as you squeeze your biceps.",
+   "Inhale and slowly begin to lower the barbell back to the starting position.",
+   "Repeat for the desired number of repetitions."
+  ],
+  "es": [
+   "Parate derecho con los pies a la anchura de los hombros y sostené una barra olímpica con agarre prono.",
+   "Dejá colgar la barra con los brazos extendidos frente a los muslos, con las palmas hacia el cuerpo.",
+   "Manteniendo los brazos superiores fijos, exhalá y flexioná el peso contrayendo los bíceps.",
+   "Seguí subiendo la barra hasta contraer del todo los bíceps, con la barra a la altura de los hombros.",
+   "Mantené la posición contraída una breve pausa apretando los bíceps.",
+   "Inhalá y empezá a bajar despacio la barra hasta la posición inicial.",
+   "Repetí la cantidad de repeticiones deseada."
+  ],
+  "descEs": "Patrón de curl general para desarrollar los brazos."
+ },
+ "0652": {
+  "en": [
+   "Hang from a pull-up bar with your palms facing towards you and your hands shoulder-width apart.",
+   "Engage your core and pull your body up towards the bar, leading with your chest.",
+   "Continue pulling until your chin is above the bar.",
+   "Pause for a moment at the top, then slowly lower your body back down to the starting position.",
+   "Repeat for the desired number of repetitions."
+  ],
+  "es": [
+   "Colgate de la barra de dominadas con las palmas mirando hacia vos y las manos a la altura de los hombros.",
+   "Activá el core y subí el cuerpo hacia la barra, llevando el pecho adelante.",
+   "Seguí subiendo hasta que el mentón pase por encima de la barra.",
+   "Hacé una pausa arriba y bajá lentamente el cuerpo hasta la posición inicial.",
+   "Repetí la cantidad de repeticiones deseada."
+  ],
+  "descEs": "Tracción vertical con agarre supino."
+ },
+ "0664": {
+  "en": [
+   "Start in a push-up position with your hands shoulder-width apart and your body in a straight line.",
+   "Lower your body towards the ground by bending your elbows, keeping your core engaged.",
+   "Push back up to the starting position.",
+   "Shift your weight onto your left hand and rotate your body to the right, lifting your right arm towards the ceiling.",
+   "Hold the side plank position for a few seconds, then return to the starting position.",
+   "Repeat the push-up and side plank on the opposite side.",
+   "Continue alternating sides for the desired number of repetitions."
+  ],
+  "es": [
+   "Empezá en posición de flexión con las manos a la anchura de los hombros y el cuerpo en línea recta.",
+   "Bajá el cuerpo hacia el piso flexionando los codos, manteniendo el core activo.",
+   "Empujá de nuevo hasta la posición inicial.",
+   "Pasá el peso a la mano izquierda y rotá el cuerpo hacia la derecha, levantando el brazo derecho hacia el techo.",
+   "Mantené la posición de plancha lateral unos segundos, después volvé a la posición inicial.",
+   "Repetí la flexión y la plancha lateral del lado opuesto.",
+   "Seguí alternando lados la cantidad de repeticiones deseada."
+  ],
+  "descEs": "Sostén de tronco contra la flexión lateral."
+ },
+ "0668": {
+  "en": [
+   "Lie flat on your back with your knees bent and feet flat on the ground.",
+   "Place your arms by your sides, palms facing down.",
+   "Engage your glutes and core, then lift your hips off the ground until your body forms a straight line from your knees to your shoulders.",
+   "Pause for a moment at the top, squeezing your glutes.",
+   "Slowly lower your hips back down to the starting position.",
+   "Repeat for the desired number of repetitions."
+  ],
+  "es": [
+   "Acostate boca arriba con las rodillas flexionadas y los pies apoyados en el piso.",
+   "Colocá los brazos a los costados, con las palmas hacia abajo.",
+   "Activá los glúteos y el core, y despegá la cadera del piso hasta que el cuerpo forme una línea recta desde las rodillas hasta los hombros.",
+   "Hacé una pausa arriba apretando los glúteos.",
+   "Bajá lentamente la cadera hasta la posición inicial.",
+   "Repetí la cantidad de repeticiones deseada."
+  ],
+  "descEs": "Puente de glúteos en el piso con fácil regulación de carga."
+ },
+ "0673": {
+  "en": [
+   "Adjust the seat height and position yourself on the machine with your knees under the pads and your feet flat on the ground.",
+   "Grasp the handles with an underhand grip, slightly wider than shoulder-width apart.",
+   "Sit upright with your chest out and shoulders back, maintaining a slight arch in your lower back.",
+   "Pull the handles down towards your chest, squeezing your shoulder blades together.",
+   "Pause for a moment at the bottom of the movement, then slowly release the handles back to the starting position.",
+   "Repeat for the desired number of repetitions."
+  ],
+  "es": [
+   "Ajustá la altura del asiento y ubicate en la máquina con las rodillas debajo de las almohadillas y los pies apoyados en el piso.",
+   "Agarrá la barra con agarre supino, un poco más ancho que la anchura de los hombros.",
+   "Sentate erguido con el pecho afuera y los hombros atrás, manteniendo un leve arco en la zona lumbar.",
+   "Tirá de la barra hacia el pecho, juntando los omóplatos.",
+   "Hacé una pausa abajo del movimiento, después soltá despacio la barra hasta la posición inicial.",
+   "Repetí la cantidad de repeticiones deseada."
+  ],
+  "descEs": "Tracción vertical en máquina cuando las dominadas no son el objetivo."
+ },
+ "0685": {
+  "en": [
+   "Start by standing upright with your feet hip-width apart.",
+   "Engage your core and keep your upper body relaxed.",
+   "Begin jogging in place, lifting your knees up towards your chest and landing softly on the balls of your feet.",
+   "Maintain a steady pace and continue jogging for the desired duration or distance.",
+   "Remember to breathe deeply and maintain good posture throughout the exercise."
+  ],
+  "es": [
+   "Empezá parado bien derecho con los pies a la altura de la cadera.",
+   "Activá el core y mantené el tren superior relajado.",
+   "Empezá a trotar, subiendo las rodillas hacia el pecho y cayendo suave sobre la punta de los pies.",
+   "Mantené un ritmo constante y seguí trotando durante el tiempo o la distancia deseada.",
+   "Acordate de respirar profundo y mantener una buena postura durante todo el ejercicio."
+  ],
+  "descEs": "Acondicionamiento en cinta a ritmo constante."
+ },
+ "0687": {
+  "en": [
+   "Sit on the ground with your knees bent and feet flat on the floor.",
+   "Lean back slightly while keeping your back straight and your core engaged.",
+   "Hold your hands together in front of your chest or hold a weight if desired.",
+   "Lift your feet off the ground, balancing on your sit bones.",
+   "Twist your torso to the right, bringing your hands or weight towards the right side of your body.",
+   "Pause for a moment, then twist your torso to the left, bringing your hands or weight towards the left side of your body.",
+   "Continue alternating sides for the desired number of repetitions."
+  ],
+  "es": [
+   "Sentate en el piso con las rodillas flexionadas y los pies apoyados en el suelo.",
+   "Inclinate levemente hacia atrás manteniendo la espalda recta y el core activo.",
+   "Mantené las manos juntas frente al pecho o sostené un peso si querés.",
+   "Levantá los pies del piso, equilibrándote sobre los isquiones.",
+   "Girá el torso hacia la derecha, llevando las manos o el peso hacia el lado derecho del cuerpo.",
+   "Hacé una pausa, después girá el torso hacia la izquierda, llevando las manos o el peso hacia el lado izquierdo del cuerpo.",
+   "Seguí alternando lados la cantidad de repeticiones deseada."
+  ],
+  "descEs": "Control rotacional del tronco y trabajo de oblicuos."
+ },
+ "0689": {
+  "en": [
+   "Sit on a flat bench with your back straight and your feet flat on the ground.",
+   "Place your hands on the sides of the bench for support.",
+   "Keeping your legs straight, slowly raise them up in front of you until they are parallel to the ground.",
+   "Pause for a moment at the top, then slowly lower your legs back down to the starting position.",
+   "Repeat for the desired number of repetitions."
+  ],
+  "es": [
+   "Sentate en un banco plano con la espalda recta y los pies apoyados en el piso.",
+   "Colocá las manos a los costados del banco para sostenerte.",
+   "Manteniendo las piernas estiradas, elevalas despacio hacia adelante hasta que queden paralelas al piso.",
+   "Hacé una pausa arriba, después bajá despacio las piernas hasta la posición inicial.",
+   "Repetí la cantidad de repeticiones deseada."
+  ],
+  "descEs": "Elevación de abdominales bajos con control estricto."
+ },
+ "0748": {
+  "en": [
+   "Adjust the height of the smith machine bar to chest level.",
+   "Lie flat on the bench with your feet firmly planted on the ground.",
+   "Grip the bar with an overhand grip slightly wider than shoulder-width apart.",
+   "Unrack the bar and lower it towards your chest, keeping your elbows tucked in.",
+   "Pause for a moment when the bar touches your chest.",
+   "Push the bar back up to the starting position, fully extending your arms.",
+   "Repeat for the desired number of repetitions."
+  ],
+  "es": [
+   "Ajustá la altura de la barra del smith a la altura del pecho.",
+   "Acostate plano en el banco con los pies firmemente apoyados en el piso.",
+   "Agarrá la barra con agarre prono un poco más ancho que la anchura de los hombros.",
+   "Sacá la barra del soporte y bajala hacia el pecho, manteniendo los codos recogidos.",
+   "Hacé una pausa cuando la barra toca el pecho.",
+   "Empujá la barra de nuevo hasta la posición inicial, extendiendo los brazos por completo.",
+   "Repetí la cantidad de repeticiones deseada."
+  ],
+  "descEs": "Press horizontal clásico para la fuerza del pecho."
+ },
+ "0749": {
+  "en": [
+   "Start by standing with your feet shoulder-width apart, toes pointing forward.",
+   "Place the barbell across your upper back, resting it on your traps.",
+   "Bend your knees slightly and hinge forward at the hips, keeping your back straight.",
+   "Lower your torso until it is parallel to the ground, feeling a stretch in your hamstrings.",
+   "Engage your glutes and hamstrings to raise your torso back up to the starting position.",
+   "Repeat for the desired number of repetitions."
+  ],
+  "es": [
+   "Empezá parado con los pies a la anchura de los hombros, las puntas de los pies hacia adelante.",
+   "Colocá la barra cruzada sobre la espalda alta, apoyándola en los trapecios.",
+   "Flexioná un poco las rodillas y hacé bisagra hacia adelante desde la cadera, manteniendo la espalda recta.",
+   "Bajá el torso hasta que quede paralelo al piso, sintiendo un estiramiento en los femorales.",
+   "Activá los glúteos y los femorales para subir el torso de nuevo hasta la posición inicial.",
+   "Repetí la cantidad de repeticiones deseada."
+  ],
+  "descEs": "Bisagra de cadera que carga fuerte los isquiotibiales."
+ },
+ "0751": {
+  "en": [
+   "Adjust the seat height and position yourself on the bench with your feet flat on the ground.",
+   "Grasp the barbell with a close grip, slightly narrower than shoulder-width apart.",
+   "Lower the barbell towards your chest, keeping your elbows close to your body.",
+   "Pause for a moment at the bottom, then push the barbell back up to the starting position.",
+   "Repeat for the desired number of repetitions."
+  ],
+  "es": [
+   "Ajustá la altura del asiento y ubicate en el banco con los pies apoyados en el piso.",
+   "Agarrá la barra con agarre cerrado, un poco más angosto que la anchura de los hombros.",
+   "Bajá la barra hacia el pecho, manteniendo los codos pegados al cuerpo.",
+   "Hacé una pausa abajo, después empujá la barra de nuevo hasta la posición inicial.",
+   "Repetí la cantidad de repeticiones deseada."
+  ],
+  "descEs": "Press pesado de tríceps con apoyo de pecho."
+ },
+ "0752": {
+  "en": [
+   "Set up the smith machine with the bar at hip height.",
+   "Stand with your feet shoulder-width apart, toes pointing slightly outward.",
+   "Bend at the hips and knees, keeping your back straight and chest up, and grip the bar with an overhand grip slightly wider than shoulder-width apart.",
+   "Engage your core and lift the bar by extending your hips and knees, keeping the bar close to your body.",
+   "Stand up straight, fully extending your hips and knees.",
+   "Lower the bar back down by bending at the hips and knees, maintaining control and keeping your back straight.",
+   "Repeat for the desired number of repetitions."
+  ],
+  "es": [
+   "Configurá el smith con la barra a la altura de la cadera.",
+   "Parate con los pies a la anchura de los hombros, las puntas de los pies levemente hacia afuera.",
+   "Flexioná la cadera y las rodillas, manteniendo la espalda recta y el pecho arriba, y agarrá la barra con agarre prono un poco más ancho que la anchura de los hombros.",
+   "Activá el core y levantá la barra extendiendo la cadera y las rodillas, manteniendo la barra pegada al cuerpo.",
+   "Parate derecho, extendiendo por completo la cadera y las rodillas.",
+   "Bajá la barra flexionando la cadera y las rodillas, manteniendo el control y la espalda recta.",
+   "Repetí la cantidad de repeticiones deseada."
+  ],
+  "descEs": "Tracción y bisagra completa de la cadena posterior."
+ },
+ "0753": {
+  "en": [
+   "Adjust the decline bench to the desired angle.",
+   "Lie down on the bench with your feet secured under the foot pads.",
+   "Grasp the barbell with an overhand grip slightly wider than shoulder-width apart.",
+   "Unrack the barbell and lower it slowly towards your chest, keeping your elbows tucked in.",
+   "Pause for a moment at the bottom, then push the barbell back up to the starting position.",
+   "Repeat for the desired number of repetitions."
+  ],
+  "es": [
+   "Ajustá el banco declinado al ángulo deseado.",
+   "Acostate en el banco con los pies asegurados debajo de los apoyapiés.",
+   "Agarrá la barra con agarre prono un poco más ancho que la anchura de los hombros.",
+   "Sacá la barra del soporte y bajala despacio hacia el pecho, manteniendo los codos recogidos.",
+   "Hacé una pausa abajo, después empujá la barra de nuevo hasta la posición inicial.",
+   "Repetí la cantidad de repeticiones deseada."
+  ],
+  "descEs": "Variante de press declinado que enfatiza el pecho bajo."
+ },
+ "0755": {
+  "en": [
+   "Adjust the barbell on the smith machine to an appropriate height for your body.",
+   "Stand with your feet shoulder-width apart, toes slightly pointed outwards.",
+   "Position yourself under the barbell, resting it on your upper traps and shoulders.",
+   "Grasp the barbell with an overhand grip, slightly wider than shoulder-width apart.",
+   "Engage your core and keep your chest up as you unrack the barbell.",
+   "Take a step back and position your feet slightly wider than shoulder-width apart.",
+   "Bend your knees and lower your body down, keeping your chest up and back straight.",
+   "Continue descending until your thighs are parallel to the ground or slightly below.",
+   "Pause for a moment at the bottom, then push through your heels to return to the starting position.",
+   "Repeat for the desired number of repetitions."
+  ],
+  "es": [
+   "Ajustá la barra del smith a una altura apropiada para tu cuerpo.",
+   "Parate con los pies a la anchura de los hombros, las puntas de los pies levemente hacia afuera.",
+   "Ubicate debajo de la barra, apoyándola sobre los trapecios y los hombros.",
+   "Agarrá la barra con agarre prono, un poco más ancho que la anchura de los hombros.",
+   "Activá el core y mantené el pecho arriba mientras sacás la barra del soporte.",
+   "Dá un paso atrás y posicioná los pies un poco más anchos que la anchura de los hombros.",
+   "Flexioná las rodillas y bajá el cuerpo, manteniendo el pecho arriba y la espalda recta.",
+   "Seguí bajando hasta que los muslos queden paralelos al piso o un poco más abajo.",
+   "Hacé una pausa abajo, después empujá con los talones para volver a la posición inicial.",
+   "Repetí la cantidad de repeticiones deseada."
+  ],
+  "descEs": "Sentadilla con apoyo que enfatiza los cuádriceps."
+ },
+ "0757": {
+  "en": [
+   "Adjust the bench to a 30-45 degree incline.",
+   "Sit on the bench with your back flat against the pad and feet firmly on the ground.",
+   "Grasp the barbell with an overhand grip slightly wider than shoulder-width apart.",
+   "Unrack the barbell and lower it slowly towards your upper chest, keeping your elbows slightly tucked in.",
+   "Pause for a moment at the bottom, then push the barbell back up to the starting position, fully extending your arms.",
+   "Repeat for the desired number of repetitions."
+  ],
+  "es": [
+   "Ajustá el banco a una inclinación de 30 a 45 grados.",
+   "Sentate en el banco con la espalda plana contra la almohadilla y los pies firmes en el piso.",
+   "Agarrá la barra con agarre prono un poco más ancho que la anchura de los hombros.",
+   "Sacá la barra del soporte y bajala despacio hacia la parte alta del pecho, manteniendo los codos levemente recogidos.",
+   "Hacé una pausa abajo, después empujá la barra de nuevo hasta la posición inicial, extendiendo los brazos por completo.",
+   "Repetí la cantidad de repeticiones deseada."
+  ],
+  "descEs": "Variante de press inclinado que enfatiza el pecho alto."
+ },
+ "0760": {
+  "en": [
+   "Adjust the barbell on the smith machine to an appropriate height for your body.",
+   "Stand with your feet shoulder-width apart, toes slightly pointed outwards.",
+   "Position yourself under the barbell, resting it on your upper traps and shoulders.",
+   "Grasp the barbell with an overhand grip, slightly wider than shoulder-width apart.",
+   "Engage your core and keep your chest up as you unrack the barbell.",
+   "Take a step back and position your feet slightly wider than shoulder-width apart.",
+   "Bend your knees and lower your body down, keeping your chest up and back straight.",
+   "Continue descending until your thighs are parallel to the ground or slightly below.",
+   "Pause for a moment at the bottom, then push through your heels to return to the starting position.",
+   "Repeat for the desired number of repetitions."
+  ],
+  "es": [
+   "Ajustá la barra del smith a una altura adecuada para tu cuerpo.",
+   "Pará con los pies a la altura de los hombros y las puntas levemente hacia afuera.",
+   "Ubicate debajo de la barra, apoyándola sobre la parte alta de los trapecios y los hombros.",
+   "Agarrá la barra con agarre prono, un poco más ancho que los hombros.",
+   "Activá el core y mantené el pecho erguido mientras destrabás la barra.",
+   "Dá un paso atrás y colocá los pies un poco más anchos que los hombros.",
+   "Flexioná las rodillas y bajá el cuerpo, manteniendo el pecho erguido y la espalda recta.",
+   "Seguí bajando hasta que los muslos queden paralelos al piso o un poco por debajo.",
+   "Hacé una pausa abajo y empujá con los talones para volver a la posición inicial.",
+   "Repetí la cantidad de repeticiones deseada."
+  ],
+  "descEs": "Sentadilla asistida para cargar fuerte los cuádriceps."
+ },
+ "0765": {
+  "en": [
+   "Stand with your feet shoulder-width apart and your knees slightly bent.",
+   "Grasp the barbell with an overhand grip, slightly wider than shoulder-width apart.",
+   "Lift the barbell off the rack and bring it down to shoulder level, with your palms facing forward.",
+   "Press the barbell upward until your arms are fully extended overhead.",
+   "Pause for a moment at the top, then slowly lower the barbell back down to shoulder level.",
+   "Repeat for the desired number of repetitions."
+  ],
+  "es": [
+   "Pará con los pies a la altura de los hombros y las rodillas levemente flexionadas.",
+   "Agarrá la barra con agarre prono, un poco más ancho que los hombros.",
+   "Destrabá la barra del soporte y bajala a la altura de los hombros, con las palmas mirando hacia adelante.",
+   "Presioná la barra hacia arriba hasta extender los brazos por completo por encima de la cabeza.",
+   "Hacé una pausa arriba y bajá lentamente la barra hasta la altura de los hombros.",
+   "Repetí la cantidad de repeticiones deseada."
+  ],
+  "descEs": "Clásico press por encima de la cabeza para deltoides y tríceps."
+ },
+ "0768": {
+  "en": [
+   "Stand in front of the smith machine with your feet shoulder-width apart.",
+   "Place one foot behind you on a bench or step, with your toes pointing forward.",
+   "Hold onto the smith machine bar for stability.",
+   "Bend your front knee and lower your body down into a lunge position, keeping your back straight.",
+   "Pause for a moment at the bottom, then push through your front heel to return to the starting position.",
+   "Repeat for the desired number of repetitions, then switch legs."
+  ],
+  "es": [
+   "Parate frente al smith con los pies a la anchura de los hombros.",
+   "Colocá un pie atrás sobre un banco o step, con las puntas de los pies hacia adelante.",
+   "Agarrate de la barra del smith para estabilizarte.",
+   "Flexioná la rodilla delantera y bajá el cuerpo a una posición de zancada, manteniendo la espalda recta.",
+   "Hacé una pausa abajo, después empujá con el talón delantero para volver a la posición inicial.",
+   "Repetí la cantidad de repeticiones deseada, después cambiá de pierna."
+  ],
+  "descEs": "Constructor unilateral estacionario de cuádriceps y glúteos."
+ },
+ "0769": {
+  "en": [
+   "Stand in front of the smith machine with your feet shoulder-width apart.",
+   "Place one foot behind you on a bench or step, with your toes pointing forward.",
+   "Hold onto the smith machine bar for stability.",
+   "Bend your front knee and lower your body down into a lunge position, keeping your back straight.",
+   "Pause for a moment at the bottom, then push through your front heel to return to the starting position.",
+   "Repeat for the desired number of repetitions, then switch legs."
+  ],
+  "es": [
+   "Pará frente al smith con los pies a la altura de los hombros.",
+   "Apoyá un pie atrás sobre un banco o step, con las puntas hacia adelante.",
+   "Sostenete de la barra del smith para mantener el equilibrio.",
+   "Flexioná la rodilla de adelante y bajá el cuerpo a posición de zancada, manteniendo la espalda recta.",
+   "Hacé una pausa abajo y empujá con el talón de adelante para volver a la posición inicial.",
+   "Repetí la cantidad de repeticiones deseada y después cambiá de pierna."
+  ],
+  "descEs": "Ejercicio unilateral para glúteos y cuádriceps."
+ },
+ "0770": {
+  "en": [
+   "Adjust the seat and foot platform of the leverage machine to your desired position.",
+   "Sit on the machine with your back against the backrest and your feet on the foot platform.",
+   "Place your hands on the handles or sides of the machine for stability.",
+   "Push one foot against the foot platform, extending your leg until it is almost fully straight.",
+   "Pause for a moment, then slowly bend your leg and return to the starting position.",
+   "Repeat with the other leg.",
+   "Continue alternating legs for the desired number of repetitions."
+  ],
+  "es": [
+   "Ajustá el asiento y la plataforma de la máquina a la posición que prefieras.",
+   "Sentate en la máquina con la espalda contra el respaldo y los pies sobre la plataforma.",
+   "Apoyá las manos en las manijas o los costados de la máquina para mantener el equilibrio.",
+   "Empujá una pierna contra la plataforma, extendiéndola hasta dejarla casi recta del todo.",
+   "Hacé una pausa y flexioná lentamente la pierna para volver a la posición inicial.",
+   "Repetí con la otra pierna.",
+   "Seguí alternando piernas la cantidad de repeticiones deseada."
+  ],
+  "descEs": "Alternativa a la sentadilla en máquina."
+ },
+ "0773": {
+  "en": [
+   "Adjust the smith machine bar to a height that allows you to stand with your feet flat on the ground and your shoulders under the bar.",
+   "Position yourself under the bar with your feet shoulder-width apart and your toes pointing forward.",
+   "Place your hands on the bar for stability.",
+   "Engage your calves and slowly raise your heels off the ground, lifting your body up onto your toes.",
+   "Pause for a moment at the top, then slowly lower your heels back down to the starting position.",
+   "Repeat for the desired number of repetitions."
+  ],
+  "es": [
+   "Ajustá la barra del smith a una altura que te permita pararte con los pies apoyados en el piso y los hombros debajo de la barra.",
+   "Ubicate debajo de la barra con los pies a la anchura de los hombros y las puntas de los pies hacia adelante.",
+   "Colocá las manos en la barra para estabilizarte.",
+   "Activá los gemelos y elevá despacio los talones del piso, levantando el cuerpo sobre las puntas de los pies.",
+   "Hacé una pausa arriba, después bajá despacio los talones hasta la posición inicial.",
+   "Repetí la cantidad de repeticiones deseada."
+  ],
+  "descEs": "Fuerza de gemelos y estabilidad del tobillo."
+ },
+ "0774": {
+  "en": [
+   "Adjust the seat height so that the handles are at shoulder level.",
+   "Sit on the machine with your back against the pad and your feet flat on the floor.",
+   "Grasp the handles with an overhand grip and lift them off the supports, extending your arms fully.",
+   "Lower the handles down to shoulder level, keeping your elbows slightly bent.",
+   "Press the handles up overhead until your arms are fully extended.",
+   "Pause for a moment at the top, then slowly lower the handles back down to shoulder level.",
+   "Repeat for the desired number of repetitions."
+  ],
+  "es": [
+   "Ajustá la altura del asiento para que las manijas queden a la altura de los hombros.",
+   "Sentate en la máquina con la espalda contra el respaldo y los pies apoyados en el piso.",
+   "Agarrá las manijas con agarre prono y destrabalas de los soportes, extendiendo los brazos por completo.",
+   "Bajá las manijas a la altura de los hombros, manteniendo los codos levemente flexionados.",
+   "Presioná las manijas hacia arriba por encima de la cabeza hasta extender los brazos por completo.",
+   "Hacé una pausa arriba y bajá lentamente las manijas a la altura de los hombros.",
+   "Repetí la cantidad de repeticiones deseada."
+  ],
+  "descEs": "Patrón de empuje estable con menos demanda del tren inferior."
+ },
+ "0795": {
+  "en": [
+   "Adjust the glute-ham raise machine to fit your body.",
+   "Position yourself face down on the machine with your ankles secured.",
+   "Place your hands on your chest or cross them over your chest.",
+   "Engage your hamstrings and glutes to lift your upper body up towards the ceiling.",
+   "Continue lifting until your body is in a straight line from your head to your heels.",
+   "Pause for a moment at the top, then slowly lower your body back down to the starting position.",
+   "Repeat for the desired number of repetitions."
+  ],
+  "es": [
+   "Ajustá la máquina de glúteo-femoral a tu cuerpo.",
+   "Ubicate boca abajo en la máquina con los tobillos sujetos.",
+   "Apoyá las manos sobre el pecho o cruzalas sobre el pecho.",
+   "Activá los isquiotibiales y los glúteos para levantar el tren superior hacia el techo.",
+   "Seguí subiendo hasta que el cuerpo quede en línea recta desde la cabeza hasta los talones.",
+   "Hacé una pausa arriba y bajá lentamente el cuerpo hasta la posición inicial.",
+   "Repetí la cantidad de repeticiones deseada."
+  ],
+  "descEs": "Fuerza de la cadena posterior con fuerte demanda de isquiotibiales."
+ },
+ "0809": {
+  "en": [
+   "Stand facing away from a suspension trainer with your feet shoulder-width apart.",
+   "Extend one leg forward and place the top of your foot in the foot cradle of the suspension trainer.",
+   "Bend your standing leg and lower your body down into a lunge position, keeping your chest up and your knee in line with your toes.",
+   "Push through your heel to return to the starting position.",
+   "Repeat for the desired number of repetitions, then switch legs."
+  ],
+  "es": [
+   "Parate de espaldas a un entrenador de suspensión con los pies a la anchura de los hombros.",
+   "Extendé una pierna hacia adelante y colocá el empeine en el estribo del entrenador de suspensión.",
+   "Flexioná la pierna de apoyo y bajá el cuerpo a una posición de zancada, manteniendo el pecho arriba y la rodilla alineada con las puntas de los pies.",
+   "Empujá con el talón para volver a la posición inicial.",
+   "Repetí la cantidad de repeticiones deseada, después cambiá de pierna."
+  ],
+  "descEs": "Constructor unilateral estacionario de cuádriceps y glúteos."
+ },
+ "0814": {
+  "en": [
+   "Sit on the edge of a bench or chair with your hands gripping the edge, fingers pointing forward.",
+   "Slide your butt off the bench, supporting your weight with your hands.",
+   "Bend your elbows and lower your body towards the ground, keeping your back close to the bench.",
+   "Pause for a moment at the bottom, then push yourself back up to the starting position.",
+   "Repeat for the desired number of repetitions."
+  ],
+  "es": [
+   "Sentate en el borde de un banco o silla con las manos agarrando el borde, los dedos hacia adelante.",
+   "Deslizá la cola fuera del banco, sosteniendo el peso con las manos.",
+   "Flexioná los codos y bajá el cuerpo hacia el piso, manteniendo la espalda cerca del banco.",
+   "Hacé una pausa abajo, después empujá de nuevo hacia arriba hasta la posición inicial.",
+   "Repetí la cantidad de repeticiones deseada."
+  ],
+  "descEs": "Movimiento compuesto de tríceps con asistencia del pecho."
+ },
+ "0832": {
+  "en": [
+   "Lie flat on your back with your knees bent and feet flat on the ground.",
+   "Hold a weight plate or dumbbell on your chest.",
+   "Engage your abs and lift your upper body off the ground, curling forward until your shoulder blades are off the ground.",
+   "Pause for a moment at the top, then slowly lower your upper body back down to the starting position.",
+   "Repeat for the desired number of repetitions."
+  ],
+  "es": [
+   "Acostate boca arriba con las rodillas flexionadas y los pies apoyados en el piso.",
+   "Sostené un disco o una mancuerna sobre el pecho.",
+   "Activá los abdominales y levantá el tronco del piso, enrollándote hacia adelante hasta despegar los omóplatos.",
+   "Hacé una pausa arriba y después bajá lentamente el tronco hasta la posición inicial.",
+   "Repetí la cantidad de repeticiones deseada."
+  ],
+  "descEs": "Flexión de tronco en recorrido completo."
+ },
+ "0846": {
+  "en": [
+   "Sit on the ground with your knees bent and your feet flat on the floor.",
+   "Hold a weight or medicine ball with both hands in front of your chest.",
+   "Lean back slightly, keeping your back straight and your core engaged.",
+   "Slowly twist your torso to the right, bringing the weight or medicine ball towards the floor on your right side.",
+   "Pause for a moment, then twist your torso to the left, bringing the weight or medicine ball towards the floor on your left side.",
+   "Continue alternating sides for the desired number of repetitions."
+  ],
+  "es": [
+   "Sentate en el piso con las rodillas flexionadas y los pies apoyados.",
+   "Sostené un disco o una pelota medicinal con ambas manos frente al pecho.",
+   "Inclinate ligeramente hacia atrás, manteniendo la espalda recta y el core activo.",
+   "Girá lentamente el torso hacia la derecha, llevando el disco o la pelota hacia el piso de ese lado.",
+   "Hacé una pausa y después girá el torso hacia la izquierda, llevando el disco o la pelota hacia el piso de ese lado.",
+   "Seguí alternando lados durante la cantidad de repeticiones deseada."
+  ],
+  "descEs": "Control rotacional del tronco y trabajo de oblicuos."
+ },
+ "0851": {
+  "en": [
+   "Stand with your feet shoulder-width apart and your toes pointing slightly outward.",
+   "Hold a weight in front of your chest with both hands, or place a barbell across your upper back.",
+   "Keeping your chest up and your core engaged, slowly lower your body down by bending at the knees and hips.",
+   "Continue lowering until your thighs are parallel to the ground or as low as you can comfortably go.",
+   "Pause for a moment at the bottom, then push through your heels to return to the starting position.",
+   "Repeat for the desired number of repetitions."
+  ],
+  "es": [
+   "Parate con los pies al ancho de los hombros y las puntas de los pies apuntando ligeramente hacia afuera.",
+   "Sostené un disco frente al pecho con ambas manos, o apoyá una barra sobre la parte alta de la espalda.",
+   "Manteniendo el pecho arriba y el core activo, bajá lentamente flexionando rodillas y caderas.",
+   "Seguí bajando hasta que los muslos queden paralelos al piso o tan abajo como puedas cómodamente.",
+   "Hacé una pausa abajo y después empujá con los talones para volver a la posición inicial.",
+   "Repetí la cantidad de repeticiones deseada."
+  ],
+  "descEs": "Patrón de aislamiento de cuádriceps con amplio recorrido de rodilla."
+ },
+ "0860": {
+  "en": [
+   "Stand facing a cable machine with your feet shoulder-width apart.",
+   "Hold the cable handle with your right hand and step back to create tension in the cable.",
+   "Bend your knees slightly and hinge forward at the hips, keeping your back straight.",
+   "Keep your upper arm close to your body and your elbow bent at a 90-degree angle.",
+   "Extend your forearm backward, straightening your arm fully.",
+   "Pause for a moment, then slowly return to the starting position.",
+   "Repeat for the desired number of repetitions, then switch sides."
+  ],
+  "es": [
+   "Parate de frente a la polea con los pies al ancho de los hombros.",
+   "Agarrá la manija de la polea con la mano derecha y dá un paso atrás para generar tensión en el cable.",
+   "Flexioná ligeramente las rodillas y hacé una bisagra de cadera hacia adelante, manteniendo la espalda recta.",
+   "Mantené el brazo pegado al cuerpo y el codo flexionado a 90 grados.",
+   "Extendé el antebrazo hacia atrás, estirando el brazo por completo.",
+   "Hacé una pausa y después volvé lentamente a la posición inicial.",
+   "Repetí la cantidad de repeticiones deseada y después cambiá de lado."
+  ],
+  "descEs": "Aislamiento de glúteo con resistencia de polea."
+ },
+ "0861": {
+  "en": [
+   "Sit on the cable row machine with your feet flat on the footrests and your knees slightly bent.",
+   "Grasp the handles with an overhand grip, keeping your back straight and your shoulders relaxed.",
+   "Pull the handles towards your body, squeezing your shoulder blades together.",
+   "Pause for a moment at the peak of the movement, then slowly release the handles back to the starting position.",
+   "Repeat for the desired number of repetitions."
+  ],
+  "es": [
+   "Sentate en la máquina de remo con los pies apoyados en los soportes y las rodillas ligeramente flexionadas.",
+   "Agarrá las manijas con un agarre prono, manteniendo la espalda recta y los hombros relajados.",
+   "Tirá de las manijas hacia el cuerpo, juntando los omóplatos.",
+   "Hacé una pausa en el punto máximo del movimiento y después soltá lentamente las manijas hasta la posición inicial.",
+   "Repetí la cantidad de repeticiones deseada."
+  ],
+  "descEs": "Tirón horizontal para dorsales y espalda media."
+ },
+ "0868": {
+  "en": [
+   "Adjust the seat height and position yourself on the leverage machine.",
+   "Place your upper arms on the pad and grip the handles with an underhand grip.",
+   "Keep your back straight and your elbows positioned on the pad.",
+   "Exhale and curl your forearms towards your upper arms, contracting your biceps.",
+   "Pause for a moment at the top of the movement, squeezing your biceps.",
+   "Inhale and slowly lower the handles back to the starting position.",
+   "Repeat for the desired number of repetitions."
+  ],
+  "es": [
+   "Ajustá la altura del asiento y acomodate en la máquina.",
+   "Apoyá los brazos sobre el pad y agarrá las manijas con agarre supino.",
+   "Mantené la espalda recta y los codos apoyados sobre el pad.",
+   "Exhalá y flexioná los antebrazos hacia los brazos, contrayendo los bíceps.",
+   "Hacé una pausa arriba apretando los bíceps.",
+   "Inhalá y bajá lentamente las manijas hasta la posición inicial.",
+   "Repetí la cantidad de repeticiones deseada."
+  ],
+  "descEs": "Curl asistido que aísla los bíceps."
+ },
+ "0872": {
+  "en": [
+   "Lie flat on your back with your arms extended along your sides.",
+   "Bend your knees and lift your feet off the ground, bringing your thighs perpendicular to the floor.",
+   "Contract your abs and curl your hips off the floor, bringing your knees towards your chest.",
+   "Pause for a moment at the top, then slowly lower your hips back down to the starting position.",
+   "Repeat for the desired number of repetitions."
+  ],
+  "es": [
+   "Acostate boca arriba con los brazos extendidos a los costados.",
+   "Flexioná las rodillas y despegá los pies del piso, llevando los muslos perpendiculares al suelo.",
+   "Contraé los abdominales y enrollá las caderas, llevando las rodillas hacia el pecho.",
+   "Hacé una pausa arriba y después bajá lentamente las caderas hasta la posición inicial.",
+   "Repetí la cantidad de repeticiones deseada."
+  ],
+  "descEs": "Movimiento clásico de abdominales por flexión de columna."
+ },
+ "0979": {
+  "en": [
+   "Attach the band to a sturdy anchor point at waist height.",
+   "Stand perpendicular to the anchor point with your feet shoulder-width apart.",
+   "Grasp the band handle with both hands and step away from the anchor point to create tension in the band.",
+   "Bring your hands to your chest, keeping your elbows bent and close to your body.",
+   "Engage your core and maintain a stable stance.",
+   "Extend your arms straight out in front of you, pushing the band away from your body.",
+   "Hold the extended position for a few seconds, focusing on maintaining tension in your core.",
+   "Slowly bring your hands back to your chest, resisting the pull of the band.",
+   "Repeat for the desired number of repetitions."
+  ],
+  "es": [
+   "Enganchá la banda a un punto de anclaje firme a la altura de la cintura.",
+   "Parate perpendicular al anclaje con los pies al ancho de los hombros.",
+   "Agarrá la manija con ambas manos y alejate del anclaje para generar tensión en la banda.",
+   "Llevá las manos al pecho, manteniendo los codos flexionados y pegados al cuerpo.",
+   "Activá el core y mantené una postura estable.",
+   "Extendé los brazos rectos hacia adelante, empujando la banda lejos del cuerpo.",
+   "Mantené la posición extendida unos segundos, enfocándote en sostener la tensión en el core.",
+   "Volvé lentamente las manos al pecho, resistiendo el tirón de la banda.",
+   "Repetí la cantidad de repeticiones deseada."
+  ],
+  "descEs": "Press de core anti-rotación."
+ },
+ "0994": {
+  "en": [
+   "Attach a weight to one end of a rope or bar.",
+   "Hold the other end of the rope or bar with both hands, palms facing down.",
+   "Stand with your feet shoulder-width apart and your arms fully extended in front of you.",
+   "Slowly roll the weight up towards your hands by flexing your wrists.",
+   "Pause for a moment at the top, then slowly lower the weight back down to the starting position.",
+   "Repeat for the desired number of repetitions."
+  ],
+  "es": [
+   "Sujetá un disco a un extremo de la cuerda del rulo de muñeca.",
+   "Sostené la barra del rulo con ambas manos, con las palmas hacia abajo.",
+   "Pará con los pies a la altura de los hombros y los brazos totalmente extendidos al frente.",
+   "Enrollá lentamente el peso hacia tus manos flexionando las muñecas.",
+   "Hacé una pausa arriba y desenrollá lentamente el peso hasta la posición inicial.",
+   "Repetí la cantidad de repeticiones deseada."
+  ],
+  "descEs": "Resistencia de antebrazo con flexión repetida de muñeca."
+ },
+ "std-cardio-rowing-machine": {
+  "en": [
+   "Sit on the rowing machine and secure your feet in the foot straps.",
+   "Grab the handle with both hands and extend your arms forward, sliding the seat toward the front.",
+   "Drive through your legs first, then lean back slightly and pull the handle toward your lower chest.",
+   "Reverse the motion in order: extend the arms, hinge forward, then bend the knees to slide back to the start.",
+   "Keep a smooth, steady rhythm and maintain a flat back throughout.",
+   "Continue rowing for the desired time or distance."
+  ],
+  "es": [
+   "Sentate en la máquina de remo y asegurá los pies en las cinchas.",
+   "Agarrá la manija con ambas manos y extendé los brazos hacia adelante, deslizando el asiento hacia el frente.",
+   "Empujá primero con las piernas, después inclinate ligeramente hacia atrás y tirá de la manija hacia la parte baja del pecho.",
+   "Invertí el movimiento en orden: extendé los brazos, hacé una bisagra hacia adelante y después flexioná las rodillas para deslizarte de vuelta al inicio.",
+   "Mantené un ritmo suave y constante, con la espalda recta en todo momento.",
+   "Seguí remando durante el tiempo o la distancia deseada."
+  ],
+  "descEs": "Opción de cardio de cuerpo completo y bajo impacto."
+ },
+ "std-cardio-shadow-boxing-bodyweight": {
+  "en": [
+   "Stand with your feet shoulder-width apart and knees slightly bent in a boxing stance.",
+   "Raise your hands to guard your face and keep your core engaged.",
+   "Throw alternating punches, rotating your torso and pivoting your feet with each strike.",
+   "Mix in jabs, crosses, and hooks while staying light on your feet.",
+   "Keep moving and breathing steadily throughout the round.",
+   "Continue for the desired time or number of rounds."
+  ],
+  "es": [
+   "Parate con los pies al ancho de los hombros y las rodillas ligeramente flexionadas en posición de boxeo.",
+   "Levantá las manos para proteger la cara y mantené el core activo.",
+   "Lanzá golpes alternados, rotando el torso y pivoteando los pies en cada golpe.",
+   "Combiná jabs, directos y ganchos manteniéndote liviano sobre los pies.",
+   "Seguí moviéndote y respirando de forma constante durante todo el round.",
+   "Continuá durante el tiempo o la cantidad de rounds deseada."
+  ],
+  "descEs": "Cardio de tren superior con movimiento rotacional."
+ },
+ "std-cardio-sprint-none": {
+  "en": [
+   "Find a clear, flat stretch of ground and warm up with light jogging.",
+   "Get into a ready stance with one foot slightly forward and your weight on the balls of your feet.",
+   "Explode forward, driving your knees high and pumping your arms at maximum effort.",
+   "Sprint at full speed for the set distance or time.",
+   "Slow down gradually and walk to recover before the next sprint.",
+   "Repeat for the desired number of intervals."
+  ],
+  "es": [
+   "Buscá un tramo de piso despejado y plano, y entrá en calor con un trote suave.",
+   "Ponete en posición de salida con un pie ligeramente adelantado y el peso sobre la parte delantera de los pies.",
+   "Salí explosivo hacia adelante, llevando las rodillas bien arriba y bombeando los brazos al máximo esfuerzo.",
+   "Esprintá a máxima velocidad durante la distancia o el tiempo establecido.",
+   "Desacelerá de a poco y caminá para recuperarte antes del próximo sprint.",
+   "Repetí la cantidad de intervalos deseada."
+  ],
+  "descEs": "Acondicionamiento de velocidad de alta intensidad."
+ },
+ "std-cardio-stair-climber-machine": {
+  "en": [
+   "Step onto the stair climber and grip the side rails lightly for balance.",
+   "Select your desired speed or resistance level and begin stepping.",
+   "Stand tall with an upright posture and avoid leaning heavily on the rails.",
+   "Drive through the full foot on each step, keeping a steady cadence.",
+   "Breathe steadily and maintain your pace throughout the session.",
+   "Continue climbing for the desired time or step count."
+  ],
+  "es": [
+   "Subite a la escaladora y agarrá los pasamanos suavemente para mantener el equilibrio.",
+   "Seleccioná la velocidad o el nivel de resistencia deseado y empezá a pisar.",
+   "Mantené el cuerpo erguido y evitá apoyarte con fuerza en los pasamanos.",
+   "Empujá con todo el pie en cada escalón, manteniendo una cadencia constante.",
+   "Respirá de forma pareja y mantené el ritmo durante toda la sesión.",
+   "Seguí subiendo durante el tiempo o la cantidad de escalones deseada."
+  ],
+  "descEs": "Cardio basado en escalones con quemazón en las piernas."
+ },
+ "std-core-dead-bug-medicine-ball": {
+  "en": [
+   "Lie flat on your back with your arms extended toward the ceiling holding a medicine ball.",
+   "Lift your legs and bend your knees to a 90-degree angle, hips and knees stacked.",
+   "Press your lower back into the floor and engage your core.",
+   "Slowly lower one leg and the opposite arm toward the floor without arching your back.",
+   "Return to the start with control, then repeat on the other side.",
+   "Continue alternating for the desired number of repetitions."
+  ],
+  "es": [
+   "Acostate boca arriba con los brazos extendidos hacia el techo sosteniendo un balón medicinal.",
+   "Levantá las piernas y flexioná las rodillas a 90 grados, con caderas y rodillas alineadas.",
+   "Presioná la zona lumbar contra el piso y activá el core.",
+   "Bajá lentamente una pierna y el brazo opuesto hacia el piso sin arquear la espalda.",
+   "Volvé al inicio con control y después repetí del otro lado.",
+   "Seguí alternando durante la cantidad de repeticiones deseada."
+  ],
+  "descEs": "Ejercicio de coordinación del core amigable con la zona lumbar."
+ },
+ "std-flexibility-cat-cow-bodyweight": {
+  "en": [
+   "Start on all fours with your hands under your shoulders and knees under your hips.",
+   "Inhale and drop your belly toward the floor, lifting your chest and tailbone into the cow position.",
+   "Exhale and round your spine toward the ceiling, tucking your chin and tailbone into the cat position.",
+   "Move slowly between the two positions, syncing the movement with your breath.",
+   "Keep the motion smooth and controlled throughout.",
+   "Repeat for the desired number of repetitions."
+  ],
+  "es": [
+   "Ponete en cuatro apoyos con las manos debajo de los hombros y las rodillas debajo de las caderas.",
+   "Inhalá y dejá caer la panza hacia el piso, levantando el pecho y el coxis en la posición de vaca.",
+   "Exhalá y redondeá la columna hacia el techo, metiendo el mentón y el coxis en la posición de gato.",
+   "Movete lentamente entre las dos posiciones, sincronizando el movimiento con la respiración.",
+   "Mantené el movimiento suave y controlado en todo momento.",
+   "Repetí la cantidad de repeticiones deseada."
+  ],
+  "descEs": "Ejercicio suave de movilidad de columna."
+ },
+ "std-flexibility-thoracic-rotation-bodyweight": {
+  "en": [
+   "Start on all fours, then sit your hips back toward your heels.",
+   "Place one hand behind your head with the elbow pointing out to the side.",
+   "Rotate your elbow down toward the opposite wrist, then open up by rotating your chest toward the ceiling.",
+   "Follow your elbow with your eyes as you rotate through the upper back.",
+   "Move slowly and breathe out as you open into the rotation.",
+   "Repeat for the desired number of repetitions, then switch sides."
+  ],
+  "es": [
+   "Ponete en cuatro apoyos y después llevá las caderas hacia atrás en dirección a los talones.",
+   "Colocá una mano detrás de la cabeza con el codo apuntando hacia el costado.",
+   "Rotá el codo hacia abajo en dirección a la muñeca opuesta y después abrite rotando el pecho hacia el techo.",
+   "Seguí el codo con la mirada mientras rotás desde la parte alta de la espalda.",
+   "Movete lentamente y exhalá a medida que te abrís en la rotación.",
+   "Repetí la cantidad de repeticiones deseada y después cambiá de lado."
+  ],
+  "descEs": "Ejercicio de movilidad rotacional de la espalda alta."
+ },
+ "std-forearms-dead-hang-pull-up-bar": {
+  "en": [
+   "Stand under a pull-up bar and reach up to grab it with an overhand grip, hands shoulder-width apart.",
+   "Lift your feet off the ground and let your body hang fully with arms extended.",
+   "Keep your shoulders slightly engaged and your core tight.",
+   "Hold the hang position for as long as you can while maintaining your grip.",
+   "Lower your feet to the ground gently to finish.",
+   "Repeat for the desired number of holds."
+  ],
+  "es": [
+   "Parate debajo de una barra de dominadas y agarrala con un agarre prono, las manos al ancho de los hombros.",
+   "Despegá los pies del piso y dejá colgar el cuerpo por completo con los brazos extendidos.",
+   "Mantené los hombros ligeramente activos y el core firme.",
+   "Sostené la posición colgado el mayor tiempo posible sin soltar el agarre.",
+   "Bajá los pies al piso con suavidad para terminar.",
+   "Repetí la cantidad de sostenidos deseada."
+  ],
+  "descEs": "Resistencia de agarre en una barra."
+ },
+ "std-forearms-farmer-carry-discs": {
+  "en": [
+   "Place a weight plate on each side of you on the floor.",
+   "Bend at your hips and knees and grip one plate in each hand.",
+   "Stand up tall with a flat back, chest up, and core braced.",
+   "Walk forward with steady, controlled steps, keeping your shoulders back.",
+   "Maintain your grip and posture for the set distance or time.",
+   "Set the plates down with control to finish."
+  ],
+  "es": [
+   "Colocá un disco a cada lado tuyo en el piso.",
+   "Flexioná caderas y rodillas y agarrá un disco con cada mano.",
+   "Incorporate erguido con la espalda recta, el pecho arriba y el core firme.",
+   "Caminá hacia adelante con pasos firmes y controlados, manteniendo los hombros hacia atrás.",
+   "Sostené el agarre y la postura durante la distancia o el tiempo establecido.",
+   "Apoyá los discos en el piso con control para terminar."
+  ],
+  "descEs": "Caminata cargada para agarre y rigidez del tronco."
+ },
+ "std-forearms-farmer-carry-kettlebell": {
+  "en": [
+   "Place a kettlebell on each side of you on the floor.",
+   "Bend at your hips and knees and grip one kettlebell in each hand.",
+   "Stand up tall with a flat back, chest up, and core braced.",
+   "Walk forward with steady, controlled steps, keeping your shoulders back.",
+   "Maintain your grip and posture for the set distance or time.",
+   "Set the kettlebells down with control to finish."
+  ],
+  "es": [
+   "Colocá una kettlebell a cada lado tuyo en el piso.",
+   "Flexioná caderas y rodillas y agarrá una kettlebell con cada mano.",
+   "Incorporate erguido con la espalda recta, el pecho arriba y el core firme.",
+   "Caminá hacia adelante con pasos firmes y controlados, manteniendo los hombros hacia atrás.",
+   "Sostené el agarre y la postura durante la distancia o el tiempo establecido.",
+   "Apoyá las kettlebells en el piso con control para terminar."
+  ],
+  "descEs": "Caminata cargada para agarre y rigidez del tronco."
+ },
+ "std-forearms-plate-pinch-discs": {
+  "en": [
+   "Place one or two weight plates together with the smooth sides facing out.",
+   "Pinch the plates with your fingers and thumb, gripping only by the surface.",
+   "Lift the plates off the ground and stand tall with your arm at your side.",
+   "Hold the pinch grip as long as you can without letting the plates slip.",
+   "Lower the plates to the ground with control.",
+   "Repeat for the desired number of holds, then switch hands."
+  ],
+  "es": [
+   "Juntá uno o dos discos con los lados lisos hacia afuera.",
+   "Pellizcá los discos con los dedos y el pulgar, agarrando solo por la superficie.",
+   "Levantá los discos del piso e incorporate erguido con el brazo al costado.",
+   "Sostené la pinza el mayor tiempo posible sin que se resbalen los discos.",
+   "Bajá los discos al piso con control.",
+   "Repetí la cantidad de sostenidos deseada y después cambiá de mano."
+  ],
+  "descEs": "Desafío de agarre estático con discos."
+ },
+ "std-glutes-frog-pump-barbell": {
+  "en": [
+   "Sit on the floor and position a barbell across your hips.",
+   "Lie back with your knees bent and the soles of your feet together, letting your knees fall open.",
+   "Brace your core and keep your chin slightly tucked.",
+   "Drive through the outer edges of your feet to lift the barbell by squeezing your glutes.",
+   "Pause and squeeze hard at the top, then lower with control.",
+   "Repeat for the desired number of repetitions."
+  ],
+  "es": [
+   "Sentate en el piso y colocá una barra cruzada sobre las caderas.",
+   "Acostate hacia atrás con las rodillas flexionadas y las plantas de los pies juntas, dejando que las rodillas se abran.",
+   "Activá el core y mantené el mentón ligeramente metido.",
+   "Empujá con los bordes externos de los pies para levantar la barra apretando los glúteos.",
+   "Hacé una pausa y apretá fuerte arriba, después bajá con control.",
+   "Repetí la cantidad de repeticiones deseada."
+  ],
+  "descEs": "Quemador de glúteos de altas repeticiones con recorrido corto."
+ },
+ "std-glutes-frog-pump-bodyweight": {
+  "en": [
+   "Lie on your back with your knees bent and the soles of your feet together, letting your knees fall open.",
+   "Rest your arms at your sides and brace your core.",
+   "Keep your chin slightly tucked and your lower back neutral.",
+   "Drive through the outer edges of your feet to lift your hips by squeezing your glutes.",
+   "Pause and squeeze hard at the top, then lower with control.",
+   "Repeat for the desired number of repetitions."
+  ],
+  "es": [
+   "Acostate boca arriba con las rodillas flexionadas y las plantas de los pies juntas, dejando que las rodillas se abran.",
+   "Apoyá los brazos a los costados y activá el core.",
+   "Mantené el mentón ligeramente metido y la zona lumbar neutra.",
+   "Empujá con los bordes externos de los pies para levantar las caderas apretando los glúteos.",
+   "Hacé una pausa y apretá fuerte arriba, después bajá con control.",
+   "Repetí la cantidad de repeticiones deseada."
+  ],
+  "descEs": "Quemador de glúteos de altas repeticiones con recorrido corto."
+ },
+ "std-glutes-frog-pump-dumbbell": {
+  "en": [
+   "Sit on the floor and place a dumbbell across your hips, holding it in place.",
+   "Lie back with your knees bent and the soles of your feet together, letting your knees fall open.",
+   "Brace your core and keep your chin slightly tucked.",
+   "Drive through the outer edges of your feet to lift the dumbbell by squeezing your glutes.",
+   "Pause and squeeze hard at the top, then lower with control.",
+   "Repeat for the desired number of repetitions."
+  ],
+  "es": [
+   "Sentate en el piso y colocá una mancuerna cruzada sobre las caderas, sosteniéndola en su lugar.",
+   "Acostate hacia atrás con las rodillas flexionadas y las plantas de los pies juntas, dejando que las rodillas se abran.",
+   "Activá el core y mantené el mentón ligeramente metido.",
+   "Empujá con los bordes externos de los pies para levantar la mancuerna apretando los glúteos.",
+   "Hacé una pausa y apretá fuerte arriba, después bajá con control.",
+   "Repetí la cantidad de repeticiones deseada."
+  ],
+  "descEs": "Quemador de glúteos de altas repeticiones con recorrido corto."
+ },
+ "std-hamstrings-nordic-curl-bench": {
+  "en": [
+   "Kneel on a pad and anchor your ankles under a bench or have a partner hold them down.",
+   "Keep your hips extended and your body in a straight line from knees to head.",
+   "Brace your core and slowly lower your torso toward the floor under control.",
+   "Resist the descent with your hamstrings for as long as possible.",
+   "Push off lightly with your hands if needed and use your hamstrings to pull back up.",
+   "Repeat for the desired number of repetitions."
+  ],
+  "es": [
+   "Arrodillate sobre una colchoneta y fijá los tobillos debajo de un banco o pedile a alguien que te los sostenga.",
+   "Mantené las caderas extendidas y el cuerpo en línea recta desde las rodillas hasta la cabeza.",
+   "Activá el core y bajá lentamente el tronco hacia el piso de forma controlada.",
+   "Resistí el descenso con los isquiotibiales el mayor tiempo posible.",
+   "Empujá suavemente con las manos si hace falta y usá los isquiotibiales para volver a subir.",
+   "Repetí la cantidad de repeticiones deseada."
+  ],
+  "descEs": "Movimiento excéntrico de isquiotibiales de alta intensidad."
+ }
+}


### PR DESCRIPTION
The new standard-library exercises shipped with **no instructions** and an **English-only description** (`description.es` was a copy of the English). This adds step-by-step instructions in **English** (from the ExerciseDB source CSV) **and Argentine Spanish**, plus a translated `description.es`, for **262 exercises**.

## Correctness — instructions match the corrected gif

The seed had mapped ~77 exercises to the **wrong source movement** (e.g. Mountain Climber → burpee, Thruster → clean-and-press); their gifs were repointed to the correct `library-gifs/<csvId>` by the gif-mismatch fix. This backfill keys the instructions off each exercise's **corrected** gif csvId, so the steps describe the movement the user actually sees:
- **170** exercises whose gif was already correct → instructions from that csvId.
- **77** repointed exercises → instructions re-derived + re-translated from the corrected csvId.
- **15** `std-*` exercises (no CSV source) → instructions written from the movement name.
- **10** still-uncovered exercises (gif wrong/missing) → **deliberately left without instructions** rather than wrong ones.

iOS/Android have bidirectional EN/ES instruction fallback, so any exercise still missing one language shows the other.

## Script

`backfill-library-instructions.cjs` reads the committed data file `scripts/data/library-exercise-instructions.json` (never re-derives mappings at run time), validates EN/ES step-count parity (fail-loud), backs up prior instructions+description, supports `--dry-run`, is idempotent, and uses field-path `description.es` so `description.en` is preserved. Admin SDK.

**Applied to prod 2026-06-13:** 262 exercises. Backup retained for rollback.

## Notes / follow-ups

- The 10 uncovered exercises need a correct gif before instructions can be added accurately (tracked alongside the gif-mismatch work).
- Spanish is Río de la Plata register; a couple of machine-translated steps drop accents — a light copy-edit pass could follow if desired.

No app code changes — pure data + tooling.