### PR TITLE
fix(gc-fitness): client initials avatar invisible on selected gold chips

### DIFF
--- a/backoffice/src/components/gc-fitness/ClientAvatar.tsx
+++ b/backoffice/src/components/gc-fitness/ClientAvatar.tsx
@@ -86,8 +86,17 @@ export function ClientAvatar({
     <div
       aria-hidden="true"
       className={cn(
-        "flex shrink-0 items-center justify-center overflow-hidden rounded-full bg-primary/10 font-medium text-primary",
+        "flex shrink-0 items-center justify-center overflow-hidden rounded-full font-medium",
         SIZE_CLASS[size],
+        // Initials-only styling (a photo covers the circle entirely, so photo
+        // avatars keep their bare look). The old `bg-primary/10` + `text-primary`
+        // was gold-on-gold: it vanished on the gold `bg-primary` chip these
+        // avatars render in when SELECTED (recent-logs / schedule / checklist
+        // client filters), and the translucent fill also blended into the
+        // `bg-muted` UNSELECTED chips. An opaque muted fill + foreground initials
+        // + an inset ring keep the initials legible and the circle delineated on
+        // white, gold, muted, and in dark mode — on any background.
+        !showImage && "bg-muted text-foreground ring-1 ring-inset ring-border",
         className,
       )}
     >

--- a/backoffice/src/lib/gc-fitness/__tests__/client-avatar.test.tsx
+++ b/backoffice/src/lib/gc-fitness/__tests__/client-avatar.test.tsx
@@ -1,0 +1,46 @@
+/**
+ * @jest-environment jsdom
+ */
+
+// client-avatar.test.tsx
+//
+// Regression for the initials fallback that vanished on selected gold chips
+// (recent-logs / schedule / checklist client filters): the old
+// `bg-primary/10` + `text-primary` scheme was gold-on-gold and disappeared on
+// the `bg-primary` selected chip. The fallback must use contrasting, non-brand
+// colors so the initials stay legible on any chip background.
+
+import "@testing-library/jest-dom";
+import { render, screen } from "@testing-library/react";
+import React from "react";
+
+import { ClientAvatar } from "@/components/gc-fitness/ClientAvatar";
+
+describe("ClientAvatar initials fallback", () => {
+  it("renders contrasting (non-brand-gold) colors so initials show on a gold chip", () => {
+    render(<ClientAvatar name="Daniel Herrera" />);
+    const el = screen.getByText("DH");
+    expect(el.className).toContain("text-foreground");
+    // The gold-on-gold scheme that caused the bug must not return.
+    expect(el.className).not.toContain("text-primary");
+    expect(el.className).not.toContain("bg-primary/10");
+  });
+
+  it("derives one or two initials from the name", () => {
+    const { rerender } = render(<ClientAvatar name="Colo" />);
+    expect(screen.getByText("C")).toBeInTheDocument();
+    rerender(<ClientAvatar name="Mateo Palma Beltran" />);
+    expect(screen.getByText("MP")).toBeInTheDocument();
+  });
+
+  it("renders the photo (no initials) when photoURL is set", () => {
+    const { container } = render(
+      <ClientAvatar
+        name="Daniel Herrera"
+        photoURL="https://lh3.googleusercontent.com/x"
+      />,
+    );
+    expect(container.querySelector("img")).not.toBeNull();
+    expect(screen.queryByText("DH")).toBeNull();
+  });
+});


### PR DESCRIPTION
## Symptom
In the **recent activity** and **agenda** client filters, a client *without a profile photo* showed **no initials** once their chip was selected (the gold pill). Clients with a Google photo (incl. Google's default colored letter-avatars, like "A"/"M") looked fine; only the no-photo ones vanished.

## Root cause
`ClientAvatar`'s initials fallback used `bg-primary/10` + `text-primary` — **gold initials on a translucent pale-gold circle**. That's gold-on-gold, so:
- on the **selected** chip (`bg-primary`, gold) both the fill and the text collapsed into the chip → invisible;
- on the **unselected** recent-logs chip (`bg-muted`, light gray) the translucent fill also blended in.

## Fix
Style the initials fallback **only** (a photo fully covers the circle, so photo avatars are untouched) with an **opaque muted fill + `text-foreground` initials + an inset ring**:

```
!showImage && "bg-muted text-foreground ring-1 ring-inset ring-border"
```

The initials stay legible and the circle stays delineated on white cards, gold selected chips, muted unselected chips, and in dark mode — on any background. Since `ClientAvatar` is shared, this fixes recent-logs, schedule, and the checklist picker in one place.

## Tests
New jsdom suite `client-avatar.test.tsx` (3): the fallback renders contrasting, non-`text-primary` colors (regression guard); derives 1–2 initials; and a `photoURL` still renders the `<img>` (not initials).

`tsc` clean. Full `npx jest`: only the two known pre-existing reds (`client-activity-time` locale flake, `workout-assignment-actions` SC#2), untouched here.