### PR TITLE
feat(wiki): add Useful links and FAQ sections

### DIFF
--- a/backoffice/src/app/gc-fitness/wiki/page.tsx
+++ b/backoffice/src/app/gc-fitness/wiki/page.tsx
@@ -6,6 +6,14 @@ import { GOLDENCROW_LOGO_DATA_URI } from "@/components/gc-fitness/goldencrow-log
 import { WIKI_COPY, WIKI_GROUPS, pick } from "./wiki-data";
 import { WikiSections } from "./wiki-sections";
 
+// Standalone (non-video) sections appended after the walkthrough groups in both
+// the table of contents and the content column. Their ids match the anchors in
+// wiki-sections.tsx.
+const WIKI_EXTRA_SECTIONS = [
+  { id: "links-utiles", title: WIKI_COPY.linksTitle },
+  { id: "faq", title: WIKI_COPY.faqTitle },
+] as const;
+
 // The Coach Wiki is intentionally PUBLIC — no getCurrentTrainer() call, anyone
 // with the link can read it. It's added to HIDDEN_SHELL_PATHS so it renders
 // standalone (no coach sidebar / no sign-in chrome). The logged-in portal links
@@ -109,6 +117,16 @@ function Toc({ locale }: { locale: string }) {
               </li>
             ))}
           </ul>
+        </div>
+      ))}
+      {WIKI_EXTRA_SECTIONS.map((section) => (
+        <div key={section.id}>
+          <a
+            href={`#${section.id}`}
+            className="block font-medium text-foreground transition-colors hover:text-primary"
+          >
+            {pick(locale, section.title)}
+          </a>
         </div>
       ))}
     </nav>

--- a/backoffice/src/app/gc-fitness/wiki/wiki-data.ts
+++ b/backoffice/src/app/gc-fitness/wiki/wiki-data.ts
@@ -27,6 +27,22 @@ export type WikiGroup = {
   videos: WikiVideo[];
 };
 
+export type WikiLink = {
+  /** Stable anchor id used for the table-of-contents deep links (#id). */
+  id: string;
+  label: Localized;
+  description: Localized;
+  /** Absolute URL (http(s) or mailto:). Always opened in a new tab. */
+  href: string;
+};
+
+export type WikiFaq = {
+  /** Stable anchor id used for the table-of-contents deep links (#id). */
+  id: string;
+  question: Localized;
+  answer: Localized;
+};
+
 export function pick(locale: string, value: Localized): string {
   return locale.startsWith("en") ? value.en : value.es;
 }
@@ -211,6 +227,68 @@ export const WIKI_GROUPS: WikiGroup[] = [
   },
 ];
 
