### PR TITLE
fix(gc-fitness): make the Coach Wiki publicly accessible

### DIFF
--- a/backoffice/src/proxy.ts
+++ b/backoffice/src/proxy.ts
@@ -55,6 +55,17 @@ export default async function proxy(request: NextRequest) {
       return NextResponse.next();
     }
 
+    // The Coach Wiki is intentionally PUBLIC — anyone with the link can read it
+    // (no trainer session required). The page itself runs no auth check and
+    // renders standalone (HIDDEN_SHELL_PATHS), so the only gate to lift is this
+    // middleware. Prefix-match so any future wiki sub-page stays public too.
+    if (
+      pathname === "/gc-fitness/wiki" ||
+      pathname.startsWith("/gc-fitness/wiki/")
+    ) {
+      return NextResponse.next();
+    }
+
     // Legacy pending-client URL compatibility:
     //   /gc-fitness/clients/mirror:{email}
     // -> /gc-fitness/clients/pending/{email}


### PR DESCRIPTION
## Problem

Opening https://golden-crow-backoffice.vercel.app/gc-fitness/wiki in an incognito window redirects to the login page, but the Coach Wiki is meant to be **public** — anyone with the link should be able to read it.

## Cause

The wiki page is already built to be public:
- the page runs **no** auth check (no `getCurrentTrainer`/`getTokens`),
- it's in `HIDDEN_SHELL_PATHS` so it renders standalone (no coach sidebar),
- the gc-fitness layout degrades gracefully to a `null` trainer.

The only gate was the auth **middleware** (`src/proxy.ts`), which bypassed the session check only for `/gc-fitness/login` and `/gc-fitness/forbidden`. `/gc-fitness/wiki` fell through to `authMiddleware`, which redirects anonymous visitors to `/gc-fitness/login`.

## Fix

Add a prefix-matched public bypass for `/gc-fitness/wiki` (and any future sub-page) in the proxy, right alongside the existing public-paths check. No page/layout changes needed — those were already public-ready.

## Test gate

- `npx tsc --noEmit` → 0 errors.
- Middleware-only change; behavior for every other `/gc-fitness/*` route is unchanged (still gated).