### PR TITLE
fix(gc-fitness-admin): hygiene scan crashed on reserved __standard__ owner id

### DIFF
--- a/backoffice/src/lib/gc-fitness/__tests__/data-hygiene-actions.reserved-id.test.ts
+++ b/backoffice/src/lib/gc-fitness/__tests__/data-hygiene-actions.reserved-id.test.ts
@@ -1,0 +1,120 @@
+// __tests__/data-hygiene-actions.reserved-id.test.ts
+//
+// Regression test for the hygiene-scan crash:
+//   "3 INVALID_ARGUMENT: Resource id \"__standard__\" is invalid because it is
+//    reserved."
+//
+// The 20 shared standard workout templates carry `trainerId: "__standard__"`.
+// The scan resolved owners via `db.collection('users').doc(trainerId)`, and
+// Firestore rejects any doc id matching /^__.*__$/ as reserved — so that point
+// read threw and (because all four loaders run under one Promise.all) blanked
+// the whole dashboard.
+//
+// The mock below mimics Firestore by THROWING from `.doc()` on a reserved id,
+// so if the guard ever regresses this suite fails loudly. With the fix, the
+// `__standard__` template is treated as a valid system owner: never point-read,
+// never flagged.
+
+jest.mock("@/lib/gc-fitness/auth-helpers", () => ({
+  getCurrentAdmin: jest.fn(),
+}));
+
+const mockCollection = jest.fn();
+const mockBucket = jest.fn();
+
+jest.mock("@/lib/firebase/gc-fitness-admin", () => ({
+  gcFitnessFirestore: jest.fn(() => ({ collection: mockCollection })),
+  gcFitnessStorage: jest.fn(() => ({ bucket: mockBucket })),
+  gcFitnessAuth: jest.fn(),
+}));
+
+import { listDataHygienePage } from "@/lib/gc-fitness/data-hygiene-actions";
+import { getCurrentAdmin } from "@/lib/gc-fitness/auth-helpers";
+
+const mockedGetCurrentAdmin = getCurrentAdmin as jest.MockedFunction<
+  typeof getCurrentAdmin
+>;
+
+const ADMIN = {
+  uid: "admin1",
+  email: "admin@x.com",
+  role: "admin" as const,
+  isTrainer: false,
+  roles: ["admin"],
+};
+
+const RESERVED = /^__.+__$/;
+
+type SeedDoc = { id: string; data: Record<string, unknown> };
+
+const DATA: Record<string, SeedDoc[]> = {
+  users: [
+    { id: "coach1", data: { role: "trainer", displayName: "Coach", email: "c@x.com" } },
+  ],
+  workout_templates: [
+    // Reserved owner — a shared standard template. Must NOT throw, NOT be flagged.
+    { id: "std1", data: { trainerId: "__standard__", name: { en: "Standard" } } },
+    // Valid owner present in the sample → no anomaly.
+    { id: "good", data: { trainerId: "coach1", name: { en: "Good" } } },
+    // Genuinely orphaned (owner missing) → still flagged.
+    { id: "orphan", data: { trainerId: "ghost", name: { en: "Orphan" } } },
+  ],
+  chats: [],
+  progress_photos: [],
+  workout_assignments: [],
+  workout_logs: [],
+  exercises: [],
+};
+
+function querySnap(docs: SeedDoc[]) {
+  return {
+    empty: docs.length === 0,
+    size: docs.length,
+    docs: docs.map((d) => ({ id: d.id, data: () => d.data, get: (k: string) => d.data[k] })),
+  };
+}
+
+function docSnap(d: SeedDoc | undefined) {
+  return d
+    ? { exists: true, id: d.id, data: () => d.data, get: (k: string) => d.data[k] }
+    : { exists: false, id: "", data: () => undefined, get: () => undefined };
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockedGetCurrentAdmin.mockResolvedValue(ADMIN);
+  mockBucket.mockReturnValue({
+    file: () => ({ exists: async () => [true], delete: async () => undefined }),
+  });
+  mockCollection.mockImplementation((name: string) => {
+    const docs = DATA[name] ?? [];
+    return {
+      limit: () => ({ get: async () => querySnap(docs) }),
+      doc: (id: string) => {
+        if (RESERVED.test(id)) {
+          // Mirror Firestore: constructing a ref with a reserved id throws.
+          throw new Error(
+            `3 INVALID_ARGUMENT: Resource id "${id}" is invalid because it is reserved.`,
+          );
+        }
+        return { get: async () => docSnap(docs.find((d) => d.id === id)) };
+      },
+    };
+  });
+});
+
+describe("listDataHygienePage — reserved-id (__standard__) handling", () => {
+  it("does not throw on a __standard__ owner and excludes it from anomalies", async () => {
+    const page = await listDataHygienePage();
+    const ids = page.rows.map((r) => r.id);
+    expect(ids).not.toContain("template:std1"); // standard/system template — not an orphan
+    expect(ids).not.toContain("template:good"); // valid owner — not an anomaly
+  });
+
+  it("still flags a genuinely orphaned template (real owner id missing)", async () => {
+    const page = await listDataHygienePage();
+    const orphan = page.rows.find((r) => r.id === "template:orphan");
+    expect(orphan).toBeDefined();
+    expect(orphan?.issue).toContain("Trainer doc missing");
+  });
+});

