### PR TITLE
feat(wiki): full-width layout + single-active Loom player

### DIFF
--- a/backoffice/src/app/gc-fitness/wiki/page.tsx
+++ b/backoffice/src/app/gc-fitness/wiki/page.tsx
@@ -1,17 +1,10 @@
 import type { Metadata } from "next";
 import { getLocale } from "next-intl/server";
-import { BookOpen, PlayCircle, Video } from "lucide-react";
+import { BookOpen, Video } from "lucide-react";
 
 import { GOLDENCROW_LOGO_DATA_URI } from "@/components/gc-fitness/goldencrow-logo-data";
-import { Badge } from "@/components/ui/badge";
-import {
-  WIKI_COPY,
-  WIKI_GROUPS,
-  loomEmbedUrl,
-  loomShareUrl,
-  pick,
-  type WikiVideo,
-} from "./wiki-data";
+import { WIKI_COPY, WIKI_GROUPS, pick } from "./wiki-data";
+import { WikiSections } from "./wiki-sections";
 
 // The Coach Wiki is intentionally PUBLIC — no getCurrentTrainer() call, anyone
 // with the link can read it. It's added to HIDDEN_SHELL_PATHS so it renders
@@ -30,7 +23,7 @@ export default async function WikiPage() {
     <div className="min-h-screen bg-background text-foreground">
       {/* Standalone brand bar (this page has no coach sidebar). */}
       <header className="sticky top-0 z-30 border-b border-border/70 bg-background/85 backdrop-blur-sm">
-        <div className="mx-auto flex w-full max-w-5xl items-center gap-3 px-4 py-3 sm:px-6">
+        <div className="mx-auto flex w-full max-w-[1800px] items-center gap-3 px-4 py-3 sm:px-6 lg:px-8">
           <span className="flex size-9 shrink-0 items-center justify-center overflow-hidden rounded-full bg-foreground shadow-sm">
             {/* eslint-disable-next-line @next/next/no-img-element */}
             <img
@@ -51,7 +44,7 @@ export default async function WikiPage() {
         </div>
       </header>
 
-      <div className="mx-auto w-full max-w-5xl px-4 py-8 sm:px-6 sm:py-10">
+      <div className="mx-auto w-full max-w-[1800px] px-4 py-8 sm:px-6 sm:py-10 lg:px-8">
         {/* Hero */}
         <div className="space-y-2">
           <p className="inline-flex items-center gap-1.5 rounded-full bg-primary/10 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-primary">
@@ -85,29 +78,8 @@ export default async function WikiPage() {
             </div>
           </aside>
 
-          {/* Content */}
-          <main className="min-w-0 space-y-12">
-            {WIKI_GROUPS.map((group) => (
-              <section
-                key={group.id}
-                id={group.id}
-                className="scroll-mt-24 space-y-5"
-              >
-                <h2 className="font-heading text-lg font-bold sm:text-xl">
-                  {pick(locale, group.title)}
-                </h2>
-                <div className="space-y-6">
-                  {group.videos.map((video) => (
-                    <VideoCard key={video.id} video={video} locale={locale} />
-                  ))}
-                </div>
-              </section>
-            ))}
-
-            <p className="border-t border-border/70 pt-8 text-sm text-muted-foreground">
-              {t("footer")}
-            </p>
-          </main>
+          {/* Content — client island: only one video plays at a time. */}
+          <WikiSections locale={locale} />
         </div>
       </div>
     </div>
@@ -143,65 +115,3 @@ function Toc({ locale }: { locale: string }) {
   );
 }
 
-function VideoCard({ video, locale }: { video: WikiVideo; locale: string }) {
-  const comingSoon = !video.loomId;
-  return (
-    <article
-      id={video.id}
-      className="scroll-mt-24 overflow-hidden rounded-2xl border border-border bg-card shadow-sm"
-    >
-      <div className="flex flex-wrap items-start justify-between gap-2 px-5 pt-5">
-        <div className="min-w-0">
-          <h3 className="font-heading text-base font-bold sm:text-lg">
-            {pick(locale, video.title)}
-          </h3>
-          <p className="mt-1 text-sm text-muted-foreground">
-            {pick(locale, video.description)}
-          </p>
-        </div>
-        {comingSoon ? (
-          <Badge variant="warning" className="shrink-0">
-            {pick(locale, WIKI_COPY.comingSoon)}
-          </Badge>
-        ) : null}
-      </div>
-
-      <div className="px-5 pb-5 pt-4">
-        {video.loomId ? (
-          <>
-            <div className="relative w-full overflow-hidden rounded-xl border border-border bg-black">
-              <div className="aspect-video">
-                <iframe
-                  src={loomEmbedUrl(video.loomId)}
-                  title={pick(locale, video.title)}
-                  allowFullScreen
-                  loading="lazy"
-                  className="absolute inset-0 h-full w-full"
-                />
-              </div>
-            </div>
-            <a
-              href={loomShareUrl(video.loomId)}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="mt-3 inline-flex items-center gap-1.5 text-sm font-medium text-primary hover:underline"
-            >
-              <PlayCircle className="h-4 w-4" />
-              {pick(locale, WIKI_COPY.openInLoom)}
-            </a>
-          </>
-        ) : (
-          <div className="flex aspect-video w-full flex-col items-center justify-center gap-2 rounded-xl border border-dashed border-border bg-muted/40 text-center">
-            <Video className="h-7 w-7 text-muted-foreground" />
-            <p className="text-sm font-medium">
-              {pick(locale, WIKI_COPY.comingSoon)}
-            </p>
-            <p className="max-w-xs px-4 text-xs text-muted-foreground">
-              {pick(locale, WIKI_COPY.comingSoonHint)}
-            </p>
-          </div>
-        )}
-      </div>
-    </article>
-  );
-}

--- a/backoffice/src/app/gc-fitness/wiki/wiki-data.ts
+++ b/backoffice/src/app/gc-fitness/wiki/wiki-data.ts
@@ -31,14 +31,31 @@ export function pick(locale: string, value: Localized): string {
   return locale.startsWith("en") ? value.en : value.es;
 }
 
-/** Build the Loom embed URL from a share id. */
-export function loomEmbedUrl(loomId: string): string {
-  return `https://www.loom.com/embed/${loomId}?hide_owner=true&hideEmbedTopBar=true`;
+/** Build the Loom embed URL from a share id. `autoplay` starts it on mount. */
+export function loomEmbedUrl(
+  loomId: string,
+  opts?: { autoplay?: boolean },
+): string {
+  const params = new URLSearchParams({
+    hide_owner: "true",
+    hideEmbedTopBar: "true",
+  });
+  if (opts?.autoplay) params.set("autoplay", "1");
+  return `https://www.loom.com/embed/${loomId}?${params.toString()}`;
 }
 
 /** Build the public Loom share URL (the "open in Loom" fallback link). */
 export function loomShareUrl(loomId: string): string {
   return `https://www.loom.com/share/${loomId}`;
+}
+
+/**
+ * Loom-hosted poster frame for a video, used on the click-to-play facade. Loaded
+ * as a CSS background so a miss degrades gracefully to the dark poster + play
+ * button (no broken-image icon).
+ */
+export function loomThumbnailUrl(loomId: string): string {
+  return `https://cdn.loom.com/sessions/thumbnails/${loomId}-with-play.jpg`;
 }
 
 export const WIKI_GROUPS: WikiGroup[] = [

--- a/backoffice/src/app/gc-fitness/wiki/wiki-sections.tsx
+++ b/backoffice/src/app/gc-fitness/wiki/wiki-sections.tsx
@@ -1,0 +1,145 @@
+"use client";
+
+import { useState } from "react";
+import { Play, PlayCircle, Video } from "lucide-react";
+
+import { Badge } from "@/components/ui/badge";
+import {
+  WIKI_COPY,
+  WIKI_GROUPS,
+  loomEmbedUrl,
+  loomShareUrl,
+  loomThumbnailUrl,
+  pick,
+  type WikiVideo,
+} from "./wiki-data";
+
+// Client island that owns the "only one video plays at a time" state. Each video
+// renders a lightweight click-to-play POSTER until activated; activating one sets
+// it as the single active id, which UNMOUNTS every other iframe — so nothing else
+// can keep playing. (It's also far lighter than mounting ~8 Loom iframes at once.)
+export function WikiSections({ locale }: { locale: string }) {
+  const [activeId, setActiveId] = useState<string | null>(null);
+
+  return (
+    <main className="min-w-0 space-y-12">
+      {WIKI_GROUPS.map((group) => (
+        <section key={group.id} id={group.id} className="scroll-mt-24 space-y-5">
+          <h2 className="font-heading text-lg font-bold sm:text-xl">
+            {pick(locale, group.title)}
+          </h2>
+          <div className="grid gap-6 xl:grid-cols-2">
+            {group.videos.map((video) => (
+              <VideoCard
+                key={video.id}
+                video={video}
+                locale={locale}
+                isActive={activeId === video.id}
+                onActivate={() => setActiveId(video.id)}
+              />
+            ))}
+          </div>
+        </section>
+      ))}
+
+      <p className="border-t border-border/70 pt-8 text-sm text-muted-foreground">
+        {pick(locale, WIKI_COPY.footer)}
+      </p>
+    </main>
+  );
+}
+
+function VideoCard({
+  video,
+  locale,
+  isActive,
+  onActivate,
+}: {
+  video: WikiVideo;
+  locale: string;
+  isActive: boolean;
+  onActivate: () => void;
+}) {
+  const comingSoon = !video.loomId;
+  const title = pick(locale, video.title);
+
+  return (
+    <article
+      id={video.id}
+      className="flex scroll-mt-24 flex-col overflow-hidden rounded-2xl border border-border bg-card shadow-sm"
+    >
+      <div className="flex flex-wrap items-start justify-between gap-2 px-5 pt-5">
+        <div className="min-w-0">
+          <h3 className="font-heading text-base font-bold sm:text-lg">{title}</h3>
+          <p className="mt-1 text-sm text-muted-foreground">
+            {pick(locale, video.description)}
+          </p>
+        </div>
+        {comingSoon ? (
+          <Badge variant="warning" className="shrink-0">
+            {pick(locale, WIKI_COPY.comingSoon)}
+          </Badge>
+        ) : null}
+      </div>
+
+      <div className="mt-auto px-5 pb-5 pt-4">
+        {video.loomId ? (
+          <>
+            {isActive ? (
+              <div className="relative w-full overflow-hidden rounded-xl border border-border bg-black">
+                <div className="aspect-video">
+                  <iframe
+                    src={loomEmbedUrl(video.loomId, { autoplay: true })}
+                    title={title}
+                    allowFullScreen
+                    allow="autoplay; fullscreen; picture-in-picture"
+                    className="absolute inset-0 h-full w-full"
+                  />
+                </div>
+              </div>
+            ) : (
+              <button
+                type="button"
+                onClick={onActivate}
+                aria-label={`${pick(locale, WIKI_COPY.openInLoom)} — ${title}`}
+                className="group relative block aspect-video w-full overflow-hidden rounded-xl border border-border bg-black bg-cover bg-center"
+                style={{
+                  backgroundImage: `url(${loomThumbnailUrl(video.loomId)})`,
+                }}
+              >
+                <span className="absolute inset-0 bg-black/30 transition-colors group-hover:bg-black/15" />
+                <span className="absolute inset-0 flex items-center justify-center">
+                  <span className="flex size-16 items-center justify-center rounded-full bg-white/90 shadow-lg transition-transform group-hover:scale-105">
+                    <Play
+                      className="h-7 w-7 translate-x-0.5 text-black"
+                      fill="currentColor"
+                    />
+                  </span>
+                </span>
+              </button>
+            )}
+            <a
+              href={loomShareUrl(video.loomId)}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="mt-3 inline-flex items-center gap-1.5 text-sm font-medium text-primary hover:underline"
+            >
+              <PlayCircle className="h-4 w-4" />
+              {pick(locale, WIKI_COPY.openInLoom)}
+            </a>
+          </>
+        ) : (
+          <div className="flex aspect-video w-full flex-col items-center justify-center gap-2 rounded-xl border border-dashed border-border bg-muted/40 text-center">
+            <Video className="h-7 w-7 text-muted-foreground" />
+            <p className="text-sm font-medium">
+              {pick(locale, WIKI_COPY.comingSoon)}
+            </p>
+            <p className="max-w-xs px-4 text-xs text-muted-foreground">
+              {pick(locale, WIKI_COPY.comingSoonHint)}
+            </p>
+          </div>
+        )}
+      </div>
+    </article>
+  );
+}


### PR DESCRIPTION
Two fixes requested on the live Coach Wiki:

### 1. Use the whole screen
The content was locked to `max-w-5xl` — a narrow centered column with large empty side margins. Widened the header + content to `max-w-[1800px]` and made each section's videos a **2-up grid on `xl`**, so wide screens actually get used instead of a single skinny column. (Cards use `flex-col` + `mt-auto` so the video areas line up across a row regardless of description length.)

### 2. Only one video plays at a time
Before, every video mounted its own live Loom `<iframe>`, so multiple could play simultaneously (and ~8 iframes loaded eagerly on page load).

Extracted a client island (`wiki-sections.tsx`) that tracks a single `activeId`:
- Each video shows a lightweight **click-to-play poster** (Loom thumbnail as a CSS background that degrades to a dark poster + play button if it 404s) until activated.
- Activating one sets it as the sole active id, which **unmounts every other iframe** — so nothing else can keep playing. The active iframe autoplays on click.
- Bonus: big perf win — at most one Loom iframe is mounted at a time instead of eight.

## Notes
- No backend/data change; the video list + Loom IDs still live in `wiki-data.ts`.
- `tsc --noEmit` clean · `next build` green (`/gc-fitness/wiki` route intact).
- The page remains a public, no-auth, standalone route.