### PR TITLE
fix(gc-fitness): habit trends shows 0/0 as 100% on client profile (#341)

### DIFF
--- a/backoffice/messages/en.json
+++ b/backoffice/messages/en.json
@@ -424,6 +424,7 @@
         "empty": "No habits assigned yet.",
         "unnamed": "(unnamed habit)",
         "daysCompleted": "days completed",
+        "noScheduled": "Not scheduled in this range",
         "streakTooltip": "{count}-occurrence streak on scheduled days",
         "rangeAll": "All",
         "range90": "90d",

--- a/backoffice/messages/es.json
+++ b/backoffice/messages/es.json
@@ -424,6 +424,7 @@
         "empty": "Aún no hay hábitos asignados.",
         "unnamed": "(hábito sin nombre)",
         "daysCompleted": "días completados",
+        "noScheduled": "Sin días programados en este rango",
         "streakTooltip": "Racha de {count} cumplimientos en días programados",
         "rangeAll": "Todo",
         "range90": "90d",

--- a/backoffice/src/app/gc-fitness/clients/[id]/_components/HabitTrendsClient.tsx
+++ b/backoffice/src/app/gc-fitness/clients/[id]/_components/HabitTrendsClient.tsx
@@ -33,6 +33,7 @@ export interface HabitTrendsClientProps {
     title: string;
     empty: string;
     daysCompleted: string;
+    noScheduled: string;
     ranges: Record<TrendRangeKey, string>;
   };
 }
@@ -56,6 +57,9 @@ export function HabitTrendsClient({ rows, labels }: HabitTrendsClientProps) {
         <ul className="grid grid-cols-1 gap-3 sm:grid-cols-2">
           {sorted.map((row) => {
             const cell = row.byRange[range];
+            // #341 — nothing was scheduled in this range: show "—", not a
+            // misleading 100% (or 0%).
+            const noData = cell.scheduled === 0;
             return (
               <li
                 key={row.id}
@@ -76,12 +80,14 @@ export function HabitTrendsClient({ rows, labels }: HabitTrendsClientProps) {
                     ) : null}
                   </div>
                   <Badge variant="secondary" className="tabular-nums">
-                    {cell.pct}%
+                    {noData ? "—" : `${cell.pct}%`}
                   </Badge>
                 </div>
-                <Progress value={cell.pct} className="h-2.5 w-full" />
+                <Progress value={noData ? 0 : cell.pct} className="h-2.5 w-full" />
                 <p className="mt-2 text-xs text-muted-foreground">
-                  {cell.completed}/{cell.scheduled || 0} {labels.daysCompleted}
+                  {noData
+                    ? labels.noScheduled
+                    : `${cell.completed}/${cell.scheduled || 0} ${labels.daysCompleted}`}
                 </p>
               </li>
             );

--- a/backoffice/src/app/gc-fitness/clients/[id]/_components/HabitTrendsWidget.tsx
+++ b/backoffice/src/app/gc-fitness/clients/[id]/_components/HabitTrendsWidget.tsx
@@ -99,9 +99,11 @@ export async function HabitTrendsWidget({ clientId, timezone }: HabitTrendsWidge
         );
         const completed = scheduled.filter((d) => completedDates.has(d)).length;
         const denom = scheduled.length;
-        // No scheduled days in the window → 100% (nothing was due), matching
-        // the iOS surface + the previous compliance widget.
-        const ratio = denom === 0 ? 1 : completed / denom;
+        // No scheduled days in the window → NO data (not 100%). #341: a habit
+        // with nothing due in the range was rendering as 100% (0/0). The client
+        // renders "—" when scheduled === 0 so it doesn't read as fully complete.
+        // Matches the shared computeAdherence (0/0 → 0).
+        const ratio = denom === 0 ? 0 : completed / denom;
         byRange[range.key] = {
           pct: Math.round(Math.max(0, Math.min(1, ratio)) * 100),
           completed,
@@ -129,6 +131,7 @@ export async function HabitTrendsWidget({ clientId, timezone }: HabitTrendsWidge
         title: t("title"),
         empty: t("empty"),
         daysCompleted: t("daysCompleted"),
+        noScheduled: t("noScheduled"),
         ranges: {
           all: t("rangeAll"),
           "90": t("range90"),


### PR DESCRIPTION
Fixes mdb1/gc-fitness#341.

## Problem
On a client's profile, the Habits trends widget showed habits with **0 scheduled days** in the selected range (e.g. 7d) as **100%** — full progress bar + "0/0 días". That reads as "fully complete" when in fact nothing was due.

## Cause
`HabitTrendsWidget` computed `ratio = denom === 0 ? 1 : completed / denom` — i.e. 0/0 → 100%. This diverged from the shared `computeAdherence` (which returns 0 for 0/0).

## Fix
- Widget: `denom === 0 ? 0` (align with `computeAdherence`).
- Client: when nothing was scheduled in the range, render **"—"** (not a misleading 100% or 0%), an empty progress bar, and a **"Not scheduled in this range" / "Sin días programados en este rango"** note instead of "0/0 días".
- New i18n key `habitTrends.noScheduled` (en + es).

## Tests
`npx jest gc-fitness` — no new failures (705 passed). The 2 red suites are the known pre-existing ones (`workout-assignment-actions`, `client-activity-time` locale flake).