### PR TITLE
fix(exercises): dedupe double-seeded standard-library twins; add stretching focus

### DIFF
--- a/backoffice/src/components/gc-fitness/__tests__/exercise-picker-popover.test.tsx
+++ b/backoffice/src/components/gc-fitness/__tests__/exercise-picker-popover.test.tsx
@@ -271,10 +271,12 @@ describe("ExercisePickerPopover level chip exclusivity (Task 3 Case 3)", () => {
 
 describe("ExercisePickerPopover lazy GIFs (Task 3 Case 4)", () => {
   it("every <img> rendered inside the picker carries loading='lazy'", () => {
+    // Distinct names so the same-name dedupe (exercise-dedupe.ts) keeps all
+    // three rows — real exercises never share a display name.
     const rows = [
-      makeRow({ id: "a", gifUrl: "https://example.com/a.gif" }),
-      makeRow({ id: "b", gifUrl: "https://example.com/b.gif" }),
-      makeRow({ id: "c", gifUrl: "https://example.com/c.gif" }),
+      makeRow({ id: "a", name: { en: "Exercise A", es: "Ejercicio A" }, gifUrl: "https://example.com/a.gif" }),
+      makeRow({ id: "b", name: { en: "Exercise B", es: "Ejercicio B" }, gifUrl: "https://example.com/b.gif" }),
+      makeRow({ id: "c", name: { en: "Exercise C", es: "Ejercicio C" }, gifUrl: "https://example.com/c.gif" }),
     ];
     mockUseExercisesQuery.mockReturnValue({
       data: rows,

--- a/backoffice/src/components/gc-fitness/exercise-multi-add-dialog.tsx
+++ b/backoffice/src/components/gc-fitness/exercise-multi-add-dialog.tsx
@@ -34,6 +34,7 @@ import {
 } from "@/lib/gc-fitness/exercises-listener";
 import { searchExercises } from "@/lib/gc-fitness/exercise-search";
 import { isPickableExercise } from "@/lib/gc-fitness/exercise-visibility";
+import { dedupeExercisesByDisplayName } from "@/lib/gc-fitness/exercise-dedupe";
 
 import {
   ChipRow,
@@ -122,7 +123,9 @@ export function ExerciseMultiAddDialog({
   }
 
   const exercises = useMemo(
-    () => (data ?? []).filter(isPickableExercise),
+    // Collapse the double-seeded standard-library duplicates (numeric-id doc +
+    // its broken-media `std-*` twin) so each exercise appears once.
+    () => dedupeExercisesByDisplayName((data ?? []).filter(isPickableExercise)),
     [data],
   );
 

--- a/backoffice/src/components/gc-fitness/exercise-picker-popover.tsx
+++ b/backoffice/src/components/gc-fitness/exercise-picker-popover.tsx
@@ -86,6 +86,7 @@ import {
   normalizeSearchText,
 } from "@/lib/gc-fitness/exercise-search";
 import { isPickableExercise } from "@/lib/gc-fitness/exercise-visibility";
+import { dedupeExercisesByDisplayName } from "@/lib/gc-fitness/exercise-dedupe";
 // Re-export the legacy helper names so existing consumers that import them
 // from THIS component keep working (exercise-multi-add-dialog.tsx and the
 // legacy src/lib/gc-fitness/__tests__/exercise-picker-popover.test.tsx).
@@ -240,7 +241,11 @@ export function ExercisePickerPopover({
   // name-aware rank), THEN cap. The `<Command shouldFilter={false}>` below
   // disables cmdk's internal matcher so it renders exactly the rows we pass.
   const { visible, overflow } = useMemo(() => {
-    const live = (data ?? []).filter(isPickableExercise);
+    // Collapse the double-seeded standard-library duplicates so each exercise
+    // appears once (numeric-id doc wins over its broken-media `std-*` twin).
+    const live = dedupeExercisesByDisplayName(
+      (data ?? []).filter(isPickableExercise),
+    );
     const ranked = searchExercises(applyFilters(live, filters), search);
     // #297 — favorites always sort first (incl. in search results), then cap.
     const ordered = sortFavoritesFirst(ranked, (r) => r.id, favIds);
@@ -253,7 +258,9 @@ export function ExercisePickerPopover({
   // Kept for the empty-state branch: distinguishes "no rows in cache" from
   // "filters narrowed to zero".
   const liveCount = useMemo(
-    () => (data ?? []).filter(isPickableExercise).length,
+    () =>
+      dedupeExercisesByDisplayName((data ?? []).filter(isPickableExercise))
+        .length,
     [data],
   );
 

--- a/backoffice/src/components/gc-fitness/generator/workout-generator-wizard.tsx
+++ b/backoffice/src/components/gc-fitness/generator/workout-generator-wizard.tsx
@@ -31,6 +31,7 @@ import { EQUIPMENT, MUSCLE_GROUPS } from "@/lib/gc-fitness/exercise-vocabulary";
 import { useExercisesQuery } from "@/lib/gc-fitness/exercises-listener";
 import { useFavorites } from "@/lib/gc-fitness/use-favorites";
 import { STANDARD_LIBRARY_TAG } from "@/lib/gc-fitness/exercise-visibility";
+import { dedupeExercisesByDisplayName } from "@/lib/gc-fitness/exercise-dedupe";
 import { createWorkoutTemplate } from "@/lib/gc-fitness/workout-template-actions";
 import type { WorkoutTemplateInput } from "@/lib/gc-fitness/workout-template-schema";
 import type { ClientRosterEntry } from "@/lib/gc-fitness/client-roster";
@@ -76,13 +77,16 @@ export function WorkoutGeneratorWizard({ clients, trainerTimezone }: Props) {
     [favorites],
   );
 
-  // Generator pool = the NEW curated standard library only.
+  // Generator pool = the NEW curated standard library only. Dedupe the
+  // double-seeded duplicates (numeric-id doc + its broken-media `std-*` twin)
+  // so each exercise appears once in the pool, replacements, and output.
   const pool: GeneratorExercise[] = useMemo(
     () =>
-      (library ?? [])
-        .filter(
+      dedupeExercisesByDisplayName(
+        (library ?? []).filter(
           (r) => r.deleted !== true && Array.isArray(r.tags) && r.tags.includes(STANDARD_LIBRARY_TAG),
-        )
+        ),
+      )
         .map((r) => ({
           id: r.id,
           name: r.name,

--- a/backoffice/src/lib/gc-fitness/__tests__/exercise-dedupe.test.ts
+++ b/backoffice/src/lib/gc-fitness/__tests__/exercise-dedupe.test.ts
@@ -1,0 +1,108 @@
+// __tests__/exercise-dedupe.test.ts
+//
+// dedupeExercisesByDisplayName collapses the double-seeded standard-library
+// duplicates (numeric-id doc + its broken-media `std-*` twin) to one row per
+// display name, preferring the doc whose media will actually render.
+
+import {
+  dedupeExercisesByDisplayName,
+  type DedupeExerciseRow,
+} from "../exercise-dedupe";
+
+interface RowSpec {
+  id: string;
+  en: string;
+  es?: string | null;
+  gifUrl?: string | null;
+  imageUrl?: string | null;
+  thumbnailURL?: string | null;
+  mediaURL?: string | null;
+  ownerId?: string | null;
+  updatedAt?: string | null;
+}
+
+function row(p: RowSpec): DedupeExerciseRow {
+  return {
+    id: p.id,
+    name: { en: p.en, es: p.es ?? null },
+    gifUrl: p.gifUrl ?? null,
+    imageUrl: p.imageUrl ?? null,
+    thumbnailURL: p.thumbnailURL ?? null,
+    mediaURL: p.mediaURL ?? null,
+    ownerId: p.ownerId ?? null,
+    updatedAt: p.updatedAt ?? null,
+  };
+}
+
+describe("dedupeExercisesByDisplayName", () => {
+  it("keeps the renderable-media numeric doc over its broken gs:// std-* twin", () => {
+    const numeric = row({
+      id: "1167",
+      en: "Chest Stretch (Bodyweight)",
+      gifUrl:
+        "https://firebasestorage.googleapis.com/v0/b/x/o/library-gifs%2F1167.gif?alt=media&token=abc",
+    });
+    const stdTwin = row({
+      id: "std-flexibility-chest-stretch-bodyweight",
+      en: "Chest Stretch (Bodyweight)",
+      gifUrl: "gs://x.firebasestorage.app/exercises/library-gifs/1167.gif",
+    });
+
+    // Order-independent: std-* first OR numeric first → numeric always wins.
+    expect(dedupeExercisesByDisplayName([stdTwin, numeric]).map((r) => r.id)).toEqual([
+      "1167",
+    ]);
+    expect(dedupeExercisesByDisplayName([numeric, stdTwin]).map((r) => r.id)).toEqual([
+      "1167",
+    ]);
+  });
+
+  it("matches case- and whitespace-insensitively", () => {
+    const a = row({ id: "1", en: "Cat-Cow (Bodyweight)", gifUrl: "https://a/g.gif" });
+    const b = row({ id: "std-cat-cow", en: "  cat-cow (bodyweight) " });
+    expect(dedupeExercisesByDisplayName([a, b])).toHaveLength(1);
+  });
+
+  it("keeps unique std-* exercises that have no numeric twin", () => {
+    const unique = row({
+      id: "std-flexibility-butterfly-stretch-bodyweight",
+      en: "Butterfly Stretch (Bodyweight)",
+      gifUrl: "gs://x/butterfly.gif",
+    });
+    const other = row({ id: "0327", en: "Chest-Supported Row (Dumbbell)" });
+    const out = dedupeExercisesByDisplayName([unique, other]);
+    expect(out.map((r) => r.id).sort()).toEqual([
+      "0327",
+      "std-flexibility-butterfly-stretch-bodyweight",
+    ]);
+  });
+
+  it("never hides a trainer's own exercise behind a same-named library doc", () => {
+    const owned = row({ id: "own-1", en: "My Stretch", ownerId: "trainer-1" });
+    const library = row({ id: "1259", en: "My Stretch", gifUrl: "https://a/g.gif" });
+    expect(dedupeExercisesByDisplayName([library, owned]).map((r) => r.id)).toEqual([
+      "own-1",
+    ]);
+  });
+
+  it("falls back to recency when media + id family tie", () => {
+    const older = row({ id: "0100", en: "Squat", updatedAt: "2026-01-01" });
+    const newer = row({ id: "0200", en: "Squat", updatedAt: "2026-06-01" });
+    expect(dedupeExercisesByDisplayName([older, newer]).map((r) => r.id)).toEqual([
+      "0200",
+    ]);
+  });
+
+  it("is a no-op when there are no duplicates", () => {
+    const rows = [
+      row({ id: "a", en: "A" }),
+      row({ id: "b", en: "B" }),
+      row({ id: "c", en: "C" }),
+    ];
+    expect(dedupeExercisesByDisplayName(rows).map((r) => r.id)).toEqual([
+      "a",
+      "b",
+      "c",
+    ]);
+  });
+});

--- a/backoffice/src/lib/gc-fitness/exercise-dedupe.ts
+++ b/backoffice/src/lib/gc-fitness/exercise-dedupe.ts
@@ -1,0 +1,102 @@
+// exercise-dedupe.ts
+//
+// Collapse same-display-name duplicate exercises in CHOICE surfaces (the
+// exercise pickers + the workout-generator pool).
+//
+// WHY: the prod standard library is double-seeded. Every curated exercise
+// exists BOTH as a numeric-id doc (e.g. `1259` — the canonical family the
+// standard workout templates reference, with working https media) AND as a
+// `std-<slug>` twin (e.g. `std-flexibility-chest-stretch-bench`) whose media is
+// a non-renderable `gs://` URL. Both carry the `standard-library` tag, so every
+// exercise shows up TWICE in pickers and the generator — the second copy with a
+// broken/placeholder thumbnail.
+//
+// This is a RENDER-LEVEL safety net (no Firestore writes): keep ONE row per
+// display name, preferring the doc whose media will actually render and the
+// trainer's own authored exercise over a same-named library doc. The underlying
+// duplicate docs stay in Firestore; a separate server-side cleanup can remove
+// them later. Applied only where a trainer PICKS an exercise — not on the
+// library-management surface, which must still show every doc for curation.
+
+export interface DedupeExerciseRow {
+  id: string;
+  name: { en?: string | null; es?: string | null };
+  gifUrl?: string | null;
+  imageUrl?: string | null;
+  thumbnailURL?: string | null;
+  mediaURL?: string | null;
+  ownerId?: string | null;
+  updatedAt?: string | null;
+}
+
+const RENDERABLE_URL = /^https?:\/\//i;
+
+/**
+ * 2 = has a directly renderable http(s) media URL; 1 = has some media URL but
+ * not directly renderable (e.g. `gs://`); 0 = no media at all.
+ */
+function mediaRank(r: DedupeExerciseRow): 0 | 1 | 2 {
+  const url = r.gifUrl ?? r.imageUrl ?? r.thumbnailURL ?? r.mediaURL ?? null;
+  if (url && RENDERABLE_URL.test(url)) return 2;
+  if (url) return 1;
+  return 0;
+}
+
+/** Normalized display key — same name (case/space-insensitive) = duplicate. */
+function displayKey(r: DedupeExerciseRow): string {
+  const en = (r.name?.en ?? "").trim().toLowerCase();
+  if (en) return en;
+  const es = (r.name?.es ?? "").trim().toLowerCase();
+  if (es) return es;
+  return `__id:${r.id}`;
+}
+
+/**
+ * True when `a` is a better representative of a duplicate cluster than `b`.
+ * Priority: (1) the trainer's own authored exercise is never hidden by a
+ * same-named library doc; (2) renderable media; (3) canonical (non `std-*`) id;
+ * (4) most recently updated.
+ */
+function isBetter(a: DedupeExerciseRow, b: DedupeExerciseRow): boolean {
+  const aOwned = a.ownerId != null;
+  const bOwned = b.ownerId != null;
+  if (aOwned !== bOwned) return aOwned;
+
+  const ra = mediaRank(a);
+  const rb = mediaRank(b);
+  if (ra !== rb) return ra > rb;
+
+  const aStd = a.id.startsWith("std-");
+  const bStd = b.id.startsWith("std-");
+  if (aStd !== bStd) return !aStd;
+
+  const ua = a.updatedAt ?? "";
+  const ub = b.updatedAt ?? "";
+  if (ua !== ub) return ua > ub;
+
+  return false;
+}
+
+/**
+ * Keep one row per normalized display name, choosing the best representative
+ * (see {@link isBetter}). Rows are emitted in first-seen order so a caller that
+ * pre-sorted the input keeps that ordering; callers that re-rank afterwards
+ * (searchExercises) are unaffected.
+ */
+export function dedupeExercisesByDisplayName<T extends DedupeExerciseRow>(
+  rows: readonly T[],
+): T[] {
+  const best = new Map<string, T>();
+  const order: string[] = [];
+  for (const row of rows) {
+    const key = displayKey(row);
+    const current = best.get(key);
+    if (!current) {
+      best.set(key, row);
+      order.push(key);
+      continue;
+    }
+    if (isBetter(row, current)) best.set(key, row);
+  }
+  return order.map((key) => best.get(key)!);
+}

--- a/backoffice/src/lib/gc-fitness/workout-generator/__tests__/presets.test.ts
+++ b/backoffice/src/lib/gc-fitness/workout-generator/__tests__/presets.test.ts
@@ -87,6 +87,13 @@ describe("muscle presets", () => {
     expect(push.muscles).toEqual(expect.arrayContaining(["chest", "shoulders", "triceps"]));
   });
 
+  it("exposes a flexibility preset that builds a stretching-only routine", () => {
+    const flex = MUSCLE_PRESETS.find((p) => p.id === "flexibility")!;
+    expect(flex).toBeDefined();
+    expect(flex.muscles).toEqual(["flexibility"]);
+    expect(expandMusclePresets(["flexibility"])).toEqual(["flexibility"]);
+  });
+
   it("expandMusclePresets unions and dedupes", () => {
     const expanded = expandMusclePresets(["push", "pull"]);
     expect(expanded).toContain("chest");

--- a/backoffice/src/lib/gc-fitness/workout-generator/muscle-presets.ts
+++ b/backoffice/src/lib/gc-fitness/workout-generator/muscle-presets.ts
@@ -66,6 +66,11 @@ export const MUSCLE_PRESETS: readonly MusclePreset[] = [
     label: { en: "Core", es: "Core" },
     muscles: ["abs", "core"],
   },
+  {
+    id: "flexibility",
+    label: { en: "Stretching / Mobility", es: "Estiramiento / Movilidad" },
+    muscles: ["flexibility"],
+  },
 ];
 
 /** Expand a set of selected preset ids into the union of their muscle groups. */


### PR DESCRIPTION
## What the user reported
1. In the workout generator there was **no way to build a stretching-only routine**.
2. **Some exercises appear more than once** in the picker — e.g. *Chest Stretch (Bench)* ×2, *Chest Stretch (Bodyweight)* ×2 — one with a real thumbnail, one with a dumbbell placeholder.

## Root cause of the duplicates (a DATA problem)
The prod standard library is **double-seeded**. Every curated exercise exists as **two** `standard-library`-tagged docs:
- a **numeric-id** doc (e.g. `1167`) — the **canonical** family: the standard workout templates reference these IDs, and they hold working `https://…` media (fixed in #164, instructions in #165);
- a **`std-<slug>`** twin (e.g. `std-flexibility-chest-stretch-bodyweight`) whose media is a non-renderable `gs://` URL — that's the placeholder twin.

Counts in prod today: **570** standard-library docs = **260 numeric + 310 `std-*`**. ~241 `std-*` are true duplicates of a numeric doc; **50 `std-*` are unique** (many are stretches/warmups: Butterfly Stretch, Calf Stretch, Cat-Cow, Full Body Stretch, General Warm-up…).

> ⚠️ Project memory recorded the `std-*` family was cleared from prod on 2026-06-12 — something re-seeded these 310 docs since. Worth investigating separately.

## This PR (render-level fix — no Firestore writes)
- **`exercise-dedupe.ts`** — `dedupeExercisesByDisplayName`: collapse same-display-name rows to one, preferring (1) the trainer's own authored exercise over a same-named library doc, (2) renderable `http(s)` media, (3) the canonical non-`std-*` id, (4) recency.
- Applied on the **choice surfaces only**: the multi-add dialog, the picker popover, and the generator pool. The **library-management list is left untouched** so curation can still see every doc.
- **Stretching focus**: new `flexibility` muscle preset (*"Estiramiento / Movilidad"*) in the generator → one-tap stretching-only routine, **rep-based** (reuses existing volume presets, per the chosen scope). The 50 unique `std-*` stretches survive dedupe and stay available.

## Deliberately out of scope (deferred)
- **Server-side data cleanup** of the ~310 `std-*` duplicates and the broken `gs://` media on the 50 unique stretches — that mutates prod data and is a separate, reviewable migration. The render dedupe hides the *visible* symptom immediately and is fully reversible.
- Time-based hold prescriptions for stretches (the chosen scope was rep-based).

## Tests
- New `exercise-dedupe.test.ts` (6 cases: media preference, order-independence, unique-`std-*` survival, owned-never-hidden, recency tie-break, no-op).
- New presets case asserting the `flexibility` preset builds a stretching-only selection.
- Updated the picker lazy-`<img>` fixture to use distinct names (it previously relied on duplicate-named rows surviving).
- Full `npx jest`: **653 passing**. The 2 remaining failures are **pre-existing on `main`** (verified by stash): `workout-assignment-actions.test.ts` SC#2 read-count + `client-activity-time.test.ts` locale flake. `tsc --noEmit` clean.