### PR TITLE
fix(generator): equipment rule + chip i18n + locale-first save form

### DIFF
--- a/backoffice/src/components/gc-fitness/generator/workout-generator-wizard.tsx
+++ b/backoffice/src/components/gc-fitness/generator/workout-generator-wizard.tsx
@@ -40,6 +40,7 @@ import { TemplateForm } from "@/components/gc-fitness/template-form";
 
 import {
   EQUIPMENT_GROUPS,
+  MUSCLE_LABELS,
   MUSCLE_PRESETS,
   WORKOUT_TYPE_PRESETS,
   computeReplacements,
@@ -204,7 +205,9 @@ export function WorkoutGeneratorWizard({ clients, trainerTimezone }: Props) {
     if (match) return match.label;
     if (muscles.size === 1) {
       const only = [...muscles][0];
-      return { en: humanize(only), es: humanize(only) };
+      // Use the bilingual muscle label so the generated workout name reads in
+      // the coach's language (e.g. "Cuádriceps · Hipertrofia"), not the raw id.
+      return MUSCLE_LABELS[only] ?? { en: humanize(only), es: humanize(only) };
     }
     return undefined;
   }, [muscles]);

--- a/backoffice/src/components/gc-fitness/generator/workout-generator-wizard.tsx
+++ b/backoffice/src/components/gc-fitness/generator/workout-generator-wizard.tsx
@@ -20,6 +20,7 @@
 // selected set, or it appears neither in the workout nor any pill.
 
 import { useMemo, useState } from "react";
+import { useTranslations } from "next-intl";
 import Link from "next/link";
 import { toast } from "sonner";
 import { ArrowLeft, ArrowRight, Check, Dumbbell, RefreshCw, Sparkles } from "lucide-react";
