### PR TITLE
feat(gc-fitness): public Coach Wiki with video walkthroughs + sidebar link

### DIFF
--- a/backoffice/messages/en.json
+++ b/backoffice/messages/en.json
@@ -51,6 +51,7 @@
     "accountGroup": "Account",
     "chat": "Chat",
     "settings": "Settings",
+    "wiki": "Wiki",
     "clientsSection": "Clients",
     "clientsSectionDescription": "Trainer roster + per-client deep view.",
     "contentSection": "Content",

--- a/backoffice/messages/es.json
+++ b/backoffice/messages/es.json
@@ -51,6 +51,7 @@
     "accountGroup": "Cuenta",
     "chat": "Chat",
     "settings": "Configuración",
+    "wiki": "Wiki",
     "clientsSection": "Clientes",
     "clientsSectionDescription": "Plantel y vista detallada por cliente.",
     "contentSection": "Contenido",

--- a/backoffice/src/app/gc-fitness/wiki/page.tsx
+++ b/backoffice/src/app/gc-fitness/wiki/page.tsx
@@ -1,0 +1,207 @@
+import type { Metadata } from "next";
+import { getLocale } from "next-intl/server";
+import { BookOpen, PlayCircle, Video } from "lucide-react";
+
+import { GOLDENCROW_LOGO_DATA_URI } from "@/components/gc-fitness/goldencrow-logo-data";
+import { Badge } from "@/components/ui/badge";
+import {
+  WIKI_COPY,
+  WIKI_GROUPS,
+  loomEmbedUrl,
+  loomShareUrl,
+  pick,
+  type WikiVideo,
+} from "./wiki-data";
+
+// The Coach Wiki is intentionally PUBLIC — no getCurrentTrainer() call, anyone
+// with the link can read it. It's added to HIDDEN_SHELL_PATHS so it renders
+// standalone (no coach sidebar / no sign-in chrome). The logged-in portal links
+// here via a left-nav item that opens this page in a new tab.
+
+export const metadata: Metadata = {
+  title: "Wiki",
+};
+
+export default async function WikiPage() {
+  const locale = await getLocale();
+  const t = (key: keyof typeof WIKI_COPY) => pick(locale, WIKI_COPY[key]);
+
+  return (
+    <div className="min-h-screen bg-background text-foreground">
+      {/* Standalone brand bar (this page has no coach sidebar). */}
+      <header className="sticky top-0 z-30 border-b border-border/70 bg-background/85 backdrop-blur-sm">
+        <div className="mx-auto flex w-full max-w-5xl items-center gap-3 px-4 py-3 sm:px-6">
+          <span className="flex size-9 shrink-0 items-center justify-center overflow-hidden rounded-full bg-foreground shadow-sm">
+            {/* eslint-disable-next-line @next/next/no-img-element */}
+            <img
+              src={GOLDENCROW_LOGO_DATA_URI}
+              alt=""
+              className="h-6 w-6 object-contain"
+            />
+          </span>
+          <div className="min-w-0">
+            <p className="truncate font-heading text-sm font-bold leading-tight">
+              {t("brand")}
+            </p>
+            <p className="truncate text-xs text-muted-foreground">
+              {t("title")}
+            </p>
+          </div>
+          <BookOpen className="ml-auto h-5 w-5 text-primary" />
+        </div>
+      </header>
+
+      <div className="mx-auto w-full max-w-5xl px-4 py-8 sm:px-6 sm:py-10">
+        {/* Hero */}
+        <div className="space-y-2">
+          <p className="inline-flex items-center gap-1.5 rounded-full bg-primary/10 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-primary">
+            <Video className="h-3.5 w-3.5" />
+            {t("eyebrow")}
+          </p>
+          <h1 className="gc-page-title text-[1.9rem] leading-tight sm:text-4xl">
+            {t("title")}
+          </h1>
+          <p className="max-w-2xl text-sm text-muted-foreground sm:text-base">
+            {t("subtitle")}
+          </p>
+        </div>
+
+        {/* Mobile quick-jump (native disclosure, no JS). */}
+        <details className="mt-6 rounded-2xl border border-border bg-card p-4 lg:hidden">
+          <summary className="cursor-pointer text-sm font-semibold">
+            {t("tocTitle")}
+          </summary>
+          <Toc locale={locale} />
+        </details>
+
+        <div className="mt-8 grid gap-10 lg:grid-cols-[210px_1fr] lg:gap-12">
+          {/* Sticky table of contents (desktop). */}
+          <aside className="hidden lg:block">
+            <div className="sticky top-24">
+              <p className="mb-3 px-1 text-[0.7rem] font-semibold uppercase tracking-wider text-muted-foreground">
+                {t("tocTitle")}
+              </p>
+              <Toc locale={locale} />
+            </div>
+          </aside>
+
+          {/* Content */}
+          <main className="min-w-0 space-y-12">
+            {WIKI_GROUPS.map((group) => (
+              <section
+                key={group.id}
+                id={group.id}
+                className="scroll-mt-24 space-y-5"
+              >
+                <h2 className="font-heading text-lg font-bold sm:text-xl">
+                  {pick(locale, group.title)}
+                </h2>
+                <div className="space-y-6">
+                  {group.videos.map((video) => (
+                    <VideoCard key={video.id} video={video} locale={locale} />
+                  ))}
+                </div>
+              </section>
+            ))}
+
+            <p className="border-t border-border/70 pt-8 text-sm text-muted-foreground">
+              {t("footer")}
+            </p>
+          </main>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function Toc({ locale }: { locale: string }) {
+  return (
+    <nav className="space-y-4 text-sm">
+      {WIKI_GROUPS.map((group) => (
+        <div key={group.id}>
+          <a
+            href={`#${group.id}`}
+            className="block font-medium text-foreground transition-colors hover:text-primary"
+          >
+            {pick(locale, group.title)}
+          </a>
+          <ul className="mt-1 space-y-1 border-l border-border pl-3">
+            {group.videos.map((video) => (
+              <li key={video.id}>
+                <a
+                  href={`#${video.id}`}
+                  className="block text-muted-foreground transition-colors hover:text-primary"
+                >
+                  {pick(locale, video.title)}
+                </a>
+              </li>
+            ))}
+          </ul>
+        </div>
+      ))}
+    </nav>
+  );
+}
+
+function VideoCard({ video, locale }: { video: WikiVideo; locale: string }) {
+  const comingSoon = !video.loomId;
+  return (
+    <article
+      id={video.id}
+      className="scroll-mt-24 overflow-hidden rounded-2xl border border-border bg-card shadow-sm"
+    >
+      <div className="flex flex-wrap items-start justify-between gap-2 px-5 pt-5">
+        <div className="min-w-0">
+          <h3 className="font-heading text-base font-bold sm:text-lg">
+            {pick(locale, video.title)}
+          </h3>
+          <p className="mt-1 text-sm text-muted-foreground">
+            {pick(locale, video.description)}
+          </p>
+        </div>
+        {comingSoon ? (
+          <Badge variant="warning" className="shrink-0">
+            {pick(locale, WIKI_COPY.comingSoon)}
+          </Badge>
+        ) : null}
+      </div>
+
+      <div className="px-5 pb-5 pt-4">
+        {video.loomId ? (
+          <>
+            <div className="relative w-full overflow-hidden rounded-xl border border-border bg-black">
+              <div className="aspect-video">
+                <iframe
+                  src={loomEmbedUrl(video.loomId)}
+                  title={pick(locale, video.title)}
+                  allowFullScreen
+                  loading="lazy"
+                  className="absolute inset-0 h-full w-full"
+                />
+              </div>
+            </div>
+            <a
+              href={loomShareUrl(video.loomId)}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="mt-3 inline-flex items-center gap-1.5 text-sm font-medium text-primary hover:underline"
+            >
+              <PlayCircle className="h-4 w-4" />
+              {pick(locale, WIKI_COPY.openInLoom)}
+            </a>
+          </>
+        ) : (
+          <div className="flex aspect-video w-full flex-col items-center justify-center gap-2 rounded-xl border border-dashed border-border bg-muted/40 text-center">
+            <Video className="h-7 w-7 text-muted-foreground" />
+            <p className="text-sm font-medium">
+              {pick(locale, WIKI_COPY.comingSoon)}
+            </p>
+            <p className="max-w-xs px-4 text-xs text-muted-foreground">
+              {pick(locale, WIKI_COPY.comingSoonHint)}
+            </p>
+          </div>
+        )}
+      </div>
+    </article>
+  );
+}

--- a/backoffice/src/app/gc-fitness/wiki/wiki-data.ts
+++ b/backoffice/src/app/gc-fitness/wiki/wiki-data.ts
@@ -1,0 +1,216 @@
+// wiki-data.ts
+//
+// Content model for the public Coach Wiki (/gc-fitness/wiki). The wiki is a
+// no-auth, anyone-can-read page, so the copy lives here as a self-contained
+// ES/EN dictionary (same pattern the workout generator uses) instead of going
+// through the next-intl message catalog — it keeps the long-form help text and
+// the Loom IDs in one reviewable place.
+//
+// To add a recorded walkthrough: drop the Loom share id into `loomId`. A video
+// without a `loomId` renders as a "coming soon" placeholder, so the section
+// structure can ship before every clip is recorded.
+
+export type Localized = { es: string; en: string };
+
+export type WikiVideo = {
+  /** Stable anchor id used for the table-of-contents deep links (#id). */
+  id: string;
+  title: Localized;
+  description: Localized;
+  /** Loom share id (the slug after /share/). Omit until the clip is recorded. */
+  loomId?: string;
+};
+
+export type WikiGroup = {
+  id: string;
+  title: Localized;
+  videos: WikiVideo[];
+};
+
+export function pick(locale: string, value: Localized): string {
+  return locale.startsWith("en") ? value.en : value.es;
+}
+
+/** Build the Loom embed URL from a share id. */
+export function loomEmbedUrl(loomId: string): string {
+  return `https://www.loom.com/embed/${loomId}?hide_owner=true&hideEmbedTopBar=true`;
+}
+
+/** Build the public Loom share URL (the "open in Loom" fallback link). */
+export function loomShareUrl(loomId: string): string {
+  return `https://www.loom.com/share/${loomId}`;
+}
+
+export const WIKI_GROUPS: WikiGroup[] = [
+  {
+    id: "primeros-pasos",
+    title: { es: "Primeros pasos", en: "Getting started" },
+    videos: [
+      {
+        id: "dashboard",
+        title: { es: "Dashboard", en: "Dashboard" },
+        description: {
+          es: "Tu pantalla de inicio: un vistazo rápido al estado de tus clientes y los pendientes del día.",
+          en: "Your home screen: a quick look at how your clients are doing and what needs attention today.",
+        },
+        loomId: "b1600e3dfe244d85aecf0a6260894cb4",
+      },
+      {
+        id: "actividad-reciente",
+        title: { es: "Actividad reciente", en: "Recent activity" },
+        description: {
+          es: "Seguí en tiempo real lo que registran tus clientes: entrenamientos completados y hábitos marcados.",
+          en: "Follow what your clients log in real time: completed workouts and checked-off habits.",
+        },
+        loomId: "8fb8fa2ec3db4a5f8b922849d1d82e18",
+      },
+    ],
+  },
+  {
+    id: "clientes",
+    title: { es: "Clientes", en: "Clients" },
+    videos: [
+      {
+        id: "agregar-cliente",
+        title: { es: "Agregar cliente", en: "Add a client" },
+        description: {
+          es: "Cómo dar de alta un nuevo cliente y dejarlo listo para empezar a entrenar.",
+          en: "How to create a new client and get them ready to start training.",
+        },
+        loomId: "2f7301abc91043f5a05ef94e464cee42",
+      },
+      {
+        id: "clientes-detalle",
+        title: {
+          es: "Clientes, detalle y comparador de fotos",
+          en: "Clients, detail view & photo comparator",
+        },
+        description: {
+          es: "El listado de clientes, la ficha detallada de cada uno y el comparador de fotos de progreso.",
+          en: "The client roster, each client's detail view, and the progress-photo comparator.",
+        },
+        loomId: "6b2b66c131f24a5ea0cb1c13cab34cfb",
+      },
+    ],
+  },
+  {
+    id: "planificacion",
+    title: { es: "Planificación", en: "Planning" },
+    videos: [
+      {
+        id: "agenda-asignaciones",
+        title: { es: "Agenda y asignaciones", en: "Schedule & assignments" },
+        description: {
+          es: "Programá entrenamientos en la agenda y asignáselos a tus clientes, incluyendo recurrencias.",
+          en: "Schedule workouts on the calendar and assign them to your clients, including recurring ones.",
+        },
+        loomId: "bd5a237e34e44bcfba23cdee1a224d71",
+      },
+      {
+        id: "checklist",
+        title: { es: "Checklist", en: "Checklist" },
+        description: {
+          es: "Tu lista de tareas pendientes para no perder de vista lo que tenés que hacer con cada cliente.",
+          en: "Your to-do list so nothing slips through the cracks for any client.",
+        },
+        loomId: "0b4ae86864184137aa87b8dc774280e2",
+      },
+      {
+        id: "notificaciones",
+        title: { es: "Notificaciones", en: "Notifications" },
+        description: {
+          es: "Renovaciones de entrenamientos y hábitos, cumpleaños y activaciones recientes de clientes.",
+          en: "Workout and habit renewals, birthdays, and recent client activations.",
+        },
+        loomId: "86cf6fb192044164871a8326a7a45aad",
+      },
+    ],
+  },
+  {
+    id: "biblioteca",
+    title: { es: "Biblioteca", en: "Library" },
+    videos: [
+      {
+        id: "biblioteca",
+        title: { es: "Biblioteca", en: "Library" },
+        description: {
+          es: "El centro de contenido: entrenamientos, ejercicios y hábitos en un solo lugar.",
+          en: "Your content hub: workouts, exercises, and habits all in one place.",
+        },
+        loomId: "ff4f7b3d6a724effb971f5f2b1742aa0",
+      },
+      {
+        id: "generador-entrenamientos",
+        title: {
+          es: "Generador y creación de entrenamientos",
+          en: "Workout generator & creation",
+        },
+        description: {
+          es: "Generá entrenamientos automáticamente o creálos a mano desde cero.",
+          en: "Auto-generate workouts or build them by hand from scratch.",
+        },
+        // Pendiente de grabación.
+      },
+      {
+        id: "crear-ejercicio",
+        title: {
+          es: "Ejercicios y creación de ejercicios",
+          en: "Exercises & creating exercises",
+        },
+        description: {
+          es: "Explorá la biblioteca de ejercicios y agregá los tuyos propios con su GIF.",
+          en: "Browse the exercise library and add your own, GIF included.",
+        },
+        // Pendiente de grabación.
+      },
+      {
+        id: "crear-habito",
+        title: {
+          es: "Hábitos y creación de hábitos",
+          en: "Habits & creating habits",
+        },
+        description: {
+          es: "Definí hábitos para asignar a tus clientes y armá los tuyos propios.",
+          en: "Define habits to assign to your clients and build your own.",
+        },
+        // Pendiente de grabación.
+      },
+    ],
+  },
+  {
+    id: "app-clientes",
+    title: { es: "App de clientes", en: "Client app" },
+    videos: [
+      {
+        id: "demo-app",
+        title: { es: "Demo de la app de clientes", en: "Client app demo" },
+        description: {
+          es: "Un recorrido por la experiencia que viven tus clientes en la app móvil.",
+          en: "A walkthrough of the experience your clients get in the mobile app.",
+        },
+        // Pendiente de grabación.
+      },
+    ],
+  },
+];
+
+export const WIKI_COPY = {
+  brand: { es: "GC Fitness", en: "GC Fitness" },
+  eyebrow: { es: "Centro de ayuda", en: "Help center" },
+  title: { es: "Wiki para coaches", en: "Coach Wiki" },
+  subtitle: {
+    es: "Videos cortos que explican cómo usar cada sección del portal de coaches.",
+    en: "Short videos explaining how to use every section of the coach portal.",
+  },
+  tocTitle: { es: "Secciones", en: "Sections" },
+  comingSoon: { es: "Próximamente", en: "Coming soon" },
+  comingSoonHint: {
+    es: "Estamos grabando este video. Vuelve pronto.",
+    en: "We're still recording this one. Check back soon.",
+  },
+  openInLoom: { es: "Ver en Loom", en: "Open in Loom" },
+  footer: {
+    es: "¿Tenés dudas que no están acá? Escribinos por chat.",
+    en: "Got a question that isn't covered here? Reach out on chat.",
+  },
+} satisfies Record<string, Localized>;

--- a/backoffice/src/components/gc-fitness/gc-fitness-shell.tsx
+++ b/backoffice/src/components/gc-fitness/gc-fitness-shell.tsx
@@ -5,6 +5,7 @@ import { usePathname } from "next/navigation";
 import {
   Activity,
   Bell,
+  BookOpen,
   CalendarDays,
   ClipboardCheck,
   Home,
@@ -43,6 +44,9 @@ import { Badge } from "@/components/ui/badge";
 const HIDDEN_SHELL_PATHS = new Set([
   "/gc-fitness/login",
   "/gc-fitness/forbidden",
+  // The Coach Wiki is a public, standalone page (its own brand bar, no coach
+  // sidebar) — it's also linked from the nav below, opening in a new tab.
+  "/gc-fitness/wiki",
 ]);
 
 // Routes that keep the consolidated "Biblioteca" nav item highlighted. The
@@ -64,6 +68,8 @@ type NavLeaf = {
   icon: React.ComponentType<{ className?: string }>;
   /** Extra paths that should also light up this item. */
   matchPaths?: string[];
+  /** Renders as an anchor that opens in a new tab (e.g. the public Wiki). */
+  external?: boolean;
 };
 type NavSection = { sectionKey: string; items: NavLeaf[] };
 
@@ -97,7 +103,15 @@ const NAV_SECTIONS: NavSection[] = [
   },
   {
     sectionKey: "accountGroup",
-    items: [{ labelKey: "settings", href: "/gc-fitness/settings", icon: Settings }],
+    items: [
+      { labelKey: "settings", href: "/gc-fitness/settings", icon: Settings },
+      {
+        labelKey: "wiki",
+        href: "/gc-fitness/wiki",
+        icon: BookOpen,
+        external: true,
+      },
+    ],
   },
 ];
 
@@ -166,6 +180,7 @@ export function GCFitnessShell({
     : NAV_SECTIONS;
 
   function isItemActive(item: NavLeaf): boolean {
+    if (item.external) return false;
     if (inLiveWorkout) return false;
     const candidates = item.matchPaths ?? [item.href];
     return candidates.some(
@@ -250,6 +265,7 @@ export function GCFitnessShell({
                           isActive={isItemActive(item)}
                           icon={<item.icon className="h-4 w-4" />}
                           badge={navBadges[item.href] > 0 ? navBadges[item.href] : null}
+                          external={item.external}
                         />
                       </SidebarMenuItem>
                     ))}
@@ -309,14 +325,30 @@ function SidebarNavLink({
   isActive,
   icon,
   badge,
+  external = false,
 }: {
   href: string;
   label: string;
   isActive: boolean;
   icon: React.ReactNode;
   badge: number | null;
+  external?: boolean;
 }) {
   const { isMobile, setOpenMobile } = useSidebar();
+  const inner = (
+    <>
+      {icon}
+      <span>{label}</span>
+      {badge !== null ? (
+        <Badge
+          variant="destructive"
+          className="ml-auto h-5 min-w-5 justify-center rounded-full px-1.5 text-[11px]"
+        >
+          {badge}
+        </Badge>
+      ) : null}
+    </>
+  );
   return (
     <SidebarMenuButton
       asChild
@@ -327,23 +359,29 @@ function SidebarNavLink({
       // as a proper icon rail. Expanded state is unchanged.
       className="group-data-[collapsible=icon]:size-11! group-data-[collapsible=icon]:rounded-full group-data-[collapsible=icon]:[&_svg]:size-5"
     >
-      <Link
-        href={href}
-        onClick={() => {
-          if (isMobile) setOpenMobile(false);
-        }}
-      >
-        {icon}
-        <span>{label}</span>
-        {badge !== null ? (
-          <Badge
-            variant="destructive"
-            className="ml-auto h-5 min-w-5 justify-center rounded-full px-1.5 text-[11px]"
-          >
-            {badge}
-          </Badge>
-        ) : null}
-      </Link>
+      {external ? (
+        // The Wiki is a public standalone page — open it in a new tab so the
+        // coach keeps their place in the portal.
+        <a
+          href={href}
+          target="_blank"
+          rel="noopener noreferrer"
+          onClick={() => {
+            if (isMobile) setOpenMobile(false);
+          }}
+        >
+          {inner}
+        </a>
+      ) : (
+        <Link
+          href={href}
+          onClick={() => {
+            if (isMobile) setOpenMobile(false);
+          }}
+        >
+          {inner}
+        </Link>
+      )}
     </SidebarMenuButton>
   );
 }


### PR DESCRIPTION
## What

Adds a **public Coach Wiki** to the GC Fitness backoffice — a no-sign-in page where coaches (or anyone with the link) can watch short video walkthroughs of every portal section.

### Public wiki page — `/gc-fitness/wiki`
- **No auth required.** Plain Server Component that never calls `getCurrentTrainer()`, and added to `HIDDEN_SHELL_PATHS` so it renders standalone (its own Golden Crow brand bar, no coach sidebar).
- **Easy to navigate:** sticky table of contents (desktop) + a native `<details>` quick-jump (mobile), with sections grouped as *Primeros pasos · Clientes · Planificación · Biblioteca · App de clientes*.
- **Responsive Loom embeds** (16:9, lazy-loaded) with an "Open in Loom" fallback link per video.
- Matches the Coach Portal redesign tokens (cards, `--primary` gold, `font-heading`).

### Sidebar link (logged-in portal)
- New **Wiki** item in the left nav (Account group, `BookOpen` icon) that **opens the wiki in a new tab** — implemented via a new `external` `NavLeaf` variant rendering a `target="_blank"` anchor instead of a `next/link`.

### Videos
8 recorded walkthroughs are embedded. The 4 not yet recorded render as **"Próximamente"** placeholders so the structure ships now:
- Biblioteca + Generador + Crear Entrenamiento
- Biblioteca + Ejercicios + Crear ejercicio
- Biblioteca + Hábitos + Crear hábito
- Demo de la App de clientes

Drop the Loom share id into `wiki-data.ts` to publish each one — no other change needed.

### i18n
Content lives in a self-contained ES/EN dict (`wiki-data.ts`, same pattern as the workout generator), keyed off `getLocale()`. The `nav.wiki` label was added to `messages/en.json` + `messages/es.json`.

## Testing
- `npx tsc --noEmit` — clean
- `npx next build` — compiles; `/gc-fitness/wiki` route registered
- `npx jest --testPathPatterns gc-fitness` — only 2 failures, both **pre-existing** and unrelated (verified red on this branch with my changes stashed): `client-activity-time` (documented locale flake, green in CI) and `workout-assignment-actions` (read-count, green in CI).

## Notes
- New files: `src/app/gc-fitness/wiki/page.tsx`, `src/app/gc-fitness/wiki/wiki-data.ts`
- The wiki is public by design (the loom videos are shared links anyway); it exposes no client data.