### PR TITLE
feat(assign): reps↔time toggle in the workout assigner per-exercise editor

### DIFF
--- a/backoffice/messages/en.json
+++ b/backoffice/messages/en.json
@@ -1553,6 +1553,8 @@
       "exerciseOverridesRepsPlaceholder": "Reps",
       "exerciseOverridesKgPlaceholder": "Kg",
       "exerciseOverridesSeconds": "Seconds",
+      "exerciseOverridesMetricReps": "By reps",
+      "exerciseOverridesMetricTime": "By time",
       "exerciseOverridesDurationPlaceholder": "60",
       "exerciseOverridesAddSet": "Add set",
       "exerciseOverridesCopyToAll": "Copy to all",

--- a/backoffice/messages/es.json
+++ b/backoffice/messages/es.json
@@ -1553,6 +1553,8 @@
       "exerciseOverridesRepsPlaceholder": "Reps",
       "exerciseOverridesKgPlaceholder": "Kg",
       "exerciseOverridesSeconds": "Segundos",
+      "exerciseOverridesMetricReps": "Por reps",
+      "exerciseOverridesMetricTime": "Por tiempo",
       "exerciseOverridesDurationPlaceholder": "60",
       "exerciseOverridesAddSet": "Agregar serie",
       "exerciseOverridesCopyToAll": "Copiar a todas",