@@ -68,6 +69,10 @@ function humanize(id: string): string {
 export function WorkoutGeneratorWizard({ clients, trainerTimezone }: Props) {
   const s = useGeneratorStrings();
   const localized = useLocalized();
+  // Reuse the shared vocabulary catalog (same source the exercise form uses) so
+  // the per-item equipment/muscle chips render in the coach's language instead
+  // of raw English identifiers.
+  const tVocab = useTranslations("exercises.vocabulary");
   const { data: library, isLoading } = useExercisesQuery();
   // #297 — the engine prefers the coach's favorited exercises within each
   // muscle bucket.
@@ -373,6 +378,9 @@ export function WorkoutGeneratorWizard({ clients, trainerTimezone }: Props) {
           key={`gen-${genVersion}`}
           mode="create"
           defaultValues={generated}
+          // Coach-language-first: show one name field + "add translation"
+          // toggle, even though the generator pre-fills both languages.
+          initialShowTranslation={false}
           onSubmit={(input) => createWorkoutTemplate(input)}
           onCreated={(id) => {
             setSavedId(id);
@@ -423,7 +431,7 @@ export function WorkoutGeneratorWizard({ clients, trainerTimezone }: Props) {
           <div className="flex flex-wrap gap-2">
             {EQUIPMENT.map((id) => (
               <Chip key={id} active={equipment.has(id)} onClick={() => toggle(setEquipment, id)}>
-                {humanize(id)}
+                {tVocab(`equipment.${id}`)}
               </Chip>
             ))}
           </div>
@@ -449,7 +457,7 @@ export function WorkoutGeneratorWizard({ clients, trainerTimezone }: Props) {
           <div className="flex flex-wrap gap-2">
             {MUSCLE_GROUPS.map((id) => (
               <Chip key={id} active={muscles.has(id)} onClick={() => toggle(setMuscles, id)}>
-                {humanize(id)}
+                {tVocab(`muscle.${id}`)}
               </Chip>
             ))}
           </div>

--- a/backoffice/src/components/gc-fitness/template-form.tsx
+++ b/backoffice/src/components/gc-fitness/template-form.tsx
@@ -158,6 +158,15 @@ export interface TemplateFormProps {
     allExerciseIds: string[];
     onReplace: (exerciseId: string) => void;
   }) => React.ReactNode;
+  /**
+   * Force the initial collapsed/expanded state of the translation fields,
+   * overriding the default "expand when the record is already bilingual" rule.
+   * The workout generator pre-fills BOTH languages of the name, which would
+   * otherwise auto-expand both panes; passing `false` keeps the coach-language-
+   * first single field (with the "add translation" toggle) like every other
+   * create flow. The pre-filled other-language value is preserved until edited.
+   */
+  initialShowTranslation?: boolean;
 }
 
 const DRAFT_STORAGE_PREFIX = "gc-fitness:template-draft:";
@@ -328,6 +337,7 @@ export function TemplateForm({
   draftKey,
   onCreated,
   renderExerciseExtras,
+  initialShowTranslation,
 }: TemplateFormProps) {
   const t = useTranslations("templates.form");
   const router = useRouter();
@@ -352,8 +362,9 @@ export function TemplateForm({
   // Coach-language-first: open the translation fields only when the record is
   // already bilingual (edit of a translated template).
   const [showSpanishFields, setShowSpanishFields] = useState(
-    hasDistinctTranslation(defaultValues?.name) ||
-      hasDistinctTranslation(defaultValues?.description),
+    initialShowTranslation ??
+      (hasDistinctTranslation(defaultValues?.name) ||
+        hasDistinctTranslation(defaultValues?.description)),
   );
   const [quickCreated, setQuickCreated] = useState<Array<{ id: string; name: string }>>([]);
   const initialDefaults = buildDefaults(defaultValues, mode);

--- a/backoffice/src/lib/gc-fitness/workout-generator/__tests__/engine.test.ts
+++ b/backoffice/src/lib/gc-fitness/workout-generator/__tests__/engine.test.ts
@@ -134,6 +134,35 @@ describe("inferAuxiliaryEquipment (name-based bench inference)", () => {
   });
 });
 
+describe("inferAuxiliaryEquipment (name-based pull-up-bar inference)", () => {
+  it("infers a pull-up bar for pull-up / chin-up / muscle-up movements (ES)", () => {
+    expect(inferAuxiliaryEquipment({ en: "", es: "Dominadas" })).toEqual(["pull_up_bar"]);
+    expect(inferAuxiliaryEquipment({ en: "", es: "Dominadas supinas" })).toEqual(["pull_up_bar"]);
+  });
+
+  it("infers a pull-up bar for English names too", () => {
+    expect(inferAuxiliaryEquipment({ en: "Pull-Ups", es: "" })).toEqual(["pull_up_bar"]);
+    expect(inferAuxiliaryEquipment({ en: "Pull Up", es: "" })).toEqual(["pull_up_bar"]);
+    expect(inferAuxiliaryEquipment({ en: "Chin-Up", es: "" })).toEqual(["pull_up_bar"]);
+    expect(inferAuxiliaryEquipment({ en: "Muscle-Up", es: "" })).toEqual(["pull_up_bar"]);
+  });
+
+  it("does NOT infer a pull-up bar for pulldowns / rows (cable or machine)", () => {
+    expect(inferAuxiliaryEquipment({ en: "Lat Pulldown", es: "Jalón al pecho" })).toEqual([]);
+    expect(inferAuxiliaryEquipment({ en: "Seated Row", es: "Remo sentado" })).toEqual([]);
+  });
+
+  it("a bodyweight-tagged pull-up still REQUIRES the bar via effectiveEquipment", () => {
+    // The real-world bug: a "Dominadas" exercise tagged only ["bodyweight"]
+    // must not slip into a bodyweight-only (no-bar) generation.
+    const pullup = ex("dom", ["back", "biceps"], ["bodyweight"]);
+    pullup.name = { en: "Pull-Ups", es: "Dominadas" };
+    expect(effectiveEquipment(pullup).sort()).toEqual(["bodyweight", "pull_up_bar"]);
+    expect(isEquipmentAllowed(pullup, new Set(["bodyweight"]))).toBe(false);
+    expect(isEquipmentAllowed(pullup, new Set(["bodyweight", "pull_up_bar"]))).toBe(true);
+  });
+});
+
 describe("isEquipmentAllowed (THE rule)", () => {
   it("allows an exercise when all its equipment is selected", () => {
     const allowed = isEquipmentAllowed(

--- a/backoffice/src/lib/gc-fitness/workout-generator/__tests__/presets.test.ts
+++ b/backoffice/src/lib/gc-fitness/workout-generator/__tests__/presets.test.ts
@@ -13,8 +13,10 @@ import {
   isGroupFullySelected,
 } from "@/lib/gc-fitness/workout-generator/equipment-groups";
 import {
+  MUSCLE_LABELS,
   MUSCLE_PRESETS,
   expandMusclePresets,
+  muscleLabelsCoverVocab,
   musclePresetsReferenceValidVocab,
 } from "@/lib/gc-fitness/workout-generator/muscle-presets";
 import {
@@ -99,6 +101,14 @@ describe("muscle presets", () => {
     expect(expanded).toContain("chest");
     expect(expanded).toContain("back");
     expect(new Set(expanded).size).toBe(expanded.length);
+  });
+
+  it("MUSCLE_LABELS covers every muscle group with both languages", () => {
+    expect(muscleLabelsCoverVocab()).toBe(true);
+    for (const m of MUSCLE_GROUPS) {
+      expect(MUSCLE_LABELS[m]?.en).toBeTruthy();
+      expect(MUSCLE_LABELS[m]?.es).toBeTruthy();
+    }
   });
 });
 

--- a/backoffice/src/lib/gc-fitness/workout-generator/engine.ts
+++ b/backoffice/src/lib/gc-fitness/workout-generator/engine.ts
@@ -66,22 +66,47 @@ const BENCH_NAME_KEYWORDS = [
   "preacher",
 ];
 
+// Name keywords that imply a pull-up bar is needed. Same gap as the bench: a
+// pull-up / chin-up / muscle-up is usually tagged only "bodyweight" (it needs
+// no external load), so "bodyweight only" (no bar) would wrongly surface them.
+// Inferring the bar from the name closes the hole structurally — when the coach
+// hasn't selected `pull_up_bar`, these movements are excluded. ES + EN keywords.
+// Kept narrow to clear bar movements; "jalón"/"pulldown" (cable/machine) and
+// rows must NOT match.
+const PULL_UP_BAR_NAME_KEYWORDS = [
+  "dominada", // ES: pull-up / chin-up
+  "pull-up",
+  "pull up",
+  "pullup",
+  "chin-up",
+  "chin up",
+  "chinup",
+  "muscle-up",
+  "muscle up",
+  "muscleup",
+];
+
 /**
  * Auxiliary equipment inferred from the exercise NAME that the data doesn't
- * tag. Today: a bench for bench/incline/decline/preacher movements. The floor
- * press ("Press de suelo" / "floor press") is explicitly bench-FREE, so it's
- * guarded even though no current keyword matches it.
+ * tag: a bench for bench/incline/decline/preacher movements, and a pull-up bar
+ * for pull-up/chin-up/muscle-up movements. The floor press ("Press de suelo" /
+ * "floor press") is explicitly bench-FREE, so it's guarded even though no
+ * current keyword matches it.
  */
 export function inferAuxiliaryEquipment(name: {
   en?: string | null;
   es?: string | null;
 }): string[] {
   const hay = `${name.en ?? ""} ${name.es ?? ""}`.toLowerCase();
+  const inferred: string[] = [];
   const isFloor = hay.includes("suelo") || hay.includes("floor");
   if (!isFloor && BENCH_NAME_KEYWORDS.some((k) => hay.includes(k))) {
-    return ["bench"];
+    inferred.push("bench");
   }
-  return [];
+  if (PULL_UP_BAR_NAME_KEYWORDS.some((k) => hay.includes(k))) {
+    inferred.push("pull_up_bar");
+  }
+  return inferred;
 }
 
 /** Full equipment an exercise needs = its tagged implement(s) PLUS any

--- a/backoffice/src/lib/gc-fitness/workout-generator/muscle-presets.ts
+++ b/backoffice/src/lib/gc-fitness/workout-generator/muscle-presets.ts
@@ -73,6 +73,41 @@ export const MUSCLE_PRESETS: readonly MusclePreset[] = [
   },
 ];
 
+/**
+ * Bilingual display label for each canonical muscle group. Needed to build the
+ * generated workout's default NAME (which carries both languages) when the
+ * coach picks a SINGLE muscle that doesn't match any preset — otherwise the
+ * name fell back to the raw English id (e.g. "Quadriceps · Hipertrofia").
+ * Mirrors the `exercises.vocabulary.muscle` next-intl catalog; the per-locale
+ * chip UI reads that catalog directly, while the engine's name builder is
+ * locale-agnostic and needs both languages here. `muscle-presets.test.ts`
+ * asserts this map covers every `MUSCLE_GROUPS` id so the two can't drift.
+ */
+export const MUSCLE_LABELS: Readonly<Record<string, { en: string; es: string }>> = {
+  abs: { en: "Abs", es: "Abdominales" },
+  arms: { en: "Arms", es: "Brazos" },
+  back: { en: "Back", es: "Espalda" },
+  biceps: { en: "Biceps", es: "Bíceps" },
+  calves: { en: "Calves", es: "Pantorrillas" },
+  cardio: { en: "Cardio", es: "Cardio" },
+  chest: { en: "Chest", es: "Pecho" },
+  core: { en: "Core", es: "Core" },
+  flexibility: { en: "Flexibility", es: "Flexibilidad" },
+  forearms: { en: "Forearms", es: "Antebrazos" },
+  full_body: { en: "Full body", es: "Cuerpo completo" },
+  glutes: { en: "Glutes", es: "Glúteos" },
+  hamstrings: { en: "Hamstrings", es: "Isquiotibiales" },
+  legs: { en: "Legs", es: "Piernas" },
+  quadriceps: { en: "Quadriceps", es: "Cuádriceps" },
+  shoulders: { en: "Shoulders", es: "Hombros" },
+  triceps: { en: "Triceps", es: "Tríceps" },
+};
+
+/** Validate that `MUSCLE_LABELS` covers every canonical `MUSCLE_GROUPS` id. */
+export function muscleLabelsCoverVocab(): boolean {
+  return (MUSCLE_GROUPS as readonly string[]).every((m) => m in MUSCLE_LABELS);
+}
+
 /** Expand a set of selected preset ids into the union of their muscle groups. */
 export function expandMusclePresets(presetIds: readonly string[]): string[] {
   const out = new Set<string>();


### PR DESCRIPTION
Fixes the issues reported on the Workout Generator wizard.

## 1. Equipment-subset rule bypassed — "Pull-Ups" added with no pull-up bar
Root cause was **data, not the engine**: the engine's hard subset rule is correct and tested, but pull-up/chin-up/muscle-up movements in the standard library are tagged only `bodyweight` (they need no external load), so selecting bodyweight without a bar let them through. Fixed by mirroring the engine's existing **name-based bench inference**: `inferAuxiliaryEquipment` now also infers `pull_up_bar` from the movement name. Keyword set is deliberately narrow (`dominada`, `pull-up`, `chin-up`, `muscle-up`, …) so lat **pulldowns** and **rows** do NOT match. Adds engine tests covering ES/EN names, the pulldown/row negatives, and a bodyweight-tagged pull-up now being excluded from a bodyweight-only generation.

## 2 & 3. Equipment & muscle chips not translated
The per-item chips (`Barbell`, `Abs`, …) rendered raw English identifiers via a local `humanize()` while only the quick-bundle/preset chips were localized. Now rendered through the shared `exercises.vocabulary` next-intl catalog (the same source the exercise form uses), so they follow the coach's locale.

## 4. Save form showed both ES + EN fields
The generator pre-fills both languages of the name, which tripped `hasDistinctTranslation` and auto-expanded both translation panes. Added an `initialShowTranslation` override to `TemplateForm` and pass `false` from the generator, so it shows one coach-language field + an "add translation" toggle like every other create flow. The pre-filled other-language value is preserved (not discarded) until the coach edits the visible field.

## Scope / parity
The Workout Generator is **backoffice-only** (no iOS/Android twin), so no cross-platform parity work applies.

## Tests
- `npx jest workout-generator` → 65 passed (incl. 4 new pull-up-bar tests).
- Full backoffice `npx jest` → only the 2 known pre-existing failures (`client-activity-time` locale flake, `workout-assignment-actions` batch test), both unrelated to this change.
- `tsc --noEmit` clean for all touched files.