+// Useful links — each opens in a new tab. Order matters (rendered as-is).
+export const WIKI_LINKS: WikiLink[] = [
+  {
+    id: "link-dashboard",
+    label: { es: "Dashboard de GC Fitness", en: "GC Fitness dashboard" },
+    description: {
+      es: "El portal de coaches donde gestionás a tus clientes, entrenamientos y hábitos.",
+      en: "The coach portal where you manage your clients, workouts, and habits.",
+    },
+    href: "https://golden-crow-backoffice.vercel.app/gc-fitness",
+  },
+  {
+    id: "link-support",
+    label: { es: "Soporte: support@goldencrowvs.com", en: "Support: support@goldencrowvs.com" },
+    description: {
+      es: "Escribinos por cualquier duda, consulta o pedido de una nueva función.",
+      en: "Email us with any question, issue, or feature request.",
+    },
+    href: "mailto:support@goldencrowvs.com",
+  },
+  {
+    id: "link-app-store",
+    label: {
+      es: "App de clientes para iPhone (App Store)",
+      en: "Client app for iPhone (App Store)",
+    },
+    description: {
+      es: "Para iPhone: descargá GC Fitness desde la App Store.",
+      en: "For iPhone: download GC Fitness from the App Store.",
+    },
+    href: "https://apps.apple.com/us/app/gc-fitness/id6771836254",
+  },
+  {
+    id: "link-play-store",
+    label: {
+      es: "App de clientes para Android (Google Play)",
+      en: "Client app for Android (Google Play)",
+    },
+    description: {
+      es: "Para Android: descargá GC Fitness desde Google Play.",
+      en: "For Android: download GC Fitness from Google Play.",
+    },
+    href: "https://play.google.com/store/apps/details?id=com.goldencrow.fitness",
+  },
+];
+
+// Frequently asked questions. Answers may contain newlines (rendered with
+// `whitespace-pre-line`).
+export const WIKI_FAQ: WikiFaq[] = [
+  {
+    id: "faq-cliente-no-aparece",
+    question: {
+      es: "Mi cliente entró a la app pero no lo veo en el dashboard.",
+      en: "My client signed into the app but I can't see them in my dashboard.",
+    },
+    answer: {
+      es: "Si el cliente inició sesión con un email distinto al que vos pre-cargaste, queda asignado a un coach general en lugar de a tu cuenta. Esto también pasa con “Iniciar sesión con Apple” cuando usan la opción de ocultar el email (Apple genera un email “relay” distinto al real). Para moverlo a tu cuenta, contactá a un miembro de GC Fitness o escribí a support@goldencrowvs.com y transferimos a ese cliente a tu cuenta.",
+      en: "If the client signed in with an email different from the one you pre-loaded, they get assigned to a general coach instead of your account. This also happens with “Sign in with Apple” when they choose to hide their email (Apple issues a “relay” address that differs from the real one). To move them to your account, contact a GC Fitness team member or email support@goldencrowvs.com and we'll transfer that client to your account.",
+    },
+  },
+];
+
 export const WIKI_COPY = {
   brand: { es: "GC Fitness", en: "GC Fitness" },
   eyebrow: { es: "Centro de ayuda", en: "Help center" },
@@ -220,6 +298,12 @@ export const WIKI_COPY = {
     en: "Short videos explaining how to use every section of the coach portal.",
   },
   tocTitle: { es: "Secciones", en: "Sections" },
+  linksTitle: { es: "Links útiles", en: "Useful links" },
+  linksSubtitle: {
+    es: "Cada link abre en una pestaña nueva.",
+    en: "Each link opens in a new tab.",
+  },
+  faqTitle: { es: "Preguntas frecuentes", en: "FAQ" },
   comingSoon: { es: "Próximamente", en: "Coming soon" },
   comingSoonHint: {
     es: "Estamos grabando este video. Vuelve pronto.",

--- a/backoffice/src/app/gc-fitness/wiki/wiki-sections.tsx
+++ b/backoffice/src/app/gc-fitness/wiki/wiki-sections.tsx
@@ -1,9 +1,11 @@
-import { PlayCircle, Video } from "lucide-react";
+import { ChevronDown, ExternalLink, PlayCircle, Video } from "lucide-react";
 
 import { Badge } from "@/components/ui/badge";
 import {
   WIKI_COPY,
+  WIKI_FAQ,
   WIKI_GROUPS,
+  WIKI_LINKS,
   loomEmbedUrl,
   loomShareUrl,
   pick,
@@ -30,6 +32,64 @@ export function WikiSections({ locale }: { locale: string }) {
           </div>
         </section>
       ))}
+
+      {/* Useful links — each opens in a new tab. */}
+      <section id="links-utiles" className="scroll-mt-24 space-y-5">
+        <div className="space-y-1">
+          <h2 className="font-heading text-lg font-bold sm:text-xl">
+            {pick(locale, WIKI_COPY.linksTitle)}
+          </h2>
+          <p className="text-sm text-muted-foreground">
+            {pick(locale, WIKI_COPY.linksSubtitle)}
+          </p>
+        </div>
+        <div className="grid gap-4 sm:grid-cols-2">
+          {WIKI_LINKS.map((link) => (
+            <a
+              key={link.id}
+              id={link.id}
+              href={link.href}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="group flex scroll-mt-24 items-start gap-3 rounded-2xl border border-border bg-card p-5 shadow-sm transition-colors hover:border-primary/50"
+            >
+              <div className="min-w-0 flex-1">
+                <h3 className="font-heading text-base font-bold transition-colors group-hover:text-primary sm:text-lg">
+                  {pick(locale, link.label)}
+                </h3>
+                <p className="mt-1 text-sm text-muted-foreground">
+                  {pick(locale, link.description)}
+                </p>
+              </div>
+              <ExternalLink className="mt-0.5 h-4 w-4 shrink-0 text-muted-foreground transition-colors group-hover:text-primary" />
+            </a>
+          ))}
+        </div>
+      </section>
+
+      {/* FAQ — native disclosure, no JS. */}
+      <section id="faq" className="scroll-mt-24 space-y-5">
+        <h2 className="font-heading text-lg font-bold sm:text-xl">
+          {pick(locale, WIKI_COPY.faqTitle)}
+        </h2>
+        <div className="space-y-3">
+          {WIKI_FAQ.map((item) => (
+            <details
+              key={item.id}
+              id={item.id}
+              className="group scroll-mt-24 rounded-2xl border border-border bg-card p-5 shadow-sm"
+            >
+              <summary className="flex cursor-pointer list-none items-start justify-between gap-3 font-heading text-base font-semibold [&::-webkit-details-marker]:hidden">
+                {pick(locale, item.question)}
+                <ChevronDown className="mt-0.5 h-4 w-4 shrink-0 text-muted-foreground transition-transform group-open:rotate-180" />
+              </summary>
+              <p className="mt-3 whitespace-pre-line text-sm leading-relaxed text-muted-foreground">
+                {pick(locale, item.answer)}
+              </p>
+            </details>
+          ))}
+        </div>
+      </section>
 
       <p className="border-t border-border/70 pt-8 text-sm text-muted-foreground">
         {pick(locale, WIKI_COPY.footer)}


### PR DESCRIPTION
## What

Adds two sections to the public Coach Wiki (`/gc-fitness/wiki`):

### Links útiles (each opens in a new tab)
- **Dashboard de GC Fitness** → the coach portal
- **Soporte: support@goldencrowvs.com** → `mailto:` for questions / feature requests
- **App de clientes para iPhone (App Store)** → https://apps.apple.com/us/app/gc-fitness/id6771836254
- **App de clientes para Android (Google Play)** → https://play.google.com/store/apps/details?id=com.goldencrow.fitness

### Preguntas frecuentes (FAQ)
One entry to start: *"Mi cliente entró a la app pero no lo veo en el dashboard."* — explains that signing in with an email different from the pre-loaded one (including **Sign in with Apple** relay/hidden emails) assigns the client to a **general coach**, and to contact a GC Fitness member or email **support@goldencrowvs.com** to have the client transferred to the coach's account.

## How

- Extends the existing self-contained ES/EN `wiki-data.ts` model with `WIKI_LINKS` + `WikiLink` and `WIKI_FAQ` + `WikiFaq`, plus section titles in `WIKI_COPY`.
- Renders both sections in `wiki-sections.tsx` (links as new-tab cards; FAQ as native `<details>` disclosures, no JS) and adds them to the table of contents.
- Fully bilingual (ES/EN) like the rest of the wiki. No auth/middleware changes.

> Note: public access to the wiki is handled separately in #208.

## Test gate
- `npx tsc --noEmit` → 0 errors.