### PR TITLE
feat(gc-fitness-admin): monitoring & observability dashboard (#312)

### DIFF
--- a/backoffice/src/app/gc-fitness/admin/audit/page.tsx
+++ b/backoffice/src/app/gc-fitness/admin/audit/page.tsx
@@ -1,0 +1,348 @@
+import Link from "next/link";
+import { redirect } from "next/navigation";
+
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { Badge } from "@/components/ui/badge";
+import { PageHeader } from "@/components/gc-fitness/page-header";
+import { PillTabs } from "@/components/gc-fitness/pill-tabs";
+import { getCurrentAdmin } from "@/lib/gc-fitness/auth-helpers";
+import {
+  listAuditTimeline,
+  listDeletionHistory,
+  type AuditAction,
+  type AuditEntry,
+  type AuditSource,
+} from "@/lib/gc-fitness/audit-actions";
+import { sectionMetadata } from "@/lib/gc-fitness/page-metadata";
+
+// Tab title: "GC Fitness - <adminPanel>" (issue #170).
+export const generateMetadata = () => sectionMetadata("adminPanel");
+
+export const dynamic = "force-dynamic";
+
+const ACTION_OPTIONS: Array<{ value: "all" | AuditAction; label: string }> = [
+  { value: "all", label: "All actions" },
+  { value: "create", label: "Created" },
+  { value: "assign", label: "Assigned" },
+  { value: "update", label: "Updated" },
+  { value: "delete", label: "Deleted" },
+  { value: "request", label: "Requested" },
+  { value: "other", label: "Other" },
+];
+
+const SOURCE_OPTIONS: Array<{ value: "all" | AuditSource; label: string }> = [
+  { value: "all", label: "All sources" },
+  { value: "coach_activity", label: "Coach activity" },
+  { value: "admin_operations", label: "Admin operations" },
+];
+
+function str(value: string | string[] | undefined): string {
+  return typeof value === "string" ? value : "";
+}
+
+function actionBadgeVariant(
+  action: AuditAction,
+): "brand" | "success" | "warning" | "violet" | "destructive" | "secondary" {
+  switch (action) {
+    case "delete":
+      return "destructive";
+    case "create":
+      return "success";
+    case "assign":
+      return "brand";
+    case "update":
+      return "warning";
+    case "request":
+      return "violet";
+    default:
+      return "secondary";
+  }
+}
+
+export default async function AuditPage({
+  searchParams,
+}: {
+  searchParams: Promise<Record<string, string | string[] | undefined>>;
+}) {
+  try {
+    await getCurrentAdmin();
+  } catch (err) {
+    const message = err instanceof Error ? err.message : "Forbidden";
+    if (message === "Forbidden") {
+      redirect("/gc-fitness/forbidden");
+    }
+    throw err;
+  }
+
+  const sp = await searchParams;
+  const tab = str(sp.tab) === "deletions" ? "deletions" : "timeline";
+  const source = (() => {
+    const v = str(sp.source);
+    return v === "coach_activity" || v === "admin_operations" ? v : "all";
+  })();
+  const action = (() => {
+    const v = str(sp.action);
+    return ACTION_OPTIONS.some((o) => o.value === v) ? (v as "all" | AuditAction) : "all";
+  })();
+  const actorQuery = str(sp.actor).trim();
+  const clientQuery = str(sp.client).trim();
+  const fromISO = str(sp.from).trim();
+  const toISO = str(sp.to).trim();
+
+  const filters = {
+    source: source as "all" | AuditSource,
+    action,
+    actorQuery,
+    clientQuery,
+    fromISO,
+    toISO,
+  };
+
+  let rows: AuditEntry[] = [];
+  let loadError = false;
+  try {
+    rows =
+      tab === "deletions"
+        ? await listDeletionHistory(filters)
+        : await listAuditTimeline(filters);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : "";
+    if (message === "Forbidden") redirect("/gc-fitness/forbidden");
+    loadError = true;
+  }
+
+  // Preserve the active tab when the filter form submits.
+  const hiddenTab = tab === "deletions" ? "deletions" : "timeline";
+
+  const buildTabHref = (target: "timeline" | "deletions") => {
+    const params = new URLSearchParams();
+    params.set("tab", target);
+    if (source !== "all") params.set("source", source);
+    if (action !== "all") params.set("action", action);
+    if (actorQuery) params.set("actor", actorQuery);
+    if (clientQuery) params.set("client", clientQuery);
+    if (fromISO) params.set("from", fromISO);
+    if (toISO) params.set("to", toISO);
+    return `/gc-fitness/admin/audit?${params.toString()}`;
+  };
+
+  return (
+    <div className="gc-page flex flex-col gap-6">
+      <PageHeader
+        title="Monitoring & observability"
+        subtitle="Unified, time-ordered trail of coach actions and admin operations — trace what happened and when."
+        actions={
+          <Button asChild variant="outline" size="sm" className="rounded-full">
+            <Link href="/gc-fitness/admin">Back to admin</Link>
+          </Button>
+        }
+      />
+
+      <PillTabs
+        activeKey={tab}
+        items={[
+          { key: "timeline", label: "Timeline", href: buildTabHref("timeline") },
+          { key: "deletions", label: "Deletions", href: buildTabHref("deletions") },
+        ]}
+      />
+
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-xl">Filters</CardTitle>
+          <CardDescription>
+            Date range is applied server-side; actor / client / action filter the
+            loaded window in memory. Times are UTC.
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <form
+            action="/gc-fitness/admin/audit"
+            method="get"
+            className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3"
+          >
+            <input type="hidden" name="tab" value={hiddenTab} />
+            <label className="flex flex-col gap-1 text-xs font-medium text-muted-foreground">
+              Source
+              <select
+                name="source"
+                defaultValue={source}
+                className="h-9 rounded-md border border-input bg-background px-3 text-sm text-foreground"
+              >
+                {SOURCE_OPTIONS.map((o) => (
+                  <option key={o.value} value={o.value}>
+                    {o.label}
+                  </option>
+                ))}
+              </select>
+            </label>
+
+            {tab === "timeline" ? (
+              <label className="flex flex-col gap-1 text-xs font-medium text-muted-foreground">
+                Action
+                <select
+                  name="action"
+                  defaultValue={action}
+                  className="h-9 rounded-md border border-input bg-background px-3 text-sm text-foreground"
+                >
+                  {ACTION_OPTIONS.map((o) => (
+                    <option key={o.value} value={o.value}>
+                      {o.label}
+                    </option>
+                  ))}
+                </select>
+              </label>
+            ) : null}
+
+            <label className="flex flex-col gap-1 text-xs font-medium text-muted-foreground">
+              Actor (uid / name / email)
+              <Input name="actor" defaultValue={actorQuery} placeholder="contains…" className="h-9" />
+            </label>
+
+            <label className="flex flex-col gap-1 text-xs font-medium text-muted-foreground">
+              Client (uid / email)
+              <Input name="client" defaultValue={clientQuery} placeholder="contains…" className="h-9" />
+            </label>
+
+            <label className="flex flex-col gap-1 text-xs font-medium text-muted-foreground">
+              From (UTC)
+              <Input name="from" type="date" defaultValue={fromISO} className="h-9" />
+            </label>
+
+            <label className="flex flex-col gap-1 text-xs font-medium text-muted-foreground">
+              To (UTC)
+              <Input name="to" type="date" defaultValue={toISO} className="h-9" />
+            </label>
+
+            <div className="flex items-end gap-2 sm:col-span-2 lg:col-span-3">
+              <Button type="submit" className="rounded-full">
+                Apply filters
+              </Button>
+              <Button asChild variant="outline" className="rounded-full">
+                <Link href={`/gc-fitness/admin/audit?tab=${hiddenTab}`}>Clear</Link>
+              </Button>
+            </div>
+          </form>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-xl">
+            {tab === "deletions" ? "Deletion history" : "Activity timeline"}
+          </CardTitle>
+          <CardDescription>
+            {tab === "deletions"
+              ? "Everything that removed data — coach removals plus admin cascade / deactivation / pending-removal operations. Who, what, and when."
+              : "Coach actions and admin operations merged into a single newest-first feed."}
+            {" "}
+            Showing {rows.length} {rows.length === 1 ? "entry" : "entries"}.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="p-0">
+          <div className="overflow-x-auto">
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>When (UTC)</TableHead>
+                  <TableHead>Actor</TableHead>
+                  <TableHead>Action</TableHead>
+                  <TableHead>Detail</TableHead>
+                  <TableHead>Client / target</TableHead>
+                  <TableHead>Source / status</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {loadError ? (
+                  <TableRow>
+                    <TableCell className="text-xs text-muted-foreground" colSpan={6}>
+                      Could not load the audit feed. Try narrowing the date range.
+                    </TableCell>
+                  </TableRow>
+                ) : rows.length === 0 ? (
+                  <TableRow>
+                    <TableCell className="text-xs text-muted-foreground" colSpan={6}>
+                      No matching events found.
+                    </TableCell>
+                  </TableRow>
+                ) : (
+                  rows.map((row) => (
+                    <TableRow
+                      key={row.id}
+                      className={row.isDeletion ? "bg-destructive/5" : undefined}
+                    >
+                      <TableCell className="whitespace-nowrap text-xs">
+                        {row.occurredAtISO
+                          ? row.occurredAtISO.replace("T", " ").replace(/\.\d+Z$/, "Z")
+                          : "—"}
+                      </TableCell>
+                      <TableCell>
+                        <div className="font-medium">{row.actorName ?? "—"}</div>
+                        <div className="text-xs text-muted-foreground">
+                          {row.actorEmail || row.actorUid || "—"}
+                        </div>
+                        <div className="text-[11px] uppercase tracking-wide text-muted-foreground/70">
+                          {row.actorRole}
+                        </div>
+                      </TableCell>
+                      <TableCell>
+                        <div className="flex flex-col gap-1">
+                          <Badge variant={actionBadgeVariant(row.action)} className="w-fit">
+                            {row.action}
+                          </Badge>
+                          <span className="text-sm">{row.title}</span>
+                        </div>
+                      </TableCell>
+                      <TableCell className="max-w-[22rem] text-xs text-muted-foreground">
+                        {row.detail ?? "—"}
+                      </TableCell>
+                      <TableCell>
+                        {row.clientId || row.clientLabel ? (
+                          <div className="space-y-0.5">
+                            <div className="text-xs">{row.clientLabel ?? "—"}</div>
+                            <div className="font-mono text-[11px] text-muted-foreground">
+                              {row.clientId ?? "—"}
+                            </div>
+                          </div>
+                        ) : (
+                          "—"
+                        )}
+                      </TableCell>
+                      <TableCell className="text-xs text-muted-foreground">
+                        <div>{row.kind}</div>
+                        {row.status ? (
+                          <Badge
+                            variant={row.status === "failed" ? "destructive" : "secondary"}
+                            className="mt-1 w-fit"
+                          >
+                            {row.status}
+                            {row.mode ? ` · ${row.mode}` : ""}
+                          </Badge>
+                        ) : null}
+                      </TableCell>
+                    </TableRow>
+                  ))
+                )}
+              </TableBody>
+            </Table>
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/backoffice/src/app/gc-fitness/admin/page.tsx
+++ b/backoffice/src/app/gc-fitness/admin/page.tsx
@@ -279,6 +279,21 @@ export default async function AdminPage({
 
       <Card>
         <CardHeader>
+          <CardTitle className="text-xl">Monitoring &amp; observability</CardTitle>
+          <CardDescription>
+            Unified, time-ordered trail of coach actions and admin operations, plus a
+            deletion history (who removed what, and when) for incident traceability.
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <Button asChild variant="outline" className="rounded-full">
+            <Link href="/gc-fitness/admin/audit">Open monitoring dashboard</Link>
+          </Button>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
           <CardTitle className="text-xl">Data hygiene</CardTitle>
           <CardDescription>Scan for orphaned users, chats, images, workouts and other suspicious records.</CardDescription>
         </CardHeader>

--- a/backoffice/src/lib/gc-fitness/__tests__/audit-actions.test.ts
+++ b/backoffice/src/lib/gc-fitness/__tests__/audit-actions.test.ts
@@ -1,0 +1,269 @@
+// __tests__/audit-actions.test.ts
+//
+// Admin Monitoring & Observability readers (issue #312, PR1). Covers the
+// admin gate, the merge + newest-first sort across coach_activity +
+// admin_operations, action mapping, actor/client identity resolution,
+// in-memory filters, deletion-history scoping, and per-source fail-soft.
+//
+// All Firebase Admin + auth surfaces are mocked — no live Firestore.
+
+jest.mock("@/lib/gc-fitness/auth-helpers", () => ({
+  getCurrentAdmin: jest.fn(),
+}));
+
+const mockCollection = jest.fn();
+const mockGetAll = jest.fn();
+
+jest.mock("@/lib/firebase/gc-fitness-admin", () => ({
+  gcFitnessFirestore: jest.fn(() => ({
+    collection: mockCollection,
+    getAll: mockGetAll,
+  })),
+  gcFitnessAuth: jest.fn(),
+}));
+
+jest.mock("firebase-admin/firestore", () => ({
+  Timestamp: { fromDate: (d: Date) => ({ __ts: d.toISOString() }) },
+  FieldValue: { serverTimestamp: () => "TS" },
+}));
+
+import {
+  listAuditTimeline,
+  listDeletionHistory,
+} from "@/lib/gc-fitness/audit-actions";
+import { getCurrentAdmin } from "@/lib/gc-fitness/auth-helpers";
+
+const mockedGetCurrentAdmin = getCurrentAdmin as jest.MockedFunction<
+  typeof getCurrentAdmin
+>;
+
+const ADMIN = {
+  uid: "admin1",
+  email: "admin@x.com",
+  role: "admin" as const,
+  isTrainer: false,
+  roles: ["admin"],
+};
+
+const ts = (iso: string) => ({ toDate: () => new Date(iso) });
+
+type DocLike = { id: string; data: () => Record<string, unknown> };
+const doc = (id: string, data: Record<string, unknown>): DocLike => ({
+  id,
+  data: () => data,
+});
+
+// Per-collection query results; a test can replace an entry with a rejecting
+// thunk to exercise the fail-soft path.
+let queryGet: Record<string, () => Promise<{ docs: DocLike[] }>>;
+const usersById = new Map<string, Record<string, unknown>>();
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockedGetCurrentAdmin.mockResolvedValue(ADMIN);
+
+  queryGet = {
+    coach_activity: async () => ({
+      docs: [
+        doc("exr:e1", {
+          trainerId: "coach1",
+          kind: "exercise",
+          title: "Ejercicio creado: Sentadilla",
+          clientId: null,
+          occurredAt: ts("2026-06-15T10:00:00.000Z"),
+          deleted: false,
+        }),
+        doc("asg:s1", {
+          trainerId: "coach1",
+          kind: "workout_assignment",
+          title: "Workout asignado: Día 1",
+          detail: "3 fechas",
+          clientId: "client1",
+          occurredAt: ts("2026-06-14T09:00:00.000Z"),
+          deleted: true,
+          deletedAt: ts("2026-06-15T08:00:00.000Z"),
+        }),
+        doc("hab:h1", {
+          trainerId: "coach2",
+          kind: "habit_assignment",
+          title: "Hábito asignado: Agua",
+          clientId: "client2",
+          occurredAt: ts("2026-06-13T09:00:00.000Z"),
+          deleted: false,
+        }),
+        doc("req:weight:client1:1", {
+          trainerId: "coach1",
+          kind: "weight_request",
+          title: "Pedir peso: Client One",
+          clientId: "client1",
+          occurredAt: ts("2026-06-12T09:00:00.000Z"),
+        }),
+      ],
+    }),
+    admin_operations: async () => ({
+      docs: [
+        doc("op1", {
+          actorUid: "admin1",
+          kind: "delete_coach_cascade",
+          mode: "execute",
+          targetUid: "coach9",
+          status: "success",
+          summary: { totalApprox: 12 },
+          createdAt: ts("2026-06-15T12:00:00.000Z"),
+        }),
+        doc("op2", {
+          actorUid: "admin1",
+          kind: "transfer_client",
+          mode: "execute",
+          targetUid: "client1",
+          status: "success",
+          summary: { action: "transfer_client", fromCoachId: "coach1", toCoachId: "coach2" },
+          createdAt: ts("2026-06-11T12:00:00.000Z"),
+        }),
+        doc("op3", {
+          actorUid: "admin1",
+          kind: "delete_client_cascade",
+          mode: "dry_run",
+          targetUid: "client2",
+          status: "success",
+          summary: { totalApprox: 5 },
+          createdAt: ts("2026-06-10T12:00:00.000Z"),
+        }),
+      ],
+    }),
+  };
+
+  usersById.clear();
+  usersById.set("coach1", { displayName: "Coach One", email: "coach1@x.com" });
+  usersById.set("coach2", { displayName: "Coach Two", email: "coach2@x.com" });
+  usersById.set("client1", { displayName: "Client One", email: "client1@x.com" });
+  usersById.set("client2", { email: "client2@x.com" });
+  usersById.set("admin1", { displayName: "Admin", email: "admin@x.com" });
+  // coach9 intentionally absent (deleted) → unresolved label.
+
+  mockCollection.mockImplementation((name: string) => {
+    const builder: Record<string, unknown> = {
+      orderBy: () => builder,
+      where: () => builder,
+      limit: () => builder,
+      get: () => (queryGet[name] ? queryGet[name]() : Promise.resolve({ docs: [] })),
+      doc: (id: string) => ({ id, __col: name }),
+    };
+    return builder;
+  });
+
+  mockGetAll.mockImplementation((...refs: Array<{ id: string }>) =>
+    Promise.resolve(
+      refs.map((r) => ({
+        id: r.id,
+        exists: usersById.has(r.id),
+        data: () => usersById.get(r.id) ?? {},
+      })),
+    ),
+  );
+});
+
+describe("listAuditTimeline", () => {
+  it("rejects when the caller is not an admin (Forbidden)", async () => {
+    mockedGetCurrentAdmin.mockRejectedValueOnce(new Error("Forbidden"));
+    await expect(listAuditTimeline()).rejects.toThrow("Forbidden");
+    expect(mockCollection).not.toHaveBeenCalled();
+  });
+
+  it("merges both sources newest-first (deletions use deletedAt timing)", async () => {
+    const rows = await listAuditTimeline();
+    expect(rows.map((r) => r.id)).toEqual([
+      "admin_operations:op1", // 06-15 12:00
+      "coach_activity:exr:e1", // 06-15 10:00
+      "coach_activity:asg:s1", // 06-15 08:00 (deletedAt, not the 06-14 occurredAt)
+      "coach_activity:hab:h1", // 06-13
+      "coach_activity:req:weight:client1:1", // 06-12
+      "admin_operations:op2", // 06-11
+      "admin_operations:op3", // 06-10
+    ]);
+  });
+
+  it("maps actions and resolves actor + client identities", async () => {
+    const rows = await listAuditTimeline();
+    const byId = Object.fromEntries(rows.map((r) => [r.id, r]));
+
+    expect(byId["coach_activity:exr:e1"].action).toBe("create");
+    expect(byId["coach_activity:exr:e1"].actorName).toBe("Coach One");
+    expect(byId["coach_activity:exr:e1"].actorEmail).toBe("coach1@x.com");
+
+    expect(byId["coach_activity:asg:s1"].action).toBe("delete");
+    expect(byId["coach_activity:asg:s1"].isDeletion).toBe(true);
+    expect(byId["coach_activity:asg:s1"].title).toBe("Workout eliminado: Día 1");
+    expect(byId["coach_activity:asg:s1"].clientLabel).toBe("client1@x.com");
+
+    expect(byId["coach_activity:hab:h1"].action).toBe("assign");
+    expect(byId["coach_activity:req:weight:client1:1"].action).toBe("request");
+
+    expect(byId["admin_operations:op1"].action).toBe("delete");
+    expect(byId["admin_operations:op1"].actorName).toBe("Admin");
+    expect(byId["admin_operations:op1"].clientLabel).toBeNull(); // coach9 deleted
+    expect(byId["admin_operations:op2"].action).toBe("update"); // transfer ≠ delete
+    expect(byId["admin_operations:op2"].isDeletion).toBe(false);
+  });
+
+  it("filters by source", async () => {
+    const rows = await listAuditTimeline({ source: "admin_operations" });
+    expect(rows).toHaveLength(3);
+    expect(rows.every((r) => r.source === "admin_operations")).toBe(true);
+  });
+
+  it("filters by action", async () => {
+    const rows = await listAuditTimeline({ action: "delete" });
+    expect(rows.map((r) => r.id).sort()).toEqual([
+      "admin_operations:op1",
+      "admin_operations:op3",
+      "coach_activity:asg:s1",
+    ]);
+  });
+
+  it("filters by actor (contains, case-insensitive)", async () => {
+    const rows = await listAuditTimeline({ actorQuery: "ADMIN" });
+    expect(rows).toHaveLength(3);
+    expect(rows.every((r) => r.actorRole === "admin")).toBe(true);
+  });
+
+  it("filters by client (uid or label contains)", async () => {
+    const rows = await listAuditTimeline({ clientQuery: "client1" });
+    expect(rows.map((r) => r.id).sort()).toEqual([
+      "admin_operations:op2",
+      "coach_activity:asg:s1",
+      "coach_activity:req:weight:client1:1",
+    ]);
+  });
+
+  it("is fail-soft: one source erroring does not blank the feed", async () => {
+    queryGet.coach_activity = async () => {
+      throw new Error("boom");
+    };
+    const rows = await listAuditTimeline();
+    expect(rows.every((r) => r.source === "admin_operations")).toBe(true);
+    expect(rows).toHaveLength(3);
+  });
+});
+
+describe("listDeletionHistory", () => {
+  it("rejects when the caller is not an admin (Forbidden)", async () => {
+    mockedGetCurrentAdmin.mockRejectedValueOnce(new Error("Forbidden"));
+    await expect(listDeletionHistory()).rejects.toThrow("Forbidden");
+  });
+
+  it("returns only data-removing entries (transfers excluded)", async () => {
+    const rows = await listDeletionHistory();
+    expect(rows.every((r) => r.isDeletion)).toBe(true);
+    expect(rows.map((r) => r.id).sort()).toEqual([
+      "admin_operations:op1",
+      "admin_operations:op3",
+      "coach_activity:asg:s1",
+    ]);
+  });
+
+  it("ignores the action filter but honors source + client filters", async () => {
+    const rows = await listDeletionHistory({ action: "create", source: "coach_activity" });
+    expect(rows.map((r) => r.id)).toEqual(["coach_activity:asg:s1"]);
+  });
+});

--- a/backoffice/src/lib/gc-fitness/audit-actions.ts
+++ b/backoffice/src/lib/gc-fitness/audit-actions.ts
@@ -1,0 +1,495 @@
+"use server";
+
+// audit-actions.ts
+//
+// Admin-only Monitoring & Observability readers (GitHub issue #312, PR1).
+//
+// Merges the two EXISTING app-level audit trails into one chronological,
+// filterable timeline so an operator can see "what happened" across the whole
+// gc-fitness surface and trace an incident back to the action that caused it:
+//
+//   - `coach_activity`   — one durable event per coach action (workout/exercise
+//                          created, workout/habit assigned, note, photo/weight
+//                          request). A removal flips `deleted: true` + stamps
+//                          `deletedAt` on the SAME event doc.
+//   - `admin_operations` — the immutable operator trail (cascade deletes,
+//                          client deactivation, pending-client removal, client
+//                          transfer) with `actorUid`, `mode`, `status`,
+//                          `summary`, `errorMessage`.
+//
+// SCOPE (PR1): a read-only dashboard over what is ALREADY logged. It is blind to
+// raw Firestore-console edits, maintenance-script writes, and direct iOS/Android
+// client writes — capturing those needs the Cloud Functions `audit_log` layer,
+// which is a deliberate FOLLOW-UP (PR2). No new collections, no new indexes.
+//
+// Query strategy: a date range (when set) is applied IN-QUERY on the single time
+// field (`occurredAt` / `createdAt`) — a single-field range + matching orderBy
+// needs no composite index. Every other filter (source, action, actor, client)
+// is applied IN MEMORY after the merge: this is an admin-scale, bounded read
+// (capped per source) and matches the existing in-memory admin readers
+// (`listRecentCoachActivity`, `searchUsersByEmailForAdmin`). Each source query
+// is fail-soft — one collection erroring never blanks the whole dashboard.
+
+import { Timestamp, type Firestore } from "firebase-admin/firestore";
+
+import { gcFitnessFirestore } from "@/lib/firebase/gc-fitness-admin";
+import { getCurrentAdmin } from "@/lib/gc-fitness/auth-helpers";
+import { COACH_ACTIVITY_COLLECTION } from "@/lib/gc-fitness/coach-activity-log";
+import { FirestoreCollections } from "@/lib/gc-fitness/collections";
+
+export type AuditSource = "coach_activity" | "admin_operations";
+
+export type AuditAction =
+  | "create"
+  | "assign"
+  | "update"
+  | "delete"
+  | "request"
+  | "other";
+
+export interface AuditEntry {
+  /** Stable, source-prefixed id (also the React key). */
+  id: string;
+  source: AuditSource;
+  occurredAtISO: string | null;
+  actorUid: string | null;
+  actorName: string | null;
+  actorEmail: string | null;
+  /** Who-kind: coach_activity events are coach actions; admin_operations are admin actions. */
+  actorRole: "coach" | "admin";
+  /** Raw event/operation kind (e.g. "exercise", "delete_coach_cascade"). */
+  kind: string;
+  action: AuditAction;
+  title: string;
+  detail: string | null;
+  clientId: string | null;
+  /** Resolved client email / pending email, for display. */
+  clientLabel: string | null;
+  /** True when the entry represents something being removed. */
+  isDeletion: boolean;
+  /** admin_operations only: "success" | "failed". */
+  status: string | null;
+  /** admin_operations only: "dry_run" | "execute". */
+  mode: string | null;
+}
+
+export interface AuditFilters {
+  source?: "all" | AuditSource;
+  action?: "all" | AuditAction;
+  /** Case-insensitive "contains" match against actor uid / name / email. */
+  actorQuery?: string | null;
+  /** Case-insensitive "contains" match against client uid / label. */
+  clientQuery?: string | null;
+  /** Inclusive start date (YYYY-MM-DD, treated as 00:00:00 UTC). */
+  fromISO?: string | null;
+  /** Inclusive end date (YYYY-MM-DD, treated as 23:59:59.999 UTC). */
+  toISO?: string | null;
+  limit?: number;
+}
+
+// How many docs to pull per source BEFORE merge/slice. Generous so a busy day
+// of one source can't crowd the other out of the page, but still bounded.
+const PER_SOURCE_CAP = 400;
+const DEFAULT_LIMIT = 200;
+const MAX_LIMIT = 500;
+
+function toIso(value: unknown): string | null {
+  if (value && typeof (value as { toDate?: () => Date }).toDate === "function") {
+    return (value as { toDate: () => Date }).toDate().toISOString();
+  }
+  if (value instanceof Date) return value.toISOString();
+  if (typeof value === "string" && value.length > 0) return value;
+  return null;
+}
+
+/** YYYY-MM-DD → Date at UTC start-of-day, or null if blank/invalid. */
+function startOfDayUtc(dateStr: string | null | undefined): Date | null {
+  if (!dateStr) return null;
+  const d = new Date(`${dateStr}T00:00:00.000Z`);
+  return Number.isNaN(d.getTime()) ? null : d;
+}
+
+/** YYYY-MM-DD → Date at UTC end-of-day, or null if blank/invalid. */
+function endOfDayUtc(dateStr: string | null | undefined): Date | null {
+  if (!dateStr) return null;
+  const d = new Date(`${dateStr}T23:59:59.999Z`);
+  return Number.isNaN(d.getTime()) ? null : d;
+}
+
+function coachActivityAction(kind: string, deleted: boolean): AuditAction {
+  if (deleted) return "delete";
+  switch (kind) {
+    case "workout_template":
+    case "exercise":
+    case "note":
+      return "create";
+    case "workout_assignment":
+    case "habit_assignment":
+      return "assign";
+    case "workout_rest_edited":
+      return "update";
+    case "progress_photo_request":
+    case "weight_request":
+      return "request";
+    default:
+      return "other";
+  }
+}
+
+/** Reword a "created/assigned" title as a "deleted" title (mirrors the My Activity reader). */
+function deletedTitle(title: string): string {
+  return title
+    .replace("Workout asignado:", "Workout eliminado:")
+    .replace("Workout creado:", "Workout eliminado:")
+    .replace("Ejercicio creado:", "Ejercicio eliminado:")
+    .replace("Hábito asignado:", "Hábito eliminado:");
+}
+
+function adminOperationTitle(kind: string, summaryAction: string | null): string {
+  if (kind === "transfer_client") return "Transferred client";
+  if (kind === "delete_coach_cascade") return "Deleted coach (cascade)";
+  if (kind === "delete_client_cascade") {
+    if (summaryAction === "deactivate_client") return "Deactivated client";
+    if (summaryAction === "remove_pending_client") return "Removed pending client";
+    return "Deleted client (cascade)";
+  }
+  return kind;
+}
+
+function adminOperationDetail(args: {
+  mode: string | null;
+  summary: Record<string, unknown> | null;
+  errorMessage: string | null;
+}): string | null {
+  const parts: string[] = [];
+  if (args.mode) parts.push(args.mode === "dry_run" ? "dry run" : "execute");
+
+  const s = args.summary ?? {};
+  const docs =
+    typeof s.deletedDocsApprox === "number"
+      ? s.deletedDocsApprox
+      : typeof s.totalApprox === "number"
+        ? s.totalApprox
+        : null;
+  if (typeof docs === "number") parts.push(`${docs} docs`);
+  if (typeof s.fromCoachId === "string" && typeof s.toCoachId === "string") {
+    parts.push(`${s.fromCoachId} → ${s.toCoachId}`);
+  }
+  if (typeof s.email === "string") parts.push(s.email);
+  if (args.errorMessage) parts.push(`error: ${args.errorMessage}`);
+
+  return parts.length > 0 ? parts.join(" · ") : null;
+}
+
+async function fetchCoachActivityEntries(
+  db: Firestore,
+  from: Date | null,
+  to: Date | null,
+): Promise<
+  Array<{
+    id: string;
+    actorUid: string | null;
+    clientId: string | null;
+    pendingEmail: string | null;
+    kind: string;
+    deleted: boolean;
+    title: string;
+    detail: string | null;
+    occurredAtISO: string | null;
+  }>
+> {
+  let q = db
+    .collection(COACH_ACTIVITY_COLLECTION)
+    .orderBy("occurredAt", "desc") as FirebaseFirestore.Query;
+  if (from) q = q.where("occurredAt", ">=", Timestamp.fromDate(from));
+  if (to) q = q.where("occurredAt", "<=", Timestamp.fromDate(to));
+  const snap = await q
+    .limit(PER_SOURCE_CAP)
+    .get()
+    .catch((err) => {
+      console.warn("[gc-fitness/audit] coach_activity query failed", err);
+      return null;
+    });
+  if (!snap) return [];
+
+  return snap.docs.map((doc) => {
+    const data = doc.data() as {
+      trainerId?: string;
+      clientId?: string;
+      pendingEmail?: string;
+      kind?: string;
+      deleted?: boolean;
+      title?: string;
+      detail?: string | null;
+      occurredAt?: unknown;
+      deletedAt?: unknown;
+    };
+    const deleted = data.deleted === true;
+    const rawTitle = typeof data.title === "string" ? data.title : "Actividad";
+    // A deletion's true timing is `deletedAt`; fall back to the original
+    // `occurredAt` for non-deletions (and old deletions missing `deletedAt`).
+    const timeIso =
+      (deleted ? toIso(data.deletedAt) : null) ?? toIso(data.occurredAt);
+    return {
+      id: `coach_activity:${doc.id}`,
+      actorUid: typeof data.trainerId === "string" ? data.trainerId : null,
+      clientId: typeof data.clientId === "string" ? data.clientId : null,
+      pendingEmail:
+        typeof data.pendingEmail === "string" && data.pendingEmail.length > 0
+          ? data.pendingEmail
+          : null,
+      kind: typeof data.kind === "string" ? data.kind : "workout_assignment",
+      deleted,
+      title: deleted ? deletedTitle(rawTitle) : rawTitle,
+      detail: typeof data.detail === "string" ? data.detail : null,
+      occurredAtISO: timeIso,
+    };
+  });
+}
+
+async function fetchAdminOperationEntries(
+  db: Firestore,
+  from: Date | null,
+  to: Date | null,
+): Promise<
+  Array<{
+    id: string;
+    actorUid: string | null;
+    targetUid: string | null;
+    kind: string;
+    summaryAction: string | null;
+    title: string;
+    detail: string | null;
+    status: string | null;
+    mode: string | null;
+    occurredAtISO: string | null;
+  }>
+> {
+  let q = db
+    .collection(FirestoreCollections.adminOperations)
+    .orderBy("createdAt", "desc") as FirebaseFirestore.Query;
+  if (from) q = q.where("createdAt", ">=", Timestamp.fromDate(from));
+  if (to) q = q.where("createdAt", "<=", Timestamp.fromDate(to));
+  const snap = await q
+    .limit(PER_SOURCE_CAP)
+    .get()
+    .catch((err) => {
+      console.warn("[gc-fitness/audit] admin_operations query failed", err);
+      return null;
+    });
+  if (!snap) return [];
+
+  return snap.docs.map((doc) => {
+    const data = doc.data() as {
+      actorUid?: string;
+      targetUid?: string;
+      kind?: string;
+      mode?: string;
+      status?: string;
+      summary?: Record<string, unknown>;
+      errorMessage?: string | null;
+      createdAt?: unknown;
+    };
+    const kind = typeof data.kind === "string" ? data.kind : "";
+    const summary =
+      data.summary && typeof data.summary === "object" ? data.summary : null;
+    const summaryAction =
+      summary && typeof summary.action === "string" ? summary.action : null;
+    const mode = typeof data.mode === "string" ? data.mode : null;
+    return {
+      id: `admin_operations:${doc.id}`,
+      actorUid: typeof data.actorUid === "string" ? data.actorUid : null,
+      targetUid: typeof data.targetUid === "string" ? data.targetUid : null,
+      kind,
+      summaryAction,
+      title: adminOperationTitle(kind, summaryAction),
+      detail: adminOperationDetail({
+        mode,
+        summary,
+        errorMessage:
+          typeof data.errorMessage === "string" && data.errorMessage.length > 0
+            ? data.errorMessage
+            : null,
+      }),
+      status: typeof data.status === "string" ? data.status : null,
+      mode,
+      occurredAtISO: toIso(data.createdAt),
+    };
+  });
+}
+
+/** Batch-resolve uid → { name, email } from the users collection (chunked getAll). */
+async function resolveUsers(
+  db: Firestore,
+  uids: Set<string>,
+): Promise<Map<string, { name: string; email: string }>> {
+  const out = new Map<string, { name: string; email: string }>();
+  const ids = Array.from(uids).filter((u) => u.length > 0);
+  if (ids.length === 0) return out;
+
+  const usersCol = db.collection(FirestoreCollections.users);
+  // getAll has no hard arg cap, but chunk defensively to keep request size sane.
+  for (let i = 0; i < ids.length; i += 200) {
+    const chunk = ids.slice(i, i + 200);
+    const refs = chunk.map((id) => usersCol.doc(id));
+    const snaps = await db.getAll(...refs).catch((err) => {
+      console.warn("[gc-fitness/audit] user resolve chunk failed", err);
+      return [] as FirebaseFirestore.DocumentSnapshot[];
+    });
+    for (const snap of snaps) {
+      if (!snap.exists) continue;
+      const data = snap.data() as { displayName?: string; email?: string };
+      out.set(snap.id, {
+        name: (data.displayName ?? data.email ?? snap.id) || snap.id,
+        email: data.email ?? "",
+      });
+    }
+  }
+  return out;
+}
+
+/**
+ * Core: fetch both sources (date-bounded), resolve identities, and merge into a
+ * single time-sorted `AuditEntry[]`. NOT sliced and NOT action/actor/client
+ * filtered — the public functions below apply those + the limit. Admin-gated.
+ */
+async function collectAuditEntries(
+  from: Date | null,
+  to: Date | null,
+): Promise<AuditEntry[]> {
+  const db = gcFitnessFirestore();
+  const [coachRaw, adminRaw] = await Promise.all([
+    fetchCoachActivityEntries(db, from, to),
+    fetchAdminOperationEntries(db, from, to),
+  ]);
+
+  const uids = new Set<string>();
+  for (const r of coachRaw) {
+    if (r.actorUid) uids.add(r.actorUid);
+    if (r.clientId) uids.add(r.clientId);
+  }
+  for (const r of adminRaw) {
+    if (r.actorUid) uids.add(r.actorUid);
+    if (r.targetUid) uids.add(r.targetUid);
+  }
+  const userById = await resolveUsers(db, uids);
+
+  const entries: AuditEntry[] = [];
+
+  for (const r of coachRaw) {
+    const actor = r.actorUid ? userById.get(r.actorUid) : undefined;
+    const clientUser = r.clientId ? userById.get(r.clientId) : undefined;
+    entries.push({
+      id: r.id,
+      source: "coach_activity",
+      occurredAtISO: r.occurredAtISO,
+      actorUid: r.actorUid,
+      actorName: actor?.name ?? null,
+      actorEmail: actor?.email ?? null,
+      actorRole: "coach",
+      kind: r.kind,
+      action: coachActivityAction(r.kind, r.deleted),
+      title: r.title,
+      detail: r.detail,
+      clientId: r.clientId,
+      clientLabel: clientUser?.email || r.pendingEmail || null,
+      isDeletion: r.deleted,
+      status: null,
+      mode: null,
+    });
+  }
+
+  for (const r of adminRaw) {
+    const actor = r.actorUid ? userById.get(r.actorUid) : undefined;
+    const targetUser = r.targetUid ? userById.get(r.targetUid) : undefined;
+    entries.push({
+      id: r.id,
+      source: "admin_operations",
+      occurredAtISO: r.occurredAtISO,
+      actorUid: r.actorUid,
+      actorName: actor?.name ?? null,
+      actorEmail: actor?.email ?? null,
+      actorRole: "admin",
+      kind: r.kind,
+      action: r.kind === "transfer_client" ? "update" : "delete",
+      title: r.title,
+      detail: r.detail,
+      clientId: r.targetUid,
+      clientLabel: targetUser?.email ?? null,
+      // A transfer is not a deletion; everything else logged here removes data.
+      isDeletion: r.kind !== "transfer_client",
+      status: r.status,
+      mode: r.mode,
+    });
+  }
+
+  entries.sort((a, b) =>
+    (b.occurredAtISO ?? "").localeCompare(a.occurredAtISO ?? ""),
+  );
+  return entries;
+}
+
+function applyInMemoryFilters(
+  entries: AuditEntry[],
+  filters: AuditFilters,
+): AuditEntry[] {
+  const source = filters.source && filters.source !== "all" ? filters.source : null;
+  const action = filters.action && filters.action !== "all" ? filters.action : null;
+  const actorQuery = (filters.actorQuery ?? "").trim().toLowerCase();
+  const clientQuery = (filters.clientQuery ?? "").trim().toLowerCase();
+
+  return entries.filter((e) => {
+    if (source && e.source !== source) return false;
+    if (action && e.action !== action) return false;
+    if (actorQuery) {
+      const hay = `${e.actorUid ?? ""} ${e.actorName ?? ""} ${e.actorEmail ?? ""}`.toLowerCase();
+      if (!hay.includes(actorQuery)) return false;
+    }
+    if (clientQuery) {
+      const hay = `${e.clientId ?? ""} ${e.clientLabel ?? ""}`.toLowerCase();
+      if (!hay.includes(clientQuery)) return false;
+    }
+    return true;
+  });
+}
+
+function clampLimit(limit: number | undefined): number {
+  if (typeof limit !== "number" || !Number.isFinite(limit)) return DEFAULT_LIMIT;
+  return Math.max(1, Math.min(Math.trunc(limit), MAX_LIMIT));
+}
+
+/**
+ * Unified, admin-gated observability timeline across `coach_activity` +
+ * `admin_operations`, newest first. Date range is applied server-side; all
+ * other filters in memory.
+ */
+export async function listAuditTimeline(
+  filters: AuditFilters = {},
+): Promise<AuditEntry[]> {
+  await getCurrentAdmin();
+  const from = startOfDayUtc(filters.fromISO);
+  const to = endOfDayUtc(filters.toISO);
+  const all = await collectAuditEntries(from, to);
+  return applyInMemoryFilters(all, filters).slice(0, clampLimit(filters.limit));
+}
+
+/**
+ * Deletion history: the same merged feed restricted to entries that REMOVED
+ * something — coach_activity events flipped `deleted: true` plus admin cascade /
+ * deactivation / pending-removal operations (transfers excluded). Answers
+ * "who deleted what, and when". The `action` filter is ignored here (the view
+ * is implicitly action=delete).
+ */
+export async function listDeletionHistory(
+  filters: AuditFilters = {},
+): Promise<AuditEntry[]> {
+  await getCurrentAdmin();
+  const from = startOfDayUtc(filters.fromISO);
+  const to = endOfDayUtc(filters.toISO);
+  const all = await collectAuditEntries(from, to);
+  const deletions = all.filter((e) => e.isDeletion);
+  return applyInMemoryFilters(deletions, { ...filters, action: "all" }).slice(
+    0,
+    clampLimit(filters.limit),
+  );
+}


### PR DESCRIPTION
## What

PR1 of the Monitoring & Observability initiative (mdb1/gc-fitness#312).

Adds an **admin-only** `/gc-fitness/admin/audit` dashboard that merges the two
existing app-level audit trails into one place:

- **`coach_activity`** — per-action coach events (workout/exercise created,
  workout/habit assigned, notes, photo/weight requests; removals flip
  `deleted: true` + `deletedAt`).
- **`admin_operations`** — operator trail (cascade deletes, client deactivation,
  pending-client removal, client transfer) with actor, mode, status, summary.

Two views:
- **Timeline** — everything, newest-first, filterable.
- **Deletions** — only entries that removed data (who deleted what + when),
  with admin cascade/deactivation/pending-removal included and transfers excluded.

Filters: source, action, actor (uid/name/email contains), client (uid/email
contains), and a UTC date range (applied server-side).

## Why

Keeps with the theme of the recent incident-traceability work (#243 storage
fix): when something breaks, an operator can see the sequence of actions that
led to the current state.

## How it's built
- `src/lib/gc-fitness/audit-actions.ts` — `listAuditTimeline` +
  `listDeletionHistory`, admin-gated via `getCurrentAdmin()`. Date range filters
  in-query on the single time field (`occurredAt`/`createdAt`) → **no new
  composite index**; all other filters in memory over a bounded per-source
  window (matches the existing `listRecentCoachActivity` pattern). Each source
  query is **fail-soft** — one collection erroring never blanks the feed. Actor
  and client identities resolved via a single chunked `users` `getAll`.
- `src/app/gc-fitness/admin/audit/page.tsx` — server component, `PillTabs`,
  `<form method="get">` filter bar (no client JS), action-coded badges,
  destructive rows tinted, `status`/`mode` surfaced for admin ops.
- Admin hub gets a link card.

## Scope / follow-up
**In scope (PR1):** dashboard over what is *already* logged.
**Out of scope (PR2):** a Cloud Functions `audit_log` `onWrite` layer to also
capture raw Firestore-console edits, maintenance-script writes, and direct
iOS/Android client writes — the agreed hybrid direction, deliberately deferred.

## Tests
- New `audit-actions.test.ts` — 11 tests: admin gate (Forbidden), merge +
  newest-first sort (deletions use `deletedAt` timing), action mapping, actor +
  client identity resolution, source/action/actor/client filters, deletion
  scoping (transfers excluded), and per-source fail-soft. ✅ green.
- `npx tsc --noEmit` ✅ clean.
- Full `npx jest`: my suite green; the only two red suites
  (`client-activity-time` locale flake, `workout-assignment-actions` SC#2)
  reproduce on a clean `origin/main` worktree — pre-existing/environmental,
  green on CI, untouched by this PR.

Closes mdb1/gc-fitness#312 (partially — PR1 of 2).