### PR TITLE
feat(gc-fitness): workout generator for the trainer backoffice

### DIFF
--- a/backoffice/messages/en.json
+++ b/backoffice/messages/en.json
@@ -589,6 +589,7 @@
       "pageHeading": "Workout Templates",
       "pageSubtitle": "Author push / pull / legs templates and assign them from the schedule view.",
       "newTemplateCta": "New template",
+      "generateCta": "Template Generator",
       "filterPlaceholder": "Filter by name or tag",
       "loadError": "Couldn't load templates.",
       "loadErrorDescription": "Check your connection and try again.",

--- a/backoffice/messages/es.json
+++ b/backoffice/messages/es.json
@@ -589,6 +589,7 @@
       "pageHeading": "Plantillas de entrenamiento",
       "pageSubtitle": "Diseñá plantillas push / pull / piernas y asignalas desde la vista de agenda.",
       "newTemplateCta": "Nueva plantilla",
+      "generateCta": "Generador de Plantillas",
       "filterPlaceholder": "Filtrar por nombre o etiqueta",
       "loadError": "No se pudieron cargar las plantillas.",
       "loadErrorDescription": "Revisá tu conexión e intentá de nuevo.",

--- a/backoffice/scripts/fix-standard-library-gif-equipment.mjs
+++ b/backoffice/scripts/fix-standard-library-gif-equipment.mjs
@@ -1,0 +1,255 @@
+// fix-standard-library-gif-equipment.mjs
+//
+// One-off, IDEMPOTENT data fix for the `exercises` standard library.
+//
+// PROBLEM: `sync-standard-exercise-gifs.ts` matches gifs to exercises by NAME
+// similarity, with equipment only a soft +0.2 bonus. When the gif dataset has
+// no same-equipment clip for a movement, a wrong-equipment gif wins — e.g.
+// "Thruster (Mancuerna)" shows the barbell thruster, "Press de suelo
+// (Mancuerna)" shows the barbell floor press, "Overhead Extension (Dumbbell)"
+// shows a swiss-ball clip. Audited: 65 / 282 standard-library docs.
+//
+// RULE (operator decision — "better no gif than a wrong gif"):
+//   For each standard-library doc, look at the gif it actually displays
+//   (gifUrl ?? imageUrl ?? thumbnailURL) and map its csvId → equipment via the
+//   gif CSV. If that equipment does NOT match the doc's equipment:
+//     a) if `thumbnailURL` (the per-doc <docId>.gif) HAS the right equipment
+//        and its asset exists → set gifUrl = thumbnailURL (show the correct one);
+//     b) otherwise → null gifUrl + imageUrl + thumbnailURL (show the placeholder).
+//   none ↔ bodyweight are treated as compatible (not a mismatch).
+//
+// SAFE: only touches docs tagged `standard-library`; dry-run by default; writes
+// a full before-state backup to scripts/backups/ before applying; idempotent
+// (a second run finds nothing to change). Never deletes docs.
+//
+// Usage (from backoffice/):
+//   node scripts/fix-standard-library-gif-equipment.mjs            # dry run
+//   node scripts/fix-standard-library-gif-equipment.mjs --apply    # write
+
+import { readFileSync, writeFileSync, existsSync, mkdirSync } from "node:fs";
+import { initializeApp, cert } from "firebase-admin/app";
+import { getFirestore, FieldValue } from "firebase-admin/firestore";
+
+const CSV_PATH =
+  process.env.GC_FITNESS_GIF_CSV_PATH ??
+  "/Users/manu/Desktop/exercises-gifs-main/exercises.csv";
+const ASSETS_DIR =
+  process.env.GC_FITNESS_GIF_ASSETS_DIR ??
+  "/Users/manu/Desktop/exercises-gifs-main/assets";
+const APPLY = process.argv.includes("--apply");
+
+// Mirrors EQUIPMENT_MAP in sync-standard-exercise-gifs.ts.
+const EQUIPMENT_MAP = {
+  barbell: "barbell",
+  bench: "bench",
+  "body weight": "bodyweight",
+  cable: "cable",
+  dumbbell: "dumbbell",
+  kettlebell: "kettlebell",
+  "leverage machine": "machine",
+  "smith machine": "smith",
+  "olympic barbell": "barbell",
+  "ez barbell": "barbell",
+  "resistance band": "resistance_band",
+  band: "resistance_band",
+  "medicine ball": "medicine_ball",
+  rope: "rope",
+  "stability ball": "swiss_ball",
+  weighted: "discs",
+  assisted: "machine",
+  "trap bar": "barbell",
+  bodyweight: "bodyweight",
+};
+
+function loadEnv() {
+  const env = {};
+  for (const line of readFileSync(".env.local", "utf8").split("\n")) {
+    const m = line.match(/^([A-Z0-9_]+)=(.*)$/);
+    if (m) env[m[1]] = m[2].replace(/^["']|["']$/g, "");
+  }
+  return env;
+}
+
+function parseCsv(filePath) {
+  const text = readFileSync(filePath, "utf8").replace(/^﻿/, "");
+  const lines = text.split(/\r?\n/).filter(Boolean);
+  const headers = lines.shift().split(",");
+  const parseLine = (line) => {
+    const out = [];
+    let cur = "";
+    let q = false;
+    for (let i = 0; i < line.length; i += 1) {
+      const c = line[i];
+      if (q) {
+        if (c === '"') {
+          if (line[i + 1] === '"') {
+            cur += '"';
+            i += 1;
+          } else q = false;
+        } else cur += c;
+      } else if (c === '"') q = true;
+      else if (c === ",") {
+        out.push(cur);
+        cur = "";
+      } else cur += c;
+    }
+    out.push(cur);
+    return out;
+  };
+  const byId = new Map();
+  for (const l of lines) {
+    const v = parseLine(l);
+    const row = Object.fromEntries(headers.map((h, i) => [h, v[i] ?? ""]));
+    byId.set(row.id, {
+      equipment: (row.equipment || "").trim().toLowerCase(),
+      name: (row.name || "").toLowerCase(),
+    });
+  }
+  return byId;
+}
+
+// Apparatus the gif NAME reveals even when the `equipment` column matches.
+// A gif "…on exercise ball" is a swiss-ball variant; if the exercise isn't a
+// swiss-ball exercise that gif is the wrong movement (the Overhead Extension
+// (Dumbbell) → ball french-press case). Kept narrow to ball/bosu — terms like
+// "bench" are NOT used here because a dumbbell press legitimately shows a bench.
+const BALL_TERMS = ["exercise ball", "stability ball", "swiss ball", "yoga ball", "bosu"];
+function gifNameImpliesBall(csvRow) {
+  return csvRow ? BALL_TERMS.some((t) => csvRow.name.includes(t)) : false;
+}
+
+const csvIdOf = (url) => {
+  if (!url || typeof url !== "string") return null;
+  const m = url.match(/library-gifs(?:%2F|\/)([A-Za-z0-9_-]+)\.gif/);
+  return m ? m[1] : null;
+};
+
+// Equipment compatibility: none and bodyweight are interchangeable.
+const compatible = (gifEq, docEq) => {
+  if (!gifEq) return null; // unknown → can't judge
+  const eq = new Set(docEq);
+  if (eq.has(gifEq)) return true;
+  if ((gifEq === "bodyweight" || gifEq === "none") && (eq.has("bodyweight") || eq.has("none")))
+    return true;
+  return false;
+};
+
+async function main() {
+  const env = loadEnv();
+  initializeApp({
+    credential: cert({
+      projectId: env.NEXT_PUBLIC_GC_FITNESS_FIREBASE_PROJECT_ID,
+      clientEmail: env.GC_FITNESS_FIREBASE_ADMIN_CLIENT_EMAIL,
+      privateKey: Buffer.from(env.GC_FITNESS_FIREBASE_ADMIN_PRIVATE_KEY, "base64").toString("utf8"),
+    }),
+  });
+  const db = getFirestore();
+  const csv = parseCsv(CSV_PATH);
+  const eqOf = (id) => (id && csv.get(id) ? EQUIPMENT_MAP[csv.get(id).equipment] : undefined);
+  // True when the gif at `csvId` is wrong for `docEq`: either an equipment
+  // mismatch OR a ball-apparatus the exercise isn't.
+  const gifIsWrong = (csvId, docEq) => {
+    const row = csv.get(csvId);
+    const eqWrong = compatible(eqOf(csvId), docEq) === false;
+    const ballWrong = gifNameImpliesBall(row) && !docEq.includes("swiss_ball");
+    return { eqWrong, ballWrong, wrong: eqWrong || ballWrong };
+  };
+
+  const snap = await db.collection("exercises").where("tags", "array-contains", "standard-library").get();
+
+  const reverts = []; // gifUrl := thumbnailURL
+  const clears = []; // null all media
+  const backup = [];
+
+  for (const d of snap.docs) {
+    const x = d.data();
+    const docEq = Array.isArray(x.equipment) ? x.equipment : [];
+    const effective = x.gifUrl || x.imageUrl || x.thumbnailURL || null;
+    const effId = csvIdOf(effective);
+    if (effId == null) continue; // no resolvable gif → leave (already placeholder)
+    if (!gifIsWrong(effId, docEq).wrong) continue; // correct → leave
+
+    // Wrong gif. Can the per-doc thumbnailURL rescue it (right movement + asset)?
+    const thumbId = csvIdOf(x.thumbnailURL);
+    const thumbOk =
+      thumbId != null &&
+      !gifIsWrong(thumbId, docEq).wrong &&
+      eqOf(thumbId) != null && // require KNOWN-correct equipment, not just "undeterminable"
+      existsSync(`${ASSETS_DIR}/${thumbId}.gif`) &&
+      x.thumbnailURL !== x.gifUrl;
+
+    backup.push({
+      id: d.id,
+      name: x.name?.es || x.name?.en || "",
+      docEquipment: docEq,
+      before: { gifUrl: x.gifUrl ?? null, imageUrl: x.imageUrl ?? null, thumbnailURL: x.thumbnailURL ?? null },
+    });
+
+    if (thumbOk) {
+      reverts.push({ id: d.id, name: x.name?.es || x.name?.en, gifUrl: x.thumbnailURL });
+    } else {
+      clears.push({ id: d.id, name: x.name?.es || x.name?.en });
+    }
+  }
+
+  console.log(
+    JSON.stringify(
+      {
+        apply: APPLY,
+        totalStandardLibrary: snap.size,
+        willRevertToThumbnail: reverts.length,
+        willClearToPlaceholder: clears.length,
+        revertSample: reverts.slice(0, 10),
+        clearSample: clears.slice(0, 15).map((c) => `${c.id} ${c.name}`),
+      },
+      null,
+      2,
+    ),
+  );
+
+  if (!APPLY) {
+    console.log("\nDRY RUN — no writes. Re-run with --apply to write.");
+    return;
+  }
+
+  if (!existsSync("scripts/backups")) mkdirSync("scripts/backups", { recursive: true });
+  const stamp = new Date().toISOString().replace(/[:.]/g, "-");
+  const backupPath = `scripts/backups/fix-gif-equipment-backup-${stamp}.json`;
+  writeFileSync(backupPath, JSON.stringify(backup, null, 2));
+  console.log(`\nBackup written: ${backupPath}`);
+
+  let batch = db.batch();
+  let n = 0;
+  const flush = async () => {
+    if (n > 0) {
+      await batch.commit();
+      batch = db.batch();
+      n = 0;
+    }
+  };
+  for (const r of reverts) {
+    batch.set(
+      db.collection("exercises").doc(r.id),
+      { gifUrl: r.gifUrl, updatedAt: FieldValue.serverTimestamp() },
+      { merge: true },
+    );
+    if (++n >= 400) await flush();
+  }
+  for (const c of clears) {
+    batch.set(
+      db.collection("exercises").doc(c.id),
+      { gifUrl: null, imageUrl: null, thumbnailURL: null, updatedAt: FieldValue.serverTimestamp() },
+      { merge: true },
+    );
+    if (++n >= 400) await flush();
+  }
+  await flush();
+  console.log(`Applied: ${reverts.length} reverted, ${clears.length} cleared.`);
+}
+
+main()
+  .then(() => process.exit(0))
+  .catch((e) => {
+    console.error(e);
+    process.exit(1);
+  });

--- a/backoffice/scripts/fix-standard-library-gif-overrides.mjs
+++ b/backoffice/scripts/fix-standard-library-gif-overrides.mjs
@@ -1,0 +1,152 @@
+// fix-standard-library-gif-overrides.mjs
+//
+// Targeted, IDEMPOTENT corrections for standard-library gifs whose EQUIPMENT
+// matches but whose MOVEMENT is wrong — undetectable by
+// fix-standard-library-gif-equipment.mjs (which keys on equipment). These are
+// found by eyeballing the app; add an entry here as they're reported.
+//
+// Each OVERRIDES entry maps a Firestore doc id → the CORRECT gif csvId from the
+// gif dataset (or `null` to clear the gif → placeholder). The script uploads
+// the csvId's local asset to Storage if it's not already there, mints a
+// download token, and points BOTH gifUrl and thumbnailURL at it.
+//
+// Usage (from backoffice/):
+//   node scripts/fix-standard-library-gif-overrides.mjs           # dry run
+//   node scripts/fix-standard-library-gif-overrides.mjs --apply   # write
+//
+// REVIEW LOG (docId | exercise | was → now):
+//   0872 | Crunch (Bodyweight) | "reverse crunch" (0872) → "crunch floor" (0274)
+
+import { readFileSync, existsSync, writeFileSync, mkdirSync } from "node:fs";
+import { randomUUID } from "node:crypto";
+import { initializeApp, cert } from "firebase-admin/app";
+import { getFirestore, FieldValue } from "firebase-admin/firestore";
+import { getStorage } from "firebase-admin/storage";
+
+// docId → csvId (correct gif) | null (clear to placeholder)
+const OVERRIDES = {
+  "0872": "0274", // Crunch (Bodyweight): reverse-crunch gif → plain floor crunch
+};
+
+const ASSETS_DIR =
+  process.env.GC_FITNESS_GIF_ASSETS_DIR ?? "/Users/manu/Desktop/exercises-gifs-main/assets";
+const REMOTE_PREFIX = "exercises/library-gifs";
+const APPLY = process.argv.includes("--apply");
+
+function loadEnv() {
+  const env = {};
+  for (const line of readFileSync(".env.local", "utf8").split("\n")) {
+    const m = line.match(/^([A-Z0-9_]+)=(.*)$/);
+    if (m) env[m[1]] = m[2].replace(/^["']|["']$/g, "");
+  }
+  return env;
+}
+
+function downloadUrl(bucketName, remotePath, token) {
+  return `https://firebasestorage.googleapis.com/v0/b/${bucketName}/o/${encodeURIComponent(
+    remotePath,
+  )}?alt=media&token=${token}`;
+}
+
+async function main() {
+  const env = loadEnv();
+  initializeApp({
+    credential: cert({
+      projectId: env.NEXT_PUBLIC_GC_FITNESS_FIREBASE_PROJECT_ID,
+      clientEmail: env.GC_FITNESS_FIREBASE_ADMIN_CLIENT_EMAIL,
+      privateKey: Buffer.from(env.GC_FITNESS_FIREBASE_ADMIN_PRIVATE_KEY, "base64").toString("utf8"),
+    }),
+  });
+  const db = getFirestore();
+  const bucketName =
+    env.NEXT_PUBLIC_GC_FITNESS_FIREBASE_STORAGE_BUCKET ?? "gcfitness-3476b.firebasestorage.app";
+  const bucket = getStorage().bucket(bucketName);
+
+  const plan = [];
+  const backup = [];
+
+  for (const [docId, csvId] of Object.entries(OVERRIDES)) {
+    const ref = db.collection("exercises").doc(docId);
+    const snap = await ref.get();
+    if (!snap.exists) {
+      plan.push({ docId, action: "SKIP (doc not found)" });
+      continue;
+    }
+    const x = snap.data();
+    backup.push({
+      docId,
+      name: x.name?.es || x.name?.en || "",
+      before: { gifUrl: x.gifUrl ?? null, imageUrl: x.imageUrl ?? null, thumbnailURL: x.thumbnailURL ?? null },
+    });
+
+    if (csvId === null) {
+      plan.push({ docId, name: x.name?.es, action: "CLEAR → placeholder" });
+      if (APPLY) {
+        await ref.set(
+          { gifUrl: null, imageUrl: null, thumbnailURL: null, updatedAt: FieldValue.serverTimestamp() },
+          { merge: true },
+        );
+      }
+      continue;
+    }
+
+    const remotePath = `${REMOTE_PREFIX}/${csvId}.gif`;
+    const file = bucket.file(remotePath);
+    let [exists] = await file.exists();
+    let token;
+    if (exists) {
+      const [md] = await file.getMetadata();
+      token = (md.metadata?.firebaseStorageDownloadTokens || "").split(",")[0];
+    }
+    const localPath = `${ASSETS_DIR}/${csvId}.gif`;
+    const needUpload = !exists || !token;
+    if (needUpload && !existsSync(localPath)) {
+      plan.push({ docId, name: x.name?.es, action: `ERROR: local asset missing ${localPath}` });
+      continue;
+    }
+    plan.push({
+      docId,
+      name: x.name?.es,
+      action: `${exists ? "reuse" : "upload"} ${csvId}.gif → gifUrl+thumbnailURL`,
+    });
+
+    if (!APPLY) continue;
+
+    if (needUpload) {
+      token = randomUUID();
+      await bucket.upload(localPath, {
+        destination: remotePath,
+        metadata: {
+          contentType: "image/gif",
+          cacheControl: "public, max-age=31536000",
+          metadata: { firebaseStorageDownloadTokens: token },
+        },
+        resumable: false,
+      });
+    }
+    const url = downloadUrl(bucketName, remotePath, token);
+    await ref.set(
+      { gifUrl: url, thumbnailURL: url, updatedAt: FieldValue.serverTimestamp() },
+      { merge: true },
+    );
+  }
+
+  console.log(JSON.stringify({ apply: APPLY, plan }, null, 2));
+
+  if (APPLY) {
+    if (!existsSync("scripts/backups")) mkdirSync("scripts/backups", { recursive: true });
+    const stamp = new Date().toISOString().replace(/[:.]/g, "-");
+    const p = `scripts/backups/fix-gif-overrides-backup-${stamp}.json`;
+    writeFileSync(p, JSON.stringify(backup, null, 2));
+    console.log(`Backup written: ${p}`);
+  } else {
+    console.log("\nDRY RUN — no writes. Re-run with --apply.");
+  }
+}
+
+main()
+  .then(() => process.exit(0))
+  .catch((e) => {
+    console.error(e);
+    process.exit(1);
+  });

--- a/backoffice/src/app/gc-fitness/templates/client.tsx
+++ b/backoffice/src/app/gc-fitness/templates/client.tsx
@@ -21,6 +21,7 @@ import {
   Pencil,
   Plus,
   Search,
+  Sparkles,
   SlidersHorizontal,
   Trash2,
 } from "lucide-react";
@@ -311,14 +312,25 @@ export function TemplatesLibraryClient({
             <p className="text-sm text-muted-foreground">{t("pageSubtitle")}</p>
           </div>
         )}
-        <Button
-          type="button"
-          onClick={() => router.push("/gc-fitness/templates/new")}
-          className="gap-2 rounded-full"
-        >
-          <Plus className="h-4 w-4" />
-          {t("newTemplateCta")}
-        </Button>
+        <div className="flex items-center gap-2">
+          <Button
+            type="button"
+            variant="outline"
+            onClick={() => router.push("/gc-fitness/templates/generate")}
+            className="gap-2 rounded-full"
+          >
+            <Sparkles className="h-4 w-4" />
+            {t("generateCta")}
+          </Button>
+          <Button
+            type="button"
+            onClick={() => router.push("/gc-fitness/templates/new")}
+            className="gap-2 rounded-full"
+          >
+            <Plus className="h-4 w-4" />
+            {t("newTemplateCta")}
+          </Button>
+        </div>
       </div>
 
       {/* Search row — rounded input with leading icon + filter affordance +

--- a/backoffice/src/app/gc-fitness/templates/generate/client.tsx
+++ b/backoffice/src/app/gc-fitness/templates/generate/client.tsx
@@ -1,0 +1,30 @@
+"use client";
+
+// /gc-fitness/templates/generate/client.tsx
+//
+// Thin client wrapper: renders the localized page header + the generator
+// wizard. Kept separate from page.tsx so the Server Component shell stays
+// `async` / provider-only.
+
+import { WorkoutGeneratorWizard } from "@/components/gc-fitness/generator/workout-generator-wizard";
+import { useGeneratorStrings } from "@/components/gc-fitness/generator/strings";
+import type { ClientRosterEntry } from "@/lib/gc-fitness/client-roster";
+
+export function WorkoutGeneratorClient({
+  clients,
+  trainerTimezone,
+}: {
+  clients: ClientRosterEntry[];
+  trainerTimezone?: string;
+}) {
+  const s = useGeneratorStrings();
+  return (
+    <div className="flex flex-col gap-6">
+      <div className="flex flex-col gap-1">
+        <h1 className="font-heading text-2xl font-semibold tracking-tight">{s.pageTitle}</h1>
+        <p className="text-sm text-muted-foreground">{s.pageSubtitle}</p>
+      </div>
+      <WorkoutGeneratorWizard clients={clients} trainerTimezone={trainerTimezone} />
+    </div>
+  );
+}

--- a/backoffice/src/app/gc-fitness/templates/generate/page.tsx
+++ b/backoffice/src/app/gc-fitness/templates/generate/page.tsx
@@ -1,0 +1,49 @@
+// /gc-fitness/templates/generate/page.tsx — Workout Generator (Server shell)
+//
+// Auth gate mirrors /gc-fitness/templates/new. Loads the client roster so the
+// success-screen assign modal can fan out to multiple clients. Mounts the
+// templates + exercises QueryProviders so `useExercisesQuery` (the engine's
+// pool) and `useWorkoutTemplates` resolve inside the wizard.
+
+import { redirect } from "next/navigation";
+
+import { getCurrentTrainer } from "@/lib/gc-fitness/auth-helpers";
+import { listClients } from "@/lib/gc-fitness/client-roster";
+import { sectionMetadata } from "@/lib/gc-fitness/page-metadata";
+
+import { ExerciseQueryProvider } from "../../exercises/providers";
+import { TemplatesQueryProvider } from "../providers";
+import { WorkoutGeneratorClient } from "./client";
+
+export const generateMetadata = () => sectionMetadata("workouts");
+
+export const dynamic = "force-dynamic";
+
+export default async function GenerateWorkoutPage() {
+  try {
+    await getCurrentTrainer();
+  } catch (err) {
+    const message = err instanceof Error ? err.message : "Forbidden";
+    if (message === "Forbidden") {
+      redirect("/gc-fitness/login");
+    }
+    throw err;
+  }
+
+  let clients: Awaited<ReturnType<typeof listClients>> = [];
+  try {
+    clients = await listClients();
+  } catch {
+    clients = [];
+  }
+
+  return (
+    <div className="mx-auto flex w-full min-w-0 max-w-3xl flex-col gap-6 px-4 py-8 sm:px-6">
+      <TemplatesQueryProvider>
+        <ExerciseQueryProvider>
+          <WorkoutGeneratorClient clients={clients} />
+        </ExerciseQueryProvider>
+      </TemplatesQueryProvider>
+    </div>
+  );
+}

--- a/backoffice/src/components/gc-fitness/generator/assign-generated-modal.tsx
+++ b/backoffice/src/components/gc-fitness/generator/assign-generated-modal.tsx
@@ -1,0 +1,331 @@
+"use client";
+
+// assign-generated-modal.tsx
+//
+// Multi-client + recurrence assignment launched from the generator success
+// screen (issue #296: "allow user to select one or multiple clients, and to
+// select the recurrence"). Thin wrapper over the existing `bulkAssignTemplate`
+// Server Action — same cadence vocabulary as AssignTemplateModal /
+// BulkAssignForm so behavior matches the rest of the schedule surface.
+
+import { useEffect, useMemo, useState } from "react";
+import { toast } from "sonner";
+
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { cn } from "@/lib/utils";
+
+import { bulkAssignTemplate } from "@/lib/gc-fitness/workout-assignment-actions";
+import { civilDateToday } from "@/lib/gc-fitness/civil-date";
+import { addCivilMonths } from "@/lib/gc-fitness/end-date-presets";
+import type { ClientRosterEntry } from "@/lib/gc-fitness/client-roster";
+
+import { useGeneratorStrings } from "./strings";
+
+interface Props {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  templateId: string;
+  clients: ClientRosterEntry[];
+  trainerTimezone?: string;
+}
+
+type Mode = "once" | "weekly" | "daily" | "everyN" | "monthly";
+
+function parseCivilToLocalDate(civil: string): Date {
+  const [y, m, d] = civil.split("-").map(Number);
+  return new Date(y, m - 1, d);
+}
+
+export function AssignGeneratedModal({
+  open,
+  onOpenChange,
+  templateId,
+  clients,
+  trainerTimezone,
+}: Props) {
+  const s = useGeneratorStrings();
+
+  const tz = useMemo(
+    () => trainerTimezone || Intl.DateTimeFormat().resolvedOptions().timeZone,
+    [trainerTimezone],
+  );
+  const today = useMemo(() => civilDateToday(tz), [tz]);
+  const [selected, setSelected] = useState<Set<string>>(new Set());
+  const [date, setDate] = useState<string>(today);
+  const [scheduledTime, setScheduledTime] = useState<string>("");
+  const [mode, setMode] = useState<Mode>("once");
+  const [weekdays, setWeekdays] = useState<Set<number>>(
+    () => new Set([parseCivilToLocalDate(today).getDay()]),
+  );
+  const [everyN, setEveryN] = useState(2);
+  const [endEnabled, setEndEnabled] = useState(true);
+  const [endDate, setEndDate] = useState<string>(addCivilMonths(today, 3));
+  const [submitting, setSubmitting] = useState(false);
+
+  useEffect(() => {
+    if (!open) return;
+    setSelected(new Set());
+    setDate(today);
+    setScheduledTime("");
+    setMode("once");
+    setWeekdays(new Set([parseCivilToLocalDate(today).getDay()]));
+    setEveryN(2);
+    setEndEnabled(true);
+    setEndDate(addCivilMonths(today, 3));
+  }, [open, today]);
+
+  function toggleClient(uid: string) {
+    setSelected((prev) => {
+      const next = new Set(prev);
+      if (next.has(uid)) next.delete(uid);
+      else next.add(uid);
+      return next;
+    });
+  }
+  function toggleAll() {
+    setSelected((prev) =>
+      prev.size === clients.length ? new Set() : new Set(clients.map((c) => c.uid)),
+    );
+  }
+  function toggleWeekday(idx: number) {
+    setWeekdays((prev) => {
+      const next = new Set(prev);
+      if (next.has(idx)) {
+        if (next.size === 1) return next;
+        next.delete(idx);
+      } else {
+        next.add(idx);
+      }
+      return next;
+    });
+  }
+
+  async function onSubmit() {
+    if (selected.size === 0) {
+      toast.error(s.pickClient);
+      return;
+    }
+    setSubmitting(true);
+    try {
+      let recurrence:
+        | { kind: "daily" }
+        | { kind: "weekly"; weekday: number }
+        | { kind: "weekly_days"; weekdays: number[] }
+        | { kind: "every_n_days"; everyN: number }
+        | { kind: "monthly"; dayOfMonth: number }
+        | undefined;
+      if (mode === "daily") recurrence = { kind: "daily" };
+      else if (mode === "everyN") recurrence = { kind: "every_n_days", everyN };
+      else if (mode === "monthly")
+        recurrence = { kind: "monthly", dayOfMonth: parseCivilToLocalDate(date).getDate() };
+      else if (mode === "weekly") {
+        const days = Array.from(weekdays).sort((a, b) => a - b);
+        recurrence =
+          days.length === 1
+            ? { kind: "weekly", weekday: days[0] }
+            : { kind: "weekly_days", weekdays: days };
+      }
+
+      const result = await bulkAssignTemplate({
+        templateId,
+        clientIds: Array.from(selected),
+        scheduledFor: date,
+        scheduledTime: scheduledTime || undefined,
+        timezone: tz,
+        recurrence,
+        endDate: mode !== "once" && endEnabled ? endDate : undefined,
+      });
+      toast.success(s.assignedOk.replace("{n}", String(result.ids.length)));
+      onOpenChange(false);
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : s.assignFailed);
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-h-[calc(100dvh-1rem)] w-[calc(100vw-1rem)] max-w-[calc(100vw-1rem)] overflow-hidden p-4 sm:max-w-2xl sm:p-6">
+        <DialogHeader>
+          <DialogTitle>{s.assignTitle}</DialogTitle>
+          <DialogDescription>{s.assignSubtitle}</DialogDescription>
+        </DialogHeader>
+
+        <div className="flex flex-1 min-h-0 flex-col gap-4 overflow-y-auto -mx-4 px-4">
+          {/* clients */}
+          <div className="flex flex-col gap-2">
+            <div className="flex items-center justify-between">
+              <span className="text-sm font-medium">
+                {s.clients} · {selected.size}
+              </span>
+              {clients.length > 0 ? (
+                <Button type="button" variant="ghost" size="sm" onClick={toggleAll}>
+                  {s.selectAll}
+                </Button>
+              ) : null}
+            </div>
+            {clients.length === 0 ? (
+              <p className="rounded-md border border-dashed p-4 text-center text-sm text-muted-foreground">
+                {s.noClients}
+              </p>
+            ) : (
+              <div className="grid max-h-56 grid-cols-1 gap-1.5 overflow-y-auto sm:grid-cols-2">
+                {clients.map((c) => {
+                  const active = selected.has(c.uid);
+                  return (
+                    <button
+                      key={c.uid}
+                      type="button"
+                      onClick={() => toggleClient(c.uid)}
+                      aria-pressed={active}
+                      className={cn(
+                        "flex items-center gap-2 rounded-md border px-3 py-2 text-left text-sm transition-colors",
+                        active
+                          ? "border-primary bg-primary/5"
+                          : "border-border bg-background hover:border-foreground/30",
+                      )}
+                    >
+                      <span
+                        className={cn(
+                          "flex h-4 w-4 shrink-0 items-center justify-center rounded border",
+                          active ? "border-primary bg-primary text-primary-foreground" : "border-muted-foreground/40",
+                        )}
+                      >
+                        {active ? "✓" : ""}
+                      </span>
+                      <span className="min-w-0 truncate">
+                        {c.coachNickname || c.displayName || c.email}
+                      </span>
+                    </button>
+                  );
+                })}
+              </div>
+            )}
+          </div>
+
+          {/* cadence */}
+          <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+            <div className="flex flex-col gap-1.5">
+              <label className="text-sm font-medium">{s.cadence}</label>
+              <Select value={mode} onValueChange={(v) => setMode(v as Mode)}>
+                <SelectTrigger>
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="once">{s.once}</SelectItem>
+                  <SelectItem value="weekly">{s.weekly}</SelectItem>
+                  <SelectItem value="daily">{s.daily}</SelectItem>
+                  <SelectItem value="everyN">{s.everyN}</SelectItem>
+                  <SelectItem value="monthly">{s.monthly}</SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
+            <div className="flex flex-col gap-1.5">
+              <label className="text-sm font-medium">{s.day}</label>
+              <input
+                type="date"
+                value={date}
+                onChange={(e) => setDate(e.target.value)}
+                className="h-10 rounded-md border bg-background px-3 text-sm"
+              />
+            </div>
+          </div>
+
+          {mode === "weekly" ? (
+            <div className="flex flex-col gap-1.5">
+              <label className="text-sm font-medium">{s.repeatOn}</label>
+              <div className="flex flex-wrap gap-2">
+                {s.weekdays.map((label, idx) => (
+                  <Button
+                    key={label}
+                    type="button"
+                    size="sm"
+                    variant={weekdays.has(idx) ? "default" : "outline"}
+                    aria-pressed={weekdays.has(idx)}
+                    onClick={() => toggleWeekday(idx)}
+                  >
+                    {label}
+                  </Button>
+                ))}
+              </div>
+            </div>
+          ) : null}
+
+          {mode === "everyN" ? (
+            <div className="flex flex-col gap-1.5">
+              <label className="text-sm font-medium">{s.everyNDays}</label>
+              <input
+                type="number"
+                min={2}
+                max={30}
+                value={everyN}
+                onChange={(e) =>
+                  setEveryN(Math.max(2, Math.min(30, Number(e.target.value) || 2)))
+                }
+                className="h-10 w-24 rounded-md border bg-background px-3 text-sm"
+              />
+            </div>
+          ) : null}
+
+          <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+            <div className="flex flex-col gap-1.5">
+              <label className="text-sm font-medium">{s.time}</label>
+              <input
+                type="time"
+                value={scheduledTime}
+                onChange={(e) => setScheduledTime(e.target.value)}
+                className="h-10 rounded-md border bg-background px-3 text-sm"
+              />
+            </div>
+            {mode !== "once" ? (
+              <div className="flex flex-col gap-1.5">
+                <label className="flex items-center gap-2 text-sm font-medium">
+                  <input
+                    type="checkbox"
+                    checked={endEnabled}
+                    onChange={(e) => setEndEnabled(e.target.checked)}
+                    className="h-4 w-4 rounded border"
+                  />
+                  {s.setEnd}
+                </label>
+                <input
+                  type="date"
+                  value={endDate}
+                  min={date}
+                  disabled={!endEnabled}
+                  onChange={(e) => setEndDate(e.target.value)}
+                  className="h-10 rounded-md border bg-background px-3 text-sm disabled:opacity-50"
+                />
+              </div>
+            ) : null}
+          </div>
+        </div>
+
+        <DialogFooter>
+          <Button variant="ghost" onClick={() => onOpenChange(false)} disabled={submitting}>
+            {s.cancel}
+          </Button>
+          <Button onClick={onSubmit} disabled={submitting || selected.size === 0}>
+            {submitting ? s.assigning : s.assignAction}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/backoffice/src/components/gc-fitness/generator/strings.ts
+++ b/backoffice/src/components/gc-fitness/generator/strings.ts
@@ -1,0 +1,244 @@
+// generator/strings.ts
+//
+// Self-contained bilingual copy for the Workout Generator surface. The rest of
+// the backoffice uses next-intl catalogs, but this feature ships a focused
+// EN/ES dictionary instead of threading ~70 keys through the two 1,797-line
+// message JSONs (which is both noisy to review and easy to drift). The data
+// layer (equipment groups, muscle/type presets) already carries {en,es}
+// labels, so this only covers chrome/labels. Pick the active strings with
+// `useGeneratorStrings()` which reads next-intl's `useLocale()`.
+
+import { useLocale } from "next-intl";
+
+type Locale = "en" | "es";
+
+const COPY = {
+  en: {
+    pageTitle: "Workout generator",
+    pageSubtitle:
+      "Pick equipment, muscles, length and style — we build the workout, you fine-tune and assign it.",
+    back: "Back",
+    next: "Next",
+    generate: "Generate workout",
+    regenerate: "Regenerate",
+    step: "Step",
+    of: "of",
+
+    // Step 1 — equipment
+    equipmentTitle: "What equipment is available?",
+    equipmentSubtitle:
+      "Tap a bundle to select several at once, or pick items individually. Only exercises whose equipment you select will be used.",
+    equipmentGroups: "Quick bundles",
+    equipmentAll: "All equipment",
+    selectedCount: "selected",
+    clear: "Clear",
+
+    // Step 2 — muscles
+    musclesTitle: "Which muscles are we training?",
+    musclesSubtitle:
+      "Tap a focus to select a group of muscles, or hand-pick individual ones.",
+    musclePresets: "Focus",
+    musclesAll: "All muscles",
+
+    // Step 3 — volume
+    volumeTitle: "How long is the workout?",
+    volumeSubtitle: "Pick a number of exercises or a time budget.",
+    byCount: "By exercises",
+    byTime: "By time",
+    exercises: "exercises",
+    minutes: "minutes",
+
+    // Step 4 — type
+    typeTitle: "What style of workout?",
+    typeSubtitle: "This sets the sets, reps and rest timers.",
+
+    // Step 5 — result
+    resultTitle: "Your generated workout",
+    resultSubtitle:
+      "Tap a replacement pill to swap an exercise. Edit any number, rename it, then save.",
+    workoutName: "Workout name",
+    estimated: "Estimated",
+    min: "min",
+    sets: "Sets",
+    reps: "Reps",
+    rest: "Rest (s)",
+    seconds: "Secs",
+    weightKg: "Weight (kg)",
+    modeWeightReps: "Weight × reps",
+    modeReps: "Reps only",
+    modeTime: "By time",
+    swapTo: "Swap:",
+    noReplacements: "No other matching exercises",
+    save: "Save workout",
+    saving: "Saving…",
+    emptyResult:
+      "No exercises matched those filters. Go back and widen the equipment or muscle selection.",
+    poolWarning:
+      "Only {n} exercises matched your filters — fewer than requested. Widen equipment/muscles for more variety.",
+    remove: "Remove",
+    addExercise: "Add exercise",
+
+    // Success
+    successTitle: "Workout saved!",
+    successSubtitle: "Saved to your library. Assign it to clients now, or later from the schedule.",
+    assign: "Assign to clients",
+    viewInLibrary: "View in library",
+    generateAnother: "Generate another",
+    duration: "Duration",
+    exercisesLabel: "Exercises",
+
+    // Validation
+    pickEquipment: "Pick at least one piece of equipment.",
+    pickMuscles: "Pick at least one muscle.",
+    saveFailed: "Couldn't save the workout.",
+    nameRequired: "Give the workout a name.",
+
+    // Assign modal
+    assignTitle: "Assign workout",
+    assignSubtitle: "Pick one or more clients and how often it repeats.",
+    clients: "Clients",
+    selectAll: "Select all",
+    cadence: "Repeat",
+    once: "Once",
+    weekly: "Weekly",
+    daily: "Daily",
+    everyN: "Every N days",
+    monthly: "Monthly",
+    repeatOn: "Repeat on",
+    everyNDays: "Repeat every N days",
+    day: "Day",
+    time: "Time (optional)",
+    endDate: "End date",
+    noEnd: "No end date",
+    setEnd: "Set an end date",
+    cancel: "Cancel",
+    assignAction: "Assign",
+    assigning: "Assigning…",
+    assignedOk: "Assigned to {n} client(s).",
+    pickClient: "Pick at least one client.",
+    noClients: "No clients yet. Add a client first.",
+    assignFailed: "Couldn't assign the workout.",
+    weekdays: ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"],
+  },
+  es: {
+    pageTitle: "Generador de rutinas",
+    pageSubtitle:
+      "Elegí equipo, músculos, duración y estilo — armamos la rutina y vos la ajustás y asignás.",
+    back: "Atrás",
+    next: "Siguiente",
+    generate: "Generar rutina",
+    regenerate: "Regenerar",
+    step: "Paso",
+    of: "de",
+
+    equipmentTitle: "¿Qué equipo hay disponible?",
+    equipmentSubtitle:
+      "Tocá un combo para seleccionar varios a la vez, o elegí ítems sueltos. Solo se usarán ejercicios cuyo equipo hayas seleccionado.",
+    equipmentGroups: "Combos rápidos",
+    equipmentAll: "Todo el equipo",
+    selectedCount: "seleccionados",
+    clear: "Limpiar",
+
+    musclesTitle: "¿Qué músculos trabajamos?",
+    musclesSubtitle:
+      "Tocá un foco para seleccionar un grupo de músculos, o elegilos uno por uno.",
+    musclePresets: "Foco",
+    musclesAll: "Todos los músculos",
+
+    volumeTitle: "¿Cuánto dura la rutina?",
+    volumeSubtitle: "Elegí una cantidad de ejercicios o un tiempo disponible.",
+    byCount: "Por ejercicios",
+    byTime: "Por tiempo",
+    exercises: "ejercicios",
+    minutes: "minutos",
+
+    typeTitle: "¿Qué estilo de rutina?",
+    typeSubtitle: "Esto define las series, reps y descansos.",
+
+    resultTitle: "Tu rutina generada",
+    resultSubtitle:
+      "Tocá una píldora de reemplazo para cambiar un ejercicio. Editá cualquier número, renombrala y guardá.",
+    workoutName: "Nombre de la rutina",
+    estimated: "Estimado",
+    min: "min",
+    sets: "Series",
+    reps: "Reps",
+    rest: "Descanso (s)",
+    seconds: "Segs",
+    weightKg: "Peso (kg)",
+    modeWeightReps: "Peso × reps",
+    modeReps: "Solo reps",
+    modeTime: "Por tiempo",
+    swapTo: "Cambiar:",
+    noReplacements: "No hay otros ejercicios que coincidan",
+    save: "Guardar rutina",
+    saving: "Guardando…",
+    emptyResult:
+      "Ningún ejercicio coincidió con esos filtros. Volvé y ampliá el equipo o los músculos.",
+    poolWarning:
+      "Solo {n} ejercicios coincidieron con tus filtros — menos de los pedidos. Ampliá equipo/músculos para más variedad.",
+    remove: "Quitar",
+    addExercise: "Agregar ejercicio",
+
+    successTitle: "¡Rutina guardada!",
+    successSubtitle:
+      "Guardada en tu biblioteca. Asignala a tus clientes ahora, o más tarde desde la agenda.",
+    assign: "Asignar a clientes",
+    viewInLibrary: "Ver en biblioteca",
+    generateAnother: "Generar otra",
+    duration: "Duración",
+    exercisesLabel: "Ejercicios",
+
+    pickEquipment: "Elegí al menos un elemento de equipo.",
+    pickMuscles: "Elegí al menos un músculo.",
+    saveFailed: "No se pudo guardar la rutina.",
+    nameRequired: "Ponele un nombre a la rutina.",
+
+    assignTitle: "Asignar rutina",
+    assignSubtitle: "Elegí uno o más clientes y con qué frecuencia se repite.",
+    clients: "Clientes",
+    selectAll: "Seleccionar todos",
+    cadence: "Repetir",
+    once: "Una vez",
+    weekly: "Semanal",
+    daily: "Diario",
+    everyN: "Cada N días",
+    monthly: "Mensual",
+    repeatOn: "Repetir los",
+    everyNDays: "Repetir cada N días",
+    day: "Día",
+    time: "Hora (opcional)",
+    endDate: "Fecha de fin",
+    noEnd: "Sin fecha de fin",
+    setEnd: "Definir fecha de fin",
+    cancel: "Cancelar",
+    assignAction: "Asignar",
+    assigning: "Asignando…",
+    assignedOk: "Asignada a {n} cliente(s).",
+    pickClient: "Elegí al menos un cliente.",
+    noClients: "Todavía no hay clientes. Agregá un cliente primero.",
+    assignFailed: "No se pudo asignar la rutina.",
+    weekdays: ["Dom", "Lun", "Mar", "Mié", "Jue", "Vie", "Sáb"],
+  },
+} as const;
+
+// Widen the literal `COPY.en` shape so EN and ES (which have different string
+// literals) are both assignable to the public type.
+export type GeneratorStrings = {
+  [K in keyof (typeof COPY)["en"]]: (typeof COPY)["en"][K] extends readonly string[]
+    ? readonly string[]
+    : string;
+};
+
+export function useGeneratorStrings(): GeneratorStrings {
+  const locale = useLocale();
+  const key: Locale = locale === "es" ? "es" : "en";
+  return COPY[key];
+}
+
+/** Pick the localized side of a {en,es} label. */
+export function useLocalized(): (label: { en: string; es: string }) => string {
+  const locale = useLocale();
+  const key: Locale = locale === "es" ? "es" : "en";
+  return (label) => label[key] || label.en;
+}

--- a/backoffice/src/components/gc-fitness/generator/workout-generator-wizard.tsx
+++ b/backoffice/src/components/gc-fitness/generator/workout-generator-wizard.tsx
@@ -1,0 +1,610 @@
+"use client";
+
+// workout-generator-wizard.tsx
+//
+// The multi-step Workout Generator (issue #296). Four authoring steps
+// (equipment → muscles → volume → type) collect the inputs; the PURE engine
+// (`@/lib/gc-fitness/workout-generator`) produces a workout; then the SAME
+// `TemplateForm` used by the normal "create workout" flow takes over for
+// editing (in-line exercise picker swap, supersets, per-set reps like
+// 12/10/8/6, transition rest, coach notes, metric + "Sin peso"). On save we
+// transition to a success step with a direct multi-client assign action.
+//
+// POOL = the new curated standard library ONLY (STANDARD_LIBRARY_TAG). Legacy
+// fexd/wger catalog docs AND coach-authored customs are excluded from
+// generation so the output is always new-naming + new-gif exercises. (The coach
+// can still manually add anything via TemplateForm's picker.)
+//
+// Equipment rule (engine): an exercise needs every piece of equipment it
+// requires — including a bench inferred from the movement name — to be in the
+// selected set, or it appears neither in the workout nor any pill.
+
+import { useMemo, useState } from "react";
+import Link from "next/link";
+import { toast } from "sonner";
+import { ArrowLeft, ArrowRight, Check, Dumbbell, RefreshCw, Sparkles } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+
+import { EQUIPMENT, MUSCLE_GROUPS } from "@/lib/gc-fitness/exercise-vocabulary";
+import { useExercisesQuery } from "@/lib/gc-fitness/exercises-listener";
+import { STANDARD_LIBRARY_TAG } from "@/lib/gc-fitness/exercise-visibility";
+import { createWorkoutTemplate } from "@/lib/gc-fitness/workout-template-actions";
+import type { WorkoutTemplateInput } from "@/lib/gc-fitness/workout-template-schema";
+import type { ClientRosterEntry } from "@/lib/gc-fitness/client-roster";
+import { TemplateForm } from "@/components/gc-fitness/template-form";
+
+import {
+  EQUIPMENT_GROUPS,
+  MUSCLE_PRESETS,
+  WORKOUT_TYPE_PRESETS,
+  computeReplacements,
+  generateWorkout,
+  getEligibleExercises,
+  isGroupFullySelected,
+  primaryCoveredMuscle,
+  type GeneratorExercise,
+  type GeneratorInput,
+} from "@/lib/gc-fitness/workout-generator";
+
+import { useGeneratorStrings, useLocalized } from "./strings";
+import { AssignGeneratedModal } from "./assign-generated-modal";
+
+interface Props {
+  clients: ClientRosterEntry[];
+  trainerTimezone?: string;
+}
+
+function humanize(id: string): string {
+  return id
+    .split("_")
+    .map((w) => w.charAt(0).toUpperCase() + w.slice(1))
+    .join(" ");
+}
+
+export function WorkoutGeneratorWizard({ clients, trainerTimezone }: Props) {
+  const s = useGeneratorStrings();
+  const localized = useLocalized();
+  const { data: library, isLoading } = useExercisesQuery();
+
+  // Generator pool = the NEW curated standard library only.
+  const pool: GeneratorExercise[] = useMemo(
+    () =>
+      (library ?? [])
+        .filter(
+          (r) => r.deleted !== true && Array.isArray(r.tags) && r.tags.includes(STANDARD_LIBRARY_TAG),
+        )
+        .map((r) => ({
+          id: r.id,
+          name: r.name,
+          muscleGroups: r.muscleGroups,
+          equipment: r.equipment,
+          metric: r.metric,
+          gifUrl: r.gifUrl,
+          thumbnailURL: r.thumbnailURL,
+          imageUrl: r.imageUrl,
+          mediaURL: r.mediaURL,
+        })),
+    [library],
+  );
+
+  const [step, setStep] = useState<1 | 2 | 3 | 4 | 5 | 6>(1);
+  const [equipment, setEquipment] = useState<Set<string>>(new Set());
+  const [muscles, setMuscles] = useState<Set<string>>(new Set());
+  const [volumeMode, setVolumeMode] = useState<"count" | "time">("count");
+  const [count, setCount] = useState(6);
+  const [minutes, setMinutes] = useState(40);
+  const [workoutType, setWorkoutType] = useState<string>("hypertrophy");
+  const [seed, setSeed] = useState(1);
+  const [genVersion, setGenVersion] = useState(0);
+
+  const [generated, setGenerated] = useState<Partial<WorkoutTemplateInput> | null>(null);
+  const [generatedName, setGeneratedName] = useState("");
+  const [poolWarning, setPoolWarning] = useState<string | null>(null);
+
+  const [savedId, setSavedId] = useState<string | null>(null);
+  const [assignOpen, setAssignOpen] = useState(false);
+
+  const TOTAL_STEPS = 5;
+
+  // Equipment-eligible standard-library pool for the current selection — the
+  // source for the generator-only replacement pills rendered under each row.
+  const poolById = useMemo(() => new Map(pool.map((e) => [e.id, e])), [pool]);
+  const eligible = useMemo(
+    () => getEligibleExercises(pool, { equipment: [...equipment], muscleGroups: [...muscles] }),
+    [pool, equipment, muscles],
+  );
+
+  // Replacement pills under an exercise row (TemplateForm `renderExerciseExtras`).
+  // Same-muscle, equipment-eligible alternatives from the new library, excluding
+  // exercises already in the workout. Tapping one swaps the row's exercise.
+  function renderExerciseExtras(ctx: {
+    index: number;
+    exerciseId: string;
+    allExerciseIds: string[];
+    onReplace: (id: string) => void;
+  }): React.ReactNode {
+    const ex = poolById.get(ctx.exerciseId);
+    if (!ex) return null;
+    const primaryMuscle = primaryCoveredMuscle(ex, muscles) ?? ex.muscleGroups[0];
+    if (!primaryMuscle) return null;
+    const used = new Set(ctx.allExerciseIds);
+    const reps = computeReplacements(
+      eligible,
+      primaryMuscle,
+      used,
+      (seed ^ ((ctx.index + 1) * 0x9e3779b1)) >>> 0,
+      5,
+    );
+    if (reps.length === 0) return null;
+    return (
+      <div className="flex flex-wrap items-center gap-1.5">
+        <span className="text-[11px] text-muted-foreground">{s.swapTo}</span>
+        {reps.map((r) => (
+          <button
+            key={r.exerciseId}
+            type="button"
+            onClick={() => ctx.onReplace(r.exerciseId)}
+            className="inline-flex items-center gap-1 rounded-full border border-border bg-background px-2.5 py-1 text-xs text-foreground transition-colors hover:border-primary hover:bg-primary/5"
+          >
+            <RefreshCw className="h-3 w-3 opacity-60" />
+            {localized(r.name)}
+          </button>
+        ))}
+      </div>
+    );
+  }
+
+  function toggle(setter: React.Dispatch<React.SetStateAction<Set<string>>>, id: string) {
+    setter((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  }
+  function toggleGroup(items: string[], fullySelected: boolean) {
+    setEquipment((prev) => {
+      const next = new Set(prev);
+      if (fullySelected) items.forEach((i) => next.delete(i));
+      else items.forEach((i) => next.add(i));
+      return next;
+    });
+  }
+  function togglePreset(presetMuscles: string[], fullySelected: boolean) {
+    setMuscles((prev) => {
+      const next = new Set(prev);
+      if (fullySelected) presetMuscles.forEach((m) => next.delete(m));
+      else presetMuscles.forEach((m) => next.add(m));
+      return next;
+    });
+  }
+
+  const focusLabel = useMemo(() => {
+    const sameSet = (a: string[], b: Set<string>) => a.length === b.size && a.every((x) => b.has(x));
+    const match = MUSCLE_PRESETS.find((p) => sameSet(p.muscles, muscles));
+    if (match) return match.label;
+    if (muscles.size === 1) {
+      const only = [...muscles][0];
+      return { en: humanize(only), es: humanize(only) };
+    }
+    return undefined;
+  }, [muscles]);
+
+  function buildInput(nextSeed: number): GeneratorInput {
+    return {
+      equipment: [...equipment],
+      muscleGroups: [...muscles],
+      volumeMode,
+      exerciseCount: count,
+      timeMinutes: minutes,
+      workoutType,
+      seed: nextSeed,
+      focusLabel,
+    };
+  }
+
+  // Convert the engine output into TemplateForm `defaultValues`. Per-set rows
+  // are derived by TemplateForm from `sets`/`reps`, so the coach can split a
+  // 4×12 into 12/10/8/6 right in the standard editor.
+  function runGeneration(nextSeed: number) {
+    const input = buildInput(nextSeed);
+    const workout = generateWorkout(input, pool);
+    const typeLabel = localized(WORKOUT_TYPE_PRESETS.find((p) => p.id === workoutType)!.label);
+    // Equipment that carries no external load — these default to "Sin peso"
+    // (reps-only). Everything else (dumbbell, barbell, cable, machine, …)
+    // defaults to "weight × reps" so the coach fills in load.
+    const NON_LOAD = new Set(["bodyweight", "none", "pull_up_bar"]);
+    const isNoLoad = (id: string) => {
+      const src = poolById.get(id);
+      const eq = src && src.equipment.length > 0 ? src.equipment : ["bodyweight"];
+      return eq.every((e) => NON_LOAD.has(e));
+    };
+    const defaults: Partial<WorkoutTemplateInput> = {
+      name: { en: workout.name.en, es: workout.name.es },
+      tag: typeLabel,
+      tags: [typeLabel],
+      exercises: workout.exercises.map((g, i) => ({
+        exerciseId: g.exerciseId,
+        sets: g.sets,
+        reps: g.metric === "time" ? 0 : g.reps,
+        rest_seconds: g.rest_seconds,
+        transition_rest_seconds: g.transition_rest_seconds,
+        order: i + 1,
+        ...(g.metric === "time"
+          ? { metric: "time" as const, durationSeconds: g.durationSeconds ?? 60 }
+          : // Reps-based: seed the Sin-peso sentinel only for no-load exercises.
+            isNoLoad(g.exerciseId)
+            ? { weightBySetKg: [] as number[] }
+            : {}),
+      })) as WorkoutTemplateInput["exercises"],
+    };
+    setGenerated(defaults);
+    setGeneratedName(workout.name.en);
+    setPoolWarning(
+      workout.exercises.length < workout.requestedCount
+        ? s.poolWarning.replace("{n}", String(workout.exercises.length))
+        : null,
+    );
+    setSeed(nextSeed);
+    setGenVersion((v) => v + 1);
+    setStep(5);
+  }
+
+  function handleGenerate() {
+    runGeneration(seed);
+  }
+  function handleRegenerate() {
+    runGeneration((seed + 0x6d2b79f5) >>> 0);
+  }
+
+  function resetAll() {
+    setStep(1);
+    setEquipment(new Set());
+    setMuscles(new Set());
+    setVolumeMode("count");
+    setCount(6);
+    setMinutes(40);
+    setWorkoutType("hypertrophy");
+    setGenerated(null);
+    setSavedId(null);
+  }
+
+  const canNext =
+    (step === 1 && equipment.size > 0) ||
+    (step === 2 && muscles.size > 0) ||
+    step === 3 ||
+    step === 4;
+
+  function goNext() {
+    if (step === 1 && equipment.size === 0) return toast.error(s.pickEquipment);
+    if (step === 2 && muscles.size === 0) return toast.error(s.pickMuscles);
+    if (step === 4) return handleGenerate();
+    setStep((step + 1) as typeof step);
+  }
+
+  // ---------------------------------------------------------------------------
+  // Success screen
+  // ---------------------------------------------------------------------------
+  if (step === 6 && savedId) {
+    return (
+      <div className="flex flex-col gap-6">
+        <div className="flex flex-col items-center gap-2 rounded-2xl border bg-card p-6 text-center">
+          <div className="flex h-12 w-12 items-center justify-center rounded-full bg-emerald-500/15 text-emerald-600">
+            <Check className="h-6 w-6" />
+          </div>
+          <h2 className="font-heading text-xl font-semibold">{s.successTitle}</h2>
+          <p className="max-w-md text-sm text-muted-foreground">{s.successSubtitle}</p>
+          {generatedName ? <p className="mt-1 text-lg font-semibold">{generatedName}</p> : null}
+        </div>
+
+        <div className="flex flex-wrap gap-2">
+          <Button onClick={() => setAssignOpen(true)} className="gap-2">
+            <Sparkles className="h-4 w-4" />
+            {s.assign}
+          </Button>
+          <Button asChild variant="outline">
+            <Link href={`/gc-fitness/templates/${savedId}/view`}>{s.viewInLibrary}</Link>
+          </Button>
+          <Button variant="ghost" onClick={resetAll}>
+            {s.generateAnother}
+          </Button>
+        </div>
+
+        <AssignGeneratedModal
+          open={assignOpen}
+          onOpenChange={setAssignOpen}
+          templateId={savedId}
+          clients={clients}
+          trainerTimezone={trainerTimezone}
+        />
+      </div>
+    );
+  }
+
+  // ---------------------------------------------------------------------------
+  // Result step — hand off to the real TemplateForm (full editor parity)
+  // ---------------------------------------------------------------------------
+  if (step === 5 && generated) {
+    return (
+      <div className="flex flex-col gap-5">
+        <div className="flex flex-wrap items-start justify-between gap-3">
+          <div>
+            <h2 className="font-heading text-lg font-semibold tracking-tight">{s.resultTitle}</h2>
+            <p className="text-sm text-muted-foreground">{s.resultSubtitle}</p>
+          </div>
+          <div className="flex gap-2">
+            <Button type="button" variant="ghost" size="sm" onClick={() => setStep(4)} className="gap-1">
+              <ArrowLeft className="h-4 w-4" />
+              {s.back}
+            </Button>
+            <Button type="button" variant="outline" size="sm" onClick={handleRegenerate} className="gap-1">
+              <RefreshCw className="h-4 w-4" />
+              {s.regenerate}
+            </Button>
+          </div>
+        </div>
+
+        {poolWarning ? (
+          <p className="rounded-md border border-amber-500/40 bg-amber-500/10 px-3 py-2 text-sm text-amber-800 dark:text-amber-200">
+            {poolWarning}
+          </p>
+        ) : null}
+
+        {/* The SAME editor as the normal create flow: in-line picker swap,
+            supersets, per-set reps/weight, transition rest, coach notes,
+            metric + "Sin peso". `key` forces a remount on regenerate so the
+            new defaults apply. */}
+        <TemplateForm
+          key={`gen-${genVersion}`}
+          mode="create"
+          defaultValues={generated}
+          onSubmit={(input) => createWorkoutTemplate(input)}
+          onCreated={(id) => {
+            setSavedId(id);
+            setStep(6);
+          }}
+          renderExerciseExtras={renderExerciseExtras}
+        />
+      </div>
+    );
+  }
+
+  // ---------------------------------------------------------------------------
+  // Wizard steps 1–4
+  // ---------------------------------------------------------------------------
+  return (
+    <div className="flex flex-col gap-6">
+      <div className="flex items-center gap-2">
+        {Array.from({ length: TOTAL_STEPS }, (_, i) => i + 1).map((n) => (
+          <div
+            key={n}
+            className={cn(
+              "h-1.5 flex-1 rounded-full transition-colors",
+              n <= step ? "bg-primary" : "bg-muted",
+            )}
+          />
+        ))}
+      </div>
+      <p className="text-xs text-muted-foreground">
+        {s.step} {Math.min(step, TOTAL_STEPS)} {s.of} {TOTAL_STEPS}
+      </p>
+
+      {step === 1 && (
+        <StepShell title={s.equipmentTitle} subtitle={s.equipmentSubtitle}>
+          <SectionLabel>{s.equipmentGroups}</SectionLabel>
+          <div className="flex flex-wrap gap-2">
+            {EQUIPMENT_GROUPS.map((g) => {
+              const full = isGroupFullySelected(g, equipment);
+              return (
+                <Chip key={g.id} active={full} onClick={() => toggleGroup(g.items, full)}>
+                  {localized(g.label)}
+                </Chip>
+              );
+            })}
+          </div>
+          <SectionLabel className="mt-4">
+            {s.equipmentAll} · {equipment.size} {s.selectedCount}
+          </SectionLabel>
+          <div className="flex flex-wrap gap-2">
+            {EQUIPMENT.map((id) => (
+              <Chip key={id} active={equipment.has(id)} onClick={() => toggle(setEquipment, id)}>
+                {humanize(id)}
+              </Chip>
+            ))}
+          </div>
+        </StepShell>
+      )}
+
+      {step === 2 && (
+        <StepShell title={s.musclesTitle} subtitle={s.musclesSubtitle}>
+          <SectionLabel>{s.musclePresets}</SectionLabel>
+          <div className="flex flex-wrap gap-2">
+            {MUSCLE_PRESETS.map((p) => {
+              const full = p.muscles.every((m) => muscles.has(m));
+              return (
+                <Chip key={p.id} active={full} onClick={() => togglePreset(p.muscles, full)}>
+                  {localized(p.label)}
+                </Chip>
+              );
+            })}
+          </div>
+          <SectionLabel className="mt-4">
+            {s.musclesAll} · {muscles.size} {s.selectedCount}
+          </SectionLabel>
+          <div className="flex flex-wrap gap-2">
+            {MUSCLE_GROUPS.map((id) => (
+              <Chip key={id} active={muscles.has(id)} onClick={() => toggle(setMuscles, id)}>
+                {humanize(id)}
+              </Chip>
+            ))}
+          </div>
+        </StepShell>
+      )}
+
+      {step === 3 && (
+        <StepShell title={s.volumeTitle} subtitle={s.volumeSubtitle}>
+          <div className="flex gap-2">
+            <Chip active={volumeMode === "count"} onClick={() => setVolumeMode("count")}>
+              {s.byCount}
+            </Chip>
+            <Chip active={volumeMode === "time"} onClick={() => setVolumeMode("time")}>
+              {s.byTime}
+            </Chip>
+          </div>
+          {volumeMode === "count" ? (
+            <div className="mt-4 flex flex-col gap-3">
+              <div className="flex items-baseline gap-2">
+                <span className="text-4xl font-semibold tabular-nums">{count}</span>
+                <span className="text-sm text-muted-foreground">{s.exercises}</span>
+              </div>
+              <input
+                type="range"
+                min={3}
+                max={15}
+                value={count}
+                onChange={(e) => setCount(Number(e.target.value))}
+                className="w-full accent-[var(--primary)]"
+              />
+            </div>
+          ) : (
+            <div className="mt-4 flex flex-col gap-3">
+              <div className="flex items-baseline gap-2">
+                <span className="text-4xl font-semibold tabular-nums">{minutes}</span>
+                <span className="text-sm text-muted-foreground">{s.minutes}</span>
+              </div>
+              <input
+                type="range"
+                min={15}
+                max={90}
+                step={5}
+                value={minutes}
+                onChange={(e) => setMinutes(Number(e.target.value))}
+                className="w-full accent-[var(--primary)]"
+              />
+            </div>
+          )}
+        </StepShell>
+      )}
+
+      {step === 4 && (
+        <StepShell title={s.typeTitle} subtitle={s.typeSubtitle}>
+          <div className="grid gap-2 sm:grid-cols-2">
+            {WORKOUT_TYPE_PRESETS.map((p) => (
+              <button
+                key={p.id}
+                type="button"
+                onClick={() => setWorkoutType(p.id)}
+                className={cn(
+                  "flex flex-col gap-1 rounded-xl border p-3 text-left transition-colors",
+                  workoutType === p.id
+                    ? "border-primary bg-primary/5 ring-1 ring-primary"
+                    : "border-border bg-card hover:border-foreground/30",
+                )}
+              >
+                <span className="text-sm font-semibold">{localized(p.label)}</span>
+                <span className="text-xs text-muted-foreground">{localized(p.description)}</span>
+                <span className="mt-1 text-[11px] text-muted-foreground">
+                  {p.sets}×{p.reps} · {p.rest_seconds}s
+                </span>
+              </button>
+            ))}
+          </div>
+        </StepShell>
+      )}
+
+      <div className="flex items-center justify-between gap-2 border-t pt-4">
+        <Button
+          type="button"
+          variant="ghost"
+          onClick={() => setStep((Math.max(1, step - 1)) as typeof step)}
+          disabled={step === 1}
+          className="gap-1"
+        >
+          <ArrowLeft className="h-4 w-4" />
+          {s.back}
+        </Button>
+
+        <Button type="button" onClick={goNext} disabled={!canNext || isLoading} className="gap-1">
+          {step === 4 ? (
+            <>
+              <Dumbbell className="h-4 w-4" />
+              {s.generate}
+            </>
+          ) : (
+            <>
+              {s.next}
+              <ArrowRight className="h-4 w-4" />
+            </>
+          )}
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Small presentational helpers
+// ---------------------------------------------------------------------------
+
+function StepShell({
+  title,
+  subtitle,
+  children,
+}: {
+  title: string;
+  subtitle: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <div className="flex flex-col gap-3">
+      <div>
+        <h2 className="font-heading text-lg font-semibold tracking-tight">{title}</h2>
+        <p className="text-sm text-muted-foreground">{subtitle}</p>
+      </div>
+      {children}
+    </div>
+  );
+}
+
+function SectionLabel({
+  children,
+  className,
+}: {
+  children: React.ReactNode;
+  className?: string;
+}) {
+  return (
+    <p className={cn("text-xs font-medium uppercase tracking-wide text-muted-foreground", className)}>
+      {children}
+    </p>
+  );
+}
+
+function Chip({
+  active,
+  onClick,
+  children,
+}: {
+  active: boolean;
+  onClick: () => void;
+  children: React.ReactNode;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      aria-pressed={active}
+      className={cn(
+        "inline-flex items-center gap-1 rounded-full border px-3 py-1.5 text-sm transition-colors",
+        active
+          ? "border-primary bg-primary text-primary-foreground"
+          : "border-border bg-background text-foreground hover:border-foreground/30",
+      )}
+    >
+      {active ? <Check className="h-3.5 w-3.5" /> : null}
+      {children}
+    </button>
+  );
+}

--- a/backoffice/src/components/gc-fitness/template-form.tsx
+++ b/backoffice/src/components/gc-fitness/template-form.tsx
@@ -133,6 +133,26 @@ export interface TemplateFormProps {
    * the edit surface. If omitted, draft autosave is disabled.
    */
   draftKey?: string;
+  /**
+   * Optional create-mode hook. When provided, a successful CREATE calls this
+   * with the new template id INSTEAD of the default `router.back()` navigation
+   * — letting an embedding flow (e.g. the workout generator) keep the form on
+   * screen and transition to its own success/assign step. No effect in edit
+   * mode. Backwards-compatible: when omitted, create navigates back as before.
+   */
+  onCreated?: (id: string) => void;
+  /**
+   * Optional per-exercise extras rendered UNDER each exercise row in the
+   * "pick exercises" step. The workout generator uses this to render
+   * replacement pills (the normal create/edit flow passes nothing, so the
+   * layout is unchanged). `onReplace` swaps the row's exercise id.
+   */
+  renderExerciseExtras?: (ctx: {
+    index: number;
+    exerciseId: string;
+    allExerciseIds: string[];
+    onReplace: (exerciseId: string) => void;
+  }) => React.ReactNode;
 }
 
 const DRAFT_STORAGE_PREFIX = "gc-fitness:template-draft:";
@@ -296,6 +316,8 @@ export function TemplateForm({
   defaultValues,
   onSubmit,
   draftKey,
+  onCreated,
+  renderExerciseExtras,
 }: TemplateFormProps) {
   const t = useTranslations("templates.form");
   const router = useRouter();
@@ -526,14 +548,21 @@ export function TemplateForm({
       form.getValues(`exercises.${index}.durationSeconds` as const) ?? 60,
     );
     const currentReps = toFiniteNumberArray(form.getValues(repsPath));
-    const currentWeight = toFiniteNumberArray(form.getValues(weightPath));
+    const rawWeight = form.getValues(weightPath);
+    // Distinguish the EXPLICIT "Sin peso" sentinel (`[]`, set by the toggle)
+    // from "no weights typed yet" (undefined). Resizing the set count must
+    // NEVER fabricate a `[]` from the latter — doing so silently flips the
+    // exercise to Sin peso (the "changing Series + Tab switched Arnold Press to
+    // Sin peso" bug). `toFiniteNumberArray` collapses both to `[]`, so we read
+    // the raw value here to keep the distinction.
+    const hasExplicitNoWeight = Array.isArray(rawWeight) && rawWeight.length === 0;
+    const currentWeight = toFiniteNumberArray(rawWeight);
     const currentDurations = toFiniteNumberArray(form.getValues(durationPath));
 
     const nextReps = Array.from({ length: safeSets }, (_, i) => {
       const v = currentReps[i];
       return Number.isFinite(v) ? v : repsFallback;
     });
-    const nextWeight = currentWeight.slice(0, safeSets);
     // Only persist the duration array when at least one entry is present
     // — keeps reps-based exercises clean (no stray `durationBySetSeconds:
     // []` on Firestore docs).
@@ -546,7 +575,16 @@ export function TemplateForm({
         : undefined;
 
     form.setValue(repsPath, nextReps, { shouldDirty: true });
-    form.setValue(weightPath, nextWeight, { shouldDirty: true });
+    if (hasExplicitNoWeight) {
+      // Preserve the explicit Sin-peso prescription across a set-count change.
+      form.setValue(weightPath, [], { shouldDirty: true });
+    } else if (currentWeight.length === 0) {
+      // No weights entered yet — keep the field undefined (NOT `[]`) so the
+      // exercise stays "weight × reps" with an empty weight column.
+      form.setValue(weightPath, undefined as unknown as number[], { shouldDirty: true });
+    } else {
+      form.setValue(weightPath, currentWeight.slice(0, safeSets), { shouldDirty: true });
+    }
     if (nextDurations !== undefined) {
       form.setValue(durationPath, nextDurations, { shouldDirty: true });
     }
@@ -722,6 +760,12 @@ export function TemplateForm({
         if (draftKey) clearDraft(draftKey);
         if (mode === "create" && result?.id) {
           toast.success(t("createdToast"));
+          // An embedding flow (e.g. the workout generator) can take over the
+          // post-create navigation to show its own success/assign step.
+          if (onCreated) {
+            onCreated(result.id);
+            return;
+          }
           // 260524 — go back in nav after create (same UX as exercise + habit forms).
           router.back();
           return;
@@ -1041,30 +1085,46 @@ export function TemplateForm({
           {step === 1 ? (
             <ul className="flex flex-col gap-2">
               {fields.map((field, index) => (
-                <li key={field.id} className="flex flex-col gap-3 rounded-xl border border-border/70 bg-muted/20 px-3 py-3 sm:flex-row sm:items-center sm:justify-between">
-                  <div className="min-w-0 flex-1">
-                    <p className="text-xs text-muted-foreground">{t("exerciseNumber", { index: index + 1 })}</p>
-                    <div className="mt-1">
-                      <ExercisePickerPopover
-                        value={form.getValues(`exercises.${index}.exerciseId` as const) ?? ""}
-                        onChange={(value) =>
-                          form.setValue(`exercises.${index}.exerciseId` as const, value, { shouldDirty: true })
-                        }
-                        ariaLabel={t("pickExerciseAria", { index: index + 1 })}
-                      />
+                <li key={field.id} className="flex flex-col gap-3 rounded-xl border border-border/70 bg-muted/20 px-3 py-3">
+                  <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+                    <div className="min-w-0 flex-1">
+                      <p className="text-xs text-muted-foreground">{t("exerciseNumber", { index: index + 1 })}</p>
+                      <div className="mt-1">
+                        <ExercisePickerPopover
+                          value={form.getValues(`exercises.${index}.exerciseId` as const) ?? ""}
+                          onChange={(value) =>
+                            form.setValue(`exercises.${index}.exerciseId` as const, value, { shouldDirty: true })
+                          }
+                          ariaLabel={t("pickExerciseAria", { index: index + 1 })}
+                        />
+                      </div>
+                    </div>
+                    <div className="flex shrink-0 items-center gap-1 self-end sm:self-center">
+                      <Button type="button" variant="ghost" size="icon" onClick={() => move(index, index - 1)} disabled={index === 0}>
+                        <ArrowUp className="h-4 w-4" />
+                      </Button>
+                      <Button type="button" variant="ghost" size="icon" onClick={() => move(index, index + 1)} disabled={index === fields.length - 1}>
+                        <ArrowDown className="h-4 w-4" />
+                      </Button>
+                      <Button type="button" variant="ghost" size="icon" onClick={() => remove(index)} className="text-destructive hover:text-destructive">
+                        <Trash2 className="h-4 w-4" />
+                      </Button>
                     </div>
                   </div>
-                  <div className="flex shrink-0 items-center gap-1 self-end sm:self-center">
-                    <Button type="button" variant="ghost" size="icon" onClick={() => move(index, index - 1)} disabled={index === 0}>
-                      <ArrowUp className="h-4 w-4" />
-                    </Button>
-                    <Button type="button" variant="ghost" size="icon" onClick={() => move(index, index + 1)} disabled={index === fields.length - 1}>
-                      <ArrowDown className="h-4 w-4" />
-                    </Button>
-                    <Button type="button" variant="ghost" size="icon" onClick={() => remove(index)} className="text-destructive hover:text-destructive">
-                      <Trash2 className="h-4 w-4" />
-                    </Button>
-                  </div>
+                  {/* Generator-only replacement pills (no-op in the normal flow). */}
+                  {renderExerciseExtras
+                    ? renderExerciseExtras({
+                        index,
+                        exerciseId: watchedExercises[index]?.exerciseId ?? "",
+                        allExerciseIds: watchedExercises
+                          .map((e) => e?.exerciseId ?? "")
+                          .filter((id): id is string => Boolean(id)),
+                        onReplace: (value) =>
+                          form.setValue(`exercises.${index}.exerciseId` as const, value, {
+                            shouldDirty: true,
+                          }),
+                      })
+                    : null}
                 </li>
               ))}
             </ul>

--- a/backoffice/src/lib/gc-fitness/workout-generator/__tests__/engine.test.ts
+++ b/backoffice/src/lib/gc-fitness/workout-generator/__tests__/engine.test.ts
@@ -1,0 +1,543 @@
+// engine.test.ts
+//
+// Exhaustive tests for the deterministic Workout Generator engine. The single
+// most important guarantee (issue #296) is the EQUIPMENT RULE: an exercise
+// requiring equipment the trainer didn't select must never appear in the
+// generated workout NOR in any replacement pill. That rule gets the most
+// coverage here.
+
+import {
+  computeReplacements,
+  deriveSeed,
+  effectiveEquipment,
+  equipmentRequirements,
+  generateWorkout,
+  getEligibleExercises,
+  inferAuxiliaryEquipment,
+  isEquipmentAllowed,
+  primaryCoveredMuscle,
+  resolveTargetCount,
+} from "@/lib/gc-fitness/workout-generator/engine";
+import type {
+  GeneratorExercise,
+  GeneratorInput,
+} from "@/lib/gc-fitness/workout-generator/types";
+
+// ---------------------------------------------------------------------------
+// Fixture pool — a small synthetic library covering several muscles/equipment.
+// ---------------------------------------------------------------------------
+
+function ex(
+  id: string,
+  muscleGroups: string[],
+  equipment: string[],
+  metric: "reps" | "time" = "reps",
+): GeneratorExercise {
+  return {
+    id,
+    name: { en: id, es: id },
+    muscleGroups,
+    equipment,
+    metric,
+  };
+}
+
+const POOL: GeneratorExercise[] = [
+  // chest
+  ex("bench-press-bb", ["chest", "triceps"], ["barbell", "bench"]),
+  ex("bench-press-db", ["chest", "triceps"], ["dumbbell", "bench"]),
+  ex("pushup", ["chest", "triceps"], ["bodyweight"]),
+  ex("cable-fly", ["chest"], ["cable"]),
+  // shoulders
+  ex("ohp-bb", ["shoulders", "triceps"], ["barbell"]),
+  ex("lateral-raise-db", ["shoulders"], ["dumbbell"]),
+  ex("pike-pushup", ["shoulders"], ["bodyweight"]),
+  // triceps
+  ex("tricep-pushdown", ["triceps"], ["cable"]),
+  ex("dips", ["triceps", "chest"], ["bodyweight", "pull_up_bar"]),
+  // back
+  ex("deadlift-bb", ["back", "hamstrings"], ["barbell"]),
+  ex("pullup", ["back", "biceps"], ["bodyweight", "pull_up_bar"]),
+  ex("row-db", ["back", "biceps"], ["dumbbell", "bench"]),
+  // biceps
+  ex("curl-db", ["biceps"], ["dumbbell"]),
+  ex("curl-bb", ["biceps"], ["barbell"]),
+  // legs
+  ex("squat-bb", ["quadriceps", "glutes"], ["barbell"]),
+  ex("goblet-squat", ["quadriceps", "glutes"], ["dumbbell"]),
+  ex("air-squat", ["quadriceps", "glutes"], ["bodyweight"]),
+  ex("lunge-db", ["quadriceps", "glutes", "hamstrings"], ["dumbbell"]),
+  // core (time-based)
+  ex("plank", ["core", "abs"], ["bodyweight"], "time"),
+  ex("hollow-hold", ["core", "abs"], ["bodyweight"], "time"),
+];
+
+function input(overrides: Partial<GeneratorInput>): GeneratorInput {
+  return {
+    equipment: ["bodyweight"],
+    muscleGroups: ["chest"],
+    volumeMode: "count",
+    exerciseCount: 4,
+    workoutType: "hypertrophy",
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// equipmentRequirements + isEquipmentAllowed
+// ---------------------------------------------------------------------------
+
+describe("equipmentRequirements", () => {
+  it("normalizes an empty equipment list to ['bodyweight']", () => {
+    expect(equipmentRequirements(ex("x", ["chest"], []))).toEqual(["bodyweight"]);
+  });
+  it("drops empty-string entries then falls back to bodyweight", () => {
+    expect(equipmentRequirements(ex("x", ["chest"], [""]))).toEqual(["bodyweight"]);
+  });
+  it("passes real requirements through unchanged", () => {
+    expect(equipmentRequirements(ex("x", ["chest"], ["barbell", "bench"]))).toEqual([
+      "barbell",
+      "bench",
+    ]);
+  });
+});
+
+describe("inferAuxiliaryEquipment (name-based bench inference)", () => {
+  it("infers a bench for bench/incline/decline/preacher movements (ES)", () => {
+    expect(inferAuxiliaryEquipment({ en: "", es: "Press de banca (Mancuerna)" })).toEqual(["bench"]);
+    expect(inferAuxiliaryEquipment({ en: "", es: "Press de banca inclinado (Mancuerna)" })).toEqual([
+      "bench",
+    ]);
+    expect(inferAuxiliaryEquipment({ en: "", es: "Curl inclinado (Mancuerna)" })).toEqual(["bench"]);
+    expect(inferAuxiliaryEquipment({ en: "", es: "Curl predicador (Mancuerna)" })).toEqual(["bench"]);
+  });
+
+  it("infers a bench for English names too", () => {
+    expect(inferAuxiliaryEquipment({ en: "Incline Bench Press", es: "" })).toEqual(["bench"]);
+    expect(inferAuxiliaryEquipment({ en: "Preacher Curl", es: "" })).toEqual(["bench"]);
+  });
+
+  it("does NOT infer a bench for a floor press ('press de suelo')", () => {
+    expect(inferAuxiliaryEquipment({ en: "", es: "Press de suelo (Mancuerna)" })).toEqual([]);
+    expect(inferAuxiliaryEquipment({ en: "Floor press", es: "" })).toEqual([]);
+  });
+
+  it("does NOT infer a bench for ordinary dumbbell movements", () => {
+    expect(inferAuxiliaryEquipment({ en: "", es: "Curl con mancuerna (Mancuerna)" })).toEqual([]);
+    expect(inferAuxiliaryEquipment({ en: "", es: "Curl martillo (Mancuerna)" })).toEqual([]);
+  });
+
+  it("effectiveEquipment merges tagged implement + inferred bench", () => {
+    const inclinePress = ex("p", ["chest"], ["dumbbell"]);
+    inclinePress.name = { en: "", es: "Press de banca inclinado (Mancuerna)" };
+    expect(effectiveEquipment(inclinePress).sort()).toEqual(["bench", "dumbbell"]);
+  });
+});
+
+describe("isEquipmentAllowed (THE rule)", () => {
+  it("allows an exercise when all its equipment is selected", () => {
+    const allowed = isEquipmentAllowed(
+      ex("x", ["chest"], ["dumbbell", "bench"]),
+      new Set(["dumbbell", "bench"]),
+    );
+    expect(allowed).toBe(true);
+  });
+
+  it("rejects an exercise when ANY required equipment is missing", () => {
+    const allowed = isEquipmentAllowed(
+      ex("x", ["chest"], ["dumbbell", "bench"]),
+      new Set(["dumbbell"]), // no bench
+    );
+    expect(allowed).toBe(false);
+  });
+
+  it("rejects a barbell exercise when barbell is not selected", () => {
+    expect(
+      isEquipmentAllowed(ex("x", ["chest"], ["barbell"]), new Set(["dumbbell", "bench"])),
+    ).toBe(false);
+  });
+
+  it("treats 'none' as always available", () => {
+    expect(isEquipmentAllowed(ex("x", ["core"], ["none"]), new Set())).toBe(true);
+  });
+
+  it("requires 'bodyweight' to be explicitly selected", () => {
+    expect(isEquipmentAllowed(ex("x", ["chest"], ["bodyweight"]), new Set())).toBe(false);
+    expect(
+      isEquipmentAllowed(ex("x", ["chest"], ["bodyweight"]), new Set(["bodyweight"])),
+    ).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// primaryCoveredMuscle
+// ---------------------------------------------------------------------------
+
+describe("primaryCoveredMuscle", () => {
+  it("returns the first selected muscle the exercise covers", () => {
+    expect(
+      primaryCoveredMuscle(ex("x", ["triceps", "chest"], []), new Set(["chest"])),
+    ).toBe("chest");
+  });
+  it("respects primary→secondary ordering", () => {
+    expect(
+      primaryCoveredMuscle(ex("x", ["chest", "triceps"], []), new Set(["chest", "triceps"])),
+    ).toBe("chest");
+  });
+  it("returns null when no muscle matches", () => {
+    expect(primaryCoveredMuscle(ex("x", ["chest"], []), new Set(["back"]))).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getEligibleExercises
+// ---------------------------------------------------------------------------
+
+describe("getEligibleExercises", () => {
+  it("returns only exercises passing both equipment and muscle filters", () => {
+    const eligible = getEligibleExercises(POOL, {
+      equipment: ["bodyweight"],
+      muscleGroups: ["chest"],
+    });
+    const ids = eligible.map((e) => e.exercise.id);
+    expect(ids).toContain("pushup");
+    expect(ids).not.toContain("bench-press-bb"); // needs barbell+bench
+    expect(ids).not.toContain("cable-fly"); // needs cable
+  });
+
+  it("excludes barbell exercises entirely when barbell is unselected", () => {
+    const eligible = getEligibleExercises(POOL, {
+      equipment: ["dumbbell", "bench", "bodyweight", "cable", "pull_up_bar"],
+      muscleGroups: ["chest", "shoulders", "triceps", "back", "biceps", "quadriceps"],
+    });
+    for (const e of eligible) {
+      expect(e.exercise.equipment).not.toContain("barbell");
+    }
+  });
+
+  it("dedupes by id", () => {
+    const dupePool = [POOL[0], POOL[0], POOL[2]];
+    const eligible = getEligibleExercises(dupePool, {
+      equipment: ["barbell", "bench", "bodyweight"],
+      muscleGroups: ["chest"],
+    });
+    expect(eligible.filter((e) => e.exercise.id === "bench-press-bb")).toHaveLength(1);
+  });
+
+  it("ignores malformed rows (no id)", () => {
+    const messyPool = [
+      { ...ex("good", ["chest"], ["bodyweight"]) },
+      { ...ex("", ["chest"], ["bodyweight"]) },
+    ];
+    const eligible = getEligibleExercises(messyPool, {
+      equipment: ["bodyweight"],
+      muscleGroups: ["chest"],
+    });
+    expect(eligible.map((e) => e.exercise.id)).toEqual(["good"]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// resolveTargetCount
+// ---------------------------------------------------------------------------
+
+describe("resolveTargetCount", () => {
+  it("uses the explicit count, clamped to 1..30", () => {
+    expect(resolveTargetCount(input({ volumeMode: "count", exerciseCount: 8 }))).toBe(8);
+    expect(resolveTargetCount(input({ volumeMode: "count", exerciseCount: 99 }))).toBe(30);
+    expect(resolveTargetCount(input({ volumeMode: "count", exerciseCount: 0 }))).toBe(6);
+  });
+
+  it("derives a count from a time budget (more time → more exercises)", () => {
+    const short = resolveTargetCount(input({ volumeMode: "time", timeMinutes: 20 }));
+    const long = resolveTargetCount(input({ volumeMode: "time", timeMinutes: 60 }));
+    expect(short).toBeGreaterThanOrEqual(1);
+    expect(long).toBeGreaterThan(short);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// generateWorkout — equipment rule end-to-end
+// ---------------------------------------------------------------------------
+
+describe("generateWorkout — equipment rule", () => {
+  const fullMuscles = [
+    "chest",
+    "shoulders",
+    "triceps",
+    "back",
+    "biceps",
+    "quadriceps",
+    "glutes",
+    "hamstrings",
+    "core",
+    "abs",
+  ];
+
+  it("NEVER includes a barbell exercise when barbell is unselected (workout + replacements)", () => {
+    const workout = generateWorkout(
+      input({
+        equipment: ["dumbbell", "bench", "bodyweight", "cable", "pull_up_bar", "resistance_band"],
+        muscleGroups: fullMuscles,
+        exerciseCount: 30,
+      }),
+      POOL,
+    );
+    const barbellIds = new Set(
+      POOL.filter((e) => e.equipment.includes("barbell")).map((e) => e.id),
+    );
+    for (const slot of workout.exercises) {
+      expect(barbellIds.has(slot.exerciseId)).toBe(false);
+      for (const rep of slot.replacements) {
+        expect(barbellIds.has(rep.exerciseId)).toBe(false);
+      }
+    }
+  });
+
+  it("bodyweight-only selection yields only bodyweight-eligible exercises", () => {
+    const workout = generateWorkout(
+      input({ equipment: ["bodyweight"], muscleGroups: fullMuscles, exerciseCount: 30 }),
+      POOL,
+    );
+    const byId = new Map(POOL.map((e) => [e.id, e]));
+    for (const slot of workout.exercises) {
+      const source = byId.get(slot.exerciseId)!;
+      expect(equipmentRequirements(source).every((r) => r === "bodyweight")).toBe(true);
+    }
+    // pull_up_bar exercises (dips/pullup) excluded since the bar wasn't selected.
+    const ids = workout.exercises.map((e) => e.exerciseId);
+    expect(ids).not.toContain("dips");
+    expect(ids).not.toContain("pullup");
+  });
+
+  it("dumbbell-only (no bench) excludes incline/bench dumbbell exercises", () => {
+    // Mirrors the real standard-library data: every doc tags ONLY its implement
+    // (dumbbell), the bench is implied by the name.
+    const libraryLike: GeneratorExercise[] = [
+      { id: "curl", name: { en: "", es: "Curl con mancuerna (Mancuerna)" }, muscleGroups: ["biceps"], equipment: ["dumbbell"] },
+      { id: "incline-curl", name: { en: "", es: "Curl inclinado (Mancuerna)" }, muscleGroups: ["biceps"], equipment: ["dumbbell"] },
+      { id: "bench-press", name: { en: "", es: "Press de banca (Mancuerna)" }, muscleGroups: ["chest"], equipment: ["dumbbell"] },
+      { id: "floor-press", name: { en: "", es: "Press de suelo (Mancuerna)" }, muscleGroups: ["chest"], equipment: ["dumbbell"] },
+    ];
+    const dumbbellOnly = getEligibleExercises(libraryLike, {
+      equipment: ["dumbbell"],
+      muscleGroups: ["biceps", "chest"],
+    }).map((e) => e.exercise.id);
+    expect(dumbbellOnly).toContain("curl");
+    expect(dumbbellOnly).toContain("floor-press"); // floor press needs no bench
+    expect(dumbbellOnly).not.toContain("incline-curl");
+    expect(dumbbellOnly).not.toContain("bench-press");
+
+    // Add a bench → the bench exercises become eligible again.
+    const withBench = getEligibleExercises(libraryLike, {
+      equipment: ["dumbbell", "bench"],
+      muscleGroups: ["biceps", "chest"],
+    }).map((e) => e.exercise.id);
+    expect(withBench).toEqual(
+      expect.arrayContaining(["curl", "incline-curl", "bench-press", "floor-press"]),
+    );
+  });
+
+  it("every replacement is itself equipment-eligible", () => {
+    const selected = new Set(["dumbbell", "bench", "bodyweight"]);
+    const byId = new Map(POOL.map((e) => [e.id, e]));
+    const workout = generateWorkout(
+      input({
+        equipment: [...selected],
+        muscleGroups: fullMuscles,
+        exerciseCount: 12,
+      }),
+      POOL,
+    );
+    for (const slot of workout.exercises) {
+      for (const rep of slot.replacements) {
+        const source = byId.get(rep.exerciseId)!;
+        expect(isEquipmentAllowed(source, selected)).toBe(true);
+      }
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// generateWorkout — selection behavior
+// ---------------------------------------------------------------------------
+
+describe("generateWorkout — selection", () => {
+  it("never picks the same exercise twice", () => {
+    const workout = generateWorkout(
+      input({
+        equipment: ["bodyweight", "dumbbell", "bench", "barbell", "cable", "pull_up_bar"],
+        muscleGroups: ["chest", "shoulders", "triceps"],
+        exerciseCount: 10,
+      }),
+      POOL,
+    );
+    const ids = workout.exercises.map((e) => e.exerciseId);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  it("spreads across selected muscles (round-robin), not all from one", () => {
+    const workout = generateWorkout(
+      input({
+        equipment: ["barbell", "dumbbell", "bench", "bodyweight", "cable", "pull_up_bar"],
+        muscleGroups: ["chest", "shoulders", "triceps"],
+        exerciseCount: 3,
+      }),
+      POOL,
+    );
+    const muscles = workout.exercises.map((e) => e.primaryMuscle);
+    // With 3 slots across 3 muscles each gets one.
+    expect(new Set(muscles)).toEqual(new Set(["chest", "shoulders", "triceps"]));
+  });
+
+  it("returns fewer than requested when the pool is too small (no repeats)", () => {
+    const workout = generateWorkout(
+      input({ equipment: ["bodyweight"], muscleGroups: ["chest"], exerciseCount: 20 }),
+      POOL,
+    );
+    // Only pushup is chest+bodyweight (dips needs pull_up_bar).
+    expect(workout.exercises).toHaveLength(1);
+    expect(workout.exercises[0].exerciseId).toBe("pushup");
+    expect(workout.eligiblePoolSize).toBe(1);
+    expect(workout.requestedCount).toBe(20);
+  });
+
+  it("produces an empty workout when nothing matches", () => {
+    const workout = generateWorkout(
+      input({ equipment: ["machine"], muscleGroups: ["calves"], exerciseCount: 5 }),
+      POOL,
+    );
+    expect(workout.exercises).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// generateWorkout — prescription from workout type
+// ---------------------------------------------------------------------------
+
+describe("generateWorkout — prescription", () => {
+  it("stamps the workout-type preset onto each exercise", () => {
+    const workout = generateWorkout(
+      input({ equipment: ["bodyweight"], muscleGroups: ["chest"], workoutType: "strength" }),
+      POOL,
+    );
+    const slot = workout.exercises[0];
+    expect(slot.sets).toBe(5);
+    expect(slot.reps).toBe(5);
+    expect(slot.rest_seconds).toBe(180);
+  });
+
+  it("marks time-based exercises with metric 'time' + a durationSeconds", () => {
+    const workout = generateWorkout(
+      input({ equipment: ["bodyweight"], muscleGroups: ["core"], workoutType: "hypertrophy" }),
+      POOL,
+    );
+    const plank = workout.exercises.find((e) => e.exerciseId === "plank");
+    expect(plank).toBeDefined();
+    expect(plank!.metric).toBe("time");
+    expect(plank!.durationSeconds).toBe(40);
+    expect(plank!.reps).toBe(0);
+  });
+
+  it("computes a positive estimated duration", () => {
+    const workout = generateWorkout(
+      input({
+        equipment: ["bodyweight", "dumbbell", "bench"],
+        muscleGroups: ["chest", "shoulders"],
+        exerciseCount: 4,
+      }),
+      POOL,
+    );
+    expect(workout.estimatedDurationMinutes).toBeGreaterThan(0);
+  });
+
+  it("builds a default name from focus label + type", () => {
+    const workout = generateWorkout(
+      input({
+        equipment: ["bodyweight"],
+        muscleGroups: ["chest"],
+        workoutType: "hypertrophy",
+        focusLabel: { en: "Push", es: "Empuje" },
+      }),
+      POOL,
+    );
+    expect(workout.name.en).toBe("Push · Hypertrophy");
+    expect(workout.name.es).toBe("Empuje · Hipertrofia");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Determinism
+// ---------------------------------------------------------------------------
+
+describe("generateWorkout — determinism", () => {
+  const base = input({
+    equipment: ["barbell", "dumbbell", "bench", "bodyweight", "cable", "pull_up_bar"],
+    muscleGroups: ["chest", "shoulders", "triceps", "back"],
+    exerciseCount: 6,
+  });
+
+  it("same input → identical workout", () => {
+    const a = generateWorkout(base, POOL);
+    const b = generateWorkout(base, POOL);
+    expect(a.exercises.map((e) => e.exerciseId)).toEqual(b.exercises.map((e) => e.exerciseId));
+  });
+
+  it("same explicit seed → identical, different seed → may differ", () => {
+    const a = generateWorkout({ ...base, seed: 1 }, POOL);
+    const b = generateWorkout({ ...base, seed: 1 }, POOL);
+    const c = generateWorkout({ ...base, seed: 999 }, POOL);
+    expect(a.exercises.map((e) => e.exerciseId)).toEqual(b.exercises.map((e) => e.exerciseId));
+    // Not a hard guarantee for all seeds, but with this pool seed 1 vs 999 differ.
+    expect(c.exercises.map((e) => e.exerciseId)).not.toEqual(
+      a.exercises.map((e) => e.exerciseId),
+    );
+  });
+
+  it("deriveSeed is stable for the same input and order-independent on lists", () => {
+    const s1 = deriveSeed(
+      input({ equipment: ["a", "b"], muscleGroups: ["chest", "back"] }),
+    );
+    const s2 = deriveSeed(
+      input({ equipment: ["b", "a"], muscleGroups: ["back", "chest"] }),
+    );
+    expect(s1).toBe(s2);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// computeReplacements — swap semantics
+// ---------------------------------------------------------------------------
+
+describe("computeReplacements", () => {
+  const eligible = getEligibleExercises(POOL, {
+    equipment: ["barbell", "dumbbell", "bench", "bodyweight", "cable", "pull_up_bar"],
+    muscleGroups: ["chest"],
+  });
+
+  it("returns only same-muscle candidates not already used", () => {
+    const used = new Set(["pushup"]);
+    const reps = computeReplacements(eligible, "chest", used, 7);
+    expect(reps.every((r) => r.primaryMuscle === "chest")).toBe(true);
+    expect(reps.map((r) => r.exerciseId)).not.toContain("pushup");
+  });
+
+  it("excludes everything currently in the workout", () => {
+    const used = new Set(eligible.map((e) => e.exercise.id));
+    expect(computeReplacements(eligible, "chest", used, 1)).toHaveLength(0);
+  });
+
+  it("recomputing after a swap drops the newly-used exercise and re-offers the old", () => {
+    // Slot currently shows pushup; replacements offer cable-fly etc.
+    const before = computeReplacements(eligible, "chest", new Set(["pushup"]), 3);
+    expect(before.map((r) => r.exerciseId)).toContain("cable-fly");
+    // Swap pushup → cable-fly. Recompute: cable-fly now used, pushup free again.
+    const after = computeReplacements(eligible, "chest", new Set(["cable-fly"]), 3);
+    expect(after.map((r) => r.exerciseId)).toContain("pushup");
+    expect(after.map((r) => r.exerciseId)).not.toContain("cable-fly");
+  });
+
+  it("respects the limit", () => {
+    expect(computeReplacements(eligible, "chest", new Set(), 1, 2)).toHaveLength(2);
+  });
+});

--- a/backoffice/src/lib/gc-fitness/workout-generator/__tests__/presets.test.ts
+++ b/backoffice/src/lib/gc-fitness/workout-generator/__tests__/presets.test.ts
@@ -1,0 +1,149 @@
+// presets.test.ts
+//
+// Locks the equipment groups, muscle presets, and workout-type presets against
+// the canonical vocabulary + the template schema bounds. These are the config
+// the wizard's step 1/2/4 chips render, so a vocab rename or an out-of-bounds
+// prescription would silently ship a broken generator without these guards.
+
+import { EQUIPMENT, MUSCLE_GROUPS } from "@/lib/gc-fitness/exercise-vocabulary";
+import {
+  EQUIPMENT_GROUPS,
+  equipmentGroupsReferenceValidVocab,
+  expandEquipmentGroups,
+  isGroupFullySelected,
+} from "@/lib/gc-fitness/workout-generator/equipment-groups";
+import {
+  MUSCLE_PRESETS,
+  expandMusclePresets,
+  musclePresetsReferenceValidVocab,
+} from "@/lib/gc-fitness/workout-generator/muscle-presets";
+import {
+  WORKOUT_TYPE_PRESETS,
+  estimateSecondsPerExercise,
+  getWorkoutTypePreset,
+} from "@/lib/gc-fitness/workout-generator/workout-type-presets";
+import { exerciseRefSchema } from "@/lib/gc-fitness/workout-template-schema";
+
+describe("equipment groups", () => {
+  it("only reference valid EQUIPMENT vocab ids", () => {
+    expect(equipmentGroupsReferenceValidVocab()).toBe(true);
+    const vocab = new Set<string>(EQUIPMENT as readonly string[]);
+    for (const group of EQUIPMENT_GROUPS) {
+      for (const item of group.items) expect(vocab.has(item)).toBe(true);
+    }
+  });
+
+  it("have unique ids and non-empty item lists", () => {
+    const ids = EQUIPMENT_GROUPS.map((g) => g.id);
+    expect(new Set(ids).size).toBe(ids.length);
+    for (const g of EQUIPMENT_GROUPS) expect(g.items.length).toBeGreaterThan(0);
+  });
+
+  it("home group auto-selects bodyweight (issue #296 example)", () => {
+    const home = EQUIPMENT_GROUPS.find((g) => g.id === "home")!;
+    expect(home.items).toContain("bodyweight");
+  });
+
+  it("expandEquipmentGroups unions items and dedupes", () => {
+    const expanded = expandEquipmentGroups(["home", "minimal"]);
+    expect(expanded).toContain("bodyweight");
+    expect(expanded).toContain("dumbbell");
+    expect(new Set(expanded).size).toBe(expanded.length);
+  });
+
+  it("expandEquipmentGroups ignores unknown group ids", () => {
+    expect(expandEquipmentGroups(["does-not-exist"])).toEqual([]);
+  });
+
+  it("isGroupFullySelected reflects the current selection", () => {
+    const home = EQUIPMENT_GROUPS.find((g) => g.id === "home")!;
+    expect(isGroupFullySelected(home, new Set(home.items))).toBe(true);
+    expect(isGroupFullySelected(home, new Set(["bodyweight"]))).toBe(false);
+  });
+});
+
+describe("muscle presets", () => {
+  it("only reference valid MUSCLE_GROUPS vocab ids", () => {
+    expect(musclePresetsReferenceValidVocab()).toBe(true);
+    const vocab = new Set<string>(MUSCLE_GROUPS as readonly string[]);
+    for (const preset of MUSCLE_PRESETS) {
+      for (const m of preset.muscles) expect(vocab.has(m)).toBe(true);
+    }
+  });
+
+  it("have unique ids and non-empty muscle lists", () => {
+    const ids = MUSCLE_PRESETS.map((p) => p.id);
+    expect(new Set(ids).size).toBe(ids.length);
+    for (const p of MUSCLE_PRESETS) expect(p.muscles.length).toBeGreaterThan(0);
+  });
+
+  it("expose the push/pull/legs/full_body presets from the issue", () => {
+    const ids = MUSCLE_PRESETS.map((p) => p.id);
+    expect(ids).toEqual(expect.arrayContaining(["push", "pull", "legs", "full_body"]));
+  });
+
+  it("push targets chest/shoulders/triceps", () => {
+    const push = MUSCLE_PRESETS.find((p) => p.id === "push")!;
+    expect(push.muscles).toEqual(expect.arrayContaining(["chest", "shoulders", "triceps"]));
+  });
+
+  it("expandMusclePresets unions and dedupes", () => {
+    const expanded = expandMusclePresets(["push", "pull"]);
+    expect(expanded).toContain("chest");
+    expect(expanded).toContain("back");
+    expect(new Set(expanded).size).toBe(expanded.length);
+  });
+});
+
+describe("workout-type presets", () => {
+  it("have unique ids", () => {
+    const ids = WORKOUT_TYPE_PRESETS.map((p) => p.id);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  it("expose the types named in the issue", () => {
+    const ids = WORKOUT_TYPE_PRESETS.map((p) => p.id);
+    expect(ids).toEqual(
+      expect.arrayContaining(["hypertrophy", "muscle_growth", "beginner"]),
+    );
+  });
+
+  it("every preset produces a prescription that passes the template Zod schema", () => {
+    for (const preset of WORKOUT_TYPE_PRESETS) {
+      // reps-based shape
+      const repsRef = exerciseRefSchema.safeParse({
+        exerciseId: "ex-1",
+        sets: preset.sets,
+        reps: preset.reps,
+        rest_seconds: preset.rest_seconds,
+        transition_rest_seconds: preset.transition_rest_seconds,
+        order: 1,
+      });
+      expect(repsRef.success).toBe(true);
+
+      // time-based shape (metric "time" requires a duration > 0)
+      const timeRef = exerciseRefSchema.safeParse({
+        exerciseId: "ex-1",
+        sets: preset.sets,
+        reps: 0,
+        rest_seconds: preset.rest_seconds,
+        transition_rest_seconds: preset.transition_rest_seconds,
+        order: 1,
+        metric: "time",
+        durationSeconds: preset.durationSeconds,
+      });
+      expect(timeRef.success).toBe(true);
+    }
+  });
+
+  it("getWorkoutTypePreset falls back to hypertrophy for unknown ids", () => {
+    expect(getWorkoutTypePreset("nope").id).toBe("hypertrophy");
+    expect(getWorkoutTypePreset("strength").id).toBe("strength");
+  });
+
+  it("estimateSecondsPerExercise grows with sets and is positive", () => {
+    const preset = getWorkoutTypePreset("hypertrophy");
+    expect(estimateSecondsPerExercise(preset, "reps")).toBeGreaterThan(0);
+    expect(estimateSecondsPerExercise(preset, "time")).toBeGreaterThan(0);
+  });
+});

--- a/backoffice/src/lib/gc-fitness/workout-generator/engine.ts
+++ b/backoffice/src/lib/gc-fitness/workout-generator/engine.ts
@@ -1,0 +1,347 @@
+// workout-generator/engine.ts
+//
+// The deterministic Workout Generator engine. PURE — no Firebase, no React, no
+// Math.random / Date.now. Given a `GeneratorInput` and an injected exercise
+// pool it produces a `GeneratedWorkout`.
+//
+// THE HARD RULE (issue #296): an exercise is only eligible if EVERY piece of
+// equipment it requires is in the trainer's selected set. If barbell wasn't
+// selected, no barbell exercise can appear — neither in the workout nor in any
+// replacement pill (replacements are drawn from the same eligible pool, so the
+// guarantee is structural). `isEquipmentAllowed` is the single chokepoint and
+// `engine.test.ts` locks it.
+//
+// Selection is muscle-balanced: candidates are bucketed by the selected muscle
+// they cover, each bucket is shuffled with a seeded PRNG, then the engine
+// round-robins across muscles so a "push" workout spreads across chest /
+// shoulders / triceps instead of stacking five chest presses.
+
+import {
+  estimateTemplateDurationMinutes,
+  type DurationEstimateExercise,
+} from "../workout-duration-estimate";
+import { hashString, mulberry32, seededShuffle } from "./prng";
+import {
+  estimateSecondsPerExercise,
+  getWorkoutTypePreset,
+} from "./workout-type-presets";
+import type {
+  GeneratedExercise,
+  GeneratedWorkout,
+  GeneratorExercise,
+  GeneratorInput,
+  ReplacementOption,
+} from "./types";
+
+/** Equipment that imposes no requirement — "none" means the exercise needs
+ *  nothing, so it's allowed regardless of selection. Everything else
+ *  (including "bodyweight") must be explicitly selected. */
+const ALWAYS_AVAILABLE_EQUIPMENT = new Set<string>(["none"]);
+
+const MAX_EXERCISES = 30; // mirrors workoutTemplateSchema.exercises.max(30)
+const MAX_REPLACEMENTS = 5;
+
+/** The equipment an exercise requires. An empty list is normalized to
+ *  `["bodyweight"]`, mirroring `equipmentListSchema` in exercise-schema.ts. */
+export function equipmentRequirements(exercise: GeneratorExercise): string[] {
+  const cleaned = (exercise.equipment ?? []).filter(
+    (e): e is string => typeof e === "string" && e.length > 0,
+  );
+  return cleaned.length > 0 ? cleaned : ["bodyweight"];
+}
+
+// Name keywords that imply a bench is needed. The standard library tags each
+// exercise with only its PRIMARY implement (e.g. "Press de banca inclinado
+// (Mancuerna)" → equipment:[dumbbell]); the bench is implied by the movement
+// name, never tagged. Without this, picking "dumbbell only" (no bench) would
+// wrongly surface incline/bench presses. ES + EN keywords.
+const BENCH_NAME_KEYWORDS = [
+  "banca",
+  "bench",
+  "inclinad",
+  "incline",
+  "declinad",
+  "decline",
+  "predicador",
+  "preacher",
+];
+
+/**
+ * Auxiliary equipment inferred from the exercise NAME that the data doesn't
+ * tag. Today: a bench for bench/incline/decline/preacher movements. The floor
+ * press ("Press de suelo" / "floor press") is explicitly bench-FREE, so it's
+ * guarded even though no current keyword matches it.
+ */
+export function inferAuxiliaryEquipment(name: {
+  en?: string | null;
+  es?: string | null;
+}): string[] {
+  const hay = `${name.en ?? ""} ${name.es ?? ""}`.toLowerCase();
+  const isFloor = hay.includes("suelo") || hay.includes("floor");
+  if (!isFloor && BENCH_NAME_KEYWORDS.some((k) => hay.includes(k))) {
+    return ["bench"];
+  }
+  return [];
+}
+
+/** Full equipment an exercise needs = its tagged implement(s) PLUS any
+ *  name-inferred auxiliary equipment (a bench). This is what eligibility
+ *  checks against. */
+export function effectiveEquipment(exercise: GeneratorExercise): string[] {
+  return Array.from(
+    new Set([
+      ...equipmentRequirements(exercise),
+      ...inferAuxiliaryEquipment(exercise.name ?? { en: "", es: "" }),
+    ]),
+  );
+}
+
+/** THE eligibility chokepoint. True iff every required equipment item (tagged
+ *  OR name-inferred) is in the selected set (or is an always-available item
+ *  like "none"). */
+export function isEquipmentAllowed(
+  exercise: GeneratorExercise,
+  selectedEquipment: ReadonlySet<string>,
+): boolean {
+  return effectiveEquipment(exercise).every(
+    (item) =>
+      ALWAYS_AVAILABLE_EQUIPMENT.has(item) || selectedEquipment.has(item),
+  );
+}
+
+/** The first selected muscle group this exercise covers, or null if none. The
+ *  ordering of `exercise.muscleGroups` is treated as primary→secondary, so the
+ *  earliest selected match is the muscle this exercise "belongs to". */
+export function primaryCoveredMuscle(
+  exercise: GeneratorExercise,
+  selectedMuscles: ReadonlySet<string>,
+): string | null {
+  for (const m of exercise.muscleGroups ?? []) {
+    if (selectedMuscles.has(m)) return m;
+  }
+  return null;
+}
+
+function effectiveMetric(exercise: GeneratorExercise): "reps" | "time" {
+  return exercise.metric === "time" ? "time" : "reps";
+}
+
+interface EligibleEntry {
+  exercise: GeneratorExercise;
+  primaryMuscle: string;
+}
+
+/** Exercises that pass BOTH the equipment filter and the muscle filter,
+ *  deduped by id, each tagged with the selected muscle it primarily covers. */
+export function getEligibleExercises(
+  pool: readonly GeneratorExercise[],
+  input: Pick<GeneratorInput, "equipment" | "muscleGroups">,
+): EligibleEntry[] {
+  const selectedEquipment = new Set(input.equipment);
+  const selectedMuscles = new Set(input.muscleGroups);
+  const seen = new Set<string>();
+  const out: EligibleEntry[] = [];
+  for (const exercise of pool) {
+    if (!exercise || typeof exercise.id !== "string" || !exercise.id) continue;
+    if (seen.has(exercise.id)) continue;
+    if (!isEquipmentAllowed(exercise, selectedEquipment)) continue;
+    const primaryMuscle = primaryCoveredMuscle(exercise, selectedMuscles);
+    if (primaryMuscle === null) continue;
+    seen.add(exercise.id);
+    out.push({ exercise, primaryMuscle });
+  }
+  return out;
+}
+
+function toReplacementOption(entry: EligibleEntry): ReplacementOption {
+  return {
+    exerciseId: entry.exercise.id,
+    name: entry.exercise.name,
+    primaryMuscle: entry.primaryMuscle,
+  };
+}
+
+/**
+ * Equipment-eligible alternatives for a slot: other exercises covering the
+ * SAME muscle, excluding any id already used in the workout. Drawn from the
+ * pre-filtered `eligible` list, so every option is guaranteed equipment-legal.
+ * Deterministic given the seed. Exposed so the UI can recompute a slot's pills
+ * after the trainer swaps an exercise.
+ */
+export function computeReplacements(
+  eligible: readonly EligibleEntry[],
+  primaryMuscle: string,
+  usedIds: ReadonlySet<string>,
+  seed: number,
+  limit: number = MAX_REPLACEMENTS,
+): ReplacementOption[] {
+  const rand = mulberry32(seed >>> 0);
+  const candidates = eligible.filter(
+    (e) => e.primaryMuscle === primaryMuscle && !usedIds.has(e.exercise.id),
+  );
+  return seededShuffle(candidates, rand).slice(0, limit).map(toReplacementOption);
+}
+
+/** Stable fallback seed derived from the input so identical inputs reproduce
+ *  the same workout even when the caller doesn't pass an explicit seed. */
+export function deriveSeed(input: GeneratorInput): number {
+  if (typeof input.seed === "number" && Number.isFinite(input.seed)) {
+    return input.seed >>> 0;
+  }
+  const key = [
+    [...input.equipment].sort().join(","),
+    [...input.muscleGroups].sort().join(","),
+    input.workoutType,
+    input.volumeMode,
+    input.exerciseCount ?? "",
+    input.timeMinutes ?? "",
+  ].join("|");
+  return hashString(key);
+}
+
+/** Resolve how many exercises to generate from the volume input. Time budgets
+ *  are converted to a count via the type preset's per-exercise estimate. */
+export function resolveTargetCount(input: GeneratorInput): number {
+  const preset = getWorkoutTypePreset(input.workoutType);
+  let raw: number;
+  if (input.volumeMode === "time") {
+    const minutes =
+      typeof input.timeMinutes === "number" && input.timeMinutes > 0
+        ? input.timeMinutes
+        : 40;
+    const perExercise = estimateSecondsPerExercise(preset, "reps");
+    raw = Math.round((minutes * 60) / Math.max(1, perExercise));
+  } else {
+    raw =
+      typeof input.exerciseCount === "number" && input.exerciseCount > 0
+        ? Math.round(input.exerciseCount)
+        : 6;
+  }
+  return Math.max(1, Math.min(MAX_EXERCISES, raw));
+}
+
+function buildDefaultName(input: GeneratorInput): { en: string; es: string } {
+  const preset = getWorkoutTypePreset(input.workoutType);
+  if (input.focusLabel && input.focusLabel.en) {
+    return {
+      en: `${input.focusLabel.en} · ${preset.label.en}`,
+      es: `${input.focusLabel.es || input.focusLabel.en} · ${preset.label.es}`,
+    };
+  }
+  return { en: preset.label.en, es: preset.label.es };
+}
+
+/**
+ * Round-robin selection across selected muscles. Walks the selected muscle
+ * order repeatedly, taking the next (shuffled) candidate from each muscle's
+ * bucket until the target count is reached or every bucket is exhausted.
+ */
+function selectExercises(
+  eligible: readonly EligibleEntry[],
+  selectedMuscleOrder: readonly string[],
+  targetCount: number,
+  seed: number,
+): EligibleEntry[] {
+  const rand = mulberry32(seed >>> 0);
+  // Bucket candidates by primary muscle, shuffled deterministically.
+  const buckets = new Map<string, EligibleEntry[]>();
+  for (const muscle of selectedMuscleOrder) {
+    const inMuscle = eligible.filter((e) => e.primaryMuscle === muscle);
+    if (inMuscle.length > 0) buckets.set(muscle, seededShuffle(inMuscle, rand));
+  }
+  const musclesWithCandidates = selectedMuscleOrder.filter((m) =>
+    buckets.has(m),
+  );
+
+  const chosen: EligibleEntry[] = [];
+  const used = new Set<string>();
+  let progressed = true;
+  while (chosen.length < targetCount && progressed) {
+    progressed = false;
+    for (const muscle of musclesWithCandidates) {
+      if (chosen.length >= targetCount) break;
+      const bucket = buckets.get(muscle);
+      if (!bucket || bucket.length === 0) continue;
+      // Pop the next unused candidate from this muscle's bucket.
+      let next: EligibleEntry | undefined;
+      while (bucket.length > 0) {
+        const candidate = bucket.shift()!;
+        if (!used.has(candidate.exercise.id)) {
+          next = candidate;
+          break;
+        }
+      }
+      if (!next) continue;
+      used.add(next.exercise.id);
+      chosen.push(next);
+      progressed = true;
+    }
+  }
+  return chosen;
+}
+
+/**
+ * Generate a complete workout. Deterministic given (input, pool): the same
+ * inputs always produce the same workout; bump `input.seed` to vary it.
+ */
+export function generateWorkout(
+  input: GeneratorInput,
+  pool: readonly GeneratorExercise[],
+): GeneratedWorkout {
+  const seed = deriveSeed(input);
+  const preset = getWorkoutTypePreset(input.workoutType);
+  const eligible = getEligibleExercises(pool, input);
+  const targetCount = resolveTargetCount(input);
+
+  const chosen = selectExercises(
+    eligible,
+    input.muscleGroups,
+    targetCount,
+    seed,
+  );
+
+  const usedIds = new Set(chosen.map((c) => c.exercise.id));
+
+  const exercises: GeneratedExercise[] = chosen.map((entry, index) => {
+    const metric = effectiveMetric(entry.exercise);
+    // Replacement seed is offset per-slot so two slots covering the same muscle
+    // don't surface the identical shuffled order.
+    const replacements = computeReplacements(
+      eligible,
+      entry.primaryMuscle,
+      usedIds,
+      (seed ^ ((index + 1) * 0x9e3779b1)) >>> 0,
+    );
+    return {
+      exerciseId: entry.exercise.id,
+      name: entry.exercise.name,
+      primaryMuscle: entry.primaryMuscle,
+      metric,
+      sets: preset.sets,
+      reps: metric === "time" ? 0 : preset.reps,
+      rest_seconds: preset.rest_seconds,
+      transition_rest_seconds: preset.transition_rest_seconds,
+      ...(metric === "time" ? { durationSeconds: preset.durationSeconds } : {}),
+      replacements,
+    };
+  });
+
+  const estimatorInput: DurationEstimateExercise[] = exercises.map((e, idx) => ({
+    exerciseId: e.exerciseId,
+    sets: e.sets,
+    reps: e.reps,
+    rest_seconds: e.rest_seconds,
+    transition_rest_seconds: e.transition_rest_seconds,
+    order: idx + 1,
+    metric: e.metric,
+    durationSeconds: e.durationSeconds ?? null,
+  }));
+
+  return {
+    name: buildDefaultName(input),
+    exercises,
+    estimatedDurationMinutes: estimateTemplateDurationMinutes(estimatorInput),
+    requestedCount: targetCount,
+    eligiblePoolSize: eligible.length,
+  };
+}

--- a/backoffice/src/lib/gc-fitness/workout-generator/equipment-groups.ts
+++ b/backoffice/src/lib/gc-fitness/workout-generator/equipment-groups.ts
@@ -1,0 +1,87 @@
+// workout-generator/equipment-groups.ts
+//
+// Equipment "bundles" the trainer can one-tap to auto-select several pieces of
+// equipment at once (issue #296 step 1: "there could be bigger groups, like
+// 'gym', or 'home'"). Each group expands to a subset of the canonical
+// `EQUIPMENT` vocabulary. Individual items remain independently selectable.
+//
+// Every id in `items` MUST exist in `EQUIPMENT` (exercise-vocabulary.ts) —
+// `equipment-groups.test.ts` asserts this so a vocab rename can't silently
+// leave a group pointing at a dead equipment id.
+
+import { EQUIPMENT } from "../exercise-vocabulary";
+
+export interface EquipmentGroup {
+  id: string;
+  label: { en: string; es: string };
+  /** Equipment vocab ids this group selects. */
+  items: string[];
+}
+
+export const EQUIPMENT_GROUPS: readonly EquipmentGroup[] = [
+  {
+    id: "full_gym",
+    label: { en: "Full gym", es: "Gimnasio completo" },
+    items: [
+      "barbell",
+      "dumbbell",
+      "cable",
+      "machine",
+      "bench",
+      "smith",
+      "pull_up_bar",
+      "kettlebell",
+      "discs",
+      "rope",
+      "medicine_ball",
+      "swiss_ball",
+      "bodyweight",
+    ],
+  },
+  {
+    id: "free_weights",
+    label: { en: "Free weights", es: "Peso libre" },
+    items: ["barbell", "dumbbell", "bench", "kettlebell", "discs", "bodyweight"],
+  },
+  {
+    id: "home",
+    label: { en: "Home", es: "Casa" },
+    items: ["bodyweight", "dumbbell", "resistance_band", "kettlebell"],
+  },
+  {
+    id: "minimal",
+    label: { en: "Minimal kit", es: "Equipo mínimo" },
+    items: ["bodyweight", "dumbbell", "resistance_band"],
+  },
+  {
+    id: "bodyweight_only",
+    label: { en: "Bodyweight only", es: "Solo peso corporal" },
+    items: ["bodyweight", "pull_up_bar"],
+  },
+];
+
+/** Expand a set of selected group ids into the union of their equipment items. */
+export function expandEquipmentGroups(groupIds: readonly string[]): string[] {
+  const out = new Set<string>();
+  for (const id of groupIds) {
+    const group = EQUIPMENT_GROUPS.find((g) => g.id === id);
+    if (!group) continue;
+    for (const item of group.items) out.add(item);
+  }
+  return Array.from(out);
+}
+
+/** True when every item the group selects is currently in `selected` (used by
+ *  the UI to render a group chip as fully-active). */
+export function isGroupFullySelected(
+  group: EquipmentGroup,
+  selected: ReadonlySet<string>,
+): boolean {
+  return group.items.every((item) => selected.has(item));
+}
+
+/** Validate that every group only references real `EQUIPMENT` vocab ids. */
+export function equipmentGroupsReferenceValidVocab(): boolean {
+  const vocab = new Set<string>(EQUIPMENT as readonly string[]);
+  return EQUIPMENT_GROUPS.every((g) => g.items.every((i) => vocab.has(i)));
+}

--- a/backoffice/src/lib/gc-fitness/workout-generator/index.ts
+++ b/backoffice/src/lib/gc-fitness/workout-generator/index.ts
@@ -1,0 +1,8 @@
+// workout-generator/index.ts — public surface of the generator module.
+
+export * from "./types";
+export * from "./engine";
+export * from "./equipment-groups";
+export * from "./muscle-presets";
+export * from "./workout-type-presets";
+export { mulberry32, hashString, seededShuffle } from "./prng";

--- a/backoffice/src/lib/gc-fitness/workout-generator/muscle-presets.ts
+++ b/backoffice/src/lib/gc-fitness/workout-generator/muscle-presets.ts
@@ -1,0 +1,86 @@
+// workout-generator/muscle-presets.ts
+//
+// Muscle "focus" presets the trainer can one-tap (issue #296 step 2: "Select
+// muscles of workout. Example: push, chest, full body, legs. This should be
+// customizable."). Each preset expands to a subset of the canonical
+// `MUSCLE_GROUPS` vocabulary; individual groups stay independently selectable
+// so a trainer can hand-pick "biceps, triceps, and back".
+//
+// Every id in `muscles` MUST exist in `MUSCLE_GROUPS` — `muscle-presets.test.ts`
+// asserts this against the vocab.
+
+import { MUSCLE_GROUPS } from "../exercise-vocabulary";
+
+export interface MusclePreset {
+  id: string;
+  label: { en: string; es: string };
+  muscles: string[];
+}
+
+export const MUSCLE_PRESETS: readonly MusclePreset[] = [
+  {
+    id: "full_body",
+    label: { en: "Full body", es: "Cuerpo completo" },
+    muscles: [
+      "chest",
+      "back",
+      "shoulders",
+      "quadriceps",
+      "hamstrings",
+      "glutes",
+      "core",
+    ],
+  },
+  {
+    id: "push",
+    label: { en: "Push", es: "Empuje" },
+    muscles: ["chest", "shoulders", "triceps"],
+  },
+  {
+    id: "pull",
+    label: { en: "Pull", es: "Tracción" },
+    muscles: ["back", "biceps", "forearms"],
+  },
+  {
+    id: "legs",
+    label: { en: "Legs", es: "Piernas" },
+    muscles: ["quadriceps", "hamstrings", "glutes", "calves"],
+  },
+  {
+    id: "upper",
+    label: { en: "Upper body", es: "Tren superior" },
+    muscles: ["chest", "back", "shoulders", "biceps", "triceps"],
+  },
+  {
+    id: "lower",
+    label: { en: "Lower body", es: "Tren inferior" },
+    muscles: ["quadriceps", "hamstrings", "glutes", "calves"],
+  },
+  {
+    id: "arms",
+    label: { en: "Arms", es: "Brazos" },
+    muscles: ["biceps", "triceps", "forearms"],
+  },
+  {
+    id: "core",
+    label: { en: "Core", es: "Core" },
+    muscles: ["abs", "core"],
+  },
+];
+
+/** Expand a set of selected preset ids into the union of their muscle groups. */
+export function expandMusclePresets(presetIds: readonly string[]): string[] {
+  const out = new Set<string>();
+  for (const id of presetIds) {
+    const preset = MUSCLE_PRESETS.find((p) => p.id === id);
+    if (!preset) continue;
+    for (const m of preset.muscles) out.add(m);
+  }
+  return Array.from(out);
+}
+
+/** Validate that every preset only references real `MUSCLE_GROUPS` vocab ids. */
+export function musclePresetsReferenceValidVocab(): boolean {
+  const vocab = new Set<string>(MUSCLE_GROUPS as readonly string[]);
+  return MUSCLE_PRESETS.every((p) => p.muscles.every((m) => vocab.has(m)));
+}

--- a/backoffice/src/lib/gc-fitness/workout-generator/prng.ts
+++ b/backoffice/src/lib/gc-fitness/workout-generator/prng.ts
@@ -1,0 +1,45 @@
+// workout-generator/prng.ts
+//
+// Tiny deterministic PRNG + helpers. The engine must be reproducible: the same
+// (input, seed) pair always yields the same workout so the test suite can
+// assert exact output and the trainer's "Regenerate" button is the ONLY source
+// of variation (it bumps the seed). We therefore never call Math.random()
+// inside the engine.
+
+/** mulberry32 — small, fast, well-distributed 32-bit PRNG. Returns a function
+ *  that yields floats in [0, 1). */
+export function mulberry32(seed: number): () => number {
+  let a = seed >>> 0;
+  return function next() {
+    a |= 0;
+    a = (a + 0x6d2b79f5) | 0;
+    let t = Math.imul(a ^ (a >>> 15), 1 | a);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+/** Stable string hash (FNV-1a, 32-bit). Used to derive a seed from the input
+ *  so identical inputs reproduce identical workouts even without an explicit
+ *  seed. */
+export function hashString(value: string): number {
+  let h = 0x811c9dc5;
+  for (let i = 0; i < value.length; i += 1) {
+    h ^= value.charCodeAt(i);
+    h = Math.imul(h, 0x01000193);
+  }
+  return h >>> 0;
+}
+
+/** Deterministic Fisher–Yates shuffle driven by a PRNG. Returns a NEW array;
+ *  the input is not mutated. */
+export function seededShuffle<T>(items: readonly T[], rand: () => number): T[] {
+  const out = items.slice();
+  for (let i = out.length - 1; i > 0; i -= 1) {
+    const j = Math.floor(rand() * (i + 1));
+    const tmp = out[i];
+    out[i] = out[j];
+    out[j] = tmp;
+  }
+  return out;
+}

--- a/backoffice/src/lib/gc-fitness/workout-generator/types.ts
+++ b/backoffice/src/lib/gc-fitness/workout-generator/types.ts
@@ -1,0 +1,92 @@
+// workout-generator/types.ts
+//
+// Shared types for the deterministic Workout Generator engine. The engine is
+// PURE and framework-free (no Firebase, no React) so it can be exhaustively
+// unit-tested in isolation. The trainer surface injects the exercise library
+// (already fetched via `useExercisesQuery`) as a plain array of
+// `GeneratorExercise` rows.
+//
+// GUARANTEE the issue (#296) calls out explicitly: an exercise that requires
+// equipment the trainer did NOT select must never appear in the generated
+// workout NOR in any replacement pill. That rule lives in `engine.ts`
+// (`isEquipmentAllowed`) and is locked by the test suite.
+
+/** Minimal shape the engine needs from an exercise library row. Structurally
+ *  satisfied by `ExerciseRow` from `exercises-listener.ts` (extra fields are
+ *  ignored), so the UI passes its rows straight through. */
+export interface GeneratorExercise {
+  id: string;
+  name: { en: string; es: string };
+  /** Canonical muscle groups from `MUSCLE_GROUPS`. */
+  muscleGroups: string[];
+  /** Canonical equipment items from `EQUIPMENT`. Empty is treated as
+   *  `["bodyweight"]` (mirrors the exercise schema normalization). */
+  equipment: string[];
+  /** Per-exercise prescription kind. Defaults to "reps" when absent. */
+  metric?: "reps" | "time" | null;
+  /** Optional preview media (passed through to the UI, ignored by the engine). */
+  gifUrl?: string | null;
+  thumbnailURL?: string | null;
+  mediaURL?: string | null;
+  imageUrl?: string | null;
+}
+
+/** How the trainer expressed workout size. */
+export type VolumeMode = "count" | "time";
+
+export interface GeneratorInput {
+  /** Selected equipment items (already expanded from any group toggles). */
+  equipment: string[];
+  /** Selected muscle groups (already expanded from any preset toggles). */
+  muscleGroups: string[];
+  /** Either a fixed exercise count or a time budget drives the size. */
+  volumeMode: VolumeMode;
+  /** Required when volumeMode === "count". */
+  exerciseCount?: number;
+  /** Required when volumeMode === "time" (minutes). */
+  timeMinutes?: number;
+  /** Workout-type preset id (see `workout-type-presets.ts`). */
+  workoutType: string;
+  /** Optional seed for deterministic selection. When omitted the engine
+   *  derives a stable seed from the input so the same inputs always yield the
+   *  same workout; bump it to "regenerate" a fresh variation. */
+  seed?: number;
+  /** Optional human label used to build the default workout name (e.g. the
+   *  muscle-preset label the trainer picked, "Push"). */
+  focusLabel?: { en: string; es: string };
+}
+
+/** A candidate swap for a generated slot. Always equipment-eligible. */
+export interface ReplacementOption {
+  exerciseId: string;
+  name: { en: string; es: string };
+  primaryMuscle: string;
+}
+
+export interface GeneratedExercise {
+  exerciseId: string;
+  name: { en: string; es: string };
+  /** The selected muscle group this slot is covering (for grouping/labels). */
+  primaryMuscle: string;
+  metric: "reps" | "time";
+  sets: number;
+  reps: number;
+  rest_seconds: number;
+  transition_rest_seconds: number;
+  /** Present when metric === "time". */
+  durationSeconds?: number;
+  /** Equipment-eligible alternatives for the same muscle, excluding exercises
+   *  already used in the workout. */
+  replacements: ReplacementOption[];
+}
+
+export interface GeneratedWorkout {
+  name: { en: string; es: string };
+  exercises: GeneratedExercise[];
+  estimatedDurationMinutes: number;
+  /** Diagnostics surfaced by the UI when the pool can't satisfy the request. */
+  requestedCount: number;
+  /** Number of exercises in the library that passed equipment + muscle
+   *  filters (the size of the pool the engine drew from). */
+  eligiblePoolSize: number;
+}

--- a/backoffice/src/lib/gc-fitness/workout-generator/workout-type-presets.ts
+++ b/backoffice/src/lib/gc-fitness/workout-generator/workout-type-presets.ts
@@ -1,0 +1,147 @@
+// workout-generator/workout-type-presets.ts
+//
+// Workout-type presets (issue #296 step 4: "Select workout type. Example:
+// resistance, muscle growth, hypertrophy, beginner, etc. this will be used by
+// the workout generator engine to decide which exercises, rest timers, etc").
+//
+// Each preset is a prescription template the engine stamps onto every generated
+// exercise: sets, reps, rest, transition rest, and — for time-based exercises
+// (planks, holds, carries) — a per-set hold duration. All values respect the
+// `exerciseRefSchema` bounds (sets 1-10, reps 0-50, rest 0-600, duration
+// 5-1800) so a generated workout always passes `createWorkoutTemplate`'s Zod
+// gate. `workout-type-presets.test.ts` asserts that invariant.
+
+import {
+  ESTIMATED_SECONDS_PER_REP,
+  ESTIMATED_SETUP_SECONDS_PER_SET,
+} from "../workout-duration-estimate";
+
+export interface WorkoutTypePreset {
+  id: string;
+  label: { en: string; es: string };
+  description: { en: string; es: string };
+  sets: number;
+  /** Reps prescribed for reps-based exercises. */
+  reps: number;
+  rest_seconds: number;
+  transition_rest_seconds: number;
+  /** Hold (seconds) prescribed for time-based exercises (metric === "time"). */
+  durationSeconds: number;
+}
+
+export const WORKOUT_TYPE_PRESETS: readonly WorkoutTypePreset[] = [
+  {
+    id: "strength",
+    label: { en: "Strength", es: "Fuerza" },
+    description: {
+      en: "Heavy, low reps, long rest.",
+      es: "Pesado, pocas reps, descanso largo.",
+    },
+    sets: 5,
+    reps: 5,
+    rest_seconds: 180,
+    transition_rest_seconds: 120,
+    durationSeconds: 30,
+  },
+  {
+    id: "hypertrophy",
+    label: { en: "Hypertrophy", es: "Hipertrofia" },
+    description: {
+      en: "Moderate reps, moderate rest — muscle growth.",
+      es: "Reps moderadas, descanso moderado — crecimiento muscular.",
+    },
+    sets: 4,
+    reps: 10,
+    rest_seconds: 75,
+    transition_rest_seconds: 60,
+    durationSeconds: 40,
+  },
+  {
+    id: "muscle_growth",
+    label: { en: "Muscle growth", es: "Volumen" },
+    description: {
+      en: "Higher volume, short-ish rest.",
+      es: "Más volumen, descanso corto.",
+    },
+    sets: 4,
+    reps: 12,
+    rest_seconds: 60,
+    transition_rest_seconds: 60,
+    durationSeconds: 45,
+  },
+  {
+    id: "endurance",
+    label: { en: "Endurance", es: "Resistencia" },
+    description: {
+      en: "High reps, minimal rest.",
+      es: "Muchas reps, descanso mínimo.",
+    },
+    sets: 3,
+    reps: 18,
+    rest_seconds: 40,
+    transition_rest_seconds: 45,
+    durationSeconds: 50,
+  },
+  {
+    id: "beginner",
+    label: { en: "Beginner", es: "Principiante" },
+    description: {
+      en: "Approachable volume, comfortable rest.",
+      es: "Volumen accesible, descanso cómodo.",
+    },
+    sets: 3,
+    reps: 12,
+    rest_seconds: 75,
+    transition_rest_seconds: 60,
+    durationSeconds: 30,
+  },
+  {
+    id: "power",
+    label: { en: "Power", es: "Potencia" },
+    description: {
+      en: "Explosive, very low reps, full recovery.",
+      es: "Explosivo, muy pocas reps, recuperación completa.",
+    },
+    sets: 4,
+    reps: 3,
+    rest_seconds: 180,
+    transition_rest_seconds: 150,
+    durationSeconds: 20,
+  },
+  {
+    id: "circuit",
+    label: { en: "Circuit", es: "Circuito" },
+    description: {
+      en: "Fast pace, minimal rest, keep moving.",
+      es: "Ritmo rápido, descanso mínimo, sin parar.",
+    },
+    sets: 3,
+    reps: 15,
+    rest_seconds: 30,
+    transition_rest_seconds: 20,
+    durationSeconds: 40,
+  },
+];
+
+export function getWorkoutTypePreset(id: string): WorkoutTypePreset {
+  return (
+    WORKOUT_TYPE_PRESETS.find((p) => p.id === id) ??
+    WORKOUT_TYPE_PRESETS.find((p) => p.id === "hypertrophy")!
+  );
+}
+
+/** Rough whole-second estimate of one exercise under a given type preset,
+ *  used to size a time-budgeted workout into an exercise count. Mirrors the
+ *  per-set formula in `workout-duration-estimate.ts` (active + rest + setup)
+ *  and adds the inter-exercise transition once. */
+export function estimateSecondsPerExercise(
+  preset: WorkoutTypePreset,
+  metric: "reps" | "time" = "reps",
+): number {
+  const active =
+    metric === "time"
+      ? preset.durationSeconds
+      : preset.reps * ESTIMATED_SECONDS_PER_REP;
+  const perSet = active + preset.rest_seconds + ESTIMATED_SETUP_SECONDS_PER_SET;
+  return perSet * preset.sets + preset.transition_rest_seconds;
+}


### PR DESCRIPTION
Implements **mdb1/gc-fitness#296** — a multi-step **Workout Generator** for the GC Fitness trainer backoffice.

## What it does
A wizard at `/gc-fitness/templates/generate` (CTA **"Generador de Plantillas"** on the templates list):

1. **Equipment** — quick bundles (Full gym, Home, Minimal, Bodyweight-only) + individual items
2. **Muscles** — focus presets (Push, Pull, Legs, Full body, Upper/Lower, Arms, Core) + individual groups
3. **Volume** — N exercises *or* a time budget
4. **Type** — Strength / Hypertrophy / Muscle growth / Endurance / Beginner / Power / Circuit
5. **Edit** — hands off to the **real `TemplateForm`** (same UX as the normal create flow): in-line picker swap, **replacement pills** (generator-only), supersets, per-set reps (12/10/8/6), transition rest, coach notes, metric + "Sin peso"
6. **Success** — direct **multi-client + recurrence** assign (`bulkAssignTemplate`)

## Engine (pure, deterministic, 57 unit tests)
`src/lib/gc-fitness/workout-generator/*` — framework-free, seeded PRNG.
- **Hard equipment rule** (the issue's key requirement): an exercise needs **every** required item selected — including a **bench inferred** from bench/incline/decline/preacher movement names — or it appears in *neither* the workout *nor* the replacement pills.
- Muscle-balanced round-robin selection; time→count sizing.
- Pool = the **new curated standard library only** (legacy fexd/wger + coach customs excluded from generation).

## Shared `TemplateForm` changes (backwards-compatible)
- New optional props: `onCreated` (let the generator keep the form on screen for its success step) and `renderExerciseExtras` (generator-only pills). The normal create/edit flow passes neither → unchanged.
- **Bug fix:** resizing the set count no longer fabricates an empty `weightBySetKg: []` (the "changing Series + Tab silently switched the exercise to *Sin peso*" bug).

## Data scripts (already run against prod `gcfitness-3476b` — idempotent, dry-run default, backups)
- `fix-standard-library-gif-equipment.mjs` — corrected ~54 standard-library docs showing a **wrong-equipment / ball-apparatus** gif (revert to the correct per-doc gif when one exists, else clear → placeholder; "better no gif than a wrong one").
- `fix-standard-library-gif-overrides.mjs` — per-doc **wrong-movement** overrides (e.g. *Crunch* was showing a *reverse crunch*). Reusable as more are reported.

## Tests / gates
- `tsc --noEmit`: **0 errors**
- New engine suites: **57 tests pass**
- Full backoffice `jest`: **626 pass**; the only 2 failing suites (`workout-assignment-actions` mock-count, `client-activity-time` locale) are **pre-existing flakes on clean `main`** (verified by stashing) — this PR adds tests and breaks none.