### PR TITLE
fix(gc-fitness-admin): resolve actor/client emails in the monitoring dashboard

### DIFF
--- a/backoffice/src/lib/gc-fitness/__tests__/audit-actions.test.ts
+++ b/backoffice/src/lib/gc-fitness/__tests__/audit-actions.test.ts
@@ -12,12 +12,10 @@ jest.mock("@/lib/gc-fitness/auth-helpers", () => ({
 }));
 
 const mockCollection = jest.fn();
-const mockGetAll = jest.fn();
 
 jest.mock("@/lib/firebase/gc-fitness-admin", () => ({
   gcFitnessFirestore: jest.fn(() => ({
     collection: mockCollection,
-    getAll: mockGetAll,
   })),
   gcFitnessAuth: jest.fn(),
 }));
@@ -147,20 +145,19 @@ beforeEach(() => {
       where: () => builder,
       limit: () => builder,
       get: () => (queryGet[name] ? queryGet[name]() : Promise.resolve({ docs: [] })),
-      doc: (id: string) => ({ id, __col: name }),
+      // resolveUsers now point-reads each referenced user via `.doc(id).get()`
+      // (no getAll/batchGet — see audit-actions.ts).
+      doc: (id: string) => ({
+        id,
+        get: async () => ({
+          id,
+          exists: usersById.has(id),
+          data: () => usersById.get(id) ?? {},
+        }),
+      }),
     };
     return builder;
   });
-
-  mockGetAll.mockImplementation((...refs: Array<{ id: string }>) =>
-    Promise.resolve(
-      refs.map((r) => ({
-        id: r.id,
-        exists: usersById.has(r.id),
-        data: () => usersById.get(r.id) ?? {},
-      })),
-    ),
-  );
 });
 
 describe("listAuditTimeline", () => {

--- a/backoffice/src/lib/gc-fitness/audit-actions.ts
+++ b/backoffice/src/lib/gc-fitness/audit-actions.ts
@@ -408,32 +408,55 @@ async function fetchAuditLogEntries(
   });
 }
 
-/** Batch-resolve uid → { name, email } from the users collection (chunked getAll). */
+/**
+ * Firestore rejects document ids matching `/^__.*__$/` ("reserved"); the shared
+ * standard templates use the `__standard__` sentinel owner. `.doc("__standard__")`
+ * throws, so reserved ids are dropped before any point read (mirrors the
+ * data-hygiene scan's guard). See `firestore-reserved-id-standard-sentinel`.
+ */
+function isReservedId(value: string): boolean {
+  return /^__.+__$/.test(value);
+}
+
+/**
+ * Resolve uid → { name, email } from the users collection.
+ *
+ * Uses INDIVIDUAL point reads (`.doc(id).get()`), NOT `getAll`/batchGet. The
+ * batchGet streaming RPC proved unreliable in the Vercel serverless runtime — it
+ * rejected, the rejection was swallowed by the catch, and EVERY actor/client in
+ * the dashboard fell back to a raw uid (no names/emails ever resolved). The
+ * unary get path is the one the other admin readers (`listRecentCoachActivity`,
+ * the hygiene scan) use successfully in the same runtime. Unique uids per page
+ * are bounded (tens), so N parallel point reads are cheap. Each read is
+ * fail-soft so one bad id never blanks the rest.
+ */
 async function resolveUsers(
   db: Firestore,
   uids: Set<string>,
 ): Promise<Map<string, { name: string; email: string }>> {
   const out = new Map<string, { name: string; email: string }>();
-  const ids = Array.from(uids).filter((u) => u.length > 0);
+  const ids = Array.from(uids).filter((u) => u.length > 0 && !isReservedId(u));
   if (ids.length === 0) return out;
 
   const usersCol = db.collection(FirestoreCollections.users);
-  // getAll has no hard arg cap, but chunk defensively to keep request size sane.
-  for (let i = 0; i < ids.length; i += 200) {
-    const chunk = ids.slice(i, i + 200);
-    const refs = chunk.map((id) => usersCol.doc(id));
-    const snaps = await db.getAll(...refs).catch((err) => {
-      console.warn("[gc-fitness/audit] user resolve chunk failed", err);
-      return [] as FirebaseFirestore.DocumentSnapshot[];
+  const snaps = await Promise.all(
+    ids.map((id) =>
+      usersCol
+        .doc(id)
+        .get()
+        .catch((err) => {
+          console.warn(`[gc-fitness/audit] user resolve failed for ${id}`, err);
+          return null;
+        }),
+    ),
+  );
+  for (const snap of snaps) {
+    if (!snap || !snap.exists) continue;
+    const data = snap.data() as { displayName?: string; email?: string };
+    out.set(snap.id, {
+      name: (data.displayName ?? data.email ?? snap.id) || snap.id,
+      email: data.email ?? "",
     });
-    for (const snap of snaps) {
-      if (!snap.exists) continue;
-      const data = snap.data() as { displayName?: string; email?: string };
-      out.set(snap.id, {
-        name: (data.displayName ?? data.email ?? snap.id) || snap.id,
-        email: data.email ?? "",
-      });
-    }
   }
   return out;
 }


### PR DESCRIPTION
## Symptom
In the **Monitoring & observability → Activity timeline**, the **Actor** column showed `—` + a raw UID for every row, and **Client / target** showed raw UIDs too — only the one row whose email came from `pendingEmail` (stored directly on the event) rendered an address.

## Root cause
The user docs *do* have emails (verified against prod via the Firestore REST API — e.g. the coach UID resolves to `manuherrera8@gmail.com`, the clients to their emails). The problem is the resolver:

`resolveUsers` used **`db.getAll(...)`** — firebase-admin's **batchGet streaming RPC**. That RPC is unreliable in the Vercel serverless runtime: it rejected, the rejection was swallowed by the `.catch`, the resolved-user map came back empty, and so `actorName` / `actorEmail` and the users-derived `clientLabel` were always null → fall back to the raw UID.

Corroboration: `batchGet` works fine via REST (so it's not data/permissions), and the *other* admin readers (`listRecentCoachActivity`, the hygiene scan) resolve users via unary **`.doc().get()`** and display names/emails correctly in the same runtime.

## Fix
Resolve via individual **`.doc(id).get()`** point reads (fail-soft per id), dropping `getAll` entirely. Unique UIDs per page are bounded (tens), so N parallel point reads are cheap for an admin page. Reserved ids (`__standard__`) are dropped before reading (a `.doc("__standard__")` would throw — same sentinel that crashed the hygiene scan in #185).

Now the timeline shows e.g. **Manu · manuherrera8@gmail.com** instead of `—` / `kXZSqc…`.

## Notes
- Deleted-client targets (e.g. a `delete_client_cascade` row) still show only the UID — their user doc no longer exists, so there's nothing to resolve. That's correct.
- This also covers the `audit_log` source rows (same resolver).

## Tests
Updated the suite's mock to serve users through `.doc(id).get()` (instead of `getAll`); existing actor/client resolution assertions pass. `tsc` clean. Full `npx jest`: only the two known pre-existing reds (`client-activity-time` locale flake, `workout-assignment-actions` SC#2), untouched here.