### PR TITLE
fix(gc-fitness): bigger, tappable collapsed sidebar rail

### DIFF
--- a/backoffice/src/components/gc-fitness/gc-fitness-shell.tsx
+++ b/backoffice/src/components/gc-fitness/gc-fitness-shell.tsx
@@ -176,7 +176,12 @@ export function GCFitnessShell({
   const coachName = trainerEmail ? deriveName(trainerEmail) : t("appName");
 
   return (
-    <SidebarProvider>
+    <SidebarProvider
+      // Widen the collapsed (icon-only) rail from the shadcn default 3rem so the
+      // larger, touch-friendly 44px nav buttons (see SidebarNavLink) sit centered
+      // with breathing room instead of cramped 32px icons in a 48px strip.
+      style={{ "--sidebar-width-icon": "3.75rem" } as React.CSSProperties}
+    >
       <div className="gc-shell-bg flex min-h-screen w-full bg-background">
         <Sidebar collapsible="icon">
           <SidebarHeader className="px-3 py-4 group-data-[collapsible=icon]:px-2">
@@ -313,7 +318,15 @@ function SidebarNavLink({
 }) {
   const { isMobile, setOpenMobile } = useSidebar();
   return (
-    <SidebarMenuButton asChild isActive={isActive} tooltip={label}>
+    <SidebarMenuButton
+      asChild
+      isActive={isActive}
+      tooltip={label}
+      // Collapsed (icon-only) rail: bump the shadcn default 32px square button to
+      // a 44px circular hit target with a 20px icon so it's easy to tap and reads
+      // as a proper icon rail. Expanded state is unchanged.
+      className="group-data-[collapsible=icon]:size-11! group-data-[collapsible=icon]:rounded-full group-data-[collapsible=icon]:[&_svg]:size-5"
+    >
       <Link
         href={href}
         onClick={() => {


### PR DESCRIPTION
## Problem
The collapsed (icon-only) nav rail looked cramped and was hard to tap: shadcn defaults are a **3rem (48px)** rail with **32px** square buttons and **16px** icons — bare floating icons, sub-44px touch targets.

## Fix (scoped to the gc-fitness shell)
- **Wider rail:** `--sidebar-width-icon` 3rem → **3.75rem (60px)** via a `style` override on `SidebarProvider` (per-instance; does not touch the shared `ui/sidebar` primitive used by other backoffice surfaces).
- **Bigger buttons:** each nav button becomes a **44px circular** hit target (HIG touch size) with a **20px** icon, via `group-data-[collapsible=icon]:size-11! / rounded-full / [&_svg]:size-5` — the same `group-data-[collapsible=icon]:` override mechanism shadcn itself uses for the collapsed sizing, so it cleanly wins over the defaults. The expanded sidebar is unchanged.

## Verify
`tsc` clean. CSS-only change to the collapsed rail — the running app is Google-auth-gated so I couldn't auto-screenshot it; worth a quick visual check after deploy (collapse the sidebar and confirm the icons are larger/centered and easy to tap).