### PR TITLE
feat(gc-fitness-chat): show 'Visto'/'Seen' under the trainer's latest read message

### DIFF
--- a/backoffice/messages/en.json
+++ b/backoffice/messages/en.json
@@ -1251,6 +1251,7 @@
       "deleteMessageDeleting": "Deleting…",
       "messageDeleted": "Message deleted.",
       "messageDeleteFailed": "Couldn't delete the message.",
+      "seen": "Seen",
       "reactionAdd": "Add a reaction",
       "reactionFailed": "Couldn't save the reaction."
     },

--- a/backoffice/messages/es.json
+++ b/backoffice/messages/es.json
@@ -1251,6 +1251,7 @@
       "deleteMessageDeleting": "Eliminando…",
       "messageDeleted": "Mensaje eliminado.",
       "messageDeleteFailed": "No se pudo eliminar el mensaje.",
+      "seen": "Visto",
       "reactionAdd": "Agregar una reacción",
       "reactionFailed": "No se pudo guardar la reacción."
     },

--- a/backoffice/src/app/gc-fitness/chat/_components/ChatConversation.tsx
+++ b/backoffice/src/app/gc-fitness/chat/_components/ChatConversation.tsx
@@ -112,6 +112,18 @@ export function ChatConversation({
     });
   }, [data]);
   const newestMessageId = messages.length ? messages[messages.length - 1].id : null;
+  // "Visto" goes under the trainer's MOST RECENT own message, and only when the
+  // client (chatId == client uid) has read it. Mirrors iMessage / the mobile
+  // apps: the receipt never hops to an older message while newer ones are still
+  // unread, so it doesn't float orphaned high up the thread.
+  const seenReceiptId = useMemo(() => {
+    for (let i = messages.length - 1; i >= 0; i--) {
+      if (messages[i].senderId === trainerUid) {
+        return messages[i].readBy?.[chatId] ? messages[i].id : null;
+      }
+    }
+    return null;
+  }, [messages, trainerUid, chatId]);
   const queryClient = useQueryClient();
 
   const partnerEntry = useMemo(
@@ -346,6 +358,7 @@ export function ChatConversation({
                   chatId={chatId}
                   message={row.message}
                   isOwn={row.message.senderId === trainerUid}
+                  showSeen={row.message.id === seenReceiptId}
                   timezone={timezone}
                   trainerUid={trainerUid}
                   partnerName={partnerName}
@@ -405,6 +418,9 @@ interface MessageBubbleProps {
   chatId: string;
   message: MessageRow;
   isOwn: boolean;
+  /** True only for the trainer's most recent own message once the client has
+   * read it — renders the "Seen"/"Visto" receipt (iMessage behavior). */
+  showSeen: boolean;
   timezone: string;
   /** quick-260603-p1p — signed-in trainer uid (resolves "You" in quotes). */
   trainerUid: string;
@@ -422,6 +438,7 @@ function MessageBubble({
   chatId,
   message,
   isOwn,
+  showSeen,
   timezone,
   trainerUid,
   partnerName,
@@ -613,6 +630,11 @@ function MessageBubble({
           />
         ) : null}
         <TimeStamp iso={message.createdAt} isOwn={isOwn} timezone={timezone} />
+        {isOwn && showSeen ? (
+          <p className="mt-0.5 text-right text-[11px] text-primary-foreground/70">
+            {t("seen")}
+          </p>
+        ) : null}
       </div>
       {!isOwn ? (
         <>


### PR DESCRIPTION
Ports the mobile chat read-receipt to the backoffice chat (parity with iOS + Android).

## What
The `readBy` map was already written by the chat but **never rendered**. Now a **'Visto'/'Seen'** label appears **only under the trainer's most recent own message**, and only when the client has read it (`readBy[chatId]`). iMessage behavior — never on an older message while newer ones are unread.

- `ChatConversation` computes `seenReceiptId` (last own message gated on the client's `readBy` slot) and passes `showSeen` to each `MessageBubble`.
- `MessageBubble` renders the receipt under the timestamp.
- New `chat.conversation.seen` string (en: Seen / es: Visto).

The backoffice chat already opened at the bottom, scrolled on new messages, and re-snapped on image load — so the read receipt was the missing piece.

## Tests
- `npx jest chat` → 7/7 green.
- `tsc --noEmit` → no new errors.

## To verify
Open a client chat, send a message, have the client read it on the app → 'Visto' appears under that (latest) message. Send another → receipt only reappears once the client reads the new one.