### PR TITLE
docs(wiki): add client-feature FAQs to coach wiki

### DIFF
--- a/backoffice/src/app/gc-fitness/wiki/wiki-data.ts
+++ b/backoffice/src/app/gc-fitness/wiki/wiki-data.ts
@@ -287,6 +287,105 @@ export const WIKI_FAQ: WikiFaq[] = [
       en: "If the client signed in with an email different from the one you pre-loaded, they get assigned to a general coach instead of your account. This also happens with “Sign in with Apple” when they choose to hide their email (Apple issues a “relay” address that differs from the real one). To move them to your account, contact a GC Fitness team member or email support@goldencrowvs.com and we'll transfer that client to your account.",
     },
   },
+  {
+    id: "faq-prellenado-pesos",
+    question: {
+      es: "¿Cómo funciona el pre-llenado de pesos para mis clientes?",
+      en: "How does weight pre-fill work for my clients?",
+    },
+    answer: {
+      es: "La primera vez que el cliente hace un ejercicio, la app le muestra los pesos que planificaste vos (los del entrenamiento). Una vez que registra ese entrenamiento, en las siguientes sesiones la app le muestra sus propios últimos pesos registrados, no los planificados.\n\nCuando cambiás los pesos de un entrenamiento —editándolo y eligiendo “actualizar ocurrencias”, o con un ajuste puntual por asignación— el cliente vuelve a ver tu nuevo plan UNA vez, con un aviso de que el coach actualizó la rutina. Después de que lo registra, vuelve a recordar sus propios pesos.\n\nEn resumen: gana siempre la intención más reciente. Si tocaste el plan después de su última carga, ve tu plan; si no, ve lo último que levantó.",
+      en: "The first time a client does an exercise, the app shows the weights you planned (the workout's prescribed weights). Once they log that workout, in later sessions the app shows their own last logged weights instead of the planned ones.\n\nWhen you change a workout's weights — editing it and choosing “update occurrences”, or making a per-assignment adjustment — the client sees your new plan ONCE, with a notice that the coach updated the routine. After they log it, it goes back to remembering their own weights.\n\nIn short: the most recent intent wins. If you touched the plan after their last log, they see your plan; otherwise they see what they last lifted.",
+    },
+  },
+  {
+    id: "faq-semanas-entrenamientos",
+    question: {
+      es: "¿Cómo funciona el sistema de semanas de los entrenamientos?",
+      en: "How does the weekly workout system work?",
+    },
+    answer: {
+      es: "Los entrenamientos se organizan por semana (de lunes a domingo, en la zona horaria del cliente). Dentro de la semana en curso, el cliente puede mover sus entrenamientos a otro día manteniendo presionada (long tap) la tarjeta del entrenamiento y eligiendo el nuevo día.\n\nEse reordenamiento solo es posible dentro de la misma semana: no se pueden mover entrenamientos de una semana a otra. Cuando termina la semana, los entrenamientos que quedaron sin hacer aparecen como “perdidos” (missed) y ya no se pueden iniciar ni registrar. La idea es que cada semana arranque limpia y la adherencia refleje lo que realmente pasó.",
+      en: "Workouts are organized by week (Monday to Sunday, in the client's timezone). Within the current week, the client can move their workouts to a different day by long-pressing (long tap) the workout card and picking the new day.\n\nThat reordering only works inside the same week — workouts can't be moved across weeks. When the week ends, any workouts left undone show up as “missed” and can no longer be started or logged. The point is that each week starts fresh and adherence reflects what actually happened.",
+    },
+  },
+  {
+    id: "faq-habitos-si-no",
+    question: {
+      es: "¿Cómo funcionan los hábitos?",
+      en: "How do habits work?",
+    },
+    answer: {
+      es: "Los hábitos son de tipo SÍ/NO: el cliente simplemente marca si lo cumplió o no en el día. Por ahora no admiten cantidades, valores numéricos ni objetivos parciales (eso puede llegar más adelante).\n\nVos definís qué hábitos asignar y en qué días aplican; el cliente los marca desde la app y vos ves la adherencia en el portal. El peso corporal NO es un hábito: se registra por separado en su propia sección de seguimiento.",
+      en: "Habits are YES/NO: the client simply checks off whether they did it that day. For now they don't support quantities, numeric values, or partial goals (that may come later).\n\nYou define which habits to assign and which days they apply to; the client checks them off in the app and you see adherence in the portal. Body weight is NOT a habit — it's logged separately in its own tracking section.",
+    },
+  },
+  {
+    id: "faq-fotos-progreso",
+    question: {
+      es: "¿Cómo funcionan las fotos de progreso?",
+      en: "How do progress photos work?",
+    },
+    answer: {
+      es: "Las fotos de progreso las saca y sube únicamente el cliente desde la app; el coach no puede subir ni borrar fotos. Se organizan por check-in (una fecha) y por ángulo: frente, perfil y espalda.\n\nAl principio el cliente puede subir libremente para armar su línea base. Una vez establecida, la app habilita un nuevo check-in cada 7 días, para tener una cadencia pareja de comparación.\n\nVos ves todas las fotos de tus clientes desde el portal, con un comparador “antes/después” y filtros por ángulo. Las fotos son privadas: solo las pueden ver el cliente y su coach asignado (regla de seguridad reforzada en Firestore y Storage). No están vinculadas al peso corporal: son un seguimiento visual aparte.",
+      en: "Progress photos are taken and uploaded only by the client from the app; the coach can't upload or delete photos. They're organized by check-in (a date) and by angle: front, side, and back.\n\nAt first the client can upload freely to build their baseline. Once that's set, the app opens a new check-in every 7 days, to keep a steady comparison cadence.\n\nYou see all of your clients' photos in the portal, with a “before/after” comparator and angle filters. Photos are private: only the client and their assigned coach can see them (enforced in both Firestore and Storage rules). They're not tied to body weight — they're a separate visual record.",
+    },
+  },
+  {
+    id: "faq-notificaciones-push",
+    question: {
+      es: "¿Cómo funcionan las notificaciones de hábitos y entrenamientos?",
+      en: "How do habit and workout notifications work?",
+    },
+    answer: {
+      es: "Los recordatorios de hábitos y de entrenamientos se envían desde nuestro servidor como notificaciones push. El recordatorio de entrenamiento se dispara unos 30 minutos antes del horario que tenga programado la asignación (necesita tener una hora asignada); el de hábitos llega en su horario diario.\n\nEl cliente puede activar o desactivar cada tipo de recordatorio desde Ajustes → Notificaciones en la app.\n\nMuy importante: si el cliente nunca le dio permiso de notificaciones a la app (el permiso del sistema operativo), no le va a llegar ninguna notificación, aunque tenga los recordatorios activados. Si un cliente dice que no recibe nada, lo primero a revisar es que haya aceptado el permiso de notificaciones del teléfono.",
+      en: "Habit and workout reminders are sent from our server as push notifications. The workout reminder fires about 30 minutes before the assignment's scheduled time (it needs a time set); the habit reminder arrives at its daily time.\n\nThe client can turn each reminder type on or off from Settings → Notifications in the app.\n\nVery important: if the client never granted the app notification permission (the OS-level permission), they won't get any notifications at all, even with reminders enabled. If a client says they're not getting anything, the first thing to check is that they accepted the phone's notification permission.",
+    },
+  },
+  {
+    id: "faq-iphone-apple-watch",
+    question: {
+      es: "¿Cómo funciona la integración con el Apple Watch?",
+      en: "How does the Apple Watch integration work?",
+    },
+    answer: {
+      es: "El cliente puede hacer todo el entrenamiento desde el Apple Watch: ver el entrenamiento del día, registrar series y repeticiones, y usar el temporizador de descanso, sin tocar el teléfono durante la sesión.\n\nAhora bien, el reloj no escribe directamente en la base de datos: le pasa los datos al iPhone. Por eso, al terminar, el cliente tiene que abrir la app de iPhone para que el entrenamiento termine de sincronizarse y quede guardado (es el iPhone el que confirma y guarda el entrenamiento final). Si solo usa el reloj y nunca abre el iPhone, el entrenamiento puede quedar pendiente de sincronizar y no te va a aparecer todavía en el portal.",
+      en: "The client can do the whole workout from the Apple Watch: see the day's workout, log sets and reps, and use the rest timer, without touching the phone during the session.\n\nThat said, the watch doesn't write to the database directly — it hands the data off to the iPhone. So when they finish, the client needs to open the iPhone app for the workout to finish syncing and be saved (the iPhone is what confirms and stores the final workout). If they only use the watch and never open the iPhone, the workout may stay pending sync and won't show up in your portal yet.",
+    },
+  },
+  {
+    id: "faq-editar-recurrencia",
+    question: {
+      es: "Edité un entrenamiento recurrente: ¿afecta a las sesiones que el cliente ya hizo?",
+      en: "I edited a recurring workout — does it affect sessions the client already did?",
+    },
+    answer: {
+      es: "No. Cuando editás un entrenamiento recurrente y elegís “actualizar ocurrencias”, los cambios se aplican a las sesiones futuras (de la ocurrencia que estás viendo en adelante), no a las que el cliente ya completó. Las sesiones ya registradas quedan tal cual se hicieron, como historial.\n\nSi solo querés cambiar una sesión puntual, podés editar esa asignación sin tocar el resto de la serie.",
+      en: "No. When you edit a recurring workout and choose “update occurrences”, the changes apply to future sessions (from the occurrence you're viewing onward), not to ones the client already completed. Already-logged sessions stay exactly as they were done, as history.\n\nIf you only want to change a single session, you can edit that one assignment without touching the rest of the series.",
+    },
+  },
+  {
+    id: "faq-reps-sin-peso",
+    question: {
+      es: "¿Puedo asignar ejercicios sin peso (peso corporal) y cómo se calcula el volumen?",
+      en: "Can I assign exercises with no weight (bodyweight), and how is volume calculated?",
+    },
+    answer: {
+      es: "Sí. Podés configurar ejercicios para que se registren solo con repeticiones (o tiempo), sin pedir peso. Es ideal para movimientos de peso corporal y movilidad.\n\nSobre el volumen: hoy se calcula como peso × repeticiones (o, en ejercicios por tiempo, en base a la duración). Los ejercicios sin peso aportan 0 al volumen total por ahora, así que no infles las expectativas de “volumen” en rutinas mayormente de peso corporal: la adherencia y las repeticiones siguen quedando registradas igual.",
+      en: "Yes. You can set up exercises to be logged with reps only (or time), without asking for weight. It's ideal for bodyweight and mobility movements.\n\nAbout volume: today it's computed as weight × reps (or, for time-based exercises, from duration). Weightless exercises contribute 0 to total volume for now, so don't over-read the “volume” number on mostly-bodyweight routines — adherence and reps are still recorded all the same.",
+    },
+  },
+  {
+    id: "faq-biblioteca-estandar",
+    question: {
+      es: "¿Para qué sirven los ejercicios y entrenamientos “estándar” de la biblioteca?",
+      en: "What are the “standard” library exercises and workouts for?",
+    },
+    answer: {
+      es: "La biblioteca incluye contenido estándar compartido (ejercicios y plantillas de entrenamiento ya armados) para que no tengas que empezar de cero. Ese contenido es de solo lectura: no se puede editar directamente.\n\nSi querés partir de una plantilla estándar y adaptarla, usá “Duplicar”: eso crea una copia tuya, editable, que podés modificar y asignar sin afectar el original compartido.",
+      en: "The library includes shared standard content (ready-made exercises and workout templates) so you don't have to start from scratch. That content is read-only — it can't be edited directly.\n\nIf you want to start from a standard template and adapt it, use “Duplicate”: that creates your own editable copy, which you can modify and assign without affecting the shared original.",
+    },
+  },
 ];
 
 export const WIKI_COPY = {


### PR DESCRIPTION
## What

Adds 10 FAQ entries (ES + EN) to the public Coach Wiki (`/gc-fitness/wiki`), explaining client-app behavior that coaches commonly ask about. Copy lives in the existing self-contained `wiki-data.ts` dictionary; the FAQ list auto-renders, so no other changes needed.

## FAQs added

Requested:
1. **Pre-llenado de pesos** — plan first → own last weights after logging → coach change shows once, then reverts ("most recent intent wins").
2. **Sistema de semanas** — long-tap to move workouts within the current week (Mon–Sun, client TZ); no cross-week moves; past-week undone workouts become "missed" and can't be started.
3. **Hábitos** — yes/no only; body weight tracked separately.
4. **Fotos de progreso** — client-only upload; check-in date + angle; free baseline then 7-day cadence; coach before/after comparator; private to client + assigned coach.
5. **Notificaciones push** — server FCM; workout ~30 min before scheduled time, habit at daily time; toggleable in app; **no OS permission = nothing arrives**.
6. **Apple Watch** — full workout on watch, but **must open the iPhone app at the end** to sync/finalize.

Extras (curated common trainer doubts):
7. Editing a recurring workout affects future sessions only.
8. Reps-without-weight exercises supported; volume = weight × reps (weightless = 0).
9. Standard library content is read-only — use Duplicate to edit.

## Verification

- Each FAQ verified against the actual iOS/backoffice/functions code (WeightPrefillResolver, week-range reschedule gate, progress-photo check-in policy + storage rules, push prefs + permission flow, watch→phone single-writer finalize).
- `tsc --noEmit` clean for `wiki-data.ts`.
- Backoffice Jest: 2 pre-existing failures unrelated to this copy-only change (`client-activity-time` locale flake; `workout-assignment-actions` batch test) — neither touches the wiki.