### PR TITLE
fix(gc-fitness): multi-word workout search + keep exercise picker scrolled to top

### DIFF
--- a/backoffice/src/app/gc-fitness/templates/client.tsx
+++ b/backoffice/src/app/gc-fitness/templates/client.tsx
@@ -66,6 +66,7 @@ import {
 } from "@/lib/gc-fitness/workout-template-actions";
 import type { WorkoutTemplateRow } from "@/lib/gc-fitness/workout-template-actions";
 import { estimateTemplateDurationMinutesFromRaw } from "@/lib/gc-fitness/workout-duration-estimate";
+import { fuzzyTokenScore } from "@/lib/gc-fitness/exercise-search";
 import type { TemplateListRow } from "@/components/gc-fitness/templates/columns";
 
 // Tag → human label (kept local — small, list-only).
@@ -206,22 +207,30 @@ export function TemplatesLibraryClient({
         (row) => row.trainerId === trainerUid && !row.isStandard,
       );
     }
-    const needle = tagFilter.trim().toLowerCase();
+    const needle = tagFilter.trim();
     if (needle) {
-      // Any-of substring match across the row name(s) plus the canonical
-      // tags[] list. Falls back to the legacy `tag` field for rows authored
-      // before multi-tag landed.
-      list = list.filter((row) => {
-        const all = row.tags && row.tags.length > 0
-          ? row.tags
-          : row.tag
-            ? [row.tag]
-            : [];
-        const haystack = [row.name.en, row.name.es, ...all]
-          .filter((value): value is string => typeof value === "string")
-          .map((value) => value.toLowerCase());
-        return haystack.some((value) => value.includes(needle));
-      });
+      // Normalized, token-based, order-independent match + relevance rank
+      // (same matcher as the exercise search). A plain substring `includes`
+      // failed multi-word queries because punctuation in the name breaks the
+      // span — e.g. "nete etapa" didn't match "Nete - Etapa 3 - Dia 1" since
+      // the " - " sits between the two words. fuzzyTokenScore normalizes both
+      // sides (hyphens/punctuation → spaces) and matches each query token
+      // against any name/tag word, then ranks best-match first.
+      const scored = list
+        .map((row) => {
+          const all = row.tags && row.tags.length > 0
+            ? row.tags
+            : row.tag
+              ? [row.tag]
+              : [];
+          const haystack = [row.name.en, row.name.es, ...all]
+            .filter((value): value is string => typeof value === "string")
+            .join(" ");
+          return { row, score: fuzzyTokenScore(needle, haystack) };
+        })
+        .filter((entry) => entry.score > 0)
+        .sort((a, b) => b.score - a.score);
+      list = scored.map((entry) => entry.row);
     }
     return draftRow ? [draftRow, ...list] : list;
   }, [data, mineOnly, trainerUid, tagFilter, draftRow]);

--- a/backoffice/src/components/gc-fitness/exercise-picker-popover.tsx
+++ b/backoffice/src/components/gc-fitness/exercise-picker-popover.tsx
@@ -55,7 +55,7 @@
 // legitimately-same-in-both-languages survivors like "Plank" don't render
 // a redundant duplicate line).
 
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { ChevronsUpDown, Copy, Search, X } from "lucide-react";
 import { useTranslations } from "next-intl";
 
