### PR TITLE
fix(gc-fitness): clearing a per-set weight no longer marks the exercise 'Sin peso'

### DIFF
--- a/backoffice/src/components/gc-fitness/__tests__/template-form-weight-clear.test.ts
+++ b/backoffice/src/components/gc-fitness/__tests__/template-form-weight-clear.test.ts
@@ -1,0 +1,45 @@
+// template-form-weight-clear.test.ts
+//
+// Regression for the "Front Raise saved as Sin peso" bug: clearing a per-set
+// weight field truncated `weightBySetKg` to `[]` for set 1 (setIdx 0). An
+// empty array is the reserved "Sin peso" (reps-only) sentinel, so a weighted
+// exercise where the trainer typed reps×weight then cleared the weight got
+// silently saved as reps-only (no PESO column). weightArrayAfterClear must
+// instead zero-fill the cleared slot and NEVER return [].
+
+import { weightArrayAfterClear } from "../template-form";
+
+describe("weightArrayAfterClear", () => {
+  it("clearing set 1 (idx 0) zero-fills instead of collapsing to [] (the bug)", () => {
+    const out = weightArrayAfterClear([20, 20, 20], 0);
+    expect(out).toEqual([0, 20, 20]);
+    expect(out.length).toBeGreaterThan(0); // never the no-weight sentinel
+  });
+
+  it("clearing a middle set zeroes only that slot", () => {
+    expect(weightArrayAfterClear([20, 25, 30], 1)).toEqual([20, 0, 30]);
+  });
+
+  it("clearing set 1 of a single-set exercise yields [0], not []", () => {
+    expect(weightArrayAfterClear([20], 0)).toEqual([0]);
+  });
+
+  it("clearing when no weights were typed yet (empty current) yields [0], not []", () => {
+    // current = [] (weightBySetKg was undefined). Must NOT stay [] — that
+    // would be read as the explicit no-weight sentinel.
+    const out = weightArrayAfterClear([], 0);
+    expect(out).toEqual([0]);
+    expect(out.length).toBe(1);
+  });
+
+  it("never returns an empty array for any reasonable set index", () => {
+    for (let i = 0; i < 5; i++) {
+      expect(weightArrayAfterClear([], i).length).toBeGreaterThan(0);
+      expect(weightArrayAfterClear([10, 10], i).length).toBeGreaterThan(0);
+    }
+  });
+
+  it("pads gaps with 0 when clearing a set beyond the current length", () => {
+    expect(weightArrayAfterClear([20], 2)).toEqual([20, 0, 0]);
+  });
+});

--- a/backoffice/src/components/gc-fitness/template-form.tsx
+++ b/backoffice/src/components/gc-fitness/template-form.tsx
@@ -187,6 +187,29 @@ function clearDraft(key: string) {
     /* ignore */
   }
 }
+
+/**
+ * The per-set weight array after a trainer CLEARS the weight field of set
+ * `setIdx`. Clearing means "0 kg for this set" — it MUST NOT collapse the
+ * array to `[]`, because an empty `weightBySetKg: []` is the reserved "Sin
+ * peso" (reps-only) sentinel set exclusively by the explicit toggle. The
+ * previous `current.slice(0, setIdx)` truncated set 1 (setIdx 0) to `[]`, so
+ * a trainer who typed reps×weight then cleared the weight had the exercise
+ * silently saved as reps-only (the Front Raise bug). This zero-fills the
+ * cleared slot and keeps the array length aligned so the weight column lives.
+ */
+export function weightArrayAfterClear(
+  current: number[],
+  setIdx: number,
+): number[] {
+  const safeLen = Math.max(setIdx + 1, current.length);
+  const out = Array.from({ length: safeLen }, (_, i) =>
+    Number.isFinite(current[i]) ? current[i] : 0,
+  );
+  out[setIdx] = 0;
+  return out;
+}
+
 function InfoTooltip({ text, label }: { text: string; label: string }) {
   return (
     <TooltipProvider>
@@ -1822,8 +1845,12 @@ export function TemplateForm({
                                     const raw = setWeightDraft[setKey];
                                     const current = toFiniteNumberArray(form.getValues(weightPath));
                                     if (raw === "") {
-                                      const trimmed = current.slice(0, Math.max(setIdx, 0));
-                                      form.setValue(weightPath, trimmed, { shouldDirty: true });
+                                      // Clearing a per-set weight = "0 kg for
+                                      // this set", NEVER the no-weight sentinel
+                                      // (`[]`, reserved for the explicit "Sin
+                                      // peso" toggle). See weightArrayAfterClear.
+                                      const zeroed = weightArrayAfterClear(current, setIdx);
+                                      form.setValue(weightPath, zeroed, { shouldDirty: true });
                                       setSetWeightDraft((prev) => {
                                         const next = { ...prev };
                                         delete next[setKey];


### PR DESCRIPTION
Reported: a saved template showed **Front Raise (Barbell)** as reps-only ("Sin peso" — no PESO column) even though the trainer entered reps × weight and just left the weights blank, while a sibling exercise correctly showed PESO 0 kg.

## Root cause

In the template editor's per-set weight input, the `onBlur` handler for a **cleared** field did:

```ts
const trimmed = current.slice(0, Math.max(setIdx, 0));
form.setValue(weightPath, trimmed, ...);
```

For **set 1** (`setIdx === 0`), `slice(0, 0)` is **`[]`**. An empty `weightBySetKg: []` is the **reserved "Sin peso" sentinel** (`hasExplicitNoWeightPrescription`, twin of iOS `ExerciseRef`) — set **only** by the explicit toggle. So typing reps×weight and then clearing the weight on set 1 silently turned the exercise into a reps-only prescription and dropped the PESO column. (Confirmed in prod: the affected exercise had `weightBySetKg: []` while its siblings had `["0","0","0"]`.)

## Fix

Extracted `weightArrayAfterClear(current, setIdx)` — it **zero-fills** the cleared slot and keeps the array length aligned, so clearing a weight means "0 kg for this set" and the weight column survives. It **never returns `[]`**; only the explicit "Sin peso" toggle produces the sentinel now.

## Tests

`template-form-weight-clear.test.ts` — 6 cases lock the invariant: clearing set 1 yields `[0, …]` not `[]`, clearing a middle set zeroes only that slot, empty-current yields `[0]`, and the result is never an empty array for any set index.

## Gate

`npx tsc --noEmit` clean; new suite 6/6; full `npx jest` 563/565 — only the 2 pre-existing baselined reds (`client-activity-time` locale flake, `workout-assignment-actions`).

## Note

The user's specific template self-corrected on a later save (Front Raise now has weight); no data fix needed. Existing `weightBySetKg: []` exercises elsewhere are mostly legitimate bodyweight/core "Sin peso" entries, so no blanket data migration — this fix prevents the bug going forward.