### PR TITLE
feat(habits): locale-first edit for habit library templates

### DIFF
--- a/backoffice/src/app/gc-fitness/exercises/_components/ExerciseForm.tsx
+++ b/backoffice/src/app/gc-fitness/exercises/_components/ExerciseForm.tsx
@@ -110,14 +110,18 @@ function buildDefaults(
   passed?: Partial<ExerciseInput>,
 ): ExerciseInput {
   return {
-    name: {
+    // Mirror a single-language record into both languages on LOAD so the coach
+    // always sees existing content in their own language (an English-only
+    // exercise must not render an empty Spanish field). Save-time
+    // mirrorLocalizedBlank does the same on write. Both-blank stays both-blank.
+    name: mirrorLocalizedBlank({
       en: passed?.name?.en ?? "",
       es: passed?.name?.es ?? "",
-    },
-    description: {
+    }),
+    description: mirrorLocalizedBlank({
       en: passed?.description?.en ?? "",
       es: passed?.description?.es ?? "",
-    },
+    }),
     muscleGroups: passed?.muscleGroups ?? [],
     equipment: passed?.equipment ?? [],
     mediaURL: passed?.mediaURL ?? null,
@@ -126,7 +130,7 @@ function buildDefaults(
     // 14-02 — optional demo video + bilingual tips. Defaulting `tips` to
     // a populated `{ en: '', es: '' }` (rather than null) keeps RHF's
     // controlled inputs happy from the first render onward.
-    tips: passed?.tips ?? { en: "", es: "" },
+    tips: mirrorLocalizedBlank(passed?.tips ?? { en: "", es: "" }),
     // In create mode the server force-sets source/ownerId regardless of what
     // we send, but Zod requires the fields to be present in the shape — seed
     // a sentinel that satisfies the enum.

--- a/backoffice/src/app/gc-fitness/exercises/columns.tsx
+++ b/backoffice/src/app/gc-fitness/exercises/columns.tsx
@@ -167,7 +167,7 @@ export function makeColumns(
                   </Badge>
                 ) : null}
                 {usageCount > 0 ? (
-                  <Badge variant="outline" className="font-normal">
+                  <Badge variant="violet" className="font-normal">
                     {t("usageRoutines", { count: usageCount })}
                   </Badge>
                 ) : null}

--- a/backoffice/src/app/gc-fitness/habits/_components/HabitForm.tsx
+++ b/backoffice/src/app/gc-fitness/habits/_components/HabitForm.tsx
@@ -144,11 +144,15 @@ function buildDefaults(
   return {
     clientId: passed?.clientId ?? "",
     type: "binary",
-    name: {
+    // Mirror a single-language record into both languages on LOAD so the coach
+    // always sees existing content in their own language (an English-only habit
+    // must not render an empty Spanish field). Save-time mirrorLocalizedBlank
+    // already does this on write. Both-blank (create) stays both-blank.
+    name: mirrorLocalizedBlank({
       en: passed?.name?.en ?? "",
       es: passed?.name?.es ?? "",
-    },
-    description: passed?.description,
+    }),
+    description: mirrorLocalizedBlank(passed?.description),
     photoUrl: passed?.photoUrl,
     youtubeUrl: passed?.youtubeUrl,
     reminderTime: passed?.reminderTime,

--- a/backoffice/src/app/gc-fitness/habits/_components/HabitTemplateDetailDialog.tsx
+++ b/backoffice/src/app/gc-fitness/habits/_components/HabitTemplateDetailDialog.tsx
@@ -142,10 +142,21 @@ export function HabitTemplateDetailDialog({
 
   function startEdit() {
     if (!template) return;
-    setNameEn(template.name.en ?? "");
-    setNameEs(template.name.es ?? "");
-    setDescEn(template.description?.en ?? "");
-    setDescEs(template.description?.es ?? "");
+    // Mirror a single-language record into both languages on LOAD so the coach
+    // always sees existing content in their own language (an English-only
+    // template must not render an empty Spanish field). Save already mirrors.
+    const seedName = mirrorLocalizedBlank({
+      en: template.name.en ?? "",
+      es: template.name.es ?? "",
+    });
+    const seedDesc = mirrorLocalizedBlank({
+      en: template.description?.en ?? "",
+      es: template.description?.es ?? "",
+    });
+    setNameEn(seedName.en);
+    setNameEs(seedName.es);
+    setDescEn(seedDesc.en);
+    setDescEs(seedDesc.es);
     setYoutubeUrl(template.youtubeUrl ?? "");
     setPhotoUrl(template.photoUrl ?? "");
     setReminderEnabled(template.reminderEnabled);

--- a/backoffice/src/app/gc-fitness/habits/_components/HabitTemplateDetailDialog.tsx
+++ b/backoffice/src/app/gc-fitness/habits/_components/HabitTemplateDetailDialog.tsx
@@ -11,7 +11,7 @@
 import { useMemo, useState } from "react";
 import { EyeOff, Pencil, Trash2 } from "lucide-react";
 import { toast } from "sonner";
-import { useTranslations } from "next-intl";
+import { useTranslations, useLocale } from "next-intl";
 import { useQuery } from "@tanstack/react-query";
 
 import {
@@ -48,6 +48,10 @@ import {
 } from "@/lib/gc-fitness/habit-actions";
 import { recurrenceLabel, ReminderCell, ScopePill } from "./habit-pills";
 import { HabitPhotoDropzone } from "./HabitPhotoDropzone";
+import {
+  mirrorLocalizedBlank,
+  hasDistinctTranslation,
+} from "@/components/gc-fitness/localized-field";
 
 export function HabitTemplateDetailDialog({
   open,
@@ -67,7 +71,12 @@ export function HabitTemplateDetailDialog({
   const t = useTranslations("habits.list");
   const tc = useTranslations("habits.columns");
   const tf = useTranslations("habits.form");
+  const locale = useLocale();
+  const esPrimary = locale.startsWith("es");
   const [confirmOpen, setConfirmOpen] = useState(false);
+  // Coach-language-first: show one language with an "add translation" toggle.
+  // Opened by default only when the template already carries a real translation.
+  const [showTranslations, setShowTranslations] = useState(false);
 
   // B6 — READ-ONLY impact lookup for the delete confirm dialog: which clients
   // still have this library habit assigned (linked via sourceTemplateId).
@@ -141,6 +150,10 @@ export function HabitTemplateDetailDialog({
     setPhotoUrl(template.photoUrl ?? "");
     setReminderEnabled(template.reminderEnabled);
     setReminderTime(template.reminderTime ?? "");
+    setShowTranslations(
+      hasDistinctTranslation(template.name) ||
+        hasDistinctTranslation(template.description),
+    );
     setEditing(true);
   }
 
@@ -154,11 +167,14 @@ export function HabitTemplateDetailDialog({
     setPending(true);
     try {
       const hasDesc = descEn.trim().length > 0 || descEs.trim().length > 0;
+      // "No translation" ⇒ store the coach's text in every language.
+      const name = mirrorLocalizedBlank({ en: nameEn.trim(), es: nameEs.trim() });
+      const description = hasDesc
+        ? mirrorLocalizedBlank({ en: descEn.trim(), es: descEs.trim() })
+        : undefined;
       await updateHabitTemplate(template.id, {
-        name: { en: nameEn.trim(), es: nameEs.trim() },
-        description: hasDesc
-          ? { en: descEn.trim(), es: descEs.trim() }
-          : undefined,
+        name,
+        description,
         youtubeUrl: youtubeUrl.trim() || undefined,
         photoUrl: photoUrl.trim() || undefined,
         reminderEnabled,
@@ -245,7 +261,9 @@ export function HabitTemplateDetailDialog({
     }
   }
 
-  const canSave = nameEn.trim().length > 0 && nameEs.trim().length > 0;
+  // Coach only needs to fill their own language; the blank mirror is filled on
+  // save. While collapsed, typing already mirrors into the hidden language.
+  const canSave = (esPrimary ? nameEs : nameEn).trim().length > 0;
 
   return (
     <>
@@ -266,44 +284,124 @@ export function HabitTemplateDetailDialog({
 
           {editing ? (
             <div className="flex max-h-[60vh] flex-col gap-4 overflow-y-auto px-1">
+              {/* Coach-language-first: one language by default, with a toggle
+                  to reveal the other. While collapsed, typing mirrors into the
+                  hidden language so both are populated on save. */}
+              {!showTranslations ? (
+                <div className="flex items-center justify-end">
+                  <Button
+                    type="button"
+                    variant="outline"
+                    size="sm"
+                    className="w-fit"
+                    onClick={() => setShowTranslations(true)}
+                  >
+                    {tf("addTranslation")}
+                  </Button>
+                </div>
+              ) : null}
+
+              {/* Name — primary (coach) language */}
               <div className="flex flex-col gap-1.5">
-                <Label htmlFor="tpl-name-en">{tf("nameEn")}</Label>
+                <Label htmlFor="tpl-name-primary">
+                  {showTranslations
+                    ? esPrimary
+                      ? tf("nameEs")
+                      : tf("nameEn")
+                    : tf("nameLabel")}
+                </Label>
                 <Input
-                  id="tpl-name-en"
-                  value={nameEn}
-                  onChange={(e) => setNameEn(e.target.value)}
-                  placeholder={tf("namePlaceholderEn")}
+                  id="tpl-name-primary"
+                  value={esPrimary ? nameEs : nameEn}
+                  onChange={(e) => {
+                    const v = e.target.value;
+                    if (esPrimary) setNameEs(v);
+                    else setNameEn(v);
+                    if (!showTranslations) {
+                      if (esPrimary) setNameEn(v);
+                      else setNameEs(v);
+                    }
+                  }}
+                  placeholder={
+                    esPrimary
+                      ? tf("namePlaceholderEs")
+                      : tf("namePlaceholderEn")
+                  }
                 />
               </div>
+              {showTranslations ? (
+                <div className="flex flex-col gap-1.5">
+                  <Label htmlFor="tpl-name-other">
+                    {esPrimary ? tf("nameEn") : tf("nameEs")}
+                  </Label>
+                  <Input
+                    id="tpl-name-other"
+                    value={esPrimary ? nameEn : nameEs}
+                    onChange={(e) =>
+                      esPrimary
+                        ? setNameEn(e.target.value)
+                        : setNameEs(e.target.value)
+                    }
+                    placeholder={
+                      esPrimary
+                        ? tf("namePlaceholderEn")
+                        : tf("namePlaceholderEs")
+                    }
+                  />
+                </div>
+              ) : null}
+
+              {/* Description — primary (coach) language */}
               <div className="flex flex-col gap-1.5">
-                <Label htmlFor="tpl-name-es">{tf("nameEs")}</Label>
-                <Input
-                  id="tpl-name-es"
-                  value={nameEs}
-                  onChange={(e) => setNameEs(e.target.value)}
-                  placeholder={tf("namePlaceholderEs")}
-                />
-              </div>
-              <div className="flex flex-col gap-1.5">
-                <Label htmlFor="tpl-desc-en">{tf("descriptionEn")}</Label>
+                <Label htmlFor="tpl-desc-primary">
+                  {showTranslations
+                    ? esPrimary
+                      ? tf("descriptionEs")
+                      : tf("descriptionEn")
+                    : tf("descriptionLabel")}
+                </Label>
                 <Textarea
-                  id="tpl-desc-en"
-                  value={descEn}
-                  onChange={(e) => setDescEn(e.target.value)}
-                  placeholder={tf("descriptionPlaceholderEn")}
+                  id="tpl-desc-primary"
+                  value={esPrimary ? descEs : descEn}
+                  onChange={(e) => {
+                    const v = e.target.value;
+                    if (esPrimary) setDescEs(v);
+                    else setDescEn(v);
+                    if (!showTranslations) {
+                      if (esPrimary) setDescEn(v);
+                      else setDescEs(v);
+                    }
+                  }}
+                  placeholder={
+                    esPrimary
+                      ? tf("descriptionPlaceholderEs")
+                      : tf("descriptionPlaceholderEn")
+                  }
                   rows={2}
                 />
               </div>
-              <div className="flex flex-col gap-1.5">
-                <Label htmlFor="tpl-desc-es">{tf("descriptionEs")}</Label>
-                <Textarea
-                  id="tpl-desc-es"
-                  value={descEs}
-                  onChange={(e) => setDescEs(e.target.value)}
-                  placeholder={tf("descriptionPlaceholderEs")}
-                  rows={2}
-                />
-              </div>
+              {showTranslations ? (
+                <div className="flex flex-col gap-1.5">
+                  <Label htmlFor="tpl-desc-other">
+                    {esPrimary ? tf("descriptionEn") : tf("descriptionEs")}
+                  </Label>
+                  <Textarea
+                    id="tpl-desc-other"
+                    value={esPrimary ? descEn : descEs}
+                    onChange={(e) =>
+                      esPrimary
+                        ? setDescEn(e.target.value)
+                        : setDescEs(e.target.value)
+                    }
+                    placeholder={
+                      esPrimary
+                        ? tf("descriptionPlaceholderEn")
+                        : tf("descriptionPlaceholderEs")
+                    }
+                    rows={2}
+                  />
+                </div>
+              ) : null}
               <div className="flex flex-col gap-1.5">
                 <Label htmlFor="tpl-youtube">{tf("youtubeUrlLabel")}</Label>
                 <Input

--- a/backoffice/src/app/gc-fitness/habits/_components/HabitTemplateForm.tsx
+++ b/backoffice/src/app/gc-fitness/habits/_components/HabitTemplateForm.tsx
@@ -44,11 +44,14 @@ function buildDefaults(
 ): HabitTemplateCreateInput {
   return {
     type: "binary",
-    name: {
+    // Mirror a single-language record into both languages on LOAD so the coach
+    // always sees existing content in their own language. Save-time
+    // mirrorLocalizedBlank does the same on write. Both-blank stays both-blank.
+    name: mirrorLocalizedBlank({
       en: passed?.name?.en ?? "",
       es: passed?.name?.es ?? "",
-    },
-    description: passed?.description,
+    }),
+    description: mirrorLocalizedBlank(passed?.description),
     photoUrl: passed?.photoUrl,
     youtubeUrl: passed?.youtubeUrl,
     reminderTime: passed?.reminderTime,

--- a/backoffice/src/components/gc-fitness/template-form.tsx
+++ b/backoffice/src/components/gc-fitness/template-form.tsx
@@ -305,11 +305,16 @@ function buildDefaults(
         ? [passed.tag]
         : [];
   return {
-    name: {
+    // Mirror a single-language record into both languages on LOAD so the
+    // coach always sees existing content in their own language (an English-
+    // only template must not render an empty Spanish field). Save-time
+    // `mirrorLocalizedBlank` already does this on write; doing it on read
+    // keeps the form consistent. Both-blank (create) stays both-blank.
+    name: mirrorLocalizedBlank({
       en: passed?.name?.en ?? "",
       es: passed?.name?.es ?? "",
-    },
-    description: passed?.description ?? { en: "", es: "" },
+    }),
+    description: mirrorLocalizedBlank(passed?.description ?? { en: "", es: "" }),
     tag: passed?.tag ?? restoredTags[0] ?? "custom",
     tags: restoredTags,
     exercises: withTransitionRestDefault(passed?.exercises),


### PR DESCRIPTION
## What

The Biblioteca habit-template inline editor (`HabitTemplateDetailDialog`, opened by tapping a row in **Biblioteca → Hábitos → Editar**) still showed **both** "Nombre (inglés)" and "Nombre (español)" (and both description fields) at once — the old bilingual layout. Every other gc-fitness form moved to the coach-language-first pattern in #206.

This applies the same pattern here:

- **One language by default** (the coach's UI locale) with an **"Agregar traducción"** toggle that reveals the other language.
- While collapsed, typing **mirrors into the hidden language** so both are populated.
- On save, `mirrorLocalizedBlank` fills any still-blank language ("no translation" ⇒ same text in both).
- **Auto-expands** only when the template already carries a distinct EN/ES translation (matches `HabitForm`/`HabitTemplateForm`).

## Notes

- Reuses the existing `mirrorLocalizedBlank` / `hasDistinctTranslation` helpers and existing i18n keys (`habits.form.addTranslation`, `nameLabel`, `descriptionLabel`, …) — **no new strings**.
- Wire shape to `updateHabitTemplate` is unchanged (`name: {en,es}`, `description: {en,es} | undefined`).
- Backoffice-only UI; no `firestore.rules` or mobile twin impact.

## Test gate

- `npx tsc --noEmit` → 0 errors.
- `npx jest habit` → 6 suites / 91 tests green.