### PR TITLE
feat(gc-fitness): coach favorites + muscle-group focus presets (#297, #299)

### DIFF
--- a/backoffice/messages/en.json
+++ b/backoffice/messages/en.json
@@ -1161,6 +1161,9 @@
       "muscleGroupsPlaceholder": "Muscle groups",
       "muscleGroupsPlaceholderCount": "Muscle groups ({count})",
       "muscleGroupsAria": "Filter by muscle groups",
+      "focusLabel": "Focus",
+      "favoritesOnlyLabel": "Favorites",
+      "favoritesOnlyAria": "Show only favorites",
       "equipmentPlaceholder": "Equipment",
       "equipmentPlaceholderCount": "Equipment ({count})",
       "equipmentAria": "Filter by equipment",
@@ -1577,6 +1580,7 @@
     "multiAddSelectedCount": "{count} selected",
     "multiAddConfirm": "Add {count}",
     "multiAddCreateNew": "Create «{term}»",
+    "filterFocus": "Focus",
     "filterMuscles": "Muscle",
     "filterEquipment": "Equipment",
     "filterLevel": "Level",
@@ -1588,6 +1592,10 @@
     "mechanicCompound": "Compound",
     "mechanicIsolation": "Isolation",
     "overflowMore": "+ {count} more — refine filter"
+  },
+  "favorites": {
+    "add": "Add to favorites",
+    "remove": "Remove from favorites"
   },
   "dialogs": {
     "deleteAssignment": {

--- a/backoffice/messages/es.json
+++ b/backoffice/messages/es.json
@@ -1161,6 +1161,9 @@
       "muscleGroupsPlaceholder": "Grupos musculares",
       "muscleGroupsPlaceholderCount": "Grupos musculares ({count})",
       "muscleGroupsAria": "Filtrar por grupos musculares",
+      "focusLabel": "Foco",
+      "favoritesOnlyLabel": "Favoritos",
+      "favoritesOnlyAria": "Mostrar solo favoritos",
       "equipmentPlaceholder": "Equipamiento",
       "equipmentPlaceholderCount": "Equipamiento ({count})",
       "equipmentAria": "Filtrar por equipamiento",
@@ -1577,6 +1580,7 @@
     "multiAddSelectedCount": "{count} elegidos",
     "multiAddConfirm": "Agregar {count}",
     "multiAddCreateNew": "Crear «{term}»",
+    "filterFocus": "Foco",
     "filterMuscles": "Músculo",
     "filterEquipment": "Equipo",
     "filterLevel": "Nivel",
@@ -1588,6 +1592,10 @@
     "mechanicCompound": "Compuesto",
     "mechanicIsolation": "Aislamiento",
     "overflowMore": "+ {count} más — refiná filtro"
+  },
+  "favorites": {
+    "add": "Agregar a favoritos",
+    "remove": "Quitar de favoritos"
   },
   "dialogs": {
     "deleteAssignment": {

--- a/backoffice/src/app/gc-fitness/exercises/_components/ExerciseFilters.tsx
+++ b/backoffice/src/app/gc-fitness/exercises/_components/ExerciseFilters.tsx
@@ -15,7 +15,7 @@
 
 import { useEffect, useState } from "react";
 import { useSearchParams } from "next/navigation";
-import { Search, SlidersHorizontal, X } from "lucide-react";
+import { Search, SlidersHorizontal, Star, X } from "lucide-react";
 import { useTranslations } from "next-intl";
 
 import { cn } from "@/lib/utils";
@@ -25,6 +25,7 @@ import {
   MUSCLE_GROUPS,
   EQUIPMENT,
 } from "@/lib/gc-fitness/exercise-vocabulary";
+import { MusclePresetChips } from "@/components/gc-fitness/muscle-preset-chips";
 import { MultiSelectCombobox } from "./MultiSelectCombobox";
 
 const STORAGE_KEY = "gc-fitness:exercise-filters";
@@ -36,6 +37,7 @@ export interface ExerciseFiltersState {
   equipment: string[];
   source: string[]; // subset of ['Standard', 'Custom']
   mineOnly: boolean;
+  favoritesOnly: boolean;
 }
 
 const EMPTY: ExerciseFiltersState = {
@@ -44,6 +46,7 @@ const EMPTY: ExerciseFiltersState = {
   equipment: [],
   source: [],
   mineOnly: false,
+  favoritesOnly: false,
 };
 
 function readFromStorage(): ExerciseFiltersState | null {
@@ -68,6 +71,7 @@ function readFromStorage(): ExerciseFiltersState | null {
         : [],
       source: normalizedSource,
       mineOnly: parsed.mineOnly === true,
+      favoritesOnly: parsed.favoritesOnly === true,
     };
   } catch {
     // Corrupted entry — wipe + start clean.
@@ -137,7 +141,8 @@ export function ExerciseFilters({ onChange }: ExerciseFiltersProps) {
     state.muscleGroups.length +
     state.equipment.length +
     state.source.length +
-    (state.mineOnly ? 1 : 0);
+    (state.mineOnly ? 1 : 0) +
+    (state.favoritesOnly ? 1 : 0);
   const showClear = activeCount > 0 || state.search.length > 0;
 
   return (
@@ -193,6 +198,45 @@ export function ExerciseFilters({ onChange }: ExerciseFiltersProps) {
             {t("mineOnlyLabel")}
           </button>
         </div>
+        {/* #297 — favorites-only toggle. Independent of the All/Mine pill. */}
+        <button
+          type="button"
+          onClick={() =>
+            setState((s) => ({ ...s, favoritesOnly: !s.favoritesOnly }))
+          }
+          aria-pressed={state.favoritesOnly}
+          aria-label={t("favoritesOnlyAria")}
+          className={cn(
+            "inline-flex min-h-9 shrink-0 items-center gap-1.5 rounded-full px-4 py-1.5 text-sm font-medium transition-colors",
+            state.favoritesOnly
+              ? "bg-amber-100 text-amber-700 ring-1 ring-amber-300 dark:bg-amber-400/15 dark:text-amber-300"
+              : "bg-muted/70 text-muted-foreground hover:text-foreground",
+          )}
+        >
+          <Star
+            className={cn(
+              "h-4 w-4",
+              state.favoritesOnly ? "fill-amber-400 text-amber-500" : "",
+            )}
+            aria-hidden="true"
+          />
+          {t("favoritesOnlyLabel")}
+        </button>
+      </div>
+
+      {/* Muscle "focus" presets (#299): one tap selects a group's muscles, e.g.
+          Push → chest + shoulders + triceps. Drives the same `muscleGroups`
+          selection as the combobox below (two-tier, like the generator). */}
+      <div className="flex flex-col gap-1.5">
+        <span className="text-xs font-medium text-muted-foreground">
+          {t("focusLabel")}
+        </span>
+        <MusclePresetChips
+          value={state.muscleGroups}
+          onChange={(next) =>
+            setState((s) => ({ ...s, muscleGroups: next }))
+          }
+        />
       </div>
 
       {/* Advanced filters: muscle / equipment / source comboboxes + clear */}

--- a/backoffice/src/app/gc-fitness/exercises/client.tsx
+++ b/backoffice/src/app/gc-fitness/exercises/client.tsx
@@ -56,6 +56,12 @@ import {
 } from "@/lib/gc-fitness/exercises-listener";
 import { searchExercises } from "@/lib/gc-fitness/exercise-search";
 import { isPickableExercise } from "@/lib/gc-fitness/exercise-visibility";
+import { useFavorites } from "@/lib/gc-fitness/use-favorites";
+import {
+  favoriteIdSet,
+  filterFavoritesOnly,
+  sortFavoritesFirst,
+} from "@/lib/gc-fitness/favorites";
 import {
   softDeleteExercise,
   duplicateExercise,
@@ -73,6 +79,7 @@ const EMPTY_FILTERS: ExerciseFiltersState = {
   equipment: [],
   source: [],
   mineOnly: false,
+  favoritesOnly: false,
 };
 
 interface ExerciseLibraryClientProps {
@@ -132,18 +139,33 @@ export function ExerciseLibraryClient({
   const router = useRouter();
   const t = useTranslations("exercises.list");
   const { data, isLoading, error, hasSnapshot } = useExercisesQuery(trainerUid);
+  const { favorites } = useFavorites();
   const queryClient = useQueryClient();
   const [filters, setFilters] = useState<ExerciseFiltersState>(EMPTY_FILTERS);
   const [confirmDelete, setConfirmDelete] = useState<ExerciseRow | null>(null);
   const [deletePending, setDeletePending] = useState(false);
+
+  const favIds = useMemo(
+    () => favoriteIdSet(favorites, "exercise"),
+    [favorites],
+  );
 
   const rows = useMemo(() => {
     const all = (data ?? []).filter(isPickableExercise);
     // Apply the non-search chip/select filters first, THEN rank + search
     // (issue #291): normalized, plural/hyphen-tolerant, best-match-first.
     const filtered = all.filter((r) => matchesFilters(r, filters, trainerUid));
-    return searchExercises(filtered, filters.search);
-  }, [data, filters, trainerUid]);
+    const searched = searchExercises(filtered, filters.search);
+    // #297 — favorites: optionally keep only starred rows, then always float
+    // favorites to the top (stable within each group).
+    const scoped = filterFavoritesOnly(
+      searched,
+      (r) => r.id,
+      favIds,
+      filters.favoritesOnly,
+    );
+    return sortFavoritesFirst(scoped, (r) => r.id, favIds);
+  }, [data, filters, trainerUid, favIds]);
 
   const handleDuplicate = useCallback(
     async (row: ExerciseRow) => {

--- a/backoffice/src/app/gc-fitness/exercises/columns.tsx
+++ b/backoffice/src/app/gc-fitness/exercises/columns.tsx
@@ -28,6 +28,7 @@ import {
   TooltipTrigger,
 } from "@/components/ui/tooltip";
 import { ExercisePreviewThumb } from "@/components/gc-fitness/exercise-preview-thumb";
+import { FavoriteStarButton } from "@/components/gc-fitness/favorite-star-button";
 import type { ExerciseRow } from "@/lib/gc-fitness/exercises-listener";
 
 // Difficulty level → semantic Badge variant per the redesign doc
@@ -87,6 +88,15 @@ export function makeColumns(
   t: TFn,
 ): ColumnDef<ExerciseRow>[] {
   return [
+    {
+      id: "favorite",
+      header: "",
+      cell: ({ row }) => (
+        <FavoriteStarButton kind="exercise" id={row.original.id} />
+      ),
+      enableSorting: false,
+      size: 40,
+    },
     {
       id: "thumbnail",
       header: "",

--- a/backoffice/src/app/gc-fitness/habits/_components/HabitLibraryTable.tsx
+++ b/backoffice/src/app/gc-fitness/habits/_components/HabitLibraryTable.tsx
@@ -23,6 +23,7 @@ import {
   TableRow,
 } from "@/components/ui/table";
 import { StorageImagePreview } from "@/components/gc-fitness/StorageImagePreview";
+import { FavoriteStarButton } from "@/components/gc-fitness/favorite-star-button";
 import type { HabitTemplateRow } from "@/lib/gc-fitness/habit-actions";
 import { ScopePill } from "./habit-pills";
 
@@ -61,6 +62,7 @@ export function HabitLibraryTable({
       <Table>
         <TableHeader>
           <TableRow>
+            <TableHead className="w-10" />
             <TableHead className="w-16">
               <span className="sr-only">{t("photo")}</span>
             </TableHead>
@@ -78,7 +80,7 @@ export function HabitLibraryTable({
           {isLoading ? (
             <TableRow>
               <TableCell
-                colSpan={3}
+                colSpan={4}
                 className="h-24 text-center text-muted-foreground"
               >
                 {loadingText}
@@ -86,7 +88,7 @@ export function HabitLibraryTable({
             </TableRow>
           ) : templates.length === 0 ? (
             <TableRow>
-              <TableCell colSpan={3} className="h-32 text-center">
+              <TableCell colSpan={4} className="h-32 text-center">
                 <p className="text-sm text-muted-foreground">{emptyText}</p>
               </TableCell>
             </TableRow>
@@ -101,6 +103,9 @@ export function HabitLibraryTable({
                   onClick={() => onRowClick(tpl)}
                   className="cursor-pointer"
                 >
+                  <TableCell className="py-2">
+                    <FavoriteStarButton kind="habitTemplate" id={tpl.id} />
+                  </TableCell>
                   <TableCell className="py-2">
                     <HabitThumb photoUrl={tpl.photoUrl} />
                   </TableCell>

--- a/backoffice/src/app/gc-fitness/habits/client.tsx
+++ b/backoffice/src/app/gc-fitness/habits/client.tsx
@@ -24,6 +24,7 @@ import {
   RotateCcw,
   Search,
   SlidersHorizontal,
+  Star,
   Trash2,
   Users,
 } from "lucide-react";
@@ -67,6 +68,12 @@ import {
   type HabitRow,
   type HabitTemplateRow,
 } from "@/lib/gc-fitness/habit-actions";
+import { useFavorites } from "@/lib/gc-fitness/use-favorites";
+import {
+  favoriteIdSet,
+  filterFavoritesOnly,
+  sortFavoritesFirst,
+} from "@/lib/gc-fitness/favorites";
 import { HabitLibraryTable } from "./_components/HabitLibraryTable";
 import { HabitTemplateDetailDialog } from "./_components/HabitTemplateDetailDialog";
 import { RecurrencePill, ReminderCell } from "./_components/habit-pills";
@@ -106,6 +113,7 @@ export function HabitsLibraryClient({
   const t = useTranslations("habits.list");
   const columnsT = useTranslations("habits.columns");
   const tTypeLabels = useTranslations("habits.list.typeLabels");
+  const tFilters = useTranslations("exercises.filters");
   const queryClient = useQueryClient();
   const [view, setView] = useState<HabitsView>("assignments");
   const [createOpen, setCreateOpen] = useState(false);
@@ -119,6 +127,13 @@ export function HabitsLibraryClient({
   // B5 — reveal toggle for the per-trainer hidden GLOBAL templates.
   const [showHidden, setShowHidden] = useState(false);
   const [restorePendingId, setRestorePendingId] = useState<string | null>(null);
+  // #297 — favorites-only toggle for the Biblioteca (template library).
+  const [favoritesOnly, setFavoritesOnly] = useState(false);
+  const { favorites } = useFavorites();
+  const favTemplateIds = useMemo(
+    () => favoriteIdSet(favorites, "habitTemplate"),
+    [favorites],
+  );
 
   const { data, isLoading, error } = useQuery({
     queryKey: HABITS_BASE_KEY,
@@ -217,14 +232,23 @@ export function HabitsLibraryClient({
   const filteredTemplates = useMemo(() => {
     const all = templates as HabitTemplateRow[];
     const needle = search.trim().toLowerCase();
-    return all.filter((tpl) => {
+    const searched = all.filter((tpl) => {
       if (needle.length > 0) {
         const hay = `${tpl.name.en} ${tpl.name.es}`.toLowerCase();
         if (!hay.includes(needle)) return false;
       }
       return true;
     });
-  }, [templates, search]);
+    // #297 — favorites: optionally keep only starred templates, then float
+    // favorites to the top.
+    const scoped = filterFavoritesOnly(
+      searched,
+      (tpl) => tpl.id,
+      favTemplateIds,
+      favoritesOnly,
+    );
+    return sortFavoritesFirst(scoped, (tpl) => tpl.id, favTemplateIds);
+  }, [templates, search, favTemplateIds, favoritesOnly]);
 
   // B5 — friendly labels for the hidden GLOBAL ids. `listHabitTemplates`
   // excludes hidden globals from `templates`, so their names aren't in that
@@ -473,6 +497,30 @@ export function HabitsLibraryClient({
 
       {view === "library" ? (
         <div className="flex flex-col gap-4">
+          {/* #297 — favorites-only toggle for the template library. */}
+          <div className="flex justify-end">
+            <button
+              type="button"
+              onClick={() => setFavoritesOnly((v) => !v)}
+              aria-pressed={favoritesOnly}
+              aria-label={tFilters("favoritesOnlyAria")}
+              className={cn(
+                "inline-flex min-h-9 shrink-0 items-center gap-1.5 rounded-full px-4 py-1.5 text-sm font-medium transition-colors",
+                favoritesOnly
+                  ? "bg-amber-100 text-amber-700 ring-1 ring-amber-300 dark:bg-amber-400/15 dark:text-amber-300"
+                  : "bg-muted/70 text-muted-foreground hover:text-foreground",
+              )}
+            >
+              <Star
+                className={cn(
+                  "h-4 w-4",
+                  favoritesOnly ? "fill-amber-400 text-amber-500" : "",
+                )}
+                aria-hidden="true"
+              />
+              {tFilters("favoritesOnlyLabel")}
+            </button>
+          </div>
           <HabitLibraryTable
             templates={filteredTemplates}
             isLoading={templatesLoading}

--- a/backoffice/src/app/gc-fitness/templates/client.tsx
+++ b/backoffice/src/app/gc-fitness/templates/client.tsx
@@ -23,6 +23,7 @@ import {
   Search,
   Sparkles,
   SlidersHorizontal,
+  Star,
   Trash2,
 } from "lucide-react";
 import { useTranslations } from "next-intl";
@@ -68,6 +69,13 @@ import {
 import type { WorkoutTemplateRow } from "@/lib/gc-fitness/workout-template-actions";
 import { estimateTemplateDurationMinutesFromRaw } from "@/lib/gc-fitness/workout-duration-estimate";
 import { fuzzyTokenScore } from "@/lib/gc-fitness/exercise-search";
+import { useFavorites } from "@/lib/gc-fitness/use-favorites";
+import {
+  favoriteIdSet,
+  filterFavoritesOnly,
+  sortFavoritesFirst,
+} from "@/lib/gc-fitness/favorites";
+import { FavoriteStarButton } from "@/components/gc-fitness/favorite-star-button";
 import type { TemplateListRow } from "@/components/gc-fitness/templates/columns";
 
 // Tag → human label (kept local — small, list-only).
@@ -135,9 +143,16 @@ export function TemplatesLibraryClient({
   const queryClient = useQueryClient();
   const [tagFilter, setTagFilter] = useState("");
   const [mineOnly, setMineOnly] = useState(false);
+  const [favoritesOnly, setFavoritesOnly] = useState(false);
   const [confirmDelete, setConfirmDelete] =
     useState<WorkoutTemplateRow | null>(null);
   const [deletePending, setDeletePending] = useState(false);
+
+  const { favorites } = useFavorites();
+  const favIds = useMemo(
+    () => favoriteIdSet(favorites, "workoutTemplate"),
+    [favorites],
+  );
 
   // Pull the entire roster from the server (the trainer surface tops out at a
   // few dozen templates, so paging server-side adds latency without saving
@@ -233,8 +248,13 @@ export function TemplatesLibraryClient({
         .sort((a, b) => b.score - a.score);
       list = scored.map((entry) => entry.row);
     }
+    // #297 — favorites: optionally keep only starred templates, then always
+    // float favorites to the top. The in-progress draft row is added AFTER, so
+    // it stays pinned at the very top regardless of favorites.
+    list = filterFavoritesOnly(list, (r) => r.id, favIds, favoritesOnly);
+    list = sortFavoritesFirst(list, (r) => r.id, favIds);
     return draftRow ? [draftRow, ...list] : list;
-  }, [data, mineOnly, trainerUid, tagFilter, draftRow]);
+  }, [data, mineOnly, trainerUid, tagFilter, draftRow, favIds, favoritesOnly]);
 
   const handlers = useMemo(
     () => ({
@@ -295,7 +315,7 @@ export function TemplatesLibraryClient({
     }
   }, [confirmDelete, queryClient, t]);
 
-  const hasFilter = tagFilter.trim().length > 0 || mineOnly;
+  const hasFilter = tagFilter.trim().length > 0 || mineOnly || favoritesOnly;
   const isUnfilteredEmpty = !isLoading && !hasFilter && rows.length === 0;
   const isFilteredEmpty = !isLoading && hasFilter && rows.length === 0;
 
@@ -380,6 +400,28 @@ export function TemplatesLibraryClient({
             {tFilters("mineOnlyLabel")}
           </button>
         </div>
+        {/* #297 — favorites-only toggle. */}
+        <button
+          type="button"
+          onClick={() => setFavoritesOnly((v) => !v)}
+          aria-pressed={favoritesOnly}
+          aria-label={tFilters("favoritesOnlyAria")}
+          className={cn(
+            "inline-flex min-h-9 shrink-0 items-center gap-1.5 rounded-full px-4 py-1.5 text-sm font-medium transition-colors",
+            favoritesOnly
+              ? "bg-amber-100 text-amber-700 ring-1 ring-amber-300 dark:bg-amber-400/15 dark:text-amber-300"
+              : "bg-muted/70 text-muted-foreground hover:text-foreground",
+          )}
+        >
+          <Star
+            className={cn(
+              "h-4 w-4",
+              favoritesOnly ? "fill-amber-400 text-amber-500" : "",
+            )}
+            aria-hidden="true"
+          />
+          {tFilters("favoritesOnlyLabel")}
+        </button>
       </div>
 
       {error && (
@@ -471,6 +513,13 @@ export function TemplatesLibraryClient({
                           {columnsT("draftBadgeTooltip")}
                         </TooltipContent>
                       </Tooltip>
+                    ) : null}
+
+                    {!row.__isDraft ? (
+                      <FavoriteStarButton
+                        kind="workoutTemplate"
+                        id={row.id}
+                      />
                     ) : null}
 
                     <div className="flex min-w-0 flex-1 flex-col gap-1.5">

--- a/backoffice/src/components/gc-fitness/__tests__/exercise-picker-popover.test.tsx
+++ b/backoffice/src/components/gc-fitness/__tests__/exercise-picker-popover.test.tsx
@@ -36,6 +36,23 @@ jest.mock("@/lib/gc-fitness/exercises-listener", () => ({
   EXERCISES_QUERY_KEY: ["gc-fitness", "exercises"],
 }));
 
+// #297 — the picker now reads favorites (star + favorites-first sort). Stub the
+// hook so the smoke tests don't pull the favorites Server Action (→
+// firebase-admin) into the bundle, and don't need a QueryClientProvider.
+jest.mock("@/lib/gc-fitness/use-favorites", () => ({
+  useFavorites: () => ({
+    favorites: {
+      exerciseIds: [],
+      workoutTemplateIds: [],
+      habitTemplateIds: [],
+    },
+    isLoading: false,
+    isFavorite: () => false,
+    toggle: jest.fn(),
+    isToggling: false,
+  }),
+}));
+
 // 260529 — the picker now calls useQueryClient() (to invalidate the
 // one-shot exercises feed after quick-create). Stub it so the smoke tests
 // don't need a real QueryClientProvider wrapper.

--- a/backoffice/src/components/gc-fitness/exercise-picker-popover.tsx
+++ b/backoffice/src/components/gc-fitness/exercise-picker-popover.tsx
@@ -101,11 +101,15 @@ import {
   type ExerciseFilters,
 } from "@/lib/gc-fitness/exercise-filter-state";
 import { MUSCLE_GROUPS, EQUIPMENT } from "@/lib/gc-fitness/exercise-vocabulary";
+import { useFavorites } from "@/lib/gc-fitness/use-favorites";
+import { favoriteIdSet, sortFavoritesFirst } from "@/lib/gc-fitness/favorites";
+import { FavoriteStarButton } from "./favorite-star-button";
 import {
   QuickCreateExercise,
   type QuickCreateSeed,
 } from "./exercise-quick-create";
 import { ExercisePreviewThumb } from "./exercise-preview-thumb";
+import { MusclePresetChips } from "./muscle-preset-chips";
 
 // Phase 24-06 Task 3 — render-window cap (Codex MEDIUM). Even with
 // lazy GIFs, rendering 250+ rows + 250 inline images strains the popover.
@@ -209,6 +213,11 @@ export function ExercisePickerPopover({
   }, [search]);
   const queryClient = useQueryClient();
   const { data, isLoading, error, hasSnapshot } = useExercisesQuery();
+  const { favorites } = useFavorites();
+  const favIds = useMemo(
+    () => favoriteIdSet(favorites, "exercise"),
+    [favorites],
+  );
 
   // Phase 24-06 Task 3 — filter chip state (muscle/equipment/level/mechanic).
   // Hook owns the immutable Set update contract (Codex MEDIUM); every
@@ -233,11 +242,13 @@ export function ExercisePickerPopover({
   const { visible, overflow } = useMemo(() => {
     const live = (data ?? []).filter(isPickableExercise);
     const ranked = searchExercises(applyFilters(live, filters), search);
+    // #297 — favorites always sort first (incl. in search results), then cap.
+    const ordered = sortFavoritesFirst(ranked, (r) => r.id, favIds);
     return {
-      visible: ranked.slice(0, RENDER_CAP),
-      overflow: Math.max(0, ranked.length - RENDER_CAP),
+      visible: ordered.slice(0, RENDER_CAP),
+      overflow: Math.max(0, ordered.length - RENDER_CAP),
     };
-  }, [data, filters, search]);
+  }, [data, filters, search, favIds]);
 
   // Kept for the empty-state branch: distinguishes "no rows in cache" from
   // "filters narrowed to zero".
@@ -310,6 +321,12 @@ export function ExercisePickerPopover({
       else next.add(value);
       return { ...prev, equipment: next };
     });
+  }
+  // #299 — muscle "focus" presets replace the whole muscle selection from the
+  // preset chips (which toggle the union in/out). A fresh Set keeps the
+  // immutable-update contract above.
+  function setMuscleSelection(nextMuscles: string[]) {
+    setFilters((prev) => ({ ...prev, muscles: new Set(nextMuscles) }));
   }
   function toggleLevel(value: string) {
     setFilters((prev) => ({
@@ -384,6 +401,7 @@ export function ExercisePickerPopover({
         <ExercisePickerFilters
           filters={filters}
           toggleMuscle={toggleMuscle}
+          setMuscleSelection={setMuscleSelection}
           toggleEquipment={toggleEquipment}
           toggleLevel={toggleLevel}
           toggleMechanic={toggleMechanic}
@@ -458,6 +476,11 @@ export function ExercisePickerPopover({
                               {ex.muscleGroups.map(formatLabel).join(", ")}
                             </span>
                           )}
+                        </span>
+                        <span
+                          onPointerDown={(event) => event.stopPropagation()}
+                        >
+                          <FavoriteStarButton kind="exercise" id={ex.id} />
                         </span>
                         <button
                           type="button"
@@ -538,6 +561,7 @@ export function ExercisePickerPopover({
 interface ExercisePickerFiltersProps {
   filters: ExerciseFilters;
   toggleMuscle: (value: string) => void;
+  setMuscleSelection: (next: string[]) => void;
   toggleEquipment: (value: string) => void;
   toggleLevel: (value: string) => void;
   toggleMechanic: (value: string) => void;
@@ -548,6 +572,7 @@ interface ExercisePickerFiltersProps {
 function ExercisePickerFilters({
   filters,
   toggleMuscle,
+  setMuscleSelection,
   toggleEquipment,
   toggleLevel,
   toggleMechanic,
@@ -558,6 +583,19 @@ function ExercisePickerFilters({
 
   return (
     <div className="border-b p-2">
+      {/* Muscle "focus" presets (#299) — one tap selects a group's muscles
+          (e.g. Push → chest + shoulders + triceps), driving the same
+          `filters.muscles` set as the individual chips below. */}
+      <ChipRow
+        testId="exercise-picker-chip-group-focus"
+        label={t("filterFocus")}
+      >
+        <MusclePresetChips
+          value={[...filters.muscles]}
+          onChange={setMuscleSelection}
+        />
+      </ChipRow>
+
       {/* Muscles (multi-select) */}
       <ChipRow
         testId="exercise-picker-chip-group-muscles"

--- a/backoffice/src/components/gc-fitness/favorite-star-button.tsx
+++ b/backoffice/src/components/gc-fitness/favorite-star-button.tsx
@@ -1,0 +1,67 @@
+"use client";
+
+// favorite-star-button.tsx
+//
+// The star toggle shown next to every favoritable row (#297): exercises,
+// workout templates, habit templates — in lists AND searches. Self-contained:
+// it reads/writes the shared `useFavorites()` cache, so dropping one into a
+// table cell or a card needs no prop-drilling of favorite state. Many instances
+// mounting at once is fine — React Query dedupes the single favorites query.
+//
+// Click is isolated (preventDefault + stopPropagation) so starring a row inside
+// a clickable table row / card doesn't also trigger the row's navigation.
+
+import { Star } from "lucide-react";
+import { useTranslations } from "next-intl";
+
+import { cn } from "@/lib/utils";
+import { useFavorites } from "@/lib/gc-fitness/use-favorites";
+import type { FavoriteKind } from "@/lib/gc-fitness/favorites";
+
+export interface FavoriteStarButtonProps {
+  kind: FavoriteKind;
+  id: string;
+  /** Star size in px (default 16). */
+  size?: number;
+  className?: string;
+}
+
+export function FavoriteStarButton({
+  kind,
+  id,
+  size = 16,
+  className,
+}: FavoriteStarButtonProps) {
+  const t = useTranslations("favorites");
+  const { isFavorite, toggle } = useFavorites();
+  const active = isFavorite(kind, id);
+
+  return (
+    <button
+      type="button"
+      aria-pressed={active}
+      aria-label={active ? t("remove") : t("add")}
+      title={active ? t("remove") : t("add")}
+      onClick={(event) => {
+        // Don't let the click bubble to a clickable row / card.
+        event.preventDefault();
+        event.stopPropagation();
+        toggle(kind, id);
+      }}
+      className={cn(
+        "inline-flex shrink-0 items-center justify-center rounded-md p-1 transition-colors hover:bg-muted",
+        className,
+      )}
+    >
+      <Star
+        style={{ width: size, height: size }}
+        className={cn(
+          active
+            ? "fill-amber-400 text-amber-400"
+            : "text-muted-foreground/60 hover:text-muted-foreground",
+        )}
+        aria-hidden="true"
+      />
+    </button>
+  );
+}

--- a/backoffice/src/components/gc-fitness/generator/workout-generator-wizard.tsx
+++ b/backoffice/src/components/gc-fitness/generator/workout-generator-wizard.tsx
@@ -29,6 +29,7 @@ import { cn } from "@/lib/utils";
 
 import { EQUIPMENT, MUSCLE_GROUPS } from "@/lib/gc-fitness/exercise-vocabulary";
 import { useExercisesQuery } from "@/lib/gc-fitness/exercises-listener";
+import { useFavorites } from "@/lib/gc-fitness/use-favorites";
 import { STANDARD_LIBRARY_TAG } from "@/lib/gc-fitness/exercise-visibility";
 import { createWorkoutTemplate } from "@/lib/gc-fitness/workout-template-actions";
 import type { WorkoutTemplateInput } from "@/lib/gc-fitness/workout-template-schema";
@@ -67,6 +68,13 @@ export function WorkoutGeneratorWizard({ clients, trainerTimezone }: Props) {
   const s = useGeneratorStrings();
   const localized = useLocalized();
   const { data: library, isLoading } = useExercisesQuery();
+  // #297 — the engine prefers the coach's favorited exercises within each
+  // muscle bucket.
+  const { favorites } = useFavorites();
+  const favoriteExerciseIds = useMemo(
+    () => favorites.exerciseIds,
+    [favorites],
+  );
 
   // Generator pool = the NEW curated standard library only.
   const pool: GeneratorExercise[] = useMemo(
@@ -202,6 +210,7 @@ export function WorkoutGeneratorWizard({ clients, trainerTimezone }: Props) {
       workoutType,
       seed: nextSeed,
       focusLabel,
+      favoriteExerciseIds,
     };
   }
 

--- a/backoffice/src/components/gc-fitness/muscle-preset-chips.tsx
+++ b/backoffice/src/components/gc-fitness/muscle-preset-chips.tsx
@@ -1,0 +1,71 @@
+"use client";
+
+// muscle-preset-chips.tsx
+//
+// One-tap muscle "focus" presets for filter surfaces (#299). The flat list of 17
+// muscle groups is confusing, so we let a trainer tap Push / Pull / Legs / Arms /
+// etc. and have it expand to that group's muscles. Reuses the SAME
+// `MUSCLE_PRESETS` source the workout generator's Step 2 uses — no new vocab — so
+// the grouping stays consistent everywhere.
+//
+// Stateless: it operates on the caller's `muscleGroups` selection. A preset chip
+// reads as ACTIVE when ALL its muscles are currently selected; tapping it toggles
+// the union in/out. The caller still renders the individual-muscle multi-select
+// underneath (two-tier UX, mirroring the generator), so hand-picking single
+// muscles keeps working.
+
+import { useLocale } from "next-intl";
+import { Check } from "lucide-react";
+
+import { cn } from "@/lib/utils";
+import { MUSCLE_PRESETS } from "@/lib/gc-fitness/workout-generator/muscle-presets";
+
+export interface MusclePresetChipsProps {
+  /** Currently-selected muscle groups (the same array the muscle filter drives). */
+  value: readonly string[];
+  /** Receives the next selection after a preset is toggled. */
+  onChange: (next: string[]) => void;
+  className?: string;
+}
+
+export function MusclePresetChips({
+  value,
+  onChange,
+  className,
+}: MusclePresetChipsProps) {
+  const locale = useLocale();
+  const selected = new Set(value);
+
+  function togglePreset(muscles: string[], full: boolean) {
+    const next = new Set(selected);
+    if (full) muscles.forEach((m) => next.delete(m));
+    else muscles.forEach((m) => next.add(m));
+    onChange(Array.from(next));
+  }
+
+  return (
+    <div className={cn("flex flex-wrap gap-2", className)}>
+      {MUSCLE_PRESETS.map((preset) => {
+        const full = preset.muscles.every((m) => selected.has(m));
+        const label = locale === "es" ? preset.label.es : preset.label.en;
+        return (
+          <button
+            key={preset.id}
+            type="button"
+            aria-pressed={full}
+            onClick={() => togglePreset(preset.muscles, full)}
+            className={cn(
+              "inline-flex items-center gap-1 rounded-full border px-3 py-1.5 text-xs font-medium transition-colors",
+              full
+                ? "border-primary bg-primary text-primary-foreground"
+                : "border-border bg-background text-foreground hover:border-foreground/30",
+            )}
+          >
+            {full ? <Check className="h-3 w-3" aria-hidden="true" /> : null}
+            {label}
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/backoffice/src/lib/gc-fitness/__tests__/exercise-picker-popover.test.tsx
+++ b/backoffice/src/lib/gc-fitness/__tests__/exercise-picker-popover.test.tsx
@@ -31,6 +31,23 @@ jest.mock("@/lib/gc-fitness/exercises-listener", () => ({
   EXERCISES_QUERY_KEY: ["gc-fitness", "exercises"],
 }));
 
+// #297 — the picker now reads favorites (star + favorites-first sort). Stub the
+// hook so these render tests don't pull the favorites Server Action (→
+// firebase-admin) into the bundle, and don't need a QueryClientProvider.
+jest.mock("@/lib/gc-fitness/use-favorites", () => ({
+  useFavorites: () => ({
+    favorites: {
+      exerciseIds: [],
+      workoutTemplateIds: [],
+      habitTemplateIds: [],
+    },
+    isLoading: false,
+    isFavorite: () => false,
+    toggle: jest.fn(),
+    isToggling: false,
+  }),
+}));
+
 // 260529 — the picker now calls useQueryClient(); stub it so these render
 // tests don't need a real QueryClientProvider.
 jest.mock("@tanstack/react-query", () => ({

--- a/backoffice/src/lib/gc-fitness/__tests__/favorites.test.ts
+++ b/backoffice/src/lib/gc-fitness/__tests__/favorites.test.ts
@@ -1,0 +1,111 @@
+import {
+  EMPTY_FAVORITES,
+  favoriteIdSet,
+  favoritesFieldForKind,
+  filterFavoritesOnly,
+  isFavorite,
+  normalizeFavorites,
+  sortFavoritesFirst,
+  type CoachFavorites,
+} from "../favorites";
+
+const FAVS: CoachFavorites = {
+  exerciseIds: ["ex-2", "ex-5"],
+  workoutTemplateIds: ["wkt-1"],
+  habitTemplateIds: [],
+};
+
+interface Row {
+  id: string;
+}
+const rows = (...ids: string[]): Row[] => ids.map((id) => ({ id }));
+const getId = (r: Row) => r.id;
+
+describe("favoritesFieldForKind", () => {
+  it("maps each kind to its array field", () => {
+    expect(favoritesFieldForKind("exercise")).toBe("exerciseIds");
+    expect(favoritesFieldForKind("workoutTemplate")).toBe("workoutTemplateIds");
+    expect(favoritesFieldForKind("habitTemplate")).toBe("habitTemplateIds");
+  });
+});
+
+describe("normalizeFavorites", () => {
+  it("defaults missing/invalid arrays to empty and drops non-strings", () => {
+    expect(normalizeFavorites(null)).toEqual(EMPTY_FAVORITES);
+    expect(
+      normalizeFavorites({
+        exerciseIds: ["a", 3, null, "b"],
+        workoutTemplateIds: "nope",
+      }),
+    ).toEqual({
+      exerciseIds: ["a", "b"],
+      workoutTemplateIds: [],
+      habitTemplateIds: [],
+    });
+  });
+});
+
+describe("favoriteIdSet / isFavorite", () => {
+  it("returns membership for the right kind", () => {
+    const set = favoriteIdSet(FAVS, "exercise");
+    expect(set.has("ex-2")).toBe(true);
+    expect(set.has("ex-1")).toBe(false);
+    expect(isFavorite(FAVS, "exercise", "ex-5")).toBe(true);
+    expect(isFavorite(FAVS, "workoutTemplate", "wkt-1")).toBe(true);
+    expect(isFavorite(FAVS, "habitTemplate", "anything")).toBe(false);
+  });
+});
+
+describe("sortFavoritesFirst", () => {
+  const favIds = new Set(["ex-5", "ex-2"]);
+
+  it("moves favorites ahead, preserving original order within each group (stable)", () => {
+    const input = rows("ex-1", "ex-2", "ex-3", "ex-5", "ex-4");
+    expect(sortFavoritesFirst(input, getId, favIds).map(getId)).toEqual([
+      // favorites keep input order (ex-2 before ex-5), not favIds order
+      "ex-2",
+      "ex-5",
+      // rest keep input order
+      "ex-1",
+      "ex-3",
+      "ex-4",
+    ]);
+  });
+
+  it("returns a new array and leaves the input untouched", () => {
+    const input = rows("ex-1", "ex-2");
+    const out = sortFavoritesFirst(input, getId, favIds);
+    expect(out).not.toBe(input);
+    expect(input.map(getId)).toEqual(["ex-1", "ex-2"]);
+  });
+
+  it("is a no-op ordering when nothing is favorited", () => {
+    const input = rows("a", "b", "c");
+    expect(sortFavoritesFirst(input, getId, new Set()).map(getId)).toEqual([
+      "a",
+      "b",
+      "c",
+    ]);
+  });
+});
+
+describe("filterFavoritesOnly", () => {
+  const favIds = new Set(["ex-2", "ex-5"]);
+  const input = rows("ex-1", "ex-2", "ex-3", "ex-5");
+
+  it("returns all rows when disabled", () => {
+    expect(filterFavoritesOnly(input, getId, favIds, false).map(getId)).toEqual([
+      "ex-1",
+      "ex-2",
+      "ex-3",
+      "ex-5",
+    ]);
+  });
+
+  it("keeps only favorites when enabled", () => {
+    expect(filterFavoritesOnly(input, getId, favIds, true).map(getId)).toEqual([
+      "ex-2",
+      "ex-5",
+    ]);
+  });
+});

--- a/backoffice/src/lib/gc-fitness/collections.ts
+++ b/backoffice/src/lib/gc-fitness/collections.ts
@@ -98,6 +98,18 @@ export const FirestoreCollections = {
   habitTemplateHidden: "habit_template_hidden",
 
   /**
+   * Per-trainer favorites (#297). Doc id = trainer uid; shape
+   * `{ exerciseIds: string[], workoutTemplateIds: string[],
+   * habitTemplateIds: string[], updatedAt }`. A coach stars exercises, workout
+   * templates, and habit templates so they sort first / can be filtered to in
+   * every authoring list & search, and so the workout generator prefers them.
+   * One read fetches all of a coach's favorites. Owner-scoped rule: only the
+   * trainer whose uid is the doc id can read/write it (mirrors
+   * `habitTemplateHidden`).
+   */
+  coachFavorites: "coach_favorites",
+
+  /**
    * Coach-authored short/medium/long-term goals visible to clients.
    */
   clientGoals: "client_goals",

--- a/backoffice/src/lib/gc-fitness/favorites-actions.ts
+++ b/backoffice/src/lib/gc-fitness/favorites-actions.ts
@@ -1,0 +1,80 @@
+"use server";
+
+// favorites-actions.ts
+//
+// Server Actions for coach favorites (#297). A coach stars exercises, workout
+// templates, and habit templates; the starred ids live in ONE per-trainer doc
+// `coach_favorites/{trainerUid}` with three arrays. This mirrors the
+// `habit_template_hidden` per-trainer pattern (`habit-actions.ts`):
+//   - `trainerUid` ALWAYS comes from `getCurrentTrainer().uid` (never trusted
+//     from input) — a coach can only read/write their OWN favorites.
+//   - writes use `arrayUnion`/`arrayRemove` + `set(..., {merge:true})` so two
+//     concurrent toggles on different kinds don't clobber each other and the
+//     same star twice is idempotent.
+//   - one `get` fetches all of a coach's favorites for the lists/generator.
+
+import { FieldValue } from "firebase-admin/firestore";
+
+import { gcFitnessFirestore } from "@/lib/firebase/gc-fitness-admin";
+
+import { getCurrentTrainer } from "./auth-helpers";
+import { FirestoreCollections } from "./collections";
+import {
+  EMPTY_FAVORITES,
+  favoritesFieldForKind,
+  normalizeFavorites,
+  type CoachFavorites,
+  type FavoriteKind,
+} from "./favorites";
+
+const FAVORITES_COLLECTION = FirestoreCollections.coachFavorites;
+
+/**
+ * Returns the calling trainer's favorites (empty arrays if they have none yet).
+ * One read on `coach_favorites/{uid}`.
+ */
+export async function listFavorites(): Promise<CoachFavorites> {
+  const trainer = await getCurrentTrainer();
+  const snap = await gcFitnessFirestore()
+    .collection(FAVORITES_COLLECTION)
+    .doc(trainer.uid)
+    .get();
+  if (!snap.exists) return { ...EMPTY_FAVORITES };
+  return normalizeFavorites(snap.data());
+}
+
+/**
+ * Stars (`next: true`) or un-stars (`next: false`) one entity for the calling
+ * trainer. Idempotent — re-starring an already-favorited id is a harmless
+ * arrayUnion no-op. Writes ONLY the affected array (merge), so a star on an
+ * exercise never touches the trainer's workout/habit favorites.
+ *
+ * Returns the up-to-date favorites so the client can reconcile its cache.
+ */
+export async function toggleFavorite(
+  kind: FavoriteKind,
+  id: string,
+  next: boolean,
+): Promise<CoachFavorites> {
+  const trainer = await getCurrentTrainer();
+  if (typeof id !== "string" || id.trim().length === 0) {
+    throw new Error("BadRequest: id is required.");
+  }
+
+  const field = favoritesFieldForKind(kind);
+  const db = gcFitnessFirestore();
+  const ref = db.collection(FAVORITES_COLLECTION).doc(trainer.uid);
+
+  await ref.set(
+    {
+      [field]: next
+        ? FieldValue.arrayUnion(id)
+        : FieldValue.arrayRemove(id),
+      updatedAt: FieldValue.serverTimestamp(),
+    },
+    { merge: true },
+  );
+
+  const snap = await ref.get();
+  return snap.exists ? normalizeFavorites(snap.data()) : { ...EMPTY_FAVORITES };
+}

--- a/backoffice/src/lib/gc-fitness/favorites.ts
+++ b/backoffice/src/lib/gc-fitness/favorites.ts
@@ -1,0 +1,103 @@
+// favorites.ts
+//
+// PURE helpers + shared types for coach favorites (#297). No Firebase, no React
+// — so the sort/filter behavior is unit-testable in isolation and reusable
+// across every list/search surface (exercises, workout templates, habit
+// templates) AND the workout generator.
+//
+// A coach's favorites live in one doc `coach_favorites/{trainerUid}` with three
+// id arrays. The server action layer (`favorites-actions.ts`) reads/writes that
+// doc; the UI consumes it through the `useFavorites()` hook; these helpers do
+// the ordering/filtering the lists need.
+
+/** The three entity kinds a coach can favorite. */
+export type FavoriteKind = "exercise" | "workoutTemplate" | "habitTemplate";
+
+/** Wire shape of `coach_favorites/{trainerUid}` (sans `updatedAt`). */
+export interface CoachFavorites {
+  exerciseIds: string[];
+  workoutTemplateIds: string[];
+  habitTemplateIds: string[];
+}
+
+export const EMPTY_FAVORITES: CoachFavorites = {
+  exerciseIds: [],
+  workoutTemplateIds: [],
+  habitTemplateIds: [],
+};
+
+/** The array field on `CoachFavorites` that backs a given kind. */
+export function favoritesFieldForKind(
+  kind: FavoriteKind,
+): keyof CoachFavorites {
+  switch (kind) {
+    case "exercise":
+      return "exerciseIds";
+    case "workoutTemplate":
+      return "workoutTemplateIds";
+    case "habitTemplate":
+      return "habitTemplateIds";
+  }
+}
+
+/** Normalize a possibly-partial/untrusted favorites payload into the full shape. */
+export function normalizeFavorites(
+  raw: Partial<Record<keyof CoachFavorites, unknown>> | null | undefined,
+): CoachFavorites {
+  const pick = (v: unknown): string[] =>
+    Array.isArray(v) ? v.filter((x): x is string => typeof x === "string") : [];
+  return {
+    exerciseIds: pick(raw?.exerciseIds),
+    workoutTemplateIds: pick(raw?.workoutTemplateIds),
+    habitTemplateIds: pick(raw?.habitTemplateIds),
+  };
+}
+
+/** The favorited id set for a given kind — O(1) membership tests for the UI. */
+export function favoriteIdSet(
+  favorites: CoachFavorites,
+  kind: FavoriteKind,
+): Set<string> {
+  return new Set(favorites[favoritesFieldForKind(kind)]);
+}
+
+export function isFavorite(
+  favorites: CoachFavorites,
+  kind: FavoriteKind,
+  id: string,
+): boolean {
+  return favorites[favoritesFieldForKind(kind)].includes(id);
+}
+
+/**
+ * STABLE "favorites first" ordering: favorited rows keep their original relative
+ * order and move ahead of the rest (which also keep their original order).
+ * Implemented by partition + concat so it's stable regardless of engine sort.
+ */
+export function sortFavoritesFirst<T>(
+  rows: readonly T[],
+  getId: (row: T) => string,
+  favIds: ReadonlySet<string>,
+): T[] {
+  const favs: T[] = [];
+  const rest: T[] = [];
+  for (const row of rows) {
+    if (favIds.has(getId(row))) favs.push(row);
+    else rest.push(row);
+  }
+  return [...favs, ...rest];
+}
+
+/**
+ * When `enabled`, keep only favorited rows; otherwise return the input
+ * unchanged. Order is preserved (callers typically sort-first beforehand).
+ */
+export function filterFavoritesOnly<T>(
+  rows: readonly T[],
+  getId: (row: T) => string,
+  favIds: ReadonlySet<string>,
+  enabled: boolean,
+): T[] {
+  if (!enabled) return [...rows];
+  return rows.filter((row) => favIds.has(getId(row)));
+}

--- a/backoffice/src/lib/gc-fitness/use-favorites.ts
+++ b/backoffice/src/lib/gc-fitness/use-favorites.ts
@@ -1,0 +1,118 @@
+// use-favorites.ts
+//
+// React-Query bridge for coach favorites (#297). Wraps the `listFavorites` /
+// `toggleFavorite` Server Actions (`favorites-actions.ts`) and exposes a small
+// surface every list/search uses:
+//   - `favorites` (the three id arrays, empty until loaded)
+//   - `isFavorite(kind, id)` for the star fill state
+//   - `toggle(kind, id)` mutation with OPTIMISTIC update + rollback, so the star
+//     flips instantly and the row re-sorts without waiting on the round-trip.
+//
+// One cache slot (`["gc-fitness", "favorites"]`) is shared across surfaces, so a
+// star toggled on the exercises page is already reflected when the picker opens.
+
+"use client";
+
+import { useCallback } from "react";
+import {
+  useMutation,
+  useQuery,
+  useQueryClient,
+} from "@tanstack/react-query";
+
+import { listFavorites, toggleFavorite } from "./favorites-actions";
+import {
+  EMPTY_FAVORITES,
+  favoritesFieldForKind,
+  isFavorite as isFavoriteIn,
+  type CoachFavorites,
+  type FavoriteKind,
+} from "./favorites";
+
+export const FAVORITES_QUERY_KEY = ["gc-fitness", "favorites"] as const;
+
+/** Apply a toggle to a favorites object immutably (for optimistic cache writes). */
+function applyToggle(
+  current: CoachFavorites,
+  kind: FavoriteKind,
+  id: string,
+  next: boolean,
+): CoachFavorites {
+  const field = favoritesFieldForKind(kind);
+  const set = new Set(current[field]);
+  if (next) set.add(id);
+  else set.delete(id);
+  return { ...current, [field]: Array.from(set) };
+}
+
+export interface UseFavoritesResult {
+  favorites: CoachFavorites;
+  isLoading: boolean;
+  isFavorite: (kind: FavoriteKind, id: string) => boolean;
+  /** Flip the favorite state for an entity (optimistic). */
+  toggle: (kind: FavoriteKind, id: string) => void;
+  isToggling: boolean;
+}
+
+export function useFavorites(): UseFavoritesResult {
+  const queryClient = useQueryClient();
+
+  const query = useQuery<CoachFavorites>({
+    queryKey: FAVORITES_QUERY_KEY,
+    queryFn: () => listFavorites(),
+    staleTime: 60_000,
+    refetchOnWindowFocus: false,
+  });
+
+  const favorites = query.data ?? EMPTY_FAVORITES;
+
+  const mutation = useMutation<
+    CoachFavorites,
+    Error,
+    { kind: FavoriteKind; id: string; next: boolean },
+    { previous: CoachFavorites | undefined }
+  >({
+    mutationFn: ({ kind, id, next }) => toggleFavorite(kind, id, next),
+    onMutate: async ({ kind, id, next }) => {
+      await queryClient.cancelQueries({ queryKey: FAVORITES_QUERY_KEY });
+      const previous =
+        queryClient.getQueryData<CoachFavorites>(FAVORITES_QUERY_KEY);
+      queryClient.setQueryData<CoachFavorites>(
+        FAVORITES_QUERY_KEY,
+        applyToggle(previous ?? EMPTY_FAVORITES, kind, id, next),
+      );
+      return { previous };
+    },
+    onError: (_err, _vars, context) => {
+      if (context?.previous !== undefined) {
+        queryClient.setQueryData(FAVORITES_QUERY_KEY, context.previous);
+      }
+    },
+    onSuccess: (server) => {
+      // Reconcile with the authoritative server state (covers concurrent
+      // toggles from another tab/device).
+      queryClient.setQueryData(FAVORITES_QUERY_KEY, server);
+    },
+  });
+
+  const isFavorite = useCallback(
+    (kind: FavoriteKind, id: string) => isFavoriteIn(favorites, kind, id),
+    [favorites],
+  );
+
+  const toggle = useCallback(
+    (kind: FavoriteKind, id: string) => {
+      const next = !isFavoriteIn(favorites, kind, id);
+      mutation.mutate({ kind, id, next });
+    },
+    [favorites, mutation],
+  );
+
+  return {
+    favorites,
+    isLoading: query.isLoading,
+    isFavorite,
+    toggle,
+    isToggling: mutation.isPending,
+  };
+}

--- a/backoffice/src/lib/gc-fitness/workout-generator/__tests__/engine.test.ts
+++ b/backoffice/src/lib/gc-fitness/workout-generator/__tests__/engine.test.ts
@@ -541,3 +541,57 @@ describe("computeReplacements", () => {
     expect(computeReplacements(eligible, "chest", new Set(), 1, 2)).toHaveLength(2);
   });
 });
+
+// ---------------------------------------------------------------------------
+// generateWorkout — favorites preference (#297)
+// ---------------------------------------------------------------------------
+
+describe("generateWorkout — favorites preference (#297)", () => {
+  // core has TWO equally-eligible bodyweight candidates (plank, hollow-hold),
+  // so the single picked exercise is decided by the seeded shuffle — unless a
+  // favorite tips it. Asserting BOTH directions proves the favorite wins
+  // regardless of which one the shuffle would have chosen.
+  const coreInput = (favoriteExerciseIds?: string[]): GeneratorInput =>
+    input({
+      equipment: ["bodyweight"],
+      muscleGroups: ["core"],
+      exerciseCount: 1,
+      favoriteExerciseIds,
+    });
+
+  it("picks the favorited exercise over an equally-eligible non-favorite", () => {
+    const withPlank = generateWorkout(coreInput(["plank"]), POOL);
+    expect(withPlank.exercises.map((e) => e.exerciseId)).toEqual(["plank"]);
+
+    const withHollow = generateWorkout(coreInput(["hollow-hold"]), POOL);
+    expect(withHollow.exercises.map((e) => e.exerciseId)).toEqual([
+      "hollow-hold",
+    ]);
+  });
+
+  it("never overrides the hard equipment rule — a favorite needing absent equipment stays excluded", () => {
+    // Favorite a barbell+bench chest press while only bodyweight is selected.
+    // The only eligible bodyweight chest exercise is pushup; the favorite must
+    // NOT appear.
+    const workout = generateWorkout(
+      input({
+        equipment: ["bodyweight"],
+        muscleGroups: ["chest"],
+        exerciseCount: 1,
+        favoriteExerciseIds: ["bench-press-bb"],
+      }),
+      POOL,
+    );
+    const ids = workout.exercises.map((e) => e.exerciseId);
+    expect(ids).not.toContain("bench-press-bb");
+    expect(ids).toEqual(["pushup"]);
+  });
+
+  it("is a no-op when no favorites are supplied (back-compat)", () => {
+    const a = generateWorkout(coreInput(), POOL);
+    const b = generateWorkout(coreInput([]), POOL);
+    expect(a.exercises.map((e) => e.exerciseId)).toEqual(
+      b.exercises.map((e) => e.exerciseId),
+    );
+  });
+});

--- a/backoffice/src/lib/gc-fitness/workout-generator/engine.ts
+++ b/backoffice/src/lib/gc-fitness/workout-generator/engine.ts
@@ -241,13 +241,25 @@ function selectExercises(
   selectedMuscleOrder: readonly string[],
   targetCount: number,
   seed: number,
+  favoriteIds: ReadonlySet<string>,
 ): EligibleEntry[] {
   const rand = mulberry32(seed >>> 0);
-  // Bucket candidates by primary muscle, shuffled deterministically.
+  // Bucket candidates by primary muscle, shuffled deterministically. Within a
+  // bucket, favorited exercises (#297) are floated ahead of the rest while
+  // KEEPING the deterministic shuffled order inside each group — so the coach's
+  // starred exercises are picked first, ties broken by the same seeded shuffle.
   const buckets = new Map<string, EligibleEntry[]>();
   for (const muscle of selectedMuscleOrder) {
     const inMuscle = eligible.filter((e) => e.primaryMuscle === muscle);
-    if (inMuscle.length > 0) buckets.set(muscle, seededShuffle(inMuscle, rand));
+    if (inMuscle.length === 0) continue;
+    const shuffled = seededShuffle(inMuscle, rand);
+    if (favoriteIds.size > 0) {
+      const favs = shuffled.filter((e) => favoriteIds.has(e.exercise.id));
+      const rest = shuffled.filter((e) => !favoriteIds.has(e.exercise.id));
+      buckets.set(muscle, [...favs, ...rest]);
+    } else {
+      buckets.set(muscle, shuffled);
+    }
   }
   const musclesWithCandidates = selectedMuscleOrder.filter((m) =>
     buckets.has(m),
@@ -298,6 +310,7 @@ export function generateWorkout(
     input.muscleGroups,
     targetCount,
     seed,
+    new Set(input.favoriteExerciseIds ?? []),
   );
 
   const usedIds = new Set(chosen.map((c) => c.exercise.id));

--- a/backoffice/src/lib/gc-fitness/workout-generator/types.ts
+++ b/backoffice/src/lib/gc-fitness/workout-generator/types.ts
@@ -54,6 +54,11 @@ export interface GeneratorInput {
   /** Optional human label used to build the default workout name (e.g. the
    *  muscle-preset label the trainer picked, "Push"). */
   focusLabel?: { en: string; es: string };
+  /** Exercise ids the coach has favorited (#297). When provided, the engine
+   *  PREFERS these within each muscle bucket (favorites are picked before
+   *  non-favorites) without changing equipment/muscle eligibility — a favorite
+   *  that fails the hard equipment rule is still excluded. */
+  favoriteExerciseIds?: string[];
 }
 
 /** A candidate swap for a generated slot. Always equipment-eligible. */


### PR DESCRIPTION
Backoffice side of two GC Fitness feature requests (issues live in `mdb1/gc-fitness`). One branch.

## #299 — muscle-group focus presets in filters
Closes mdb1/gc-fitness#299

The flat list of 17 muscle groups is confusing. This adds one-tap **focus presets** (Push / Pull / Legs / Arms / Upper / Lower / Core / Full body) that expand to their muscle subset.

- Reuses the **existing** `MUSCLE_PRESETS` + `expandMusclePresets()` the workout generator's Step 2 already uses — no new vocabulary, consistent grouping everywhere.
- New shared `MusclePresetChips` component wired into the **exercise library filter** and the **exercise picker** (the generator already had presets). The individual-muscle multi-select stays underneath (two-tier UX, same as the generator).
- EN/ES labels come from `MUSCLE_PRESETS`; section labels added to `messages/{en,es}.json`.

## #297 — coach favorites
Closes mdb1/gc-fitness#297

Coaches can **star** exercises, workout templates, and habit templates. Favorites **sort first** in every list & search, a **"Favorites"** toggle filters to only-favorites, and the **workout generator prefers** favorited exercises.

- **Storage:** one doc per trainer `coach_favorites/{uid}` with three id arrays, mirroring `habit_template_hidden` (one read fetches all favorites — cost-efficient). The Firestore **rule + rules tests** ship in the gc-fitness repo: **mdb1/gc-fitness#302** (must be deployed for writes to succeed in prod).
- `favorites.ts` pure helpers (`sortFavoritesFirst` / `filterFavoritesOnly` / `normalizeFavorites`) + jest; `favorites-actions.ts` Server Actions (`listFavorites` / `toggleFavorite` via arrayUnion/arrayRemove merge); `useFavorites()` React-Query hook with optimistic toggle; shared `FavoriteStarButton`.
- Surfaces: exercises list + picker, workout-templates list, habit-template library, and the generator engine (`favoriteExerciseIds` threaded through `GeneratorInput`; favorites float to the front of each muscle bucket **without** overriding the hard equipment rule).

## Tests
- Backoffice `jest` green — favorites helpers, engine favorites cases, picker smoke tests updated to stub `useFavorites`. (Pre-existing reds unchanged: `client-activity-time` locale flake, `workout-assignment-actions` — both fail on clean `main` too.)
- `tsc --noEmit` clean.
- Firestore rules gate green in gc-fitness repo (coach-favorites suite + full firestore/storage suites).

## ⚠️ Deploy ordering
`coach_favorites` writes are denied until the rule (mdb1/gc-fitness#302) is deployed (`firebase deploy --only firestore:rules`). Merge/deploy the rule **before or with** this backoffice deploy, since `main` here auto-deploys to production.

iOS / Android / watch untouched (backoffice-only authoring UI).