### PR TITLE
feat(gc-fitness): usage-count pills in the Biblioteca

### DIFF
--- a/backoffice/messages/en.json
+++ b/backoffice/messages/en.json
@@ -554,7 +554,8 @@
       "draftUntitled": "(untitled draft)",
       "draftBadgeTooltip": "Incomplete draft — cannot be assigned until completed",
       "draftResumeCta": "Continue draft",
-      "draftPendingLabel": "Draft"
+      "draftPendingLabel": "Draft",
+      "assignmentCount": "{count, plural, one {# assignment} other {# assignments}}"
     },
     "viewPage": {
       "standardBadge": "Standard",
@@ -1060,7 +1061,8 @@
       "duplicate": "Duplicate",
       "delete": "Delete",
       "wgerReadOnlyTooltip": "Library exercises are read-only. Duplicate to customize.",
-      "metricTimeBadgeTitle": "Time-based exercise"
+      "metricTimeBadgeTitle": "Time-based exercise",
+      "usageRoutines": "{count, plural, one {# routine} other {# routines}}"
     },
     "editPage": {
       "title": "Edit exercise",

--- a/backoffice/messages/es.json
+++ b/backoffice/messages/es.json
@@ -554,7 +554,8 @@
       "draftUntitled": "(borrador sin título)",
       "draftBadgeTooltip": "Borrador incompleto — no se puede asignar hasta completarse",
       "draftResumeCta": "Continuar borrador",
-      "draftPendingLabel": "Borrador"
+      "draftPendingLabel": "Borrador",
+      "assignmentCount": "{count, plural, one {# asignación} other {# asignaciones}}"
     },
     "viewPage": {
       "standardBadge": "Standard",
@@ -1065,7 +1066,8 @@
       "duplicate": "Duplicar",
       "delete": "Eliminar",
       "wgerReadOnlyTooltip": "Los ejercicios de la biblioteca son de solo lectura. Duplicalos para personalizarlos.",
-      "metricTimeBadgeTitle": "Ejercicio por tiempo"
+      "metricTimeBadgeTitle": "Ejercicio por tiempo",
+      "usageRoutines": "{count, plural, one {# rutina} other {# rutinas}}"
     },
     "editPage": {
       "title": "Editar ejercicio",

--- a/backoffice/src/app/gc-fitness/exercises/client.tsx
+++ b/backoffice/src/app/gc-fitness/exercises/client.tsx
@@ -57,6 +57,7 @@ import {
 import { searchExercises } from "@/lib/gc-fitness/exercise-search";
 import { isPickableExercise } from "@/lib/gc-fitness/exercise-visibility";
 import { useFavorites } from "@/lib/gc-fitness/use-favorites";
+import { useExerciseUsageCounts } from "@/lib/gc-fitness/library-usage-listeners";
 import {
   favoriteIdSet,
   filterFavoritesOnly,
@@ -197,7 +198,11 @@ export function ExerciseLibraryClient({
   );
 
   const columnsT = useTranslations("exercises.columns");
-  const columns = useMemo(() => makeColumns(handlers, columnsT), [handlers, columnsT]);
+  const { data: usageCounts } = useExerciseUsageCounts();
+  const columns = useMemo(
+    () => makeColumns(handlers, columnsT, usageCounts),
+    [handlers, columnsT, usageCounts],
+  );
 
   const table = useReactTable({
     data: rows,

--- a/backoffice/src/app/gc-fitness/exercises/columns.tsx
+++ b/backoffice/src/app/gc-fitness/exercises/columns.tsx
@@ -86,6 +86,7 @@ type TFn = ReturnType<typeof useTranslations>;
 export function makeColumns(
   handlers: ExerciseColumnHandlers,
   t: TFn,
+  usageCounts?: Record<string, number>,
 ): ColumnDef<ExerciseRow>[] {
   return [
     {
@@ -125,41 +126,49 @@ export function makeColumns(
     {
       accessorKey: "name.en",
       header: t("name"),
-      cell: ({ row }) => (
-        <div className="flex flex-col">
-          <div className="flex items-center gap-1.5">
-            <span className="font-medium">{row.original.name.en || t("untitled")}</span>
-            {row.original.metric === "time" ? (
-              <Badge
-                variant="outline"
-                className="px-1.5 py-0 text-[10px]"
-                title={t("metricTimeBadgeTitle")}
-              >
-                {"⏱"}
-              </Badge>
-            ) : null}
-          </div>
-          {row.original.name.es && (
-            <span className="text-xs text-muted-foreground">
-              {row.original.name.es}
-            </span>
-          )}
-          {row.original.tags?.length ? (
-            <div className="mt-1 flex flex-wrap gap-1">
-              {row.original.tags.slice(0, 2).map((tag) => (
-                <Badge key={tag} variant="secondary" className="font-normal">
-                  {formatLabel(tag)}
-                </Badge>
-              ))}
-              {row.original.tags.length > 2 ? (
-                <Badge variant="secondary" className="font-normal">
-                  +{row.original.tags.length - 2}
+      cell: ({ row }) => {
+        const usageCount = usageCounts?.[row.original.id] ?? 0;
+        return (
+          <div className="flex flex-col">
+            <div className="flex items-center gap-1.5">
+              <span className="font-medium">{row.original.name.en || t("untitled")}</span>
+              {row.original.metric === "time" ? (
+                <Badge
+                  variant="outline"
+                  className="px-1.5 py-0 text-[10px]"
+                  title={t("metricTimeBadgeTitle")}
+                >
+                  {"⏱"}
                 </Badge>
               ) : null}
             </div>
-          ) : null}
-        </div>
-      ),
+            {row.original.name.es && (
+              <span className="text-xs text-muted-foreground">
+                {row.original.name.es}
+              </span>
+            )}
+            {row.original.tags?.length || usageCount > 0 ? (
+              <div className="mt-1 flex flex-wrap gap-1">
+                {row.original.tags?.slice(0, 2).map((tag) => (
+                  <Badge key={tag} variant="secondary" className="font-normal">
+                    {formatLabel(tag)}
+                  </Badge>
+                ))}
+                {row.original.tags && row.original.tags.length > 2 ? (
+                  <Badge variant="secondary" className="font-normal">
+                    +{row.original.tags.length - 2}
+                  </Badge>
+                ) : null}
+                {usageCount > 0 ? (
+                  <Badge variant="outline" className="font-normal">
+                    {t("usageRoutines", { count: usageCount })}
+                  </Badge>
+                ) : null}
+              </div>
+            ) : null}
+          </div>
+        );
+      },
     },
     {
       id: "category",

--- a/backoffice/src/app/gc-fitness/templates/client.tsx
+++ b/backoffice/src/app/gc-fitness/templates/client.tsx
@@ -70,6 +70,7 @@ import type { WorkoutTemplateRow } from "@/lib/gc-fitness/workout-template-actio
 import { estimateTemplateDurationMinutesFromRaw } from "@/lib/gc-fitness/workout-duration-estimate";
 import { fuzzyTokenScore } from "@/lib/gc-fitness/exercise-search";
 import { useFavorites } from "@/lib/gc-fitness/use-favorites";
+import { useTemplateAssignmentCounts } from "@/lib/gc-fitness/library-usage-listeners";
 import {
   favoriteIdSet,
   filterFavoritesOnly,
@@ -160,6 +161,7 @@ export function TemplatesLibraryClient({
   // both names and tags, so a query like "Pull" surfaces "PULL Manu" as well
   // as rows tagged "Pull".
   const { data, isLoading, error } = useWorkoutTemplates();
+  const { data: assignmentCounts } = useTemplateAssignmentCounts();
 
   // Read the in-progress "new" draft from localStorage so we can surface it as
   // a virtual row at the top of the list. Re-read on the `storage` event so a
@@ -542,6 +544,14 @@ export function TemplatesLibraryClient({
                               {TAG_LABELS[raw] ?? raw}
                             </Badge>
                           ))}
+                          {!row.__isDraft &&
+                          (assignmentCounts?.[row.id] ?? 0) > 0 ? (
+                            <Badge variant="outline" className="font-normal">
+                              {columnsT("assignmentCount", {
+                                count: assignmentCounts?.[row.id] ?? 0,
+                              })}
+                            </Badge>
+                          ) : null}
                         </div>
                       </div>
                       <p className="flex items-center gap-1.5 text-sm text-muted-foreground">

--- a/backoffice/src/lib/gc-fitness/__tests__/library-usage-counts.test.ts
+++ b/backoffice/src/lib/gc-fitness/__tests__/library-usage-counts.test.ts
@@ -1,0 +1,85 @@
+import {
+  tallyExerciseUsage,
+  tallyTemplateAssignments,
+} from "../library-usage-counts";
+
+describe("tallyExerciseUsage", () => {
+  it("counts distinct templates per exerciseId", () => {
+    const counts = tallyExerciseUsage([
+      { id: "t1", exercises: [{ exerciseId: "a" }, { exerciseId: "b" }] },
+      { id: "t2", exercises: [{ exerciseId: "a" }] },
+    ]);
+    expect(counts).toEqual({ a: 2, b: 1 });
+  });
+
+  it("counts a template once even if it lists the same exercise twice", () => {
+    const counts = tallyExerciseUsage([
+      { id: "t1", exercises: [{ exerciseId: "a" }, { exerciseId: "a" }] },
+    ]);
+    expect(counts).toEqual({ a: 1 });
+  });
+
+  it("ignores deleted templates and blank/missing exercise ids", () => {
+    const counts = tallyExerciseUsage([
+      { id: "t1", deleted: true, exercises: [{ exerciseId: "a" }] },
+      { id: "t2", exercises: [{ exerciseId: "" }, { exerciseId: null }, null] },
+      { id: "t3", exercises: null },
+      { id: "t4", exercises: [{ exerciseId: "b" }] },
+    ]);
+    expect(counts).toEqual({ b: 1 });
+  });
+});
+
+describe("tallyTemplateAssignments", () => {
+  const today = "2026-06-16";
+
+  it("counts today and future, ignores the past", () => {
+    const counts = tallyTemplateAssignments(
+      [
+        { id: "a1", templateId: "t1", scheduledFor: "2026-06-15" }, // past
+        { id: "a2", templateId: "t1", scheduledFor: "2026-06-16" }, // today
+        { id: "a3", templateId: "t1", scheduledFor: "2026-06-20" }, // future
+      ],
+      today,
+    );
+    expect(counts).toEqual({ t1: 2 });
+  });
+
+  it("collapses a recurring series to one, counting it if any occurrence is today/future", () => {
+    const counts = tallyTemplateAssignments(
+      [
+        { id: "a1", templateId: "t1", scheduledFor: "2026-06-10", seriesId: "S" },
+        { id: "a2", templateId: "t1", scheduledFor: "2026-06-17", seriesId: "S" },
+        { id: "a3", templateId: "t1", scheduledFor: "2026-06-24", seriesId: "S" },
+        { id: "a4", templateId: "t1", scheduledFor: "2026-06-18" }, // separate one-off
+      ],
+      today,
+    );
+    // series S = 1 (has future occurrences) + one-off a4 = 1 → total 2
+    expect(counts).toEqual({ t1: 2 });
+  });
+
+  it("drops a series whose only occurrences are in the past", () => {
+    const counts = tallyTemplateAssignments(
+      [
+        { id: "a1", templateId: "t1", scheduledFor: "2026-06-01", seriesId: "S" },
+        { id: "a2", templateId: "t1", scheduledFor: "2026-06-08", seriesId: "S" },
+      ],
+      today,
+    );
+    expect(counts).toEqual({});
+  });
+
+  it("buckets per template and skips docs without a templateId", () => {
+    const counts = tallyTemplateAssignments(
+      [
+        { id: "a1", templateId: "t1", scheduledFor: "2026-06-20" },
+        { id: "a2", templateId: "t2", scheduledFor: "2026-06-20" },
+        { id: "a3", templateId: null, scheduledFor: "2026-06-20" },
+        { id: "a4", templateId: "", scheduledFor: "2026-06-20" },
+      ],
+      today,
+    );
+    expect(counts).toEqual({ t1: 1, t2: 1 });
+  });
+});

--- a/backoffice/src/lib/gc-fitness/library-usage-counts.ts
+++ b/backoffice/src/lib/gc-fitness/library-usage-counts.ts
@@ -1,0 +1,92 @@
+// library-usage-counts.ts
+//
+// PURE tally helpers for the Biblioteca usage pills (no Firestore / no server
+// deps — unit-testable). Two counts:
+//
+//  1. Exercise → in how many ROUTINES (workout templates) it's used.
+//  2. Workout template → how many ASSIGNMENTS it has, where a recurring
+//     assignment counts as ONE (grouped by series) and only today+future
+//     occurrences count.
+//
+// The Server Actions in workout-template-actions / workout-assignment-actions
+// fetch the docs and delegate the counting here.
+
+/** Minimal shape of a workout-template doc needed to tally exercise usage. */
+export interface TemplateForUsage {
+  id: string;
+  deleted?: boolean;
+  exercises?: Array<{ exerciseId?: string | null } | null> | null;
+}
+
+/**
+ * Map of `exerciseId` → number of DISTINCT (non-deleted) templates that
+ * reference it. A template that lists the same exercise twice still counts
+ * once for that template.
+ */
+export function tallyExerciseUsage(
+  templates: TemplateForUsage[],
+): Record<string, number> {
+  const counts: Record<string, number> = {};
+  for (const template of templates) {
+    if (!template || template.deleted === true) continue;
+    const exercises = Array.isArray(template.exercises)
+      ? template.exercises
+      : [];
+    const idsInTemplate = new Set<string>();
+    for (const ex of exercises) {
+      const id = ex?.exerciseId;
+      if (typeof id === "string" && id) idsInTemplate.add(id);
+    }
+    for (const id of idsInTemplate) {
+      counts[id] = (counts[id] ?? 0) + 1;
+    }
+  }
+  return counts;
+}
+
+/** Minimal shape of a workout-assignment doc needed to tally per template. */
+export interface AssignmentForUsage {
+  id: string;
+  templateId?: string | null;
+  scheduledFor?: string | null;
+  /** Shared uuid across the docs of a recurring series; null on one-offs. */
+  seriesId?: string | null;
+}
+
+/**
+ * Map of `templateId` → number of DISTINCT assignment "series" scheduled for
+ * `today` or later. Recurring assignments (same `seriesId` across many
+ * occurrence docs) collapse to a single count; a series is counted as long as
+ * it has at least one occurrence on/after `today`. Past-only assignments are
+ * ignored. One-off docs (no `seriesId`) are keyed by their own doc id.
+ *
+ * `today` is a civil-date string `YYYY-MM-DD` in the trainer's timezone;
+ * comparison is lexicographic (valid for zero-padded ISO dates).
+ */
+export function tallyTemplateAssignments(
+  assignments: AssignmentForUsage[],
+  today: string,
+): Record<string, number> {
+  // templateId → set of series keys with a today/future occurrence.
+  const seriesByTemplate = new Map<string, Set<string>>();
+  for (const a of assignments) {
+    if (!a) continue;
+    const templateId = a.templateId;
+    const scheduledFor = a.scheduledFor;
+    if (typeof templateId !== "string" || !templateId) continue;
+    if (typeof scheduledFor !== "string" || scheduledFor < today) continue;
+    const seriesKey =
+      typeof a.seriesId === "string" && a.seriesId ? a.seriesId : a.id;
+    let set = seriesByTemplate.get(templateId);
+    if (!set) {
+      set = new Set<string>();
+      seriesByTemplate.set(templateId, set);
+    }
+    set.add(seriesKey);
+  }
+  const counts: Record<string, number> = {};
+  for (const [templateId, set] of seriesByTemplate) {
+    counts[templateId] = set.size;
+  }
+  return counts;
+}

--- a/backoffice/src/lib/gc-fitness/library-usage-listeners.ts
+++ b/backoffice/src/lib/gc-fitness/library-usage-listeners.ts
@@ -1,0 +1,43 @@
+// library-usage-listeners.ts
+//
+// React-Query bridges for the Biblioteca usage pills. Both wrap a Server
+// Action (same rationale as workout-templates-listener: the count queries are
+// trainer-scoped and run server-side). Counts are cheap to be slightly stale,
+// so a 60s staleTime is plenty live for a library overview.
+
+"use client";
+
+import { useQuery } from "@tanstack/react-query";
+
+import { countExerciseTemplateUsage } from "./workout-template-actions";
+import { countTemplateAssignments } from "./workout-assignment-actions";
+
+export const EXERCISE_USAGE_QUERY_KEY = [
+  "gc-fitness",
+  "exercise-usage-counts",
+] as const;
+
+export const TEMPLATE_ASSIGNMENT_QUERY_KEY = [
+  "gc-fitness",
+  "template-assignment-counts",
+] as const;
+
+/** `exerciseId` → number of routines (templates) using it. */
+export function useExerciseUsageCounts() {
+  return useQuery<Record<string, number>>({
+    queryKey: EXERCISE_USAGE_QUERY_KEY,
+    queryFn: () => countExerciseTemplateUsage(),
+    staleTime: 60_000,
+    refetchOnWindowFocus: false,
+  });
+}
+
+/** `templateId` → number of today/future assignment series (recurring = 1). */
+export function useTemplateAssignmentCounts() {
+  return useQuery<Record<string, number>>({
+    queryKey: TEMPLATE_ASSIGNMENT_QUERY_KEY,
+    queryFn: () => countTemplateAssignments(),
+    staleTime: 60_000,
+    refetchOnWindowFocus: false,
+  });
+}

--- a/backoffice/src/lib/gc-fitness/workout-assignment-actions.ts
+++ b/backoffice/src/lib/gc-fitness/workout-assignment-actions.ts
@@ -61,6 +61,10 @@ import { FirestoreCollections } from "./collections";
 import { normalizeMirrorEmail } from "./email-normalization";
 import { civilDateFormat } from "./civil-date";
 import { getTrainerTimezone } from "./trainer-timezone";
+import {
+  tallyTemplateAssignments,
+  type AssignmentForUsage,
+} from "./library-usage-counts";
 
 const TEMPLATES = FirestoreCollections.workoutTemplates;
 const ASSIGNMENTS = FirestoreCollections.workoutAssignments;
@@ -2198,4 +2202,38 @@ export async function listAssignmentsForTrainerDay(
     id: string;
     data: () => Record<string, unknown>;
   }>).map(snapToRow);
+}
+
+/**
+ * Map of `templateId` → number of assignment series scheduled today or later,
+ * scoped to this trainer. A recurring assignment counts as ONE (collapsed by
+ * `seriesId`); past-only assignments are ignored. Powers the "N asignaciones"
+ * pill on the workout-template library rows.
+ *
+ * Index-light: a single `trainerId ==` equality (auto-indexed); the
+ * today/future filter + series collapse run in memory (see
+ * `tallyTemplateAssignments`). "Today" is the trainer's civil date.
+ */
+export async function countTemplateAssignments(): Promise<
+  Record<string, number>
+> {
+  const trainer = await getCurrentTrainer();
+  const tz = await getTrainerTimezone();
+  const today = civilDateFormat(new Date(), tz);
+  const db = gcFitnessFirestore();
+  const snap = await db
+    .collection(ASSIGNMENTS)
+    .where("trainerId", "==", trainer.uid)
+    .get();
+  const assignments: AssignmentForUsage[] = snap.docs.map((d) => {
+    const data = d.data() as Record<string, unknown>;
+    return {
+      id: d.id,
+      templateId: typeof data.templateId === "string" ? data.templateId : null,
+      scheduledFor:
+        typeof data.scheduledFor === "string" ? data.scheduledFor : null,
+      seriesId: typeof data.seriesId === "string" ? data.seriesId : null,
+    };
+  });
+  return tallyTemplateAssignments(assignments, today);
 }

--- a/backoffice/src/lib/gc-fitness/workout-template-actions.ts
+++ b/backoffice/src/lib/gc-fitness/workout-template-actions.ts
@@ -40,6 +40,10 @@ import {
 import { FirestoreCollections } from "./collections";
 import { estimateTemplateDurationMinutesFromRaw } from "./workout-duration-estimate";
 import { resolveExerciseDocsById } from "./exercise-resolution";
+import {
+  tallyExerciseUsage,
+  type TemplateForUsage,
+} from "./library-usage-counts";
 
 const COLLECTION = FirestoreCollections.workoutTemplates;
 
@@ -584,4 +588,35 @@ function extractPreviewUrl(
   const pick = (raw: unknown): string | null =>
     typeof raw === "string" && raw.trim().length > 0 ? raw : null;
   return pick(source.gifUrl) ?? pick(source.imageUrl) ?? pick(source.thumbnailURL);
+}
+
+/**
+ * Map of `exerciseId` → number of templates that use it, across the trainer's
+ * own templates + the shared standard library (non-deleted). Powers the
+ * "in N routines" pill on the exercise-library rows. Reuses the same
+ * index-light ownership/standard queries as `listWorkoutTemplates`.
+ */
+export async function countExerciseTemplateUsage(): Promise<
+  Record<string, number>
+> {
+  const trainer = await getCurrentTrainer();
+  const db = gcFitnessFirestore();
+  const [ownSnap, standardSnap] = await Promise.all([
+    db.collection(COLLECTION).where("trainerId", "==", trainer.uid).get(),
+    db.collection(COLLECTION).where("isStandard", "==", true).get(),
+  ]);
+  const dedup = new Map(
+    [...ownSnap.docs, ...standardSnap.docs].map((d) => [d.id, d]),
+  );
+  const templates: TemplateForUsage[] = [...dedup.values()].map((d) => {
+    const data = d.data() as Record<string, unknown>;
+    return {
+      id: d.id,
+      deleted: data.deleted === true,
+      exercises: Array.isArray(data.exercises)
+        ? (data.exercises as Array<{ exerciseId?: string | null }>)
+        : [],
+    };
+  });
+  return tallyExerciseUsage(templates);
 }


### PR DESCRIPTION
Adds usage-count pills to the GC Fitness library rows, as requested.

## What
- **Exercises tab:** each exercise row shows a pill "**N rutinas**" — in how many routines (workout templates) the exercise is used.
- **Workouts tab:** each workout row shows a pill "**N asignaciones**" — how many assignments it has.

### Counting rules (per request)
- A **recurring** assignment counts as **1** (occurrences collapse by `seriesId`).
- Only **today + future** assignments count (`scheduledFor >= today` in the trainer's civil date); past ones are ignored.
- Exercise→routine count is over the trainer's own templates **+ the standard library** (non-deleted), counted once per template.
- Pills only render when the count is > 0.

## How
- `library-usage-counts.ts` — **pure, unit-tested** tally helpers (`tallyExerciseUsage`, `tallyTemplateAssignments`). 7 tests covering distinct-per-template, recurring-collapse, past-exclusion, bucketing.
- Server actions: `countExerciseTemplateUsage` (reuses the index-light owned+standard query from `listWorkoutTemplates`) and `countTemplateAssignments` (single `trainerId ==` equality — auto-indexed, no composite index; today/future + series collapse done in memory).
- React-query hooks (`library-usage-listeners.ts`), 60s staleTime.
- Pills are `Badge variant="outline"` on the exercise name cell + the template row badges. EN/ES plural strings added.

## Notes / decisions
- **Exercise usage spans owned + standard templates** (the same set the Workouts library shows). If you want "my routines only", it's a one-line filter.
- No `firestore.rules` / index changes. Reads are trainer-scoped server-side.

## Test gate
`npx jest`: **691 pass** (incl. the 7 new tally tests). The 2 failing suites (`client-activity-time` locale flake — green in CI; `workout-assignment-actions` bulk-assign) are **pre-existing on main** and unrelated.