### PR TITLE
fix(gc-fitness): Hollow Hold gif + Squat (Bodyweight) in standard library

### DIFF
--- a/backoffice/package.json
+++ b/backoffice/package.json
@@ -12,6 +12,7 @@
     "seed:gc-fitness-library": "node scripts/seed-gc-fitness-library.cjs",
     "seed:gc-fitness-standard-library": "node --experimental-transform-types scripts/sync-standard-exercise-library.ts",
     "seed:gc-fitness-standard-gifs": "node --experimental-transform-types scripts/sync-standard-exercise-gifs.ts",
+    "seed:gc-fitness-external-gifs": "node --experimental-transform-types scripts/assign-external-gifs.ts",
     "merge:gc-fitness-standard-exercises": "node --experimental-transform-types scripts/merge-standard-exercises.ts",
     "archive:gc-fitness-legacy-standard-duplicates": "node --experimental-transform-types scripts/archive-legacy-standard-duplicates.ts",
     "archive:gc-fitness-legacy-habit-templates": "node scripts/archive-legacy-gc-fitness-habit-templates.cjs",

--- a/backoffice/scripts/assign-external-gifs.ts
+++ b/backoffice/scripts/assign-external-gifs.ts
@@ -1,0 +1,171 @@
+/**
+ * Assign exercise gifs that DON'T live in the Desktop CSV/assets dataset used by
+ * `sync-standard-exercise-gifs.ts`. Some standard-library exercises (e.g. Hollow
+ * Hold) have no clip in the free-exercise-db CSV, so the fuzzy matcher there would
+ * pick an unrelated movement. For those we host a hand-picked external gif:
+ * download it, upload to the SAME public-read `exercises/library-gifs/` namespace,
+ * and point the exercise doc's `gifUrl` at the `gs://` path (the apps' media
+ * resolver turns that into a tokenless download URL — the library-gifs path is
+ * public-read, so no `?token=` is baked in and re-uploads don't 403).
+ *
+ * Keyed by `name.en` so the exercise doc id is resolved from the single source of
+ * truth (`STANDARD_LIBRARY_EXERCISES`), exactly like the CSV sync. The matching
+ * entry in `sync-standard-exercise-gifs.ts` OVERRIDES is set to `null` so a full
+ * gif re-sync never clobbers what we set here.
+ *
+ *   node --experimental-transform-types scripts/assign-external-gifs.ts [--dry-run]
+ *
+ * Requires admin creds in `.env.local` (same vars the other sync scripts use).
+ */
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { initializeApp, cert, getApps } from "firebase-admin/app";
+import { FieldValue, getFirestore } from "firebase-admin/firestore";
+import { getStorage } from "firebase-admin/storage";
+
+import { STANDARD_LIBRARY_EXERCISES } from "../src/lib/gc-fitness/exercise-standard-library.ts";
+
+const DEFAULT_BUCKET = "gcfitness-3476b.firebasestorage.app";
+const COLLECTION = "exercises";
+const REMOTE_PREFIX = "exercises/library-gifs";
+
+/**
+ * `name.en` → externally hosted gif URL. The remote object is named after the
+ * exercise slug so it never collides with the 4-digit CSV ids.
+ */
+const EXTERNAL_GIFS: Record<string, string> = {
+  "Hollow Hold (Bodyweight)":
+    "https://fitcron.com/wp-content/uploads/2024/05/12461301-Hollow-Hold_Waist_720.gif",
+};
+
+function loadEnv() {
+  const envPath = path.resolve(process.cwd(), ".env.local");
+  if (!fs.existsSync(envPath)) return;
+  for (const line of fs.readFileSync(envPath, "utf8").split(/\r?\n/)) {
+    const match = line.match(/^([A-Z0-9_]+)=(.*)$/);
+    if (match && process.env[match[1]] === undefined) {
+      process.env[match[1]] = match[2];
+    }
+  }
+}
+
+function initAdmin() {
+  if (getApps().length > 0) return;
+  const projectId = process.env.NEXT_PUBLIC_GC_FITNESS_FIREBASE_PROJECT_ID;
+  const clientEmail = process.env.GC_FITNESS_FIREBASE_ADMIN_CLIENT_EMAIL;
+  const privateKey = process.env.GC_FITNESS_FIREBASE_ADMIN_PRIVATE_KEY;
+  if (!projectId || !clientEmail || !privateKey) {
+    throw new Error("Missing Firebase admin credentials in environment.");
+  }
+  initializeApp({
+    credential: cert({
+      projectId,
+      clientEmail,
+      privateKey: Buffer.from(privateKey, "base64").toString("utf8"),
+    }),
+  });
+}
+
+function getBucketName(): string {
+  return (
+    process.env.NEXT_PUBLIC_GC_FITNESS_FIREBASE_STORAGE_BUCKET ?? DEFAULT_BUCKET
+  );
+}
+
+function slugify(value: string): string {
+  return value
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+}
+
+async function downloadToTemp(url: string, slug: string): Promise<string> {
+  const res = await fetch(url);
+  if (!res.ok) {
+    throw new Error(`Download failed (${res.status}) for ${url}`);
+  }
+  const buf = Buffer.from(await res.arrayBuffer());
+  const tmpPath = path.join(os.tmpdir(), `ext-gif-${slug}.gif`);
+  fs.writeFileSync(tmpPath, buf);
+  return tmpPath;
+}
+
+async function uploadGif(localPath: string, remotePath: string): Promise<string> {
+  const bucket = getStorage().bucket(getBucketName());
+  await bucket.upload(localPath, {
+    destination: remotePath,
+    metadata: {
+      contentType: "image/gif",
+      cacheControl: "public, max-age=31536000",
+    },
+    resumable: false,
+  });
+  return `gs://${getBucketName()}/${remotePath}`;
+}
+
+async function main() {
+  loadEnv();
+  initAdmin();
+  const dryRun = process.argv.slice(2).includes("--dry-run");
+  const db = getFirestore();
+
+  const results: Array<Record<string, unknown>> = [];
+
+  for (const [nameEn, url] of Object.entries(EXTERNAL_GIFS)) {
+    const exercise = STANDARD_LIBRARY_EXERCISES.find((e) => e.name.en === nameEn);
+    if (!exercise) {
+      results.push({ nameEn, status: "SKIP — no exercise with that name.en" });
+      continue;
+    }
+
+    const docRef = db.collection(COLLECTION).doc(exercise.exerciseId);
+    const snap = await docRef.get();
+    if (!snap.exists) {
+      results.push({
+        nameEn,
+        exerciseId: exercise.exerciseId,
+        status: "SKIP — doc not seeded in prod (run library sync first)",
+      });
+      continue;
+    }
+
+    const slug = slugify(exercise.exerciseId);
+    const remotePath = `${REMOTE_PREFIX}/${slug}.gif`;
+
+    if (dryRun) {
+      results.push({
+        nameEn,
+        exerciseId: exercise.exerciseId,
+        currentGifUrl: snap.get("gifUrl") ?? null,
+        wouldUpload: url,
+        wouldSetGifUrl: `gs://${getBucketName()}/${remotePath}`,
+        status: "DRY RUN",
+      });
+      continue;
+    }
+
+    const tmpPath = await downloadToTemp(url, slug);
+    const gifUrl = await uploadGif(tmpPath, remotePath);
+    fs.rmSync(tmpPath, { force: true });
+    await docRef.set(
+      { gifUrl, updatedAt: FieldValue.serverTimestamp() },
+      { merge: true },
+    );
+    results.push({
+      nameEn,
+      exerciseId: exercise.exerciseId,
+      previousGifUrl: snap.get("gifUrl") ?? null,
+      gifUrl,
+      status: "UPDATED",
+    });
+  }
+
+  console.log(JSON.stringify({ dryRun, results }, null, 2));
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/backoffice/scripts/sync-standard-exercise-gifs.ts
+++ b/backoffice/scripts/sync-standard-exercise-gifs.ts
@@ -122,6 +122,10 @@ const OVERRIDES: Record<string, string | null> = {
   "Inchworm (Bodyweight)": "1471",
   "World's Greatest Stretch (Bodyweight)": "1604",
   "Glute Bridge March (Bodyweight)": "3561",
+  // No hollow-hold clip exists in the CSV dataset — the fuzzy matcher would pick
+  // an unrelated movement. Skip here; the correct gif is hosted externally and
+  // assigned by `assign-external-gifs.ts`.
+  "Hollow Hold (Bodyweight)": null,
   "General Warm-up (None)": null,
   "Cardio Warm-up (None)": null,
   "Jumping Jacks (Bodyweight)": null,


### PR DESCRIPTION
Two standard-library content fixes, applied to prod (`gcfitness-3476b`) and shipped as committed, reproducible scripts.

## 1. Hollow Hold gif was wrong
The free-exercise-db CSV has **no hollow-hold clip**, so the fuzzy matcher in `sync-standard-exercise-gifs.ts` assigned an unrelated movement (`library-gifs/0276.gif`).

## 2. Bodyweight squat naming / duplicate
The library had no bodyweight bilateral squat in the TS source, but prod already had an orphan `std-legs-squat-bodyweight` ("Squat (Bodyweight)"). The first commit here added a SECOND one ("Bodyweight Squat (Bodyweight)") → two squats in the library. Resolved by renaming the family `baseEn` → "Squat" so the source produces (and adopts) `std-legs-squat-bodyweight` as canonical, and soft-deleting the duplicate.

## Changes
- **New `scripts/assign-external-gifs.ts`** — hosts hand-picked external gifs for exercises with no CSV clip: download → upload to the public-read `exercises/library-gifs/` namespace → set the doc `gifUrl` to the `gs://` path (tokenless / re-upload-safe). Keyed by `name.en`; guards doc-exists; supports per-entry request headers (the squat source hotlink-protects without a browser UA + Referer) + content-type guard.
- **`OVERRIDES["Hollow Hold (Bodyweight)"] = null`** in the CSV sync so a re-sync never re-clobbers it.
- **New "Squat" family** (legs group, bodyweight): EN `Squat (Bodyweight)`, ES `Sentadilla (Peso corporal)`, aliases Bodyweight Squat / Air Squat.
- **`sync-standard-exercise-library.ts`: `--only=<ids>` filter + `loadEnv()`** — add/sync one exercise without re-writing all ~260 docs (which bumps every timestamp and resets `deleted:false`, risking resurrecting soft-deleted dups).

Gifs (owner-provided): Hollow Hold = fitcron; Squat = inspireusafoundation.

## Applied to prod + verified
- `std-core-hollow-hold-bodyweight` gif → `library-gifs/std-core-hollow-hold-bodyweight.gif`.
- `std-legs-squat-bodyweight` ("Squat (Bodyweight)") synced from source + approved gif assigned.
- `std-legs-bodyweight-squat-bodyweight` duplicate **soft-deleted**.
- All gif public URLs verified `200 image/gif`.

## Test gate
`npx jest`: 684 pass; the 2 failing suites (`client-activity-time` locale flake — green in CI; `workout-assignment-actions` bulk-assign) are **pre-existing on main** and unrelated. No `firestore.rules` change.