### PR TITLE
fix(gc-fitness): collapse recurring audit rows, attribute trigger writes, fix timeline overflow

### DIFF
--- a/backoffice/src/app/gc-fitness/admin/audit/page.tsx
+++ b/backoffice/src/app/gc-fitness/admin/audit/page.tsx
@@ -259,7 +259,7 @@ export default async function AuditPage({
         </CardHeader>
         <CardContent className="p-0">
           <div className="overflow-x-auto">
-            <Table>
+            <Table className="min-w-[60rem]">
               <TableHeader>
                 <TableRow>
                   <TableHead>When (UTC)</TableHead>
@@ -289,36 +289,43 @@ export default async function AuditPage({
                       key={row.id}
                       className={row.isDeletion ? "bg-destructive/5" : undefined}
                     >
-                      <TableCell className="whitespace-nowrap text-xs">
+                      <TableCell className="whitespace-nowrap align-top text-xs">
                         {row.occurredAtISO
                           ? row.occurredAtISO.replace("T", " ").replace(/\.\d+Z$/, "Z")
                           : "—"}
                       </TableCell>
-                      <TableCell>
+                      <TableCell className="align-top">
                         <div className="font-medium">{row.actorName ?? "—"}</div>
-                        <div className="text-xs text-muted-foreground">
+                        <div className="text-xs break-all text-muted-foreground">
                           {row.actorEmail || row.actorUid || "—"}
                         </div>
                         <div className="text-[11px] uppercase tracking-wide text-muted-foreground/70">
-                          {row.actorRole}
+                          {row.source === "audit_log" ? "Firestore write" : row.actorRole}
                         </div>
                       </TableCell>
-                      <TableCell>
+                      <TableCell className="align-top">
                         <div className="flex flex-col gap-1">
-                          <Badge variant={actionBadgeVariant(row.action)} className="w-fit">
-                            {row.action}
-                          </Badge>
+                          <div className="flex flex-wrap items-center gap-1">
+                            <Badge variant={actionBadgeVariant(row.action)} className="w-fit">
+                              {row.action}
+                            </Badge>
+                            {row.occurrenceCount ? (
+                              <Badge variant="secondary" className="w-fit">
+                                ×{row.occurrenceCount} recurrence
+                              </Badge>
+                            ) : null}
+                          </div>
                           <span className="text-sm">{row.title}</span>
                         </div>
                       </TableCell>
-                      <TableCell className="max-w-[22rem] text-xs text-muted-foreground">
+                      <TableCell className="max-w-[24rem] align-top whitespace-normal text-xs text-muted-foreground [overflow-wrap:anywhere]">
                         {row.detail ?? "—"}
                       </TableCell>
-                      <TableCell>
+                      <TableCell className="align-top">
                         {row.clientId || row.clientLabel ? (
                           <div className="space-y-0.5">
-                            <div className="text-xs">{row.clientLabel ?? "—"}</div>
-                            <div className="font-mono text-[11px] text-muted-foreground">
+                            <div className="text-xs break-all">{row.clientLabel ?? "—"}</div>
+                            <div className="font-mono text-[11px] break-all text-muted-foreground">
                               {row.clientId ?? "—"}
                             </div>
                           </div>
@@ -326,8 +333,10 @@ export default async function AuditPage({
                           "—"
                         )}
                       </TableCell>
-                      <TableCell className="text-xs text-muted-foreground">
-                        <div>{row.kind}</div>
+                      <TableCell className="align-top text-xs text-muted-foreground">
+                        <div className="whitespace-normal [overflow-wrap:anywhere]">
+                          {row.kind}
+                        </div>
                         {row.status ? (
                           <Badge
                             variant={row.status === "failed" ? "destructive" : "secondary"}

--- a/backoffice/src/lib/gc-fitness/__tests__/audit-actions.test.ts
+++ b/backoffice/src/lib/gc-fitness/__tests__/audit-actions.test.ts
@@ -343,3 +343,49 @@ describe("audit_log as a third source (#312 PR2)", () => {
     ]);
   });
 });
+
+describe("audit_log recurring-series collapse + actor attribution", () => {
+  const UUID = "010cc42d-5608-42f1-bd9d-2a150f22cfbc";
+
+  function recurringDoc(date: string) {
+    return doc(`aud-${date}`, {
+      collection: "workout_assignments",
+      docId: `asg-choqBshr7PewXYbns1EKerc8bVk1-${date}-${UUID}`,
+      op: "update",
+      changedFields: ["templateSnapshot", "updatedAt"],
+      changedFieldCount: 2,
+      actorUid: null, // background trigger — no auth principal
+      trainerId: "coach1", // owner stamped on the doc
+      clientId: "client1",
+      occurredAt: ts("2026-06-15T23:33:17.000Z"),
+    });
+  }
+
+  beforeEach(() => {
+    queryGet.audit_log = async () => ({
+      docs: [
+        recurringDoc("20270503"),
+        recurringDoc("20270104"),
+        recurringDoc("20261214"),
+      ],
+    });
+  });
+
+  it("collapses one recurring edit into a SINGLE row with an occurrence count", async () => {
+    const rows = await listAuditTimeline({ source: "audit_log" });
+    expect(rows).toHaveLength(1);
+    const row = rows[0];
+    expect(row.occurrenceCount).toBe(3);
+    expect(row.title).toBe("Updated workout assignment · recurring");
+    expect(row.detail).toContain("asg-choqBshr7PewXYbns1EKerc8bVk1");
+    expect(row.detail).toContain("3 occurrences");
+    expect(row.detail).toContain("2026-12-14 → 2027-05-03");
+  });
+
+  it("attributes the trigger write to the owning trainer (not a bare system blank)", async () => {
+    const rows = await listAuditTimeline({ source: "audit_log" });
+    expect(rows[0].actorUid).toBe("coach1");
+    expect(rows[0].actorName).toBe("Coach One");
+    expect(rows[0].actorEmail).toBe("coach1@x.com");
+  });
+});

--- a/backoffice/src/lib/gc-fitness/__tests__/audit-grouping.test.ts
+++ b/backoffice/src/lib/gc-fitness/__tests__/audit-grouping.test.ts
@@ -1,0 +1,124 @@
+// __tests__/audit-grouping.test.ts
+//
+// Pure unit tests for the recurring-series collapse used by the admin audit
+// timeline. A single coach edit to a recurring workout series re-writes every
+// future occurrence; the DB-layer capture emits one audit_log doc per write, so
+// the dashboard must collapse them back into one row.
+
+import {
+  dateRangeLabel,
+  fmtYmd,
+  groupRecurringAuditEntries,
+  recurringSeries,
+  type RawAuditLogEntry,
+} from "@/lib/gc-fitness/audit-grouping";
+
+const UUID = "010cc42d-5608-42f1-bd9d-2a150f22cfbc";
+const UUID2 = "ea91a182-95d0-4080-b727-65b985fc7bb9";
+
+function raw(over: Partial<RawAuditLogEntry> & { id: string }): RawAuditLogEntry {
+  return {
+    collection: "workout_assignments",
+    docId: `asg-SERIES-20270101-${UUID}`,
+    op: "update",
+    changedFields: ["templateSnapshot", "updatedAt"],
+    changedFieldCount: 2,
+    actorUid: null,
+    trainerId: "coach1",
+    coachId: null,
+    clientId: "client1",
+    occurredAtISO: "2026-06-15T23:33:17.000Z",
+    ...over,
+  };
+}
+
+describe("recurringSeries", () => {
+  it("parses `asg-<root>-<YYYYMMDD>-<uuid>` into root + date", () => {
+    expect(
+      recurringSeries(`asg-choqBshr7PewXYbns1EKerc8bVk1-20270503-${UUID}`),
+    ).toEqual({ root: "asg-choqBshr7PewXYbns1EKerc8bVk1", date: "20270503" });
+  });
+
+  it("returns null when there is no trailing date+uuid", () => {
+    expect(recurringSeries("asg-choqBshr7PewXYbns1EKerc8bVk1")).toBeNull();
+    expect(recurringSeries("ex-7")).toBeNull();
+    expect(recurringSeries("client1")).toBeNull();
+    // Date but no full UUID → not a recurring occurrence id.
+    expect(recurringSeries("asg-abc-20270503-deadbeef")).toBeNull();
+  });
+});
+
+describe("fmtYmd / dateRangeLabel", () => {
+  it("formats a compact date", () => {
+    expect(fmtYmd("20270503")).toBe("2027-05-03");
+  });
+
+  it("builds a single date or a min→max range", () => {
+    expect(dateRangeLabel([])).toBeNull();
+    expect(dateRangeLabel(["20270503"])).toBe("2027-05-03");
+    expect(dateRangeLabel(["20270503", "20260921", "20271231"])).toBe(
+      "2026-09-21 → 2027-12-31",
+    );
+  });
+});
+
+describe("groupRecurringAuditEntries", () => {
+  it("collapses same series + op + actor + minute into one group, newest as head", () => {
+    const entries = [
+      raw({ id: "a", docId: `asg-S1-20270503-${UUID}` }),
+      raw({ id: "b", docId: `asg-S1-20270104-${UUID}` }),
+      raw({ id: "c", docId: `asg-S1-20261214-${UUID}` }),
+    ];
+    const groups = groupRecurringAuditEntries(entries);
+
+    expect(groups).toHaveLength(1);
+    expect(groups[0].count).toBe(3);
+    expect(groups[0].head.id).toBe("a"); // newest-first input preserved
+    expect(groups[0].root).toBe("asg-S1");
+    expect(groups[0].dates.sort()).toEqual(["20261214", "20270104", "20270503"]);
+  });
+
+  it("does NOT merge across different series root, op, actor or minute", () => {
+    const entries = [
+      raw({ id: "root-a", docId: `asg-A-20270101-${UUID}` }),
+      raw({ id: "root-b", docId: `asg-B-20270101-${UUID}` }),
+      raw({ id: "op", docId: `asg-A-20270202-${UUID}`, op: "create" }),
+      raw({ id: "actor", docId: `asg-A-20270303-${UUID}`, trainerId: "coach2" }),
+      raw({
+        id: "minute",
+        docId: `asg-A-20270404-${UUID}`,
+        occurredAtISO: "2026-06-15T23:34:17.000Z",
+      }),
+    ];
+    const groups = groupRecurringAuditEntries(entries);
+    // Five distinct keys → five standalone groups.
+    expect(groups).toHaveLength(5);
+    expect(groups.every((g) => g.count === 1)).toBe(true);
+    expect(groups.every((g) => g.root === null)).toBe(true);
+  });
+
+  it("keeps non-recurring ids and non-assignment collections as standalone rows", () => {
+    const entries = [
+      raw({ id: "ex", collection: "exercises", docId: "ex-7" }),
+      // A recurring-looking id in a different collection must NOT collapse.
+      raw({ id: "log1", collection: "workout_logs", docId: `wl-S-20270101-${UUID}` }),
+      raw({ id: "log2", collection: "workout_logs", docId: `wl-S-20270102-${UUID}` }),
+      raw({ id: "one-off", docId: "asg-plain-no-date" }),
+    ];
+    const groups = groupRecurringAuditEntries(entries);
+    expect(groups).toHaveLength(4);
+    expect(groups.every((g) => g.count === 1 && g.root === null)).toBe(true);
+  });
+
+  it("collapses a recurring CREATE burst too (not just updates)", () => {
+    const entries = [
+      raw({ id: "c1", op: "create", docId: `asg-NEW-20270101-${UUID}` }),
+      raw({ id: "c2", op: "create", docId: `asg-NEW-20270108-${UUID2}` }),
+    ];
+    const groups = groupRecurringAuditEntries(entries);
+    expect(groups).toHaveLength(1);
+    expect(groups[0].count).toBe(2);
+    expect(groups[0].head.op).toBe("create");
+    expect(groups[0].root).toBe("asg-NEW");
+  });
+});

--- a/backoffice/src/lib/gc-fitness/audit-actions.ts
+++ b/backoffice/src/lib/gc-fitness/audit-actions.ts
@@ -42,6 +42,10 @@
 import { Timestamp, type Firestore } from "firebase-admin/firestore";
 
 import { gcFitnessFirestore } from "@/lib/firebase/gc-fitness-admin";
+import {
+  dateRangeLabel,
+  groupRecurringAuditEntries,
+} from "@/lib/gc-fitness/audit-grouping";
 import { getCurrentAdmin } from "@/lib/gc-fitness/auth-helpers";
 import { COACH_ACTIVITY_COLLECTION } from "@/lib/gc-fitness/coach-activity-log";
 import { FirestoreCollections } from "@/lib/gc-fitness/collections";
@@ -84,6 +88,13 @@ export interface AuditEntry {
   status: string | null;
   /** admin_operations only: "dry_run" | "execute". */
   mode: string | null;
+  /**
+   * audit_log only: when a single coach edit re-wrote a recurring workout
+   * series, the DB-layer capture emits one entry per future occurrence. We
+   * collapse those into ONE row; this is how many occurrences it represents
+   * (>1). Absent/undefined for ordinary single-doc entries.
+   */
+  occurrenceCount?: number;
 }
 
 export interface AuditFilters {
@@ -356,6 +367,8 @@ async function fetchAuditLogEntries(
     changedFields: string[];
     changedFieldCount: number;
     actorUid: string | null;
+    trainerId: string | null;
+    coachId: string | null;
     clientId: string | null;
     occurredAtISO: string | null;
   }>
@@ -382,6 +395,8 @@ async function fetchAuditLogEntries(
       changedFields?: unknown;
       changedFieldCount?: number;
       actorUid?: string | null;
+      trainerId?: string | null;
+      coachId?: string | null;
       clientId?: string | null;
       occurredAt?: unknown;
       eventTime?: unknown;
@@ -400,6 +415,8 @@ async function fetchAuditLogEntries(
           ? data.changedFieldCount
           : changedFields.length,
       actorUid: typeof data.actorUid === "string" ? data.actorUid : null,
+      trainerId: typeof data.trainerId === "string" ? data.trainerId : null,
+      coachId: typeof data.coachId === "string" ? data.coachId : null,
       clientId: typeof data.clientId === "string" ? data.clientId : null,
       // `occurredAt` is the server write time; `eventTime` is the CloudEvent
       // time — prefer occurredAt, fall back to eventTime.
@@ -488,6 +505,11 @@ async function collectAuditEntries(
   }
   for (const r of auditRaw) {
     if (r.actorUid) uids.add(r.actorUid);
+    // Background triggers carry no auth principal, so attribute the DB-layer
+    // capture to the owning trainer/coach stamped on the doc — that's the
+    // "whose data changed" answer (far more useful than a bare "system").
+    if (r.trainerId) uids.add(r.trainerId);
+    if (r.coachId) uids.add(r.coachId);
     if (r.clientId) uids.add(r.clientId);
   }
   const userById = await resolveUsers(db, uids);
@@ -541,31 +563,54 @@ async function collectAuditEntries(
     });
   }
 
-  for (const r of auditRaw) {
-    const actor = r.actorUid ? userById.get(r.actorUid) : undefined;
-    const clientUser = r.clientId ? userById.get(r.clientId) : undefined;
-    const op = (["create", "update", "delete"].includes(r.op)
-      ? r.op
+  // Collapse recurring-series writes into one row each (auditRaw is newest-first;
+  // the grouping preserves that order and exposes the newest member as `head`).
+  for (const g of groupRecurringAuditEntries(auditRaw)) {
+    const head = g.head;
+    // No auth context on the trigger → attribute to the doc's owner (trainer,
+    // then coach), falling back to any explicitly-stamped actor field.
+    const effectiveActorUid =
+      head.actorUid ?? head.trainerId ?? head.coachId ?? null;
+    const actor = effectiveActorUid ? userById.get(effectiveActorUid) : undefined;
+    const clientUser = head.clientId ? userById.get(head.clientId) : undefined;
+    const op = (["create", "update", "delete"].includes(head.op)
+      ? head.op
       : "update") as AuditAction;
-    const fieldList = r.changedFields.slice(0, 8).join(", ");
-    const moreFields = r.changedFieldCount > 8 ? "…" : "";
+    const fieldList = head.changedFields.slice(0, 8).join(", ");
+    const moreFields = head.changedFieldCount > 8 ? "…" : "";
+    const baseTitle = `${OP_PAST[head.op] ?? head.op} ${humanCollection(head.collection)}`;
+
+    let title = baseTitle;
+    let detail: string;
+    if (g.count > 1 && g.root) {
+      const range = dateRangeLabel(g.dates);
+      title = `${baseTitle} · recurring`;
+      const bits = [g.root, `${g.count} occurrences`];
+      if (range) bits.push(range);
+      if (fieldList) bits.push(`${fieldList}${moreFields}`);
+      detail = bits.join(" · ");
+    } else {
+      detail = fieldList ? `${head.docId} · ${fieldList}${moreFields}` : head.docId;
+    }
+
     entries.push({
-      id: r.id,
+      id: head.id,
       source: "audit_log",
-      occurredAtISO: r.occurredAtISO,
-      actorUid: r.actorUid,
+      occurredAtISO: head.occurredAtISO,
+      actorUid: effectiveActorUid,
       actorName: actor?.name ?? null,
       actorEmail: actor?.email ?? null,
       actorRole: "system",
-      kind: r.collection,
+      kind: head.collection,
       action: op,
-      title: `${OP_PAST[r.op] ?? r.op} ${humanCollection(r.collection)}`,
-      detail: fieldList ? `${r.docId} · ${fieldList}${moreFields}` : r.docId,
-      clientId: r.clientId,
+      title,
+      detail,
+      clientId: head.clientId,
       clientLabel: clientUser?.email ?? null,
-      isDeletion: r.op === "delete",
+      isDeletion: head.op === "delete",
       status: null,
       mode: null,
+      occurrenceCount: g.count > 1 ? g.count : undefined,
     });
   }
 

--- a/backoffice/src/lib/gc-fitness/audit-grouping.ts
+++ b/backoffice/src/lib/gc-fitness/audit-grouping.ts
@@ -1,0 +1,112 @@
+// audit-grouping.ts
+//
+// Pure (no Firestore, no "use server") helpers for the admin audit timeline.
+// Extracted from audit-actions.ts so the recurring-collapse logic — the riskiest
+// part (id regex + minute bucketing) — can be unit-tested in isolation.
+//
+// Why this exists: a recurring workout assignment is stored as one doc PER
+// occurrence date (`asg-<seriesRoot>-<YYYYMMDD>-<uuid>`). A single coach edit to
+// the series re-writes every future occurrence, and the DB-layer capture
+// (`onAuditableWrite` Cloud Function) emits one `audit_log` doc per write — so the
+// dashboard showed dozens of near-identical "Updated workout assignment" rows for
+// one action. We collapse them back into a single row, mirroring how My Activity
+// shows a recurrence as one action.
+
+export interface RawAuditLogEntry {
+  id: string;
+  collection: string;
+  docId: string;
+  op: string;
+  changedFields: string[];
+  changedFieldCount: number;
+  actorUid: string | null;
+  trainerId: string | null;
+  coachId: string | null;
+  clientId: string | null;
+  occurredAtISO: string | null;
+}
+
+export interface AuditLogGroup {
+  /** Newest member (auditRaw is newest-first; preserved here). */
+  head: RawAuditLogEntry;
+  members: RawAuditLogEntry[];
+  /** Series root when this is a collapsed recurring group (count > 1), else null. */
+  root: string | null;
+  count: number;
+  /** Sorted YYYYMMDD occurrence dates, for collapsed groups. */
+  dates: string[];
+}
+
+// Match is deliberately strict (full trailing UUID after an 8-digit date) so
+// unrelated ids never collapse together.
+const RECURRING_ASSIGNMENT_ID =
+  /^(.*)-(\d{8})-[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+export function recurringSeries(
+  docId: string,
+): { root: string; date: string } | null {
+  const m = RECURRING_ASSIGNMENT_ID.exec(docId);
+  return m ? { root: m[1], date: m[2] } : null;
+}
+
+/** "20270503" → "2027-05-03". */
+export function fmtYmd(yyyymmdd: string): string {
+  return `${yyyymmdd.slice(0, 4)}-${yyyymmdd.slice(4, 6)}-${yyyymmdd.slice(6, 8)}`;
+}
+
+/** Min→max occurrence-date range label, or null if none parse. */
+export function dateRangeLabel(dates: string[]): string | null {
+  if (dates.length === 0) return null;
+  const sorted = [...dates].sort();
+  return sorted.length === 1
+    ? fmtYmd(sorted[0])
+    : `${fmtYmd(sorted[0])} → ${fmtYmd(sorted[sorted.length - 1])}`;
+}
+
+/**
+ * Collapse recurring-series writes. Entries sharing the SAME series root, op,
+ * actor (uid/trainer), client and minute merge into one group; everything else
+ * stays a standalone group of one. Input order (newest-first) is preserved, and
+ * `head` is the newest member of each group.
+ *
+ * Only `workout_assignments` docs whose id matches the recurring pattern are
+ * eligible — any other collection or a non-matching id is always its own row.
+ */
+export function groupRecurringAuditEntries(
+  raw: RawAuditLogEntry[],
+): AuditLogGroup[] {
+  const groups: Array<{ members: RawAuditLogEntry[]; root: string | null }> = [];
+  const indexByKey = new Map<string, number>();
+
+  for (const r of raw) {
+    const series =
+      r.collection === "workout_assignments" ? recurringSeries(r.docId) : null;
+    const key = series
+      ? `rec|${r.collection}|${r.op}|${r.actorUid ?? ""}|${r.trainerId ?? ""}|${
+          r.clientId ?? ""
+        }|${series.root}|${(r.occurredAtISO ?? "").slice(0, 16)}`
+      : `solo|${r.id}`;
+    const at = indexByKey.get(key);
+    if (at === undefined) {
+      indexByKey.set(key, groups.length);
+      groups.push({ members: [r], root: series?.root ?? null });
+    } else {
+      groups[at].members.push(r);
+    }
+  }
+
+  return groups.map((g) => {
+    const collapsed = g.members.length > 1;
+    return {
+      head: g.members[0],
+      members: g.members,
+      root: collapsed ? g.root : null,
+      count: g.members.length,
+      dates: collapsed
+        ? g.members
+            .map((m) => recurringSeries(m.docId)?.date)
+            .filter((d): d is string => typeof d === "string")
+        : [],
+    };
+  });
+}


### PR DESCRIPTION
Fixes the three issues spotted in the admin **Monitoring & observability → Activity timeline**, all stemming from how `audit_log` (the DB-layer `onAuditableWrite` capture) entries were rendered.

### 1. Broken UI (column overflow)
The **Detail** cell had `max-w-[22rem]` but inherited `whitespace-nowrap` from the base `TableCell`, so long doc-ids / field-lists **overflowed horizontally on top of the neighboring columns** (the overlapping text in the screenshot).
- Long-content cells now wrap: `whitespace-normal` + `[overflow-wrap:anywhere]` (Detail, Source/status, Client uid).
- The table gets a `min-w-[60rem]` so it **scrolls** on narrow screens instead of squashing.
- Rows are `align-top` so multi-line cells line up.

### 2. Recurring update created dozens of rows ❌ → one row ✅
A single coach edit to a **recurring** workout series re-writes every future occurrence doc (`asg-<series>-<YYYYMMDD>-<uuid>`), and `onAuditableWrite` emits **one `audit_log` doc per write** — so one action showed as ~10+ identical "Updated workout assignment" rows.

The dashboard now **collapses** entries sharing `series-root + op + actor + minute` into a single row with:
- an **`×N recurrence`** badge,
- a date range in the detail (`asg-… · 3 occurrences · 2026-12-14 → 2027-05-03`).

This mirrors how *My Activity* already shows a recurrence as one action. The collapse logic lives in a new **pure, unit-tested** `audit-grouping.ts` — the regex is strict (full trailing UUID after an 8-digit date) and only `workout_assignments` ids are eligible, so unrelated docs never merge.

> No Cloud Functions change: the per-write capture stays max-fidelity **by design** (it's the immutable DB trail). Only the dashboard *presentation* collapses.

### 3. "SYSTEM" → something useful
Background triggers carry no auth principal, so `audit_log` rows showed `— / — / SYSTEM`. The capture **does** persist `trainerId`/`coachId` on the doc, so we now:
- attribute the write to the owning **trainer/coach** (the "whose data changed" answer) — the row shows their name/email,
- label the role **"Firestore write"** instead of the bare "system".

## Tests
- New `audit-grouping.test.ts` (pure): series parsing, date range, collapse/no-merge boundaries, create-burst, non-assignment exclusion.
- New integration cases in `audit-actions.test.ts`: 3 occurrence docs → 1 row with `occurrenceCount: 3` + date range, and trainer attribution.
- `npx jest audit-*` → **24 passing**. Full gc-fitness suite: only the 2 documented pre-existing flakes (`client-activity-time` locale, `workout-assignment-actions` read-count) remain red, both green on CI.
- `tsc --noEmit` clean · `next build` green.

## Out of scope (noted separately)
The "falta caching de imágenes en la app de Android" note is a separate Android-repo task — not touched here.