### PR TITLE
docs(wiki): add Loom videos for create-workout & workout-generator

### DIFF
--- a/backoffice/src/app/gc-fitness/wiki/wiki-data.ts
+++ b/backoffice/src/app/gc-fitness/wiki/wiki-data.ts
@@ -173,16 +173,28 @@ export const WIKI_GROUPS: WikiGroup[] = [
         loomId: "ff4f7b3d6a724effb971f5f2b1742aa0",
       },
       {
-        id: "generador-entrenamientos",
+        id: "crear-entrenamiento",
         title: {
-          es: "Generador y creación de entrenamientos",
-          en: "Workout generator & creation",
+          es: "Crear entrenamiento",
+          en: "Create a workout",
         },
         description: {
-          es: "Generá entrenamientos automáticamente o creálos a mano desde cero.",
-          en: "Auto-generate workouts or build them by hand from scratch.",
+          es: "Armá un entrenamiento a mano desde cero, ejercicio por ejercicio.",
+          en: "Build a workout by hand from scratch, exercise by exercise.",
         },
-        // Pendiente de grabación.
+        loomId: "fd2087071c4e4c3eb1c8c3487c8db39b",
+      },
+      {
+        id: "generador-entrenamientos",
+        title: {
+          es: "Generador de entrenamientos",
+          en: "Workout generator",
+        },
+        description: {
+          es: "Generá entrenamientos automáticamente eligiendo equipo, músculos, duración y estilo.",
+          en: "Auto-generate workouts by choosing equipment, muscles, duration, and style.",
+        },
+        loomId: "10a9e60ad71a449a84b3499fb8f52b7e",
       },
       {
         id: "crear-ejercicio",

--- a/backoffice/src/app/gc-fitness/wiki/wiki-data.ts
+++ b/backoffice/src/app/gc-fitness/wiki/wiki-data.ts
@@ -420,7 +420,9 @@ export const WIKI_COPY = {
     es: "Estamos grabando este video. Vuelve pronto.",
     en: "We're still recording this one. Check back soon.",
   },
-  openInLoom: { es: "Ver en Loom", en: "Open in Loom" },
+  copyLink: { es: "Copiar", en: "Copy" },
+  copiedLink: { es: "¡Copiado!", en: "Copied!" },
+  openLink: { es: "Abrir en una pestaña nueva", en: "Open in a new tab" },
   footer: {
     es: "¿Tenés dudas que no están acá? Escribinos por chat.",
     en: "Got a question that isn't covered here? Reach out on chat.",

--- a/backoffice/src/app/gc-fitness/wiki/wiki-link-cards.tsx
+++ b/backoffice/src/app/gc-fitness/wiki/wiki-link-cards.tsx
@@ -1,0 +1,95 @@
+"use client";
+
+// wiki-link-cards.tsx
+//
+// Client island for the "Useful links" cards. Split out from the (server)
+// WikiSections so the copy-to-clipboard button can be interactive. Each card
+// links out in a new tab; the http(s) links also show their URL with a copy
+// button. `mailto:` links (e.g. support) skip the URL row — there's nothing
+// useful to copy to a clipboard there.
+
+import { useState } from "react";
+import { Check, Copy, ExternalLink } from "lucide-react";
+
+import { WIKI_COPY, WIKI_LINKS, pick, type WikiLink } from "./wiki-data";
+
+export function WikiLinkCards({ locale }: { locale: string }) {
+  return (
+    <div className="grid gap-4 sm:grid-cols-2">
+      {WIKI_LINKS.map((link) => (
+        <WikiLinkCard key={link.id} link={link} locale={locale} />
+      ))}
+    </div>
+  );
+}
+
+function WikiLinkCard({ link, locale }: { link: WikiLink; locale: string }) {
+  const [copied, setCopied] = useState(false);
+  const showUrl = !link.href.startsWith("mailto:");
+
+  async function copy() {
+    try {
+      await navigator.clipboard.writeText(link.href);
+      setCopied(true);
+      window.setTimeout(() => setCopied(false), 1500);
+    } catch {
+      // Clipboard may be unavailable (insecure context / denied) — no-op.
+    }
+  }
+
+  return (
+    <div
+      id={link.id}
+      className="group flex scroll-mt-24 flex-col gap-3 rounded-2xl border border-border bg-card p-5 shadow-sm transition-colors hover:border-primary/50"
+    >
+      <div className="flex items-start gap-3">
+        <a
+          href={link.href}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="min-w-0 flex-1"
+        >
+          <h3 className="font-heading text-base font-bold transition-colors group-hover:text-primary sm:text-lg">
+            {pick(locale, link.label)}
+          </h3>
+          <p className="mt-1 text-sm text-muted-foreground">
+            {pick(locale, link.description)}
+          </p>
+        </a>
+        <a
+          href={link.href}
+          target="_blank"
+          rel="noopener noreferrer"
+          aria-label={pick(locale, WIKI_COPY.openLink)}
+          className="mt-0.5 shrink-0 text-muted-foreground transition-colors hover:text-primary"
+        >
+          <ExternalLink className="h-4 w-4" />
+        </a>
+      </div>
+
+      {showUrl ? (
+        <div className="flex items-center gap-2 rounded-lg border border-border bg-muted/40 px-3 py-2">
+          <span
+            className="min-w-0 flex-1 truncate font-mono text-xs text-muted-foreground"
+            title={link.href}
+          >
+            {link.href}
+          </span>
+          <button
+            type="button"
+            onClick={copy}
+            aria-label={pick(locale, copied ? WIKI_COPY.copiedLink : WIKI_COPY.copyLink)}
+            className="inline-flex shrink-0 items-center gap-1.5 rounded-md border border-border bg-background px-2.5 py-1 text-xs font-medium text-foreground transition-colors hover:border-primary hover:text-primary"
+          >
+            {copied ? (
+              <Check className="h-3.5 w-3.5 text-emerald-600" />
+            ) : (
+              <Copy className="h-3.5 w-3.5" />
+            )}
+            {pick(locale, copied ? WIKI_COPY.copiedLink : WIKI_COPY.copyLink)}
+          </button>
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/backoffice/src/app/gc-fitness/wiki/wiki-sections.tsx
+++ b/backoffice/src/app/gc-fitness/wiki/wiki-sections.tsx
@@ -1,16 +1,15 @@
-import { ChevronDown, ExternalLink, PlayCircle, Video } from "lucide-react";
+import { ChevronDown, Video } from "lucide-react";
 
 import { Badge } from "@/components/ui/badge";
 import {
   WIKI_COPY,
   WIKI_FAQ,
   WIKI_GROUPS,
-  WIKI_LINKS,
   loomEmbedUrl,
-  loomShareUrl,
   pick,
   type WikiVideo,
 } from "./wiki-data";
+import { WikiLinkCards } from "./wiki-link-cards";
 
 // Full-width 2-up layout. Every walkthrough renders as a live Loom embed so all
 // posters/thumbnails are visible at once — no click-to-play facade and no
@@ -43,28 +42,7 @@ export function WikiSections({ locale }: { locale: string }) {
             {pick(locale, WIKI_COPY.linksSubtitle)}
           </p>
         </div>
-        <div className="grid gap-4 sm:grid-cols-2">
-          {WIKI_LINKS.map((link) => (
-            <a
-              key={link.id}
-              id={link.id}
-              href={link.href}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="group flex scroll-mt-24 items-start gap-3 rounded-2xl border border-border bg-card p-5 shadow-sm transition-colors hover:border-primary/50"
-            >
-              <div className="min-w-0 flex-1">
-                <h3 className="font-heading text-base font-bold transition-colors group-hover:text-primary sm:text-lg">
-                  {pick(locale, link.label)}
-                </h3>
-                <p className="mt-1 text-sm text-muted-foreground">
-                  {pick(locale, link.description)}
-                </p>
-              </div>
-              <ExternalLink className="mt-0.5 h-4 w-4 shrink-0 text-muted-foreground transition-colors group-hover:text-primary" />
-            </a>
-          ))}
-        </div>
+        <WikiLinkCards locale={locale} />
       </section>
 
       {/* FAQ — native disclosure, no JS. */}
@@ -123,28 +101,17 @@ function VideoCard({ video, locale }: { video: WikiVideo; locale: string }) {
 
       <div className="mt-auto px-5 pb-5 pt-4">
         {video.loomId ? (
-          <>
-            <div className="relative w-full overflow-hidden rounded-xl border border-border bg-black">
-              <div className="aspect-video">
-                <iframe
-                  src={loomEmbedUrl(video.loomId)}
-                  title={title}
-                  allowFullScreen
-                  loading="lazy"
-                  className="absolute inset-0 h-full w-full"
-                />
-              </div>
+          <div className="relative w-full overflow-hidden rounded-xl border border-border bg-black">
+            <div className="aspect-video">
+              <iframe
+                src={loomEmbedUrl(video.loomId)}
+                title={title}
+                allowFullScreen
+                loading="lazy"
+                className="absolute inset-0 h-full w-full"
+              />
             </div>
-            <a
-              href={loomShareUrl(video.loomId)}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="mt-3 inline-flex items-center gap-1.5 text-sm font-medium text-primary hover:underline"
-            >
-              <PlayCircle className="h-4 w-4" />
-              {pick(locale, WIKI_COPY.openInLoom)}
-            </a>
-          </>
+          </div>
         ) : (
           <div className="flex aspect-video w-full flex-col items-center justify-center gap-2 rounded-xl border border-dashed border-border bg-muted/40 text-center">
             <Video className="h-7 w-7 text-muted-foreground" />


### PR DESCRIPTION
## What

Adds two recorded Loom walkthroughs to the Library section of the Coach Wiki, splitting the old combined placeholder into the two videos that were actually recorded:

- **Crear entrenamiento** — `fd2087071c4e4c3eb1c8c3487c8db39b`
- **Generador de entrenamientos** — `10a9e60ad71a449a84b3499fb8f52b7e`

The remaining clips (Crear ejercicio, Crear hábito, Demo de la app de clientes) stay as "coming soon" placeholders until their links arrive.

`tsc --noEmit` clean for `wiki-data.ts`.