### PR TITLE
feat(gc-fitness): bodyweight-aware volume formula + snapshot denorm — #243 phase 2 (backoffice)

### DIFF
--- a/backoffice/src/lib/gc-fitness/__tests__/live-workout-volume.test.ts
+++ b/backoffice/src/lib/gc-fitness/__tests__/live-workout-volume.test.ts
@@ -62,6 +62,46 @@ describe("computeTotalVolumeKg", () => {
       computeTotalVolumeKg([set({ weightKg: 10, durationSeconds: 100 })]),
     ).toBe(16.67);
   });
+
+  // 26-vol (#243) — bodyweight-aware volume.
+  describe("bodyweight-aware (#243)", () => {
+    it("adds bodyWeight × factor × reps for a bodyweight movement", () => {
+      // Pull-up: 80 kg bodyweight × 1.0 × 10 reps = 800.
+      const sets = [set({ exerciseId: "pullup", weightKg: 0, reps: 10 })];
+      expect(computeTotalVolumeKg(sets, 80, { pullup: 1.0 })).toBe(800);
+    });
+
+    it("adds the added weight on top of bodyweight load (weighted pull-up)", () => {
+      // (80 × 1.0 + 20) × 5 = 500.
+      const sets = [set({ exerciseId: "pullup", weightKg: 20, reps: 5 })];
+      expect(computeTotalVolumeKg(sets, 80, { pullup: 1.0 })).toBe(500);
+    });
+
+    it("uses the per-movement fraction (push-up ~0.64)", () => {
+      // 70 × 0.64 × 10 = 448.
+      const sets = [set({ exerciseId: "pushup", weightKg: 0, reps: 10 })];
+      expect(computeTotalVolumeKg(sets, 70, { pushup: 0.64 })).toBe(448);
+    });
+
+    it("counts a bodyweight time hold (plank) via load·minutes", () => {
+      // 70 × 0.6 × (120/60) = 84.
+      const sets = [
+        set({ exerciseId: "plank", weightKg: 0, durationSeconds: 120 }),
+      ];
+      expect(computeTotalVolumeKg(sets, 70, { plank: 0.6 })).toBe(84);
+    });
+
+    it("degrades to load-only when bodyWeight is 0 (no logged weight)", () => {
+      const sets = [set({ exerciseId: "pullup", weightKg: 0, reps: 10 })];
+      expect(computeTotalVolumeKg(sets, 0, { pullup: 1.0 })).toBe(0);
+    });
+
+    it("ignores bodyweight for a free-weight exercise with no factor", () => {
+      // Barbell row at 60 kg × 8, no factor entry → 480 (bodyweight irrelevant).
+      const sets = [set({ exerciseId: "row", weightKg: 60, reps: 8 })];
+      expect(computeTotalVolumeKg(sets, 80, {})).toBe(480);
+    });
+  });
 });
 
 describe("computeDurationSeconds", () => {

--- a/backoffice/src/lib/gc-fitness/live-workout-volume.ts
+++ b/backoffice/src/lib/gc-fitness/live-workout-volume.ts
@@ -6,23 +6,42 @@
 //
 // Volume contract (mirrors iOS):
 //   - WARMUP sets are EXCLUDED from total volume.
-//   - reps-based set:  weightKg * reps
-//   - time-based set:  weightKg * (durationSeconds / 60)   — a bodyweight
-//     plank (weightKg = 0) contributes 0, which is correct.
+//   - effective per-rep load = weightKg + bodyWeightKg × bodyweightLoadFactor
+//   - reps-based set:  effectiveLoad × reps
+//   - time-based set:  effectiveLoad × (durationSeconds / 60)
 //   A set counts as time-based when it carries a positive durationSeconds.
+//
+// 26-vol (#243) — bodyweight-aware volume. The per-exercise
+// `bodyweightLoadFactor` (0 = pure external load; ~1.0 = full body weight) and
+// the client's `bodyWeightKg` are OPTIONAL inputs: when omitted (or 0, or no
+// factor for an exercise), the math degrades EXACTLY to the previous
+// load-only behavior (a bodyweight push-up at 0 kg → 0). Forward-only: callers
+// pass real values only at finalize once the client has a logged body weight.
 
 import type { SessionSetLog } from "./live-workout-types";
 
-/** Σ working volume in kg. Warmups excluded; time sets use weight·minutes. */
-export function computeTotalVolumeKg(sets: SessionSetLog[]): number {
+/**
+ * Σ working volume in kg. Warmups excluded; time sets use load·minutes.
+ *
+ * @param bodyWeightKg client's body weight (0 → no body-weight contribution).
+ * @param bodyweightLoadFactorByExerciseId per-exercise fraction of body weight
+ *   the movement loads; missing exercise → 0 (pure external load).
+ */
+export function computeTotalVolumeKg(
+  sets: SessionSetLog[],
+  bodyWeightKg = 0,
+  bodyweightLoadFactorByExerciseId: Record<string, number> = {},
+): number {
   let total = 0;
   for (const set of sets) {
     if (set.isWarmup) continue;
+    const factor = bodyweightLoadFactorByExerciseId[set.exerciseId] ?? 0;
+    const effectiveLoad = set.weightKg + bodyWeightKg * factor;
     const duration = set.durationSeconds ?? 0;
     if (duration > 0) {
-      total += set.weightKg * (duration / 60);
+      total += effectiveLoad * (duration / 60);
     } else {
-      total += set.weightKg * set.reps;
+      total += effectiveLoad * set.reps;
     }
   }
   // Round to 2 decimals to avoid float dust on the wire (iOS stores a Double;

--- a/backoffice/src/lib/gc-fitness/workout-assignment-actions.ts
+++ b/backoffice/src/lib/gc-fitness/workout-assignment-actions.ts
@@ -162,6 +162,10 @@ async function templateSnapshotForAssignment(
         Number.isFinite(transitionRestSecondsRaw)
           ? Math.max(0, Math.min(600, transitionRestSecondsRaw))
           : 60;
+      // 26-vol (#243) — denormalize the exercise's bodyweightLoadFactor into
+      // the frozen snapshot (like name/license) so workout finalize can compute
+      // bodyweight-aware volume without re-reading the live exercise doc.
+      const bodyweightLoadFactor = source?.bodyweightLoadFactor;
       return {
         ...exercise,
         transition_rest_seconds: transitionRestSeconds,
@@ -169,6 +173,10 @@ async function templateSnapshotForAssignment(
           (source?.name as { en: string; es: string } | undefined) ??
           ({ en: exerciseId, es: "" } as const),
         ...(source?.license ? { license: source.license } : {}),
+        ...(typeof bodyweightLoadFactor === "number" &&
+        Number.isFinite(bodyweightLoadFactor)
+          ? { bodyweightLoadFactor }
+          : {}),
       };
     }),
   };


### PR DESCRIPTION
Backoffice half of Phase 2 (#243). Twin work for iOS/Android lands in gc-fitness.

## What
- **`computeTotalVolumeKg(sets, bodyWeightKg = 0, bodyweightLoadFactorByExerciseId = {})`** — per-set effective load = `weightKg + bodyWeightKg × factor`, then `× reps` (or `× duration/60`). The two new params are **optional/defaulted**, so every existing caller compiles unchanged and produces the **exact same numbers** (bodyweight 0 / no factor → load-only, a 0 kg rep → 0). + bodyweight unit tests.
- **`templateSnapshotForAssignment`** denormalizes the exercise's `bodyweightLoadFactor` into the frozen snapshot (alongside `name`/`license`) so workout finalize can read it without re-fetching the live exercise doc.

## Behavior-neutral
**No call site passes a real body weight yet**, so production `total_volume_kg` is unchanged. Activating it at the finalize paths (with the client's logged body weight + the factor map from the snapshot) is **Phase 2b** — the forward-only behavior change, done with on-device verification.

## Gate
- `live-workout-volume.test.ts`: **16 green** (6 new bodyweight cases: pull-up = bw×1×reps, weighted pull-up adds external kg, push-up fraction, plank time-hold, bw=0 degrades to 0, free-weight ignores bodyweight).
- `tsc` clean. Full `npx jest` unchanged except the pre-existing reds (SC#2, client-activity-time).

Depends conceptually on #181 (the `bodyweightLoadFactor` field) but touches disjoint files — no merge conflict; can land in either order.