### PR TITLE
feat(schedule): edit recurring workout cadence from this occurrence forward

### DIFF
--- a/backoffice/src/components/gc-fitness/schedule/workout-detail-dialog.tsx
+++ b/backoffice/src/components/gc-fitness/schedule/workout-detail-dialog.tsx
@@ -20,6 +20,7 @@ import {
   MessageCircle,
   Pencil,
   Play,
+  Repeat,
   Trash2,
   User,
 } from "lucide-react";
@@ -53,6 +54,7 @@ import {
 import { WorkoutLogDetailView } from "@/components/gc-fitness/workout-log-detail-view";
 import { WorkoutAssignmentDeleteDialog } from "@/components/gc-fitness/workout-assignment-delete-dialog";
 import { WorkoutAssignmentEditDialog } from "./workout-assignment-edit-dialog";
+import { WorkoutRecurrenceEditDialog } from "./workout-recurrence-edit-dialog";
 
 interface WorkoutDetailDialogProps {
   open: boolean;
@@ -105,6 +107,7 @@ export function WorkoutDetailDialog({
 }: WorkoutDetailDialogProps) {
   const [deleteOpen, setDeleteOpen] = useState(false);
   const [editOpen, setEditOpen] = useState(false);
+  const [recurrenceOpen, setRecurrenceOpen] = useState(false);
 
   const { data, isLoading, error } = useQuery({
     queryKey: ["assignment-detail", assignmentId],
@@ -132,8 +135,17 @@ export function WorkoutDetailDialog({
     if (!open) {
       setDeleteOpen(false);
       setEditOpen(false);
+      setRecurrenceOpen(false);
     }
   }, [open]);
+
+  // "Editar recurrencia" only applies to a recurring series (seriesId set) that
+  // still has upcoming occurrences — i.e. scheduled or started, not a finished
+  // (completed/missed) one. Single assignments have no recurrence to change.
+  const canEditRecurrence =
+    Boolean(data?.seriesId) &&
+    data?.status !== "completed" &&
+    data?.status !== "missed";
 
   return (
     <>
@@ -226,6 +238,17 @@ export function WorkoutDetailDialog({
                 </Link>
               </Button>
             ) : null}
+            {canEditRecurrence ? (
+              <Button
+                variant="outline"
+                disabled={!data || isLoading}
+                onClick={() => setRecurrenceOpen(true)}
+                className="gap-1"
+              >
+                <Repeat className="size-4" />
+                Editar recurrencia
+              </Button>
+            ) : null}
             <Button
               variant="outline"
               disabled={!data || isLoading}
@@ -255,6 +278,21 @@ export function WorkoutDetailDialog({
           assignmentId={data.id}
           onSaved={() => {
             setEditOpen(false);
+            onOpenChange(false);
+            onDeleted();
+          }}
+        />
+      ) : null}
+
+      {data && recurrenceOpen ? (
+        <WorkoutRecurrenceEditDialog
+          open={recurrenceOpen}
+          onOpenChange={(o) => setRecurrenceOpen(o)}
+          assignmentId={data.id}
+          scheduledFor={data.scheduledFor}
+          recurrence={data.recurrence}
+          onSaved={() => {
+            setRecurrenceOpen(false);
             onOpenChange(false);
             onDeleted();
           }}

--- a/backoffice/src/components/gc-fitness/schedule/workout-recurrence-edit-dialog.tsx
+++ b/backoffice/src/components/gc-fitness/schedule/workout-recurrence-edit-dialog.tsx
@@ -1,0 +1,306 @@
+"use client";
+
+// workout-recurrence-edit-dialog.tsx
+//
+// Edits the cadence of a RECURRING workout series "from this occurrence
+// forward" (de aquí en adelante). Opened from the read-only detail dialog's
+// "Editar recurrencia" CTA, which only renders it for scheduled/started
+// occurrences that carry a `seriesId`.
+//
+// The picker mirrors the recurrence section of assign-template-modal.tsx
+// (mode + weekday chips + every-N + monthly) but is standalone and seeded from
+// the occurrence's current recurrence rule. On save it calls
+// editAssignmentRecurrence, which deletes the future scheduled docs in the
+// series and re-expands the new rule over the same window (preserving past /
+// completed occurrences). Copy is hardcoded Spanish to match the detail
+// dialog's existing convention (the 26-07 i18n pass will lift both together).
+
+import { useMemo, useState } from "react";
+import { toast } from "sonner";
+
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { editAssignmentRecurrence } from "@/lib/gc-fitness/workout-assignment-actions";
+
+type Mode = "weekly" | "daily" | "everyN" | "monthly";
+
+type RecurrenceRule =
+  | { kind: "daily" }
+  | { kind: "weekly"; weekday: number }
+  | { kind: "weekly_days"; weekdays: number[] }
+  | { kind: "every_n_days"; everyN: number }
+  | { kind: "monthly"; dayOfMonth: number };
+
+interface WorkoutRecurrenceEditDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  assignmentId: string;
+  /** The viewed occurrence's civil date "YYYY-MM-DD" — the "from here" cutoff. */
+  scheduledFor: string;
+  /** The occurrence's current recurrence rule (used to seed the picker). */
+  recurrence: Record<string, unknown> | null;
+  onSaved: () => void;
+}
+
+// Weekday short labels, Sunday-first to match WEEKDAY_KEYS indexing in the
+// assign modal (0 = Sunday … 6 = Saturday).
+const WEEKDAY_SHORT = ["Dom", "Lun", "Mar", "Mié", "Jue", "Vie", "Sáb"];
+
+/** "YYYY-MM-DD" → day-of-month (1..31), or 1 when the date is malformed. */
+function dayOfMonthFromCivil(civil: string): number {
+  const parts = civil.split("-");
+  const d = Number(parts[2]);
+  return Number.isFinite(d) && d >= 1 && d <= 31 ? d : 1;
+}
+
+/** Derive the initial picker state from the occurrence's current recurrence. */
+function seedFromRecurrence(
+  recurrence: Record<string, unknown> | null,
+  scheduledFor: string,
+): { mode: Mode; weekdays: Set<number>; everyN: number } {
+  const fallbackWeekday = (() => {
+    const [y, m, d] = scheduledFor.split("-").map(Number);
+    if (!y || !m || !d) return 1;
+    return new Date(y, m - 1, d).getDay();
+  })();
+  const kind = recurrence?.kind;
+  if (kind === "daily") {
+    return { mode: "daily", weekdays: new Set([fallbackWeekday]), everyN: 2 };
+  }
+  if (kind === "every_n_days") {
+    const n = Number(recurrence?.everyN);
+    return {
+      mode: "everyN",
+      weekdays: new Set([fallbackWeekday]),
+      everyN: Number.isFinite(n) ? Math.max(2, Math.min(30, n)) : 2,
+    };
+  }
+  if (kind === "monthly") {
+    return { mode: "monthly", weekdays: new Set([fallbackWeekday]), everyN: 2 };
+  }
+  if (kind === "weekly_days" && Array.isArray(recurrence?.weekdays)) {
+    const days = (recurrence!.weekdays as unknown[])
+      .map(Number)
+      .filter((n) => Number.isInteger(n) && n >= 0 && n <= 6);
+    return {
+      mode: "weekly",
+      weekdays: new Set(days.length ? days : [fallbackWeekday]),
+      everyN: 2,
+    };
+  }
+  if (kind === "weekly" && Number.isInteger(Number(recurrence?.weekday))) {
+    return {
+      mode: "weekly",
+      weekdays: new Set([Number(recurrence!.weekday)]),
+      everyN: 2,
+    };
+  }
+  // Unknown / single → default to a weekly picker seeded on the occurrence day.
+  return { mode: "weekly", weekdays: new Set([fallbackWeekday]), everyN: 2 };
+}
+
+export function WorkoutRecurrenceEditDialog({
+  open,
+  onOpenChange,
+  assignmentId,
+  scheduledFor,
+  recurrence,
+  onSaved,
+}: WorkoutRecurrenceEditDialogProps) {
+  const seed = useMemo(
+    () => seedFromRecurrence(recurrence, scheduledFor),
+    [recurrence, scheduledFor],
+  );
+  const [mode, setMode] = useState<Mode>(seed.mode);
+  const [weekdays, setWeekdays] = useState<Set<number>>(seed.weekdays);
+  const [everyN, setEveryN] = useState<number>(seed.everyN);
+  const [everyNDraft, setEveryNDraft] = useState<string>(String(seed.everyN));
+  const [pending, setPending] = useState(false);
+
+  function toggleWeekday(idx: number) {
+    setWeekdays((prev) => {
+      const next = new Set(prev);
+      if (next.has(idx)) {
+        next.delete(idx);
+      } else {
+        next.add(idx);
+      }
+      return next;
+    });
+  }
+
+  function buildRule(): RecurrenceRule | null {
+    if (mode === "daily") return { kind: "daily" };
+    if (mode === "everyN") return { kind: "every_n_days", everyN };
+    if (mode === "monthly") {
+      return { kind: "monthly", dayOfMonth: dayOfMonthFromCivil(scheduledFor) };
+    }
+    // weekly
+    const sorted = Array.from(weekdays).sort((a, b) => a - b);
+    if (sorted.length === 0) return null;
+    return sorted.length === 1
+      ? { kind: "weekly", weekday: sorted[0] }
+      : { kind: "weekly_days", weekdays: sorted };
+  }
+
+  async function handleSave() {
+    const rule = buildRule();
+    if (!rule) {
+      toast.error("Elegí al menos un día de la semana.");
+      return;
+    }
+    setPending(true);
+    try {
+      const result = await editAssignmentRecurrence(assignmentId, {
+        recurrence: rule,
+      });
+      toast.success(
+        `Recurrencia actualizada · ${result.createdCount} ${
+          result.createdCount === 1 ? "fecha" : "fechas"
+        } reprogramada${result.createdCount === 1 ? "" : "s"}.`,
+      );
+      onSaved();
+      onOpenChange(false);
+    } catch (err) {
+      toast.error(
+        err instanceof Error
+          ? err.message
+          : "No se pudo actualizar la recurrencia.",
+      );
+    } finally {
+      setPending(false);
+    }
+  }
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(next) => {
+        if (!next && pending) return; // block close while in flight
+        onOpenChange(next);
+      }}
+    >
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle>Editar recurrencia</DialogTitle>
+          <DialogDescription>
+            Cambia los días desde esta fecha en adelante. Las ocurrencias
+            pasadas y completadas no se modifican.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="flex flex-col gap-4">
+          <div className="flex flex-col gap-1.5">
+            <label className="text-sm font-medium">Frecuencia</label>
+            <Select
+              value={mode}
+              onValueChange={(value) => setMode(value as Mode)}
+            >
+              <SelectTrigger>
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="weekly">Semanal</SelectItem>
+                <SelectItem value="daily">Diaria</SelectItem>
+                <SelectItem value="everyN">Cada N días</SelectItem>
+                <SelectItem value="monthly">Mensual</SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+
+          {mode === "weekly" ? (
+            <div className="flex flex-col gap-1.5">
+              <label className="text-sm font-medium">Repetir los días</label>
+              <div className="flex flex-wrap gap-2">
+                {WEEKDAY_SHORT.map((label, idx) => {
+                  const active = weekdays.has(idx);
+                  return (
+                    <Button
+                      key={label}
+                      type="button"
+                      variant={active ? "default" : "outline"}
+                      size="sm"
+                      onClick={() => toggleWeekday(idx)}
+                      aria-pressed={active}
+                    >
+                      {label}
+                    </Button>
+                  );
+                })}
+              </div>
+            </div>
+          ) : null}
+
+          {mode === "everyN" ? (
+            <div className="flex flex-col gap-1.5">
+              <label className="text-sm font-medium" htmlFor="recur-every-n">
+                Repetir cada
+              </label>
+              <div className="flex items-center gap-2">
+                <input
+                  id="recur-every-n"
+                  type="number"
+                  min={2}
+                  max={30}
+                  value={everyNDraft}
+                  onChange={(event) => {
+                    const raw = event.target.value;
+                    setEveryNDraft(raw);
+                    if (raw.trim() === "") return;
+                    const next = Number(raw);
+                    if (!Number.isFinite(next)) return;
+                    setEveryN(Math.max(2, Math.min(30, next)));
+                  }}
+                  onBlur={() => {
+                    const next = Number(everyNDraft);
+                    const normalized = Number.isFinite(next)
+                      ? Math.max(2, Math.min(30, next))
+                      : everyN;
+                    setEveryN(normalized);
+                    setEveryNDraft(String(normalized));
+                  }}
+                  className="h-10 w-24 rounded-md border bg-background px-3 text-sm"
+                />
+                <span className="text-sm text-muted-foreground">días</span>
+              </div>
+            </div>
+          ) : null}
+
+          {mode === "monthly" ? (
+            <p className="text-xs text-muted-foreground">
+              Se repetirá el día {dayOfMonthFromCivil(scheduledFor)} de cada mes.
+            </p>
+          ) : null}
+        </div>
+
+        <DialogFooter className="gap-2 sm:gap-2">
+          <Button
+            variant="ghost"
+            onClick={() => onOpenChange(false)}
+            disabled={pending}
+            className="sm:mr-auto"
+          >
+            Cancelar
+          </Button>
+          <Button onClick={() => void handleSave()} disabled={pending}>
+            {pending ? "Guardando…" : "Guardar"}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/backoffice/src/lib/gc-fitness/__tests__/workout-assignment-actions.recurrence.test.ts
+++ b/backoffice/src/lib/gc-fitness/__tests__/workout-assignment-actions.recurrence.test.ts
@@ -1,0 +1,278 @@
+// __tests__/workout-assignment-actions.recurrence.test.ts
+//
+// Behavior tests for editAssignmentRecurrence — "edit the recurrence from this
+// occurrence forward" (de aquí en adelante). The action deletes the future
+// scheduled docs in the series and re-expands the new rule over the original
+// window, leaving past/completed occurrences untouched (mirrors the
+// cascade-delete semantics).
+//
+// All Firebase Admin + next-firebase-auth-edge surfaces are mocked — no live
+// Firestore writes happen. Mock shape mirrors workout-assignment-actions.test.ts.
+
+jest.mock("next/headers", () => ({
+  cookies: jest.fn().mockResolvedValue({ get: () => undefined }),
+}));
+jest.mock("next-firebase-auth-edge", () => ({
+  getTokens: jest.fn(),
+}));
+
+const mockSet = jest.fn();
+const mockGet = jest.fn();
+
+const mockDoc = jest.fn((id?: string) => ({
+  set: mockSet,
+  get: mockGet,
+  id: id ?? "MOCK_DOC_ID",
+}));
+
+const mockWhere = jest.fn();
+const mockQueryGet = jest.fn();
+
+const mockCollection = jest.fn(() => ({
+  doc: mockDoc,
+  where: mockWhere,
+  get: mockQueryGet,
+}));
+
+mockWhere.mockImplementation(() => ({
+  where: mockWhere,
+  get: mockQueryGet,
+}));
+
+const mockBatchSet = jest.fn();
+const mockBatchDelete = jest.fn();
+const mockBatchCommit = jest.fn();
+const mockBatch = jest.fn(() => ({
+  set: mockBatchSet,
+  delete: mockBatchDelete,
+  commit: mockBatchCommit,
+}));
+
+const mockGetAll = jest.fn(() => Promise.resolve([]));
+
+jest.mock("@/lib/firebase/gc-fitness-admin", () => ({
+  gcFitnessFirestore: jest.fn(() => ({
+    collection: mockCollection,
+    batch: mockBatch,
+    getAll: mockGetAll,
+  })),
+}));
+
+jest.mock("firebase-admin/firestore", () => ({
+  FieldValue: {
+    serverTimestamp: jest.fn(() => "SERVER_TIMESTAMP_SENTINEL"),
+  },
+  Timestamp: {
+    fromDate: jest.fn((d: Date) => ({ __ts: d.toISOString() })),
+  },
+}));
+
+import { editAssignmentRecurrence } from "../workout-assignment-actions";
+import { getTokens } from "next-firebase-auth-edge";
+
+const mockedGetTokens = getTokens as jest.MockedFunction<typeof getTokens>;
+
+const ALLOWED_EMAIL = "trainer@example.com";
+const ALLOWED_UID = "trainer-uid-1";
+const OTHER_TRAINER_UID = "trainer-uid-2";
+const CLIENT_UID = "client-uid-1";
+
+function fakeTokens() {
+  return {
+    token: "fake-token",
+    decodedToken: { uid: ALLOWED_UID, email: ALLOWED_EMAIL, role: "trainer" },
+  } as unknown as Awaited<ReturnType<typeof getTokens>>;
+}
+
+const SNAPSHOT = { name: { en: "Mobility A", es: "Movilidad A" }, exercises: [] };
+
+function anchorSnap(opts?: {
+  exists?: boolean;
+  trainerId?: string;
+  seriesId?: string | null;
+  scheduledFor?: string;
+  prescriptionUpdatedAt?: unknown;
+}) {
+  return {
+    exists: opts?.exists ?? true,
+    data: () => ({
+      trainerId: opts?.trainerId ?? ALLOWED_UID,
+      clientId: CLIENT_UID,
+      templateId: "tpl-abc",
+      templateSnapshot: SNAPSHOT,
+      scheduledFor: opts?.scheduledFor ?? "2026-06-15",
+      scheduledTime: "08:00",
+      meetingNotes: null,
+      timezone: "America/Mexico_City",
+      status: "scheduled",
+      seriesId: opts?.seriesId === undefined ? "ser-1" : opts.seriesId,
+      prescriptionUpdatedAt: opts?.prescriptionUpdatedAt ?? "PRESCR_TS",
+    }),
+  };
+}
+
+// Mon/Wed/Fri series across 2026-06-10..2026-06-19, plus a past COMPLETED doc.
+// (June 1 2026 is a Monday, so 15=Mon, 17=Wed, 19=Fri, 10=Wed, 12=Fri.)
+function monWedFriSeriesDocs() {
+  return {
+    docs: [
+      {
+        ref: { id: "asg-past" },
+        data: () => ({ scheduledFor: "2026-06-10", status: "completed" }),
+      },
+      {
+        ref: { id: "asg-1" },
+        data: () => ({ scheduledFor: "2026-06-15", status: "scheduled" }),
+      },
+      {
+        ref: { id: "asg-2" },
+        data: () => ({ scheduledFor: "2026-06-17", status: "scheduled" }),
+      },
+      {
+        ref: { id: "asg-3" },
+        data: () => ({ scheduledFor: "2026-06-19", status: "scheduled" }),
+      },
+    ],
+  };
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  process.env.GC_FITNESS_TEAM_ALLOWLIST = ALLOWED_EMAIL;
+  process.env.NEXT_PUBLIC_GC_FITNESS_FIREBASE_API_KEY = "fake-api-key";
+  process.env.GC_FITNESS_COOKIE_SIGNATURE_KEY = "fake-cookie-sig";
+  process.env.NEXT_PUBLIC_GC_FITNESS_FIREBASE_PROJECT_ID = "gcfitness-3476b";
+  process.env.GC_FITNESS_FIREBASE_ADMIN_CLIENT_EMAIL =
+    "admin@gcfitness-3476b.iam.gserviceaccount.com";
+  process.env.GC_FITNESS_FIREBASE_ADMIN_PRIVATE_KEY = Buffer.from(
+    "fake-private-key",
+  ).toString("base64");
+
+  mockWhere.mockImplementation(() => ({ where: mockWhere, get: mockQueryGet }));
+  mockBatch.mockImplementation(() => ({
+    set: mockBatchSet,
+    delete: mockBatchDelete,
+    commit: mockBatchCommit,
+  }));
+  mockBatchCommit.mockResolvedValue(undefined);
+});
+
+describe("editAssignmentRecurrence", () => {
+  it("deletes future scheduled docs and re-creates the new rule from the cutoff (Mon/Wed/Fri → Mon/Fri)", async () => {
+    mockedGetTokens.mockResolvedValue(fakeTokens());
+    mockGet.mockResolvedValue(anchorSnap());
+    mockQueryGet.mockResolvedValue(monWedFriSeriesDocs());
+
+    const result = await editAssignmentRecurrence("asg-1", {
+      recurrence: { kind: "weekly_days", weekdays: [1, 5] },
+    });
+
+    // All 3 future scheduled docs replaced; the past completed doc untouched.
+    expect(mockBatchDelete).toHaveBeenCalledTimes(3);
+    // New Mon/Fri dates at/after the cutoff 2026-06-15: 06-15 (Mon), 06-19 (Fri).
+    expect(mockBatchSet).toHaveBeenCalledTimes(2);
+    const newDates = mockBatchSet.mock.calls
+      .map((c) => c[1].scheduledFor)
+      .sort();
+    expect(newDates).toEqual(["2026-06-15", "2026-06-19"]);
+    expect(mockBatchCommit).toHaveBeenCalledTimes(1);
+
+    for (const call of mockBatchSet.mock.calls) {
+      const doc = call[1];
+      expect(doc.seriesId).toBe("ser-1");
+      expect(doc.recurrence).toEqual({ kind: "weekly_days", weekdays: [1, 5] });
+      expect(doc.status).toBe("scheduled");
+      expect(doc.clientId).toBe(CLIENT_UID);
+      // Prescription-freshness anchor carried over (NOT reset) so the client
+      // keeps their per-exercise weight prefill on an unchanged prescription.
+      expect(doc.prescriptionUpdatedAt).toBe("PRESCR_TS");
+    }
+
+    expect(result).toEqual({ ok: true, removedCount: 3, createdCount: 2 });
+  });
+
+  it("new doc ids follow asg-{clientId}-{YYYYMMDD}-{uuid}", async () => {
+    mockedGetTokens.mockResolvedValue(fakeTokens());
+    mockGet.mockResolvedValue(anchorSnap());
+    mockQueryGet.mockResolvedValue(monWedFriSeriesDocs());
+
+    await editAssignmentRecurrence("asg-1", {
+      recurrence: { kind: "weekly_days", weekdays: [1, 5] },
+    });
+
+    // The anchor read also calls doc("asg-1"); the two CREATED docs carry the
+    // full asg-{clientId}-{YYYYMMDD}-{uuid} shape — match on that pattern.
+    const createdIds = mockDoc.mock.calls
+      .map((c) => c[0])
+      .filter(
+        (id): id is string =>
+          typeof id === "string" && /^asg-client-uid-1-\d{8}-/.test(id),
+      );
+    expect(createdIds.length).toBe(2);
+    for (const id of createdIds) {
+      expect(id).toMatch(/^asg-client-uid-1-2026061[59]-/);
+    }
+  });
+
+  it("rejects a non-recurring (single) assignment — nothing to reschedule", async () => {
+    mockedGetTokens.mockResolvedValue(fakeTokens());
+    mockGet.mockResolvedValue(anchorSnap({ seriesId: null }));
+
+    await expect(
+      editAssignmentRecurrence("asg-1", {
+        recurrence: { kind: "daily" },
+      }),
+    ).rejects.toThrow(/not recurring/i);
+    expect(mockBatchSet).not.toHaveBeenCalled();
+    expect(mockBatchDelete).not.toHaveBeenCalled();
+  });
+
+  it("rejects a 'single' target recurrence (UI never offers it)", async () => {
+    mockedGetTokens.mockResolvedValue(fakeTokens());
+    mockGet.mockResolvedValue(anchorSnap());
+
+    await expect(
+      editAssignmentRecurrence("asg-1", {
+        recurrence: { kind: "single" },
+      }),
+    ).rejects.toThrow(/recurring cadence/i);
+    expect(mockBatchSet).not.toHaveBeenCalled();
+  });
+
+  it("rejects when the caller is not the assignment's trainer", async () => {
+    mockedGetTokens.mockResolvedValue(fakeTokens());
+    mockGet.mockResolvedValue(anchorSnap({ trainerId: OTHER_TRAINER_UID }));
+
+    await expect(
+      editAssignmentRecurrence("asg-1", {
+        recurrence: { kind: "daily" },
+      }),
+    ).rejects.toThrow(/not your assignment/i);
+    expect(mockBatchSet).not.toHaveBeenCalled();
+    expect(mockBatchDelete).not.toHaveBeenCalled();
+  });
+
+  it("rejects when the assignment does not exist", async () => {
+    mockedGetTokens.mockResolvedValue(fakeTokens());
+    mockGet.mockResolvedValue(anchorSnap({ exists: false }));
+
+    await expect(
+      editAssignmentRecurrence("asg-missing", {
+        recurrence: { kind: "daily" },
+      }),
+    ).rejects.toThrow(/not found/i);
+  });
+
+  it("queries the series scoped to BOTH trainerId and seriesId (no cross-tenant fan-out)", async () => {
+    mockedGetTokens.mockResolvedValue(fakeTokens());
+    mockGet.mockResolvedValue(anchorSnap());
+    mockQueryGet.mockResolvedValue(monWedFriSeriesDocs());
+
+    await editAssignmentRecurrence("asg-1", {
+      recurrence: { kind: "weekly_days", weekdays: [1, 5] },
+    });
+
+    expect(mockWhere).toHaveBeenCalledWith("trainerId", "==", ALLOWED_UID);
+    expect(mockWhere).toHaveBeenCalledWith("seriesId", "==", "ser-1");
+  });
+});

--- a/backoffice/src/lib/gc-fitness/workout-assignment-actions.ts
+++ b/backoffice/src/lib/gc-fitness/workout-assignment-actions.ts
@@ -40,6 +40,8 @@ import {
   assignTemplateRecurringSchema,
   bulkAssignSchema,
   editAssignmentSchema,
+  recurrenceSchema,
+  CIVIL_DATE_REGEX,
   MAX_CLIENTS_PER_BATCH,
   MAX_OPS_PER_BATCH,
   OPS_PER_ASSIGNMENT,
@@ -1969,6 +1971,191 @@ export async function editAssignmentExercises(
   await batch.commit();
 
   return { ok: true, updatedCount: targets.length };
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// editAssignmentRecurrence — change which days a recurring series lands on,
+// "from this occurrence forward" (de aquí en adelante).
+// ─────────────────────────────────────────────────────────────────────────────
+//
+// The trainer opens ONE occurrence of a recurring series in the detail dialog
+// (e.g. "Mon/Wed/Fri") and wants to switch it to "Mon/Fri" going forward
+// without disturbing what already happened. Because a recurring assignment is
+// not a single parent doc but a fan-out of per-date docs that share a
+// `seriesId` (see assignTemplateRecurring), "edit the recurrence" is modeled as
+// delete-future-scheduled + re-expand the new rule, mirroring the cascade-delete
+// semantics of deleteAssignment(id, {cascadeFromDate}):
+//
+//   cutoff       = the viewed occurrence's scheduledFor (same anchor the delete
+//                  dialog uses for "this and all future occurrences"). The detail
+//                  dialog only surfaces this action for scheduled/started
+//                  occurrences, so the cutoff is today-or-future in practice.
+//   seriesStart  = earliest scheduledFor in the series — the anchor that keeps
+//                  every_n_days phase stable across the edit.
+//   windowEnd    = latest scheduledFor in the series — preserves the original
+//                  horizon (no endDate is persisted on the docs, so the existing
+//                  span IS the source of truth for "how far out").
+//
+// Past / started / completed / missed docs are never touched (status filter,
+// exactly like the cascade delete). Per-occurrence exercise edits on future
+// docs are intentionally NOT preserved — a recurrence change is structural; the
+// new docs are seeded from the viewed occurrence's snapshot (the workout the
+// trainer is looking at). Weight-prefill freshness anchors
+// (prescriptionUpdatedAt[ByExerciseId]) are carried over from the anchor so an
+// unchanged prescription does NOT reset the client's per-exercise weight prefill.
+const editAssignmentRecurrenceSchema = z.object({
+  recurrence: recurrenceSchema,
+});
+
+export async function editAssignmentRecurrence(
+  id: string,
+  inputRaw: unknown,
+): Promise<{ ok: true; removedCount: number; createdCount: number }> {
+  const trainer = await getCurrentTrainer();
+  const input = editAssignmentRecurrenceSchema.parse(inputRaw);
+
+  // "single" collapses a series to one date — that's a delete, not a recurrence
+  // edit. The UI never offers it; reject defensively.
+  if (input.recurrence.kind === "single") {
+    throw new Error("Choose a recurring cadence (not a single date).");
+  }
+  const recurrence = input.recurrence as ExpandableRecurrence;
+
+  const db = gcFitnessFirestore();
+  const ref = db.collection(ASSIGNMENTS).doc(id);
+  const snap = await ref.get();
+  if (!snap.exists) throw new Error("Not found");
+  const anchor = snap.data() as {
+    trainerId?: string;
+    clientId?: string | null;
+    pendingEmail?: string | null;
+    templateId?: string;
+    templateSnapshot?: unknown;
+    scheduledFor?: string;
+    scheduledTime?: string | null;
+    meetingNotes?: string | null;
+    timezone?: string | null;
+    seriesId?: string | null;
+    prescriptionUpdatedAt?: unknown;
+    prescriptionUpdatedAtByExerciseId?: unknown;
+  };
+  if (anchor.trainerId !== trainer.uid) {
+    throw new Error("Not your assignment.");
+  }
+  if (!anchor.seriesId || typeof anchor.seriesId !== "string") {
+    throw new Error("This workout is not recurring — nothing to reschedule.");
+  }
+  const cutoff =
+    typeof anchor.scheduledFor === "string" ? anchor.scheduledFor : "";
+  if (!CIVIL_DATE_REGEX.test(cutoff)) {
+    throw new Error("Assignment is missing a valid scheduled date.");
+  }
+
+  // Load the whole series for this trainer to derive the original window AND the
+  // set of future-scheduled docs to replace.
+  const seriesSnap = await db
+    .collection(ASSIGNMENTS)
+    .where("trainerId", "==", trainer.uid)
+    .where("seriesId", "==", anchor.seriesId)
+    .get();
+
+  let seriesStart = cutoff;
+  let windowEnd = cutoff;
+  const toDelete: FirebaseFirestore.DocumentReference[] = [];
+  const keptDates: string[] = [];
+  for (const d of seriesSnap.docs) {
+    const dd = d.data() as { scheduledFor?: string; status?: string };
+    const when = typeof dd.scheduledFor === "string" ? dd.scheduledFor : "";
+    if (!CIVIL_DATE_REGEX.test(when)) continue;
+    if (when < seriesStart) seriesStart = when;
+    if (when > windowEnd) windowEnd = when;
+    const isFutureScheduled =
+      when >= cutoff && (!dd.status || dd.status === "scheduled");
+    if (isFutureScheduled) {
+      toDelete.push(d.ref);
+    } else {
+      // Untouched docs (past, or started/completed/missed) keep their dates —
+      // they form part of the post-edit series picture for the activity log.
+      keptDates.push(when);
+    }
+  }
+
+  // Re-expand the NEW rule over the original span, anchored at the series start
+  // (keeps every_n_days phase), then keep only dates at/after the cutoff.
+  const newDates = expandRecurrenceDates(
+    recurrence,
+    seriesStart,
+    windowEnd,
+  ).filter((date) => date >= cutoff);
+  if (newDates.length === 0) {
+    throw new Error(
+      "The new recurrence produces no upcoming dates in this series.",
+    );
+  }
+
+  const recurrencePayload: Record<string, unknown> = recurrence;
+  const clientId = anchor.clientId ?? null;
+  const idSegment =
+    typeof clientId === "string" && clientId ? clientId : "pending";
+
+  const batch = db.batch();
+  for (const delRef of toDelete) {
+    batch.delete(delRef);
+  }
+  for (const date of newDates) {
+    const ymd = date.replace(/-/g, "");
+    const docId = `asg-${idSegment}-${ymd}-${randomUUID()}`;
+    const docRef = db.collection(ASSIGNMENTS).doc(docId);
+    batch.set(docRef, {
+      templateId: anchor.templateId ?? null,
+      templateSnapshot: anchor.templateSnapshot ?? null,
+      clientId,
+      pendingEmail: anchor.pendingEmail ?? null,
+      trainerId: trainer.uid,
+      scheduledFor: date,
+      scheduledTime: anchor.scheduledTime ?? null,
+      meetingNotes: anchor.meetingNotes ?? null,
+      timezone: anchor.timezone ?? null,
+      status: "scheduled" as const,
+      createdAt: FieldValue.serverTimestamp(),
+      updatedAt: FieldValue.serverTimestamp(),
+      // Carry the prescription-freshness anchor so an unchanged prescription
+      // does NOT reset the client's per-exercise weight prefill (the recurrence
+      // change is structural, not a re-prescription).
+      prescriptionUpdatedAt:
+        anchor.prescriptionUpdatedAt ?? FieldValue.serverTimestamp(),
+      ...(anchor.prescriptionUpdatedAtByExerciseId !== undefined
+        ? {
+            prescriptionUpdatedAtByExerciseId:
+              anchor.prescriptionUpdatedAtByExerciseId,
+          }
+        : {}),
+      recurrence: recurrencePayload,
+      seriesId: anchor.seriesId,
+    });
+  }
+  await batch.commit();
+
+  // Re-record the series event so My Activity reflects the new date set. Same
+  // eventId (`asg:${seriesId}`) → recordCoachActivityEvent merges in place.
+  await recordCoachActivityEvent(
+    db,
+    seriesAssignmentEvent({
+      trainerId: trainer.uid,
+      seriesId: anchor.seriesId,
+      templateName: (anchor.templateSnapshot as { name?: unknown })?.name,
+      clientId,
+      pendingEmail: anchor.pendingEmail ?? null,
+      recurrence: recurrencePayload,
+      dates: [...keptDates, ...newDates],
+    }),
+  );
+
+  return {
+    ok: true,
+    removedCount: toDelete.length,
+    createdCount: newDates.length,
+  };
 }
 
 // ─────────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## What

Trainers viewing a client's **recurring** assigned workout could only edit its exercises — there was no way to change *which days it lands on*. This adds an **"Editar recurrencia"** action to the read-only detail dialog so a series can be re-cadenced (e.g. **Lun/Mié/Vie → Lun/Vie**) **de aquí en adelante**, leaving past/completed occurrences alone.

![flow: detail dialog → Editar recurrencia → picker]

## How

A recurring assignment isn't a single parent doc — it's a fan-out of per-date docs sharing a `seriesId` (see `assignTemplateRecurring`). So the new `editAssignmentRecurrence` server action models the edit as **delete-future-scheduled + re-expand the new rule over the original window**, mirroring the existing cascade-delete semantics:

- **cutoff** = the viewed occurrence's `scheduledFor` (the same anchor the delete dialog uses for *"esto y todas las futuras ocurrencias"*). The detail dialog only surfaces the action for `scheduled`/`started` occurrences, so the cutoff is today-or-future in practice.
- **seriesStart** (earliest date in the series) anchors `every_n_days` phase; **windowEnd** (latest date) preserves the original horizon — no `endDate` is persisted on docs, so the existing span *is* the source of truth.
- Only `status == "scheduled"` future docs are replaced. Past / started / completed / missed docs are never touched.
- `prescriptionUpdatedAt[ByExerciseId]` is carried over from the anchor, so an unchanged prescription does **not** reset the client's per-exercise weight prefill (the change is structural, not a re-prescription).
- Re-records the `asg:<seriesId>` coach-activity event so **My Activity** reflects the new date set.

### UI
- `WorkoutRecurrenceEditDialog` — weekly (multi-weekday chips) / daily / cada-N-días / mensual picker, seeded from the occurrence's current rule. Copy is hardcoded Spanish to match the detail dialog's existing convention (the 26-07 i18n pass will lift both together).
- Button shown only for recurring (`seriesId` set), non-finished (`!completed && !missed`) occurrences.

## Files
- `src/lib/gc-fitness/workout-assignment-actions.ts` — new `editAssignmentRecurrence` server action.
- `src/components/gc-fitness/schedule/workout-recurrence-edit-dialog.tsx` — new picker dialog.
- `src/components/gc-fitness/schedule/workout-detail-dialog.tsx` — wire the CTA + dialog.
- `src/lib/gc-fitness/__tests__/workout-assignment-actions.recurrence.test.ts` — 7 new tests.

## Notes / behavior decisions
- **Scope is recurring series only.** A single (non-recurring) assignment has no recurrence to edit (action rejects with a clear message); turning a single into a series is out of scope.
- **Per-occurrence exercise edits on future docs are intentionally not preserved** across a recurrence change — new docs are seeded from the viewed occurrence's snapshot (the workout the trainer is looking at).
- Admin SDK writes (server-side) → **no `firestore.rules` change** needed.

## Test gate
- New suite `workout-assignment-actions.recurrence.test.ts`: **7/7 green**.
- `tsc --noEmit`: clean.
- Full `npx jest`: **646 passing**. Two failing suites are **pre-existing on `main`** (verified via `git stash`), not caused by this change:
  - `workout-assignment-actions.test.ts` → SC#2 `bulkAssignTemplate` read-count assertion (unrelated to this PR).
  - `client-activity-time.test.ts` → known local non-`en-US` locale flake (green in CI).