@@ -198,6 +198,15 @@ export function ExercisePickerPopover({
   const [open, setOpen] = useState(false);
   const [search, setSearch] = useState("");
   const [seed, setSeed] = useState<QuickCreateSeed | null>(null);
+  // Keep the results list pinned to the TOP whenever the query changes. cmdk
+  // preserves its highlighted item and scrolls it into view; since our ranked
+  // search re-orders the list on every keystroke, that item could be mid-list,
+  // making the popover auto-scroll DOWN and hide the best (top) matches. Reset
+  // the scroll position after each search change so the first results show.
+  const listRef = useRef<HTMLDivElement | null>(null);
+  useEffect(() => {
+    if (listRef.current) listRef.current.scrollTop = 0;
+  }, [search]);
   const queryClient = useQueryClient();
   const { data, isLoading, error, hasSnapshot } = useExercisesQuery();
 
@@ -399,7 +408,7 @@ export function ExercisePickerPopover({
               className="h-10 border-0 focus:ring-0"
             />
           </div>
-          <CommandList>
+          <CommandList ref={listRef}>
             {isLoading || !hasSnapshot ? (
               <CommandEmpty>{t("loadingExercises")}</CommandEmpty>
             ) : error ? (

--- a/backoffice/src/lib/gc-fitness/__tests__/template-search-tokens.test.ts
+++ b/backoffice/src/lib/gc-fitness/__tests__/template-search-tokens.test.ts
@@ -1,0 +1,42 @@
+// template-search-tokens.test.ts
+//
+// Regression for the workout (template) list search: a plain substring
+// `includes` failed multi-word queries because punctuation in the template
+// name breaks the span — "nete etapa" didn't match "Nete - Etapa 3 - Dia 1"
+// since " - " sits between the two words. The list now uses fuzzyTokenScore
+// (the same normalized, token-based matcher as the exercise search).
+
+import { fuzzyTokenScore } from "../exercise-search";
+
+// Mirror the haystack the templates client builds: name.en + name.es + tags.
+function templateScore(query: string, name: string, tags: string[] = []): number {
+  return fuzzyTokenScore(query, [name, ...tags].join(" "));
+}
+
+describe("template list token search", () => {
+  it('matches "nete etapa" against "Nete - Etapa 3 - Dia 1" (the bug)', () => {
+    expect(templateScore("nete etapa", "Nete - Etapa 3 - Dia 1")).toBeGreaterThan(0);
+  });
+
+  it('still matches the single token "nete"', () => {
+    expect(templateScore("nete", "Nete - Etapa 3 - Dia 1")).toBeGreaterThan(0);
+  });
+
+  it('matches "nete et" (partial trailing token)', () => {
+    expect(templateScore("nete et", "Nete - Etapa 3 - Dia 1")).toBeGreaterThan(0);
+  });
+
+  it("does not match an unrelated query", () => {
+    expect(templateScore("legs press", "Nete - Etapa 3 - Dia 1")).toBe(0);
+  });
+
+  it("matches against a tag word too", () => {
+    expect(templateScore("pull nete", "Tiroides 2 Nete", ["Nete", "Pull"])).toBeGreaterThan(0);
+  });
+
+  it('ranks an exact-ish name above a looser match for "push nete"', () => {
+    const exact = templateScore("push nete", "Push 2 NETE", ["Nete"]);
+    const loose = templateScore("push nete", "Nete - Etapa 3 - Dia 1", ["Nete"]);
+    expect(exact).toBeGreaterThan(loose);
+  });
+});


### PR DESCRIPTION
Two search UX bugs.

## 1. Workout (template) search missed multi-word queries

Searching **"nete"** found the templates, but **"nete etapa"** / **"nete et"** returned nothing. The list used a plain substring `includes(needle)` against the lowercased name — and "Nete - Etapa 3 - Dia 1" does NOT contain the substring "nete etapa" because the `" - "` sits between the two words.

**Fix:** the list now uses `fuzzyTokenScore` (the same normalized, token-based, order-independent matcher as the exercise search). It maps hyphens/punctuation to word separators and matches each query token against any name/tag word, then **ranks best-match first**. "nete etapa" → matches "Nete - Etapa 3 - Dia 1".

## 2. Exercise picker auto-scrolled down while typing

When typing in the exercise picker, the list jumped **down** mid-results instead of staying at the top. cmdk preserves its highlighted item and scrolls it into view; since our ranked search re-orders the list on every keystroke, that item lands mid-list and the popover scrolls to it.

**Fix:** reset the `CommandList` scrollTop to 0 on every search change, so the first (best) results are always visible.

## Tests / gate

`template-search-tokens.test.ts` (6 cases): "nete etapa" / "nete et" match, single token still matches, unrelated query doesn't, tag-word match, and exact-ish ranks above loose. `npx tsc --noEmit` clean; exercise-search/picker suites green (41/41 across the touched suites).