--- a/backoffice/src/components/gc-fitness/schedule/assign-template-modal.tsx
+++ b/backoffice/src/components/gc-fitness/schedule/assign-template-modal.tsx
@@ -166,6 +166,11 @@ export function AssignTemplateModal({
         // template exercise's hasExplicitNoWeightPrescription; ON → the
         // override writes weightBySetKg: [] + hides the kg column.
         noWeight: boolean;
+        // The trainer can switch an exercise between reps- and time-based at
+        // assignment time. Undefined → inherit the template/exercise metric;
+        // set → the chosen metric. The override emits `metric` + per-set
+        // duration when this differs from the template's effective metric.
+        metric?: "reps" | "time";
       }
     >
   >({});
@@ -223,6 +228,7 @@ export function AssignTemplateModal({
             notes: string;
             setRows: Array<{ reps: string; kg: string; duration?: string }>;
             noWeight: boolean;
+            metric?: "reps" | "time";
           }>>((acc, exercise) => {
             // Reconstruct one row per prescribed set. Pull reps from
             // repsBySet[i] if present, otherwise from the exercise-level
@@ -315,8 +321,13 @@ export function AssignTemplateModal({
         if (!draft) return null;
 
         // 26-03 — effective metric per PATTERNS.md §17 + Shared 1.
-        const effectiveMetric: "reps" | "time" =
+        // The trainer's per-assignment toggle (draft.metric) wins over the
+        // template's metric; falls back to template ?? source ?? "reps".
+        const templateMetric: "reps" | "time" =
           exercise.metric ?? exercise.sourceMetric ?? "reps";
+        const effectiveMetric: "reps" | "time" =
+          draft.metric ?? templateMetric;
+        const changedMetric = effectiveMetric !== templateMetric;
 
         // setRows → reps[] + kg[] + sets count, cleaning non-finite entries.
         const repsBySet = draft.setRows
@@ -412,7 +423,8 @@ export function AssignTemplateModal({
           !changedRest &&
           !changedTransitionRest &&
           !changedNotes &&
-          !changedDurations
+          !changedDurations &&
+          !changedMetric
         ) {
           return null;
         }
@@ -442,9 +454,18 @@ export function AssignTemplateModal({
               }
             : {}),
           ...(changedNotes ? { notes: nextNotes } : {}),
-          // 26-03 — Duration override write (time exercises only).
-          ...(effectiveMetric === "time" && changedDurations
-            ? { durationBySetSeconds: finalDurationBySetSeconds }
+          // Emit the chosen metric when the trainer flipped reps↔time so the
+          // assignment snapshot carries the new metric (consumers branch on it).
+          ...(changedMetric ? { metric: effectiveMetric } : {}),
+          // 26-03 — Duration override write (time exercises only). Also writes
+          // on a reps→time flip (base durations are empty → changedDurations).
+          // durationSeconds is the exercise-level fallback (the time analog of
+          // `reps`) so the snapshot satisfies "metric=time needs a duration".
+          ...(effectiveMetric === "time" && (changedDurations || changedMetric)
+            ? {
+                durationBySetSeconds: finalDurationBySetSeconds,
+                durationSeconds: finalDurationBySetSeconds[0] ?? 60,
+              }
             : {}),
         };
       })
@@ -471,6 +492,32 @@ export function AssignTemplateModal({
       return {
         ...prev,
         [exerciseIndex]: { ...cur, setRows: next },
+      };
+    });
+  }
+
+  // Flip an exercise between reps- and time-based at assignment time. When
+  // switching to "time", seed each set row's `duration` (so the seconds inputs
+  // start populated instead of empty); `fallbackDuration` is the template's
+  // exercise-level duration when present, else 60s.
+  function setExerciseMetric(
+    exerciseIndex: number,
+    metric: "reps" | "time",
+    fallbackDuration: number,
+  ) {
+    setOverrideDrafts((prev) => {
+      const cur = prev[exerciseIndex];
+      if (!cur) return prev;
+      const setRows =
+        metric === "time"
+          ? cur.setRows.map((row) => ({
+              ...row,
+              duration: row.duration ?? String(fallbackDuration),
+            }))
+          : cur.setRows;
+      return {
+        ...prev,
+        [exerciseIndex]: { ...cur, metric, setRows },
       };
     });
   }
@@ -914,9 +961,10 @@ export function AssignTemplateModal({
               if (!draft) return null;
               // 26-03 — effective metric cascade per PATTERNS.md §17.
               // Drives the SEGUNDOS↔REPS header swap + per-row input
-              // field bind below.
+              // field bind below. The trainer's per-assignment toggle
+              // (draft.metric) wins over the template's metric.
               const effectiveMetric: "reps" | "time" =
-                exercise.metric ?? exercise.sourceMetric ?? "reps";
+                draft.metric ?? exercise.metric ?? exercise.sourceMetric ?? "reps";
               const group = exercise.supersetGroup ?? null;
               const prevGroup =
                 idx > 0
@@ -981,6 +1029,50 @@ export function AssignTemplateModal({
                       >
                         {t("exerciseOverridesNoWeight")}
                       </button>
+                      {/* Reps↔time toggle — lets the trainer switch this
+                          exercise to time-based (seconds/holds, e.g. for
+                          stretches) at assignment time, regardless of the
+                          template's metric. */}
+                      <div className="inline-flex shrink-0 items-center gap-1">
+                        <button
+                          type="button"
+                          tabIndex={-1}
+                          aria-pressed={effectiveMetric === "reps"}
+                          onClick={() =>
+                            setExerciseMetric(
+                              exercise.index,
+                              "reps",
+                              exercise.durationSeconds ?? 60,
+                            )
+                          }
+                          className={`inline-flex h-6 items-center rounded-md border px-2 text-[11px] font-medium ${
+                            effectiveMetric === "reps"
+                              ? "border-foreground bg-foreground text-background"
+                              : "border-border/70 bg-background text-foreground hover:border-foreground/30"
+                          }`}
+                        >
+                          {t("exerciseOverridesMetricReps")}
+                        </button>
+                        <button
+                          type="button"
+                          tabIndex={-1}
+                          aria-pressed={effectiveMetric === "time"}
+                          onClick={() =>
+                            setExerciseMetric(
+                              exercise.index,
+                              "time",
+                              exercise.durationSeconds ?? 60,
+                            )
+                          }
+                          className={`inline-flex h-6 items-center rounded-md border px-2 text-[11px] font-medium ${
+                            effectiveMetric === "time"
+                              ? "border-foreground bg-foreground text-background"
+                              : "border-border/70 bg-background text-foreground hover:border-foreground/30"
+                          }`}
+                        >
+                          {t("exerciseOverridesMetricTime")}
+                        </button>
+                      </div>
                     </div>
                     <div className="min-w-0 sm:w-[16rem]">
                       <label className="min-w-0 text-[11px] font-medium text-muted-foreground">

--- a/backoffice/src/lib/gc-fitness/__tests__/workout-assignment-actions.test.ts
+++ b/backoffice/src/lib/gc-fitness/__tests__/workout-assignment-actions.test.ts
@@ -283,6 +283,31 @@ describe("assignTemplate", () => {
     expect(payload.updatedAt).toBe("SERVER_TIMESTAMP_SENTINEL");
   });
 
+  it("applies a reps→time metric override (metric + per-set + fallback duration) into the snapshot", async () => {
+    mockedGetTokens.mockResolvedValue(fakeTokens({ role: "trainer" }));
+    mockGet.mockResolvedValue(fakeTemplateSnap({ exists: true }));
+    mockSet.mockResolvedValue(undefined);
+
+    await assignTemplate({
+      templateId: "tpl-abc",
+      clientId: CLIENT_UID,
+      scheduledFor: "2026-06-01",
+      exerciseOverrides: [
+        {
+          index: 0,
+          metric: "time",
+          durationBySetSeconds: [30, 30, 45],
+          durationSeconds: 30,
+        },
+      ],
+    });
+
+    const ex = mockSet.mock.calls[0][0].templateSnapshot.exercises[0];
+    expect(ex.metric).toBe("time");
+    expect(ex.durationBySetSeconds).toEqual([30, 30, 45]);
+    expect(ex.durationSeconds).toBe(30);
+  });
+
   it("writes scheduledFor verbatim as a string (Pitfall 1 — no Timestamp conversion)", async () => {
     mockedGetTokens.mockResolvedValue(fakeTokens({ role: "trainer" }));
     mockGet.mockResolvedValue(fakeTemplateSnap({ exists: true }));

--- a/backoffice/src/lib/gc-fitness/workout-assignment-actions.ts
+++ b/backoffice/src/lib/gc-fitness/workout-assignment-actions.ts
@@ -219,6 +219,9 @@ function applyExerciseOverrides(
         notes?: string;
         weightBySetKg?: number[];
         repsBySet?: number[];
+        metric?: "reps" | "time";
+        durationBySetSeconds?: number[];
+        durationSeconds?: number;
       }>
     | undefined,
 ) {
@@ -245,6 +248,16 @@ function applyExerciseOverrides(
         : {}),
       ...(override.repsBySet !== undefined
         ? { repsBySet: override.repsBySet }
+        : {}),
+      // 26-03 — reps↔time at assignment time. Consumers branch on `metric`,
+      // so writing it (plus the per-set + fallback durations) is enough to
+      // switch an exercise to time-based; the stale reps array stays inert.
+      ...(override.metric !== undefined ? { metric: override.metric } : {}),
+      ...(override.durationBySetSeconds !== undefined
+        ? { durationBySetSeconds: override.durationBySetSeconds }
+        : {}),
+      ...(override.durationSeconds !== undefined
+        ? { durationSeconds: override.durationSeconds }
         : {}),
     };
   }


### PR DESCRIPTION
## What the user reported
In the **"Asignar una plantilla de entrenamiento"** modal you couldn't change an exercise to **time-based ("por tiempo")** — the per-exercise editor only showed REPS and KG, with no reps↔time toggle.

## Why it was only half-wired
The data model and plumbing already supported time-based prescriptions everywhere except the assigner's toggle:
- `templateSnapshot` exercises carry `metric` / `durationBySetSeconds` / `durationSeconds`.
- The assignment **override Zod schema already accepted** `metric` + `durationBySetSeconds` + `durationSeconds`.
- The assign modal **already rendered seconds inputs** when `effectiveMetric === "time"` — but the metric was read-only (cascaded from the template), so a trainer could never flip it.

Two gaps remained: (1) no UI toggle, and (2) `applyExerciseOverrides` silently dropped `metric`/duration fields.

## This PR
- **Toggle UI** — a "Por reps / Por tiempo" control on each exercise in the assigner header (mirrors the template form). Stored as `draft.metric`, which overrides the template metric. Flipping to time **seeds each set row's duration** (`template.durationSeconds ?? 60`) so the seconds inputs start populated instead of empty.
- **Override emission** — when the trainer flips the metric, the override now emits `metric` + `durationBySetSeconds` + `durationSeconds` (the time analog of `reps`). Reps/repsBySet are not written for time exercises (PATTERNS.md §17).
- **`applyExerciseOverrides`** (server) now merges `metric` / `durationBySetSeconds` / `durationSeconds` into the frozen snapshot. Consumers branch on `metric`, so a stale reps array stays inert.
- **No schema change** — the override schema already accepted these fields.

## Scope notes
- Works alongside the existing "Sin peso" toggle (time-based bodyweight stretches: tap both).
- This is the assigner (`assignTemplate` / `assignTemplateRecurring`). The per-occurrence edit dialog (`editAssignmentExercises`) already supported metric; this brings the **assign** path to parity.

## Tests
- New `assignTemplate` case: a reps→time override writes `metric:"time"` + `durationBySetSeconds` + `durationSeconds` into the snapshot. Green.
- `tsc --noEmit` clean; both message JSONs valid.
- Full `npx jest`: **640 passing**. The 2 failures are **pre-existing on `main`** (verified earlier by stash): `workout-assignment-actions.test.ts` SC#2 read-count + `client-activity-time.test.ts` locale flake. My new test in that suite passes.