### PR TITLE
feat(gc-fitness): bodyweightLoadFactor on exercise schema + ExerciseRow — #243 phase 1

### DIFF
--- a/backoffice/src/components/gc-fitness/__tests__/exercise-picker-popover.test.tsx
+++ b/backoffice/src/components/gc-fitness/__tests__/exercise-picker-popover.test.tsx
@@ -115,6 +115,8 @@ function makeRow(overrides: Partial<ExerciseRow> = {}): ExerciseRow {
     // `metric` became a required ExerciseRow field (Phase 26-02); the fixture
     // predated it. Default to "reps"; `...overrides` can still flip it.
     metric: "reps",
+    // 26-vol (#243) — bodyweightLoadFactor is a required ExerciseRow field.
+    bodyweightLoadFactor: null,
     ...overrides,
   };
 }

--- a/backoffice/src/lib/gc-fitness/__tests__/exercise-filter-state.test.ts
+++ b/backoffice/src/lib/gc-fitness/__tests__/exercise-filter-state.test.ts
@@ -58,6 +58,7 @@ function row(over: Partial<ExerciseRow> = {}): ExerciseRow {
     category: null,
     force: null,
     metric: "reps",
+    bodyweightLoadFactor: null,
     ...over,
   };
 }

--- a/backoffice/src/lib/gc-fitness/__tests__/exercise-picker-popover.test.tsx
+++ b/backoffice/src/lib/gc-fitness/__tests__/exercise-picker-popover.test.tsx
@@ -100,6 +100,8 @@ function makeRow(overrides: Partial<ExerciseRow> = {}): ExerciseRow {
     // `metric` became a required ExerciseRow field (Phase 26-02); the fixture
     // predated it. Default to "reps"; `...overrides` can still flip it.
     metric: "reps",
+    // 26-vol (#243) — bodyweightLoadFactor is a required ExerciseRow field.
+    bodyweightLoadFactor: null,
     ...overrides,
   };
 }

--- a/backoffice/src/lib/gc-fitness/__tests__/exercise-schema.test.ts
+++ b/backoffice/src/lib/gc-fitness/__tests__/exercise-schema.test.ts
@@ -47,6 +47,23 @@ describe("exerciseSchema", () => {
     expect(parsed.source).toBe("trainer");
   });
 
+  // 26-vol (#243) — bodyweightLoadFactor is optional/nullable, clamped 0..5.
+  it("accepts a bodyweightLoadFactor in range and rejects out-of-range / wrong type", () => {
+    expect(
+      exerciseSchema.parse({ ...VALID_INPUT, bodyweightLoadFactor: 0.64 })
+        .bodyweightLoadFactor,
+    ).toBe(0.64);
+    // Absent → undefined (optional); the listener/snapToRow normalizes to null.
+    expect(exerciseSchema.parse(VALID_INPUT).bodyweightLoadFactor).toBeUndefined();
+    expect(
+      exerciseSchema.safeParse({ ...VALID_INPUT, bodyweightLoadFactor: 6 }).success,
+    ).toBe(false);
+    expect(
+      exerciseSchema.safeParse({ ...VALID_INPUT, bodyweightLoadFactor: "0.5" })
+        .success,
+    ).toBe(false);
+  });
+
   // T2: nameEn empty → verbatim UI-SPEC copy
   it("rejects empty name.en with the exact UI-SPEC copy", () => {
     expect(firstError({ ...VALID_INPUT, name: { en: "", es: "x" } })).toBe(

--- a/backoffice/src/lib/gc-fitness/exercise-schema.ts
+++ b/backoffice/src/lib/gc-fitness/exercise-schema.ts
@@ -196,6 +196,11 @@ export const exerciseSchema = z.object({
   ownerId: z.string().nullable(),
   version: z.number().int().min(1).default(1),
   metric: metricSchema,
+  // 26-vol (#243) — fraction of the client's body weight this movement loads,
+  // for bodyweight-aware volume. 0 (or absent) = pure external load (free
+  // weights/machines) → body weight contributes nothing; ~1.0 = ~full body
+  // weight (pull-up, dip). Twin of iOS/Android `Exercise.bodyweightLoadFactor`.
+  bodyweightLoadFactor: z.number().min(0).max(5).optional().nullable(),
 });
 
 // Partial — used by `updateExercise` which patches subsets of the shape.

--- a/backoffice/src/lib/gc-fitness/exercises-listener.ts
+++ b/backoffice/src/lib/gc-fitness/exercises-listener.ts
@@ -128,6 +128,13 @@ export interface ExerciseRow {
    * active-workout UIs in 26-03 / 26-04.
    */
   metric: "reps" | "time";
+  /**
+   * 26-vol (#243) — fraction of the client's body weight this movement loads,
+   * for bodyweight-aware volume. `null`/absent = pure external load (free
+   * weights); `~1.0` = ~full body weight (pull-up, dip). Twin of iOS/Android
+   * `Exercise.bodyweightLoadFactor`.
+   */
+  bodyweightLoadFactor: number | null;
 }
 
 // Re-exported from a firebase-free module so non-listener call sites (e.g.
@@ -231,6 +238,12 @@ export function snapToRow(d: QueryDocumentSnapshot<DocumentData>): ExerciseRow {
     force: typeof data.force === "string" ? data.force : null,
     // Phase 26-02 — forgiving fallback to "reps" on absent/unknown wire value.
     metric: data.metric === "time" ? "time" : "reps",
+    // 26-vol (#243) — forgiving: only a finite number survives; else null.
+    bodyweightLoadFactor:
+      typeof data.bodyweightLoadFactor === "number" &&
+      Number.isFinite(data.bodyweightLoadFactor)
+        ? data.bodyweightLoadFactor
+        : null,
   };
 }
 


### PR DESCRIPTION
Backoffice twin of [gc-fitness#313] — Phase 1 of bodyweight-aware volume (#243).

## What
Adds the optional **`bodyweightLoadFactor`** field to the exercise model on the backoffice surface, matching the iOS/Android `Exercise.bodyweightLoadFactor`. It's the fraction of the client's body weight a movement loads (0/absent = pure external load; ~1.0 = full body weight like a pull-up), clamped 0..5.

- `exercise-schema.ts` — `bodyweightLoadFactor: z.number().min(0).max(5).optional().nullable()` on `exerciseSchema`.
- `exercises-listener.ts` — `bodyweightLoadFactor: number | null` on `ExerciseRow` + forgiving `snapToRow` mapping (finite number → value, else `null`).

**Inert for now** — no consumer reads it yet (the volume formula + snapshot denormalization are Phase 2). **No coach-facing form input** either: we won't surface a control that does nothing; the standard library gets values from the Phase 1b curation script, and the editor input lands when the feature is live.

## No backend change
Exercise writes go through the Admin SDK (server actions), so there's no `firestore.rules` gate; the gc-fitness `/exercises` create rule uses `hasAll([...])` anyway (extra keys allowed).

## Tests / gate
- New `exerciseSchema` case: in-range accepted, out-of-range (6) and wrong-type ("0.5") rejected, absent → undefined.
- Updated the `ExerciseRow` fixtures (picker ×2, filter-state) for the new required field.
- `tsc --noEmit` clean. Full `npx jest`: **641 passing**; the only 2 failures are the pre-existing reds on `main` (client-activity-time locale flake, workout-assignment-actions SC#2).