--- a/backoffice/src/lib/gc-fitness/data-hygiene-actions.ts
+++ b/backoffice/src/lib/gc-fitness/data-hygiene-actions.ts
@@ -63,6 +63,42 @@ function safeString(value: unknown): string | null {
   return typeof value === "string" && value.trim().length > 0 ? value.trim() : null;
 }
 
+/**
+ * Firestore rejects document IDs matching `/^__.*__$/` ("reserved"). The shared
+ * standard workout templates use the `__standard__` sentinel as their owner
+ * (`trainerId: "__standard__"`), so resolving one through
+ * `db.collection('users').doc(trainerId)` throws
+ *   `INVALID_ARGUMENT: Resource id "__standard__" is invalid because it is reserved`
+ * — which previously killed the ENTIRE hygiene scan (all four loaders run under
+ * one `Promise.all`).
+ *
+ * Treat any reserved owner/reference id as a VALID system owner: never
+ * point-read it (that throws) and never flag it as an orphan (a `__standard__`
+ * template is legitimately system-owned, not structurally broken).
+ */
+function isReservedId(value: string | null | undefined): boolean {
+  return typeof value === "string" && /^__.+__$/.test(value);
+}
+
+/**
+ * Resolve a referenced user by id through `cache`, falling back to a single
+ * point read (cached). Returns the sentinel `"reserved"` for Firestore reserved
+ * ids (e.g. `__standard__`) so callers skip the existence/role validation
+ * instead of point-reading (which throws) or false-flagging it as missing.
+ */
+async function resolveUserRef(
+  db: FirebaseFirestore.Firestore,
+  cache: Map<string, Record<string, unknown> | null>,
+  id: string,
+): Promise<Record<string, unknown> | null | "reserved"> {
+  if (isReservedId(id)) return "reserved";
+  if (cache.has(id)) return cache.get(id) ?? null;
+  const snap = await db.collection(FirestoreCollections.users).doc(id).get();
+  const data = snap.exists ? (snap.data() as Record<string, unknown>) : null;
+  cache.set(id, data);
+  return data;
+}
+
 function normalizeScanSort(iso: string | null): string {
   return iso ?? "";
 }
