### PR TITLE
fix(gc-fitness): exclude client rest edits from coach 'Mi Actividad'

### DIFF
--- a/backoffice/src/app/gc-fitness/my-activity/MyActivityFeed.tsx
+++ b/backoffice/src/app/gc-fitness/my-activity/MyActivityFeed.tsx
@@ -41,7 +41,8 @@ import {
 const TYPE_OPTION_KEYS: string[] = [
   "all",
   "workout_assignment",
-  "workout_rest_edited",
+  // `workout_rest_edited` is a CLIENT action (they edit their own rests); it's
+  // excluded from "Mi Actividad", so it's not offered as a filter here.
   "habit_assignment",
   "progress_photo_request",
   "weight_request",

--- a/backoffice/src/lib/gc-fitness/coach-activity-actions.ts
+++ b/backoffice/src/lib/gc-fitness/coach-activity-actions.ts
@@ -155,6 +155,11 @@ export async function listMyCoachActivityPage(
       occurredAt?: unknown;
     };
     const evKind = (typeof data.kind === "string" ? data.kind : "workout_assignment") as CoachActivityKind;
+    // `workout_rest_edited` is written by the iOS `editAssignmentRests` function
+    // when the CLIENT edits their own rest times — it's the client's action, not
+    // the coach's, so it doesn't belong in the coach's "Mi Actividad". (It still
+    // lives in coach_activity for the admin audit dashboard.)
+    if (evKind === "workout_rest_edited") continue;
     // When BOTH clientId and kind filters are set, clientId was applied
     // server-side; apply kind here in memory.
     if (clientId && kindFilter && kindFilter !== "chat" && evKind !== kindFilter) {


### PR DESCRIPTION
## Problem
"Mi Actividad" (the coach's own activity log) was showing **"Descansos editados: …"** rows that the **clients** created when they edited their own rest times in the mobile app. That doesn't make sense as a coach action.

## Cause
`workout_rest_edited` events are written by the iOS `editAssignmentRests` Cloud Function (client edits their own rests). They land in `coach_activity` (keyed by the coach's `trainerId`) and were rendered in My Activity alongside genuine coach actions.

## Fix (backoffice only)
- `listMyCoachActivityPage` now **skips** `workout_rest_edited` events (they're the client's action, not the coach's).
- Removed `workout_rest_edited` from the "Tipo" filter options.
- The events **stay in `coach_activity`** so the **admin audit dashboard** (which audits all writes) still shows them.

No Cloud Function / rules changes.

## Tests
`npx jest gc-fitness` — my change adds no failures. The 2 failing suites are **pre-existing & unrelated**: `workout-assignment-actions` (confirmed failing on a clean tree) and `client-activity-time` (the known non-en-US locale flake, green in CI).