### PR TITLE
feat(gc-fitness-admin): surface audit_log as a 3rd source in the monitoring dashboard (#312)

### DIFF
--- a/backoffice/src/app/gc-fitness/admin/audit/page.tsx
+++ b/backoffice/src/app/gc-fitness/admin/audit/page.tsx
@@ -50,6 +50,7 @@ const SOURCE_OPTIONS: Array<{ value: "all" | AuditSource; label: string }> = [
   { value: "all", label: "All sources" },
   { value: "coach_activity", label: "Coach activity" },
   { value: "admin_operations", label: "Admin operations" },
+  { value: "audit_log", label: "Firestore writes (audit log)" },
 ];
 
 function str(value: string | string[] | undefined): string {
@@ -94,7 +95,9 @@ export default async function AuditPage({
   const tab = str(sp.tab) === "deletions" ? "deletions" : "timeline";
   const source = (() => {
     const v = str(sp.source);
-    return v === "coach_activity" || v === "admin_operations" ? v : "all";
+    return v === "coach_activity" || v === "admin_operations" || v === "audit_log"
+      ? v
+      : "all";
   })();
   const action = (() => {
     const v = str(sp.action);

--- a/backoffice/src/lib/gc-fitness/__tests__/audit-actions.test.ts
+++ b/backoffice/src/lib/gc-fitness/__tests__/audit-actions.test.ts
@@ -267,3 +267,82 @@ describe("listDeletionHistory", () => {
     expect(rows.map((r) => r.id)).toEqual(["coach_activity:asg:s1"]);
   });
 });
+
+describe("audit_log as a third source (#312 PR2)", () => {
+  // Default mock has no audit_log docs; each test seeds them so the existing
+  // coach_activity / admin_operations assertions above stay exact.
+  beforeEach(() => {
+    queryGet.audit_log = async () => ({
+      docs: [
+        doc("aud1", {
+          collection: "exercises",
+          docId: "ex-7",
+          op: "create",
+          changedFields: ["name", "trainerId"],
+          changedFieldCount: 2,
+          actorUid: null,
+          clientId: null,
+          occurredAt: ts("2026-06-15T13:00:00.000Z"),
+        }),
+        doc("aud2", {
+          collection: "users",
+          docId: "client1",
+          op: "update",
+          changedFields: ["coachId"],
+          changedFieldCount: 1,
+          actorUid: "admin1",
+          clientId: "client1",
+          occurredAt: ts("2026-06-15T11:30:00.000Z"),
+        }),
+        doc("aud3", {
+          collection: "workout_logs",
+          docId: "log-1",
+          op: "delete",
+          changedFields: ["sets", "status", "clientId", "totalVolumeKg", "prs"],
+          changedFieldCount: 5,
+          actorUid: null,
+          clientId: "client2",
+          occurredAt: ts("2026-06-09T10:00:00.000Z"),
+        }),
+      ],
+    });
+  });
+
+  it("maps audit_log docs to system-actor entries with op→action + resolved identities", async () => {
+    const rows = await listAuditTimeline();
+    const byId = Object.fromEntries(rows.map((r) => [r.id, r]));
+
+    expect(byId["audit_log:aud1"].source).toBe("audit_log");
+    expect(byId["audit_log:aud1"].action).toBe("create");
+    expect(byId["audit_log:aud1"].actorRole).toBe("system");
+    expect(byId["audit_log:aud1"].title).toBe("Created exercise");
+    expect(byId["audit_log:aud1"].actorUid).toBeNull();
+
+    // Best-effort actorUid resolves to a user identity.
+    expect(byId["audit_log:aud2"].action).toBe("update");
+    expect(byId["audit_log:aud2"].title).toBe("Updated user");
+    expect(byId["audit_log:aud2"].actorName).toBe("Admin");
+    expect(byId["audit_log:aud2"].clientLabel).toBe("client1@x.com");
+    expect(byId["audit_log:aud2"].detail).toBe("client1 · coachId");
+
+    expect(byId["audit_log:aud3"].action).toBe("delete");
+    expect(byId["audit_log:aud3"].isDeletion).toBe(true);
+  });
+
+  it("source=audit_log returns only audit_log entries", async () => {
+    const rows = await listAuditTimeline({ source: "audit_log" });
+    expect(rows).toHaveLength(3);
+    expect(rows.every((r) => r.source === "audit_log")).toBe(true);
+  });
+
+  it("deletion history includes audit_log deletes alongside the others", async () => {
+    const rows = await listDeletionHistory();
+    expect(rows.every((r) => r.isDeletion)).toBe(true);
+    expect(rows.map((r) => r.id).sort()).toEqual([
+      "admin_operations:op1",
+      "admin_operations:op3",
+      "audit_log:aud3",
+      "coach_activity:asg:s1",
+    ]);
+  });
+});

--- a/backoffice/src/lib/gc-fitness/__tests__/collections.test.ts
+++ b/backoffice/src/lib/gc-fitness/__tests__/collections.test.ts
@@ -54,6 +54,10 @@ describe("FirestoreCollections — literal-string contract with Swift twin", () 
     expect(FirestoreCollections.appConfig).toBe("app_config");
   });
 
+  it("auditLog is 'audit_log' (#312 PR2 — server/functions-only, no Swift twin)", () => {
+    expect(FirestoreCollections.auditLog).toBe("audit_log");
+  });
+
   it("every value is lowercase snake_case", () => {
     for (const [key, value] of Object.entries(FirestoreCollections)) {
       expect(value).toBe(value.toLowerCase());

--- a/backoffice/src/lib/gc-fitness/audit-actions.ts
+++ b/backoffice/src/lib/gc-fitness/audit-actions.ts
@@ -17,10 +17,19 @@
 //                          transfer) with `actorUid`, `mode`, `status`,
 //                          `summary`, `errorMessage`.
 //
-// SCOPE (PR1): a read-only dashboard over what is ALREADY logged. It is blind to
-// raw Firestore-console edits, maintenance-script writes, and direct iOS/Android
-// client writes — capturing those needs the Cloud Functions `audit_log` layer,
-// which is a deliberate FOLLOW-UP (PR2). No new collections, no new indexes.
+//   - `audit_log`        — (PR2) the immutable DB-layer trail written by the
+//                          `onAuditableWrite` Cloud Functions: one entry per
+//                          create/update/delete on a monitored collection,
+//                          capturing raw Firestore-console edits, maintenance-
+//                          script writes, and direct iOS/Android client writes
+//                          that the two app-level trails above are blind to.
+//                          Its actor is "system" (background triggers have no
+//                          auth context; a best-effort `actorUid` may still be
+//                          stamped on the doc).
+//
+// No new indexes (single-field range + matching orderBy per source). audit_log
+// can be high-volume (max-fidelity capture), so it is read newest-first under
+// the same bounded per-source cap as the other two.
 //
 // Query strategy: a date range (when set) is applied IN-QUERY on the single time
 // field (`occurredAt` / `createdAt`) — a single-field range + matching orderBy
@@ -37,7 +46,7 @@ import { getCurrentAdmin } from "@/lib/gc-fitness/auth-helpers";
 import { COACH_ACTIVITY_COLLECTION } from "@/lib/gc-fitness/coach-activity-log";
 import { FirestoreCollections } from "@/lib/gc-fitness/collections";
 
-export type AuditSource = "coach_activity" | "admin_operations";
+export type AuditSource = "coach_activity" | "admin_operations" | "audit_log";
 
 export type AuditAction =
   | "create"
@@ -55,8 +64,12 @@ export interface AuditEntry {
   actorUid: string | null;
   actorName: string | null;
   actorEmail: string | null;
-  /** Who-kind: coach_activity events are coach actions; admin_operations are admin actions. */
-  actorRole: "coach" | "admin";
+  /**
+   * Who-kind: coach_activity events are coach actions; admin_operations are
+   * admin actions; audit_log is a DB-layer capture with no auth context, so its
+   * actor is "system" (best-effort actorUid may still be resolved from the doc).
+   */
+  actorRole: "coach" | "admin" | "system";
   /** Raw event/operation kind (e.g. "exercise", "delete_coach_cascade"). */
   kind: string;
   action: AuditAction;
@@ -318,6 +331,83 @@ async function fetchAdminOperationEntries(
   });
 }
 
+const OP_PAST: Record<string, string> = {
+  create: "Created",
+  update: "Updated",
+  delete: "Deleted",
+};
+
+/** "workout_assignments" → "workout assignment" (singular-ish, for titles). */
+function humanCollection(collection: string): string {
+  const spaced = collection.replace(/_/g, " ");
+  return spaced.endsWith("s") ? spaced.slice(0, -1) : spaced;
+}
+
+async function fetchAuditLogEntries(
+  db: Firestore,
+  from: Date | null,
+  to: Date | null,
+): Promise<
+  Array<{
+    id: string;
+    collection: string;
+    docId: string;
+    op: string;
+    changedFields: string[];
+    changedFieldCount: number;
+    actorUid: string | null;
+    clientId: string | null;
+    occurredAtISO: string | null;
+  }>
+> {
+  let q = db
+    .collection(FirestoreCollections.auditLog)
+    .orderBy("occurredAt", "desc") as FirebaseFirestore.Query;
+  if (from) q = q.where("occurredAt", ">=", Timestamp.fromDate(from));
+  if (to) q = q.where("occurredAt", "<=", Timestamp.fromDate(to));
+  const snap = await q
+    .limit(PER_SOURCE_CAP)
+    .get()
+    .catch((err) => {
+      console.warn("[gc-fitness/audit] audit_log query failed", err);
+      return null;
+    });
+  if (!snap) return [];
+
+  return snap.docs.map((doc) => {
+    const data = doc.data() as {
+      collection?: string;
+      docId?: string;
+      op?: string;
+      changedFields?: unknown;
+      changedFieldCount?: number;
+      actorUid?: string | null;
+      clientId?: string | null;
+      occurredAt?: unknown;
+      eventTime?: unknown;
+    };
+    const changedFields = Array.isArray(data.changedFields)
+      ? data.changedFields.filter((f): f is string => typeof f === "string")
+      : [];
+    return {
+      id: `audit_log:${doc.id}`,
+      collection: typeof data.collection === "string" ? data.collection : "?",
+      docId: typeof data.docId === "string" ? data.docId : "?",
+      op: typeof data.op === "string" ? data.op : "update",
+      changedFields,
+      changedFieldCount:
+        typeof data.changedFieldCount === "number"
+          ? data.changedFieldCount
+          : changedFields.length,
+      actorUid: typeof data.actorUid === "string" ? data.actorUid : null,
+      clientId: typeof data.clientId === "string" ? data.clientId : null,
+      // `occurredAt` is the server write time; `eventTime` is the CloudEvent
+      // time — prefer occurredAt, fall back to eventTime.
+      occurredAtISO: toIso(data.occurredAt) ?? toIso(data.eventTime),
+    };
+  });
+}
+
 /** Batch-resolve uid → { name, email } from the users collection (chunked getAll). */
 async function resolveUsers(
   db: Firestore,
@@ -358,9 +448,10 @@ async function collectAuditEntries(
   to: Date | null,
 ): Promise<AuditEntry[]> {
   const db = gcFitnessFirestore();
-  const [coachRaw, adminRaw] = await Promise.all([
+  const [coachRaw, adminRaw, auditRaw] = await Promise.all([
     fetchCoachActivityEntries(db, from, to),
     fetchAdminOperationEntries(db, from, to),
+    fetchAuditLogEntries(db, from, to),
   ]);
 
   const uids = new Set<string>();
@@ -371,6 +462,10 @@ async function collectAuditEntries(
   for (const r of adminRaw) {
     if (r.actorUid) uids.add(r.actorUid);
     if (r.targetUid) uids.add(r.targetUid);
+  }
+  for (const r of auditRaw) {
+    if (r.actorUid) uids.add(r.actorUid);
+    if (r.clientId) uids.add(r.clientId);
   }
   const userById = await resolveUsers(db, uids);
 
@@ -420,6 +515,34 @@ async function collectAuditEntries(
       isDeletion: r.kind !== "transfer_client",
       status: r.status,
       mode: r.mode,
+    });
+  }
+
+  for (const r of auditRaw) {
+    const actor = r.actorUid ? userById.get(r.actorUid) : undefined;
+    const clientUser = r.clientId ? userById.get(r.clientId) : undefined;
+    const op = (["create", "update", "delete"].includes(r.op)
+      ? r.op
+      : "update") as AuditAction;
+    const fieldList = r.changedFields.slice(0, 8).join(", ");
+    const moreFields = r.changedFieldCount > 8 ? "…" : "";
+    entries.push({
+      id: r.id,
+      source: "audit_log",
+      occurredAtISO: r.occurredAtISO,
+      actorUid: r.actorUid,
+      actorName: actor?.name ?? null,
+      actorEmail: actor?.email ?? null,
+      actorRole: "system",
+      kind: r.collection,
+      action: op,
+      title: `${OP_PAST[r.op] ?? r.op} ${humanCollection(r.collection)}`,
+      detail: fieldList ? `${r.docId} · ${fieldList}${moreFields}` : r.docId,
+      clientId: r.clientId,
+      clientLabel: clientUser?.email ?? null,
+      isDeletion: r.op === "delete",
+      status: null,
+      mode: null,
     });
   }
 

--- a/backoffice/src/lib/gc-fitness/collections.ts
+++ b/backoffice/src/lib/gc-fitness/collections.ts
@@ -180,6 +180,20 @@ export const FirestoreCollections = {
    * `FirestoreCollections.appConfig` (same-commit invariant, Pitfall 7).
    */
   appConfig: "app_config",
+
+  /**
+   * Immutable Firestore-mutation audit trail (issue #312, PR2). One entry per
+   * create/update/delete on a monitored high-risk collection, written
+   * EXCLUSIVELY by the `onAuditableWrite` Cloud Functions (one onDocumentWritten
+   * trigger per monitored collection) via the Admin SDK. Captures the mutations
+   * the app-level `coach_activity` / `admin_operations` trails miss (raw console
+   * edits, maintenance-script writes, direct mobile-client writes). Read ONLY by
+   * the backoffice monitoring dashboard via the Admin SDK; firestore.rules denies
+   * all client access. No Swift twin — the iOS/watch surfaces never touch it (the
+   * functions repo uses a local `AUDIT_LOG_COLLECTION` string), same backoffice/
+   * server-only status as `adminOperations` / `coachAllowlist`.
+   */
+  auditLog: "audit_log",
 } as const;
 
 /**


### PR DESCRIPTION
## What

PR2b — the backoffice half of #312 PR2. Wires the new Cloud Functions `audit_log`
capture (gc-fitness #316) into the `/gc-fitness/admin/audit` dashboard as a third
merged source, alongside `coach_activity` and `admin_operations`.

With this, the dashboard finally shows the mutations the app-level trails are
**blind to** — raw Firestore-console edits, maintenance-script writes, and direct
iOS/Android client writes — each with the field-level diff and timing.

## Changes
- **`collections.ts`** — add `auditLog: "audit_log"` (+ lock test). Server/functions-only; **no Swift twin** (iOS never reads it; the functions repo uses a local `AUDIT_LOG_COLLECTION` constant), same status as `adminOperations` / `coachAllowlist`.
- **`audit-actions.ts`** — fetch `audit_log` as a 3rd source in `collectAuditEntries`. Maps `op`→`action` (create/update/delete), `title` like "Updated user", `detail` = `docId · changedFields`, `actorRole: "system"` (DB-layer capture has no auth context) with a **best-effort `actorUid` resolved** to a user identity, and the owner-hint `clientId` resolved + filterable. Same date-in-query / in-memory-filter / **fail-soft** / bounded per-source cap as the other two.
- **`page.tsx`** — add the **"Firestore writes (audit log)"** source filter option + accept it in the source-param validation. The `create/update/delete` actions already exist in the action filter and the deletion view already keys off `isDeletion`, so both work for audit_log with no further change.
- **+4 tests** in `audit-actions.test.ts` (mapping, `source=audit_log`, deletion inclusion). The existing exact-list assertions are preserved because the default mock seeds no audit_log docs.

## Sequencing / safety
Independent of #316's merge: until the functions are **deployed** (`firebase deploy --only functions`), `audit_log` is simply empty and the fetch is fail-soft, so the dashboard degrades gracefully. Safe to merge in either order.

## Tests
- `audit-actions` + `collections` suites green (26 tests).
- `tsc --noEmit` clean.
- Full `npx jest`: 669 pass; only the two known pre-existing reds (`client-activity-time` locale flake, `workout-assignment-actions` SC#2) remain — both reproduce on clean `origin/main`, untouched here.

Completes the #312 hybrid: PR1 (dashboard, #183, merged) + PR2a (capture, gc-fitness #316) + PR2b (this).