@@ -166,7 +202,7 @@ async function loadUserAnomalies(): Promise<DataHygieneRow[]> {
     if (role === "client") {
       if (!coachId) {
         issues.push("Missing coachId");
-      } else {
+      } else if (!isReservedId(coachId)) {
         let coach = liveByUid.get(coachId);
         if (!coach) {
           const coachSnap = await db.collection(FirestoreCollections.users).doc(coachId).get();
@@ -236,35 +272,25 @@ async function loadChatAnomalies(): Promise<DataHygieneRow[]> {
     if (!clientId) {
       issues.push("Missing clientId");
     } else {
-      let clientDoc = userMap.get(clientId) ?? null;
-      if (!clientDoc) {
-        const clientSnap = await db.collection(FirestoreCollections.users).doc(clientId).get();
-        clientDoc = clientSnap.exists ? (clientSnap.data() as Record<string, unknown>) : null;
-        if (clientDoc) {
-          userMap.set(clientId, clientDoc);
+      const clientDoc = await resolveUserRef(db, userMap, clientId);
+      if (clientDoc !== "reserved") {
+        if (!clientDoc) {
+          issues.push("Client doc missing");
+        } else if (clientDoc.role !== "client") {
+          issues.push("Client doc has the wrong role");
         }
-      }
-      if (!clientDoc) {
-        issues.push("Client doc missing");
-      } else if (clientDoc.role !== "client") {
-        issues.push("Client doc has the wrong role");
       }
     }
     if (!coachId) {
       issues.push("Missing coachId");
     } else {
-      let coachDoc = userMap.get(coachId) ?? null;
-      if (!coachDoc) {
-        const coachSnap = await db.collection(FirestoreCollections.users).doc(coachId).get();
-        coachDoc = coachSnap.exists ? (coachSnap.data() as Record<string, unknown>) : null;
-        if (coachDoc) {
-          userMap.set(coachId, coachDoc);
+      const coachDoc = await resolveUserRef(db, userMap, coachId);
+      if (coachDoc !== "reserved") {
+        if (!coachDoc) {
+          issues.push("Coach doc missing");
+        } else if (coachDoc.role !== "trainer") {
+          issues.push("Coach doc has the wrong role");
         }
-      }
-      if (!coachDoc) {
-        issues.push("Coach doc missing");
-      } else if (coachDoc.role !== "trainer") {
-        issues.push("Coach doc has the wrong role");
       }
     }
     if (!safeString(data.createdAt) && !toIso(data.createdAt)) {
@@ -334,18 +360,13 @@ async function loadPhotoAnomalies(): Promise<DataHygieneRow[]> {
     if (!clientId) {
       issues.push("Missing clientId");
     } else {
-      let clientDoc = userMap.get(clientId) ?? null;
-      if (!clientDoc) {
-        const clientSnap = await db.collection(FirestoreCollections.users).doc(clientId).get();
-        clientDoc = clientSnap.exists ? (clientSnap.data() as Record<string, unknown>) : null;
-        if (clientDoc) {
-          userMap.set(clientId, clientDoc);
+      const clientDoc = await resolveUserRef(db, userMap, clientId);
+      if (clientDoc !== "reserved") {
+        if (!clientDoc) {
+          issues.push("Client doc missing");
+        } else if (clientDoc.role !== "client") {
+          issues.push("Client doc has the wrong role");
         }
-      }
-      if (!clientDoc) {
-        issues.push("Client doc missing");
-      } else if (clientDoc.role !== "client") {
-        issues.push("Client doc has the wrong role");
       }
     }
     if (!storagePath) {
@@ -401,18 +422,15 @@ async function loadWorkoutAnomalies(): Promise<DataHygieneRow[]> {
     if (!trainerId) {
       issues.push("Missing trainerId");
     } else {
-      let trainerDoc = userMap.get(trainerId) ?? null;
-      if (!trainerDoc) {
-        const trainerSnap = await db.collection(FirestoreCollections.users).doc(trainerId).get();
-        trainerDoc = trainerSnap.exists ? (trainerSnap.data() as Record<string, unknown>) : null;
-        if (trainerDoc) {
-          userMap.set(trainerId, trainerDoc);
+      const trainerDoc = await resolveUserRef(db, userMap, trainerId);
+      // "reserved" → the `__standard__` system owner of a shared standard
+      // template; legitimately not a real trainer doc, so not an anomaly.
+      if (trainerDoc !== "reserved") {
+        if (!trainerDoc) {
+          issues.push("Trainer doc missing");
+        } else if (trainerDoc.role !== "trainer") {
+          issues.push("Trainer doc has the wrong role");
         }
-      }
-      if (!trainerDoc) {
-        issues.push("Trainer doc missing");
-      } else if (trainerDoc.role !== "trainer") {
-        issues.push("Trainer doc has the wrong role");
       }
     }
     if (issues.length === 0) continue;
@@ -436,35 +454,25 @@ async function loadWorkoutAnomalies(): Promise<DataHygieneRow[]> {
     if (!trainerId) {
       issues.push("Missing trainerId");
     } else {
-      let trainerDoc = userMap.get(trainerId) ?? null;
-      if (!trainerDoc) {
-        const trainerSnap = await db.collection(FirestoreCollections.users).doc(trainerId).get();
-        trainerDoc = trainerSnap.exists ? (trainerSnap.data() as Record<string, unknown>) : null;
-        if (trainerDoc) {
-          userMap.set(trainerId, trainerDoc);
+      const trainerDoc = await resolveUserRef(db, userMap, trainerId);
+      if (trainerDoc !== "reserved") {
+        if (!trainerDoc) {
+          issues.push("Trainer doc missing");
+        } else if (trainerDoc.role !== "trainer") {
+          issues.push("Trainer doc has the wrong role");
         }
-      }
-      if (!trainerDoc) {
-        issues.push("Trainer doc missing");
-      } else if (trainerDoc.role !== "trainer") {
-        issues.push("Trainer doc has the wrong role");
       }
     }
     if (!clientId) {
       issues.push("Missing clientId");
     } else {
-      let clientDoc = userMap.get(clientId) ?? null;
-      if (!clientDoc) {
-        const clientSnap = await db.collection(FirestoreCollections.users).doc(clientId).get();
-        clientDoc = clientSnap.exists ? (clientSnap.data() as Record<string, unknown>) : null;
-        if (clientDoc) {
-          userMap.set(clientId, clientDoc);
+      const clientDoc = await resolveUserRef(db, userMap, clientId);
+      if (clientDoc !== "reserved") {
+        if (!clientDoc) {
+          issues.push("Client doc missing");
+        } else if (clientDoc.role !== "client") {
+          issues.push("Client doc has the wrong role");
         }
-      }
-      if (!clientDoc) {
-        issues.push("Client doc missing");
-      } else if (clientDoc.role !== "client") {
-        issues.push("Client doc has the wrong role");
       }
     }
     if (issues.length === 0) continue;
@@ -490,22 +498,19 @@ async function loadWorkoutAnomalies(): Promise<DataHygieneRow[]> {
     if (!trainerId) {
       issues.push("Missing trainerId");
     } else {
-      let trainerDoc = userMap.get(trainerId) ?? null;
-      if (!trainerDoc) {
-        const trainerSnap = await db.collection(FirestoreCollections.users).doc(trainerId).get();
-        trainerDoc = trainerSnap.exists ? (trainerSnap.data() as Record<string, unknown>) : null;
-        if (trainerDoc) {
-          userMap.set(trainerId, trainerDoc);
+      const trainerDoc = await resolveUserRef(db, userMap, trainerId);
+      if (trainerDoc !== "reserved") {
+        if (!trainerDoc) {
+          issues.push("Trainer doc missing");
+        } else if (trainerDoc.role !== "trainer") {
+          issues.push("Trainer doc has the wrong role");
         }
-      }
-      if (!trainerDoc) {
-        issues.push("Trainer doc missing");
-      } else if (trainerDoc.role !== "trainer") {
-        issues.push("Trainer doc has the wrong role");
       }
     }
     if (!clientId) {
       issues.push("Missing clientId");
+    } else if (isReservedId(clientId)) {
+      // System sentinel owner — not an anomaly.
     } else if (!userMap.has(clientId)) {
       issues.push("Client doc missing");
     } else if (userMap.get(clientId)?.role !== "client") {
@@ -545,6 +550,8 @@ async function loadWorkoutAnomalies(): Promise<DataHygieneRow[]> {
     if (source === "trainer") {
       if (!ownerId) {
         issues.push("Missing ownerId");
+      } else if (isReservedId(ownerId)) {
+        // System/standard-library sentinel owner — not an anomaly.
       } else if (!userMap.has(ownerId)) {
         issues.push("Trainer doc missing");
       } else if (userMap.get(ownerId)?.role !== "trainer") {


### PR DESCRIPTION
## Symptom
The **Data hygiene** dashboard failed to load:
> Hygiene scan could not load
> `3 INVALID_ARGUMENT: Resource id "__standard__" is invalid because it is reserved.`

## Root cause
The 20 shared standard workout templates carry `trainerId: "__standard__"`. The scan resolves each record's owner via `db.collection('users').doc(trainerId).get()`. Firestore **rejects any document id matching `/^__.*__$/` as reserved**, so `.doc("__standard__")` throws `INVALID_ARGUMENT` — and because all four loaders run under a single `Promise.all`, that one throw **blanked the entire scan**.

## Fix
Treat reserved owner/reference ids as **valid system owners**: never point-read them (that throws) and never flag them as orphans (a `__standard__` template is legitimately system-owned, not structurally broken).

- Added `isReservedId()` + a `resolveUserRef()` helper that returns a `"reserved"` sentinel for reserved ids (short-circuits before any `.doc()` read).
- Routed **every** foreign-key user lookup through the guard, not just the template branch that crashed: `user.coachId`, chat `clientId`/`coachId`, photo `clientId`, template/assignment/log `trainerId` + `clientId`, exercise `ownerId`. Defense-in-depth against any future reserved sentinel.

## Test
New `data-hygiene-actions.reserved-id.test.ts` mocks Firestore to **throw from `.doc()` on a reserved id** (mirroring prod), so the suite fails loudly if the guard regresses. Asserts: (1) a `__standard__` template neither throws nor is flagged; (2) a genuinely orphaned template (real-but-missing owner) is **still** flagged `Trainer doc missing`.

- `tsc --noEmit` clean. New suite green. Full `npx jest`: only the two known pre-existing reds (`client-activity-time` locale flake, `workout-assignment-actions` SC#2 — both reproduce on clean `origin/main`), untouched here.