### PR TITLE
fix(gc-fitness): dedupe the exercise library list + search

### DIFF
--- a/backoffice/src/app/gc-fitness/exercises/client.tsx
+++ b/backoffice/src/app/gc-fitness/exercises/client.tsx
@@ -56,6 +56,7 @@ import {
 } from "@/lib/gc-fitness/exercises-listener";
 import { searchExercises } from "@/lib/gc-fitness/exercise-search";
 import { isPickableExercise } from "@/lib/gc-fitness/exercise-visibility";
+import { dedupeExercisesByDisplayName } from "@/lib/gc-fitness/exercise-dedupe";
 import { useFavorites } from "@/lib/gc-fitness/use-favorites";
 import {
   favoriteIdSet,
@@ -151,7 +152,14 @@ export function ExerciseLibraryClient({
   );
 
   const rows = useMemo(() => {
-    const all = (data ?? []).filter(isPickableExercise);
+    // Collapse the double-seeded standard-library twins (numeric-id + std-*
+    // docs of the same exercise) BEFORE filter/search, so the library list +
+    // search show ONE row per exercise — the same render-dedupe the pickers
+    // and generator already apply. Prefers owned > renderable-media >
+    // canonical id > recency; the duplicate docs stay in Firestore.
+    const all = dedupeExercisesByDisplayName(
+      (data ?? []).filter(isPickableExercise),
+    );
     // Apply the non-search chip/select filters first, THEN rank + search
     // (issue #291): normalized, plural/hyphen-tolerant, best-match-first.
     const filtered = all.filter((r) => matchesFilters(r, filters, trainerUid));


### PR DESCRIPTION
Fixes the duplicated exercises seen in the library when searching (e.g. two "Hollow Hold (Bodyweight)", two "Dead Bug (Bodyweight)").

## Cause
The prod `exercises` collection is **double-seeded**: every standard exercise exists as a numeric-id doc AND a `std-*` twin, both tagged `standard-library`. The pickers/generator already collapse these via `dedupeExercisesByDisplayName`, but the **library-management list + search did not** (it was deliberately left un-deduped "for curation").

## Fix
Apply the same render-dedupe to the library list, before filter/search. One row per display name; the helper prefers **owned > renderable media > canonical (non `std-*`) id > recency**, so:
- your own custom exercises are never hidden behind a library twin,
- the twin with a working thumbnail wins.

**No Firestore writes** — purely a render-level collapse. The duplicate docs stay in the DB for a future server-side cleanup (the real root-cause fix is still deferred — the twins keep getting re-seeded).

## Test gate
`npx jest`: 684 pass. The `exercise-dedupe` suite already covers the helper. The 2 failing suites (`client-activity-time` locale flake — green in CI; `workout-assignment-actions` bulk-assign) are **pre-existing on main** and unrelated.

## Note
Touches the same `exercises/client.tsx` `rows` memo as #202 (usage pills); a trivial merge resolution if both land — the two changes are independent (this wraps `all` in dedupe; #202 adds the usage-count hook + column arg).