### PR TITLE
feat(gc-fitness): Wiki share links (#349) + recurrence/habit calendar previews (#294)

### DIFF
--- a/backoffice/messages/en.json
+++ b/backoffice/messages/en.json
@@ -1052,7 +1052,9 @@
         "rejectNoId": "Save the habit first, then add a photo.",
         "successToast": "Photo uploaded.",
         "failToast": "Photo upload failed. Try again."
-      }
+      },
+      "schedulePreviewHeading": "Calendar preview",
+      "schedulePreviewCount": "{count, plural, =0 {No active days yet} one {# active day highlighted} other {# active days highlighted}}"
     }
   },
   "exercises": {

--- a/backoffice/messages/en.json
+++ b/backoffice/messages/en.json
@@ -1554,7 +1554,8 @@
         "thursday": "Thursday",
         "friday": "Friday",
         "saturday": "Saturday"
-      }
+      },
+      "recurrencePreviewCount": "{count, plural, =0 {No dates match yet} one {# date highlighted on the calendar} other {# dates highlighted on the calendar}}"
     },
     "bulkConfirm": {
       "titleSingular": "Assign “{template}” to {count} client on {date}?",
@@ -1635,7 +1636,8 @@
       "errorPickTemplate": "Pick a template first.",
       "errorFallback": "Assignment failed.",
       "successOnce": "Template assigned.",
-      "successRecurring": "Recurring assignment created ({count} workouts)."
+      "successRecurring": "Recurring assignment created ({count} workouts).",
+      "recurrencePreviewCount": "{count, plural, =0 {No dates match yet} one {# date highlighted on the calendar} other {# dates highlighted on the calendar}}"
     }
   },
   "picker": {

--- a/backoffice/messages/es.json
+++ b/backoffice/messages/es.json
@@ -1052,7 +1052,9 @@
         "rejectNoId": "Guardá el hábito primero y luego agregá una foto.",
         "successToast": "Foto subida.",
         "failToast": "No se pudo subir la foto. Intentá de nuevo."
-      }
+      },
+      "schedulePreviewHeading": "Vista previa en el calendario",
+      "schedulePreviewCount": "{count, plural, =0 {Todavía no hay días activos} one {# día activo marcado} other {# días activos marcados}}"
     }
   },
   "exercises": {

--- a/backoffice/messages/es.json
+++ b/backoffice/messages/es.json
@@ -1554,7 +1554,8 @@
         "thursday": "Jueves",
         "friday": "Viernes",
         "saturday": "Sábado"
-      }
+      },
+      "recurrencePreviewCount": "{count, plural, =0 {Todavía no hay fechas} one {# fecha marcada en el calendario} other {# fechas marcadas en el calendario}}"
     },
     "bulkConfirm": {
       "titleSingular": "¿Asignar “{template}” a {count} cliente el {date}?",
@@ -1635,7 +1636,8 @@
       "errorPickTemplate": "Elegí primero una plantilla.",
       "errorFallback": "Falló la asignación.",
       "successOnce": "Plantilla asignada.",
-      "successRecurring": "Asignación recurrente creada ({count} entrenamientos)."
+      "successRecurring": "Asignación recurrente creada ({count} entrenamientos).",
+      "recurrencePreviewCount": "{count, plural, =0 {Todavía no hay fechas} one {# fecha marcada en el calendario} other {# fechas marcadas en el calendario}}"
     }
   },
   "picker": {

--- a/backoffice/src/app/gc-fitness/habits/_components/HabitForm.tsx
+++ b/backoffice/src/app/gc-fitness/habits/_components/HabitForm.tsx
@@ -15,7 +15,7 @@
 // (immutable post-create per the schema doc + rule layer enforcement); the
 // value still appears in the form so the trainer sees what they're editing.
 
-import { useEffect, useState, useTransition } from "react";
+import { useEffect, useMemo, useState, useTransition } from "react";
 import { useRouter } from "next/navigation";
 import { useForm, useWatch, Controller } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
@@ -62,7 +62,26 @@ import {
   inferEndDatePresetWeeks,
   localDateToCivil,
 } from "@/lib/gc-fitness/end-date-presets";
+import { Calendar } from "@/components/ui/calendar";
+import { isHabitScheduledOn } from "@/lib/gc-fitness/habit-schedule";
+import {
+  addCivilDays,
+  MAX_RECURRING_OCCURRENCES,
+  NO_END_HORIZON_DAYS,
+} from "@/lib/gc-fitness/recurrence-expansion";
 import { HabitPhotoDropzone } from "./HabitPhotoDropzone";
+
+// #294 — class applied to every day cell the habit will be active on, so the
+// trainer previews the schedule on the calendar before assigning. Matches the
+// workout assign forms.
+const HABIT_PREVIEW_CLASS =
+  "rounded-md bg-primary/15 font-semibold text-primary";
+
+/** "YYYY-MM-DD" → local-time Date at midnight (no UTC shift). */
+function parseCivilToLocalDate(civil: string): Date {
+  const [y, m, d] = civil.split("-").map(Number);
+  return new Date(y, m - 1, d);
+}
 
 export type HabitFormMode = "create" | "edit";
 
@@ -241,6 +260,43 @@ export function HabitForm({
     useWatch({ control: form.control, name: "scheduleWeekdays" }) ?? [];
   const watchedScheduleMonthDays =
     useWatch({ control: form.control, name: "scheduleMonthDays" }) ?? [];
+
+  // #294 — civil dates this habit will be active on, for the calendar preview.
+  // Walks the schedule window through `isHabitScheduledOn` (the SAME predicate
+  // the app + backoffice use to decide whether a habit shows on a given day),
+  // so the highlighted days are exactly when the client will see the habit.
+  // No end date → bounded to the rolling horizon and capped, same as workouts.
+  const previewDates = useMemo<Date[]>(() => {
+    const startsOn = watchedStartsOn;
+    if (!startsOn) return [];
+    const horizonEnd = addCivilDays(startsOn, NO_END_HORIZON_DAYS);
+    const windowEnd =
+      watchedEndsOn && watchedEndsOn < horizonEnd ? watchedEndsOn : horizonEnd;
+    const habit = {
+      scheduleType: watchedScheduleType,
+      startsOn,
+      endsOn: watchedEndsOn || undefined,
+      scheduleCadence: watchedScheduleCadence,
+      scheduleWeekdays: watchedScheduleWeekdays,
+      scheduleMonthDays: watchedScheduleMonthDays,
+    };
+    const dates: Date[] = [];
+    for (let d = startsOn; d <= windowEnd; d = addCivilDays(d, 1)) {
+      if (isHabitScheduledOn(habit, d)) {
+        dates.push(parseCivilToLocalDate(d));
+        if (dates.length >= MAX_RECURRING_OCCURRENCES) break;
+      }
+    }
+    return dates;
+  }, [
+    watchedScheduleType,
+    watchedStartsOn,
+    watchedEndsOn,
+    watchedScheduleCadence,
+    watchedScheduleWeekdays,
+    watchedScheduleMonthDays,
+  ]);
+
   const initialStartsOn =
     typeof initialDefaults.startsOn === "string" ? initialDefaults.startsOn : "";
   const initialEndsOn =
@@ -804,6 +860,23 @@ export function HabitForm({
               ) : null}
             </div>
           )}
+
+          {/* #294 — read-only calendar preview of the active days. */}
+          {watchedStartsOn ? (
+            <div className="flex flex-col gap-1.5 border-t pt-4">
+              <FormLabel>{t("schedulePreviewHeading")}</FormLabel>
+              <Calendar
+                mode="single"
+                selected={parseCivilToLocalDate(watchedStartsOn)}
+                defaultMonth={parseCivilToLocalDate(watchedStartsOn)}
+                modifiers={{ habit: previewDates }}
+                modifiersClassNames={{ habit: HABIT_PREVIEW_CLASS }}
+              />
+              <p className="text-xs font-medium text-primary">
+                {t("schedulePreviewCount", { count: previewDates.length })}
+              </p>
+            </div>
+          ) : null}
         </div>
 
         <div className="flex flex-col gap-3 rounded-[1.25rem] border border-border bg-card p-5 shadow-sm">

--- a/backoffice/src/app/gc-fitness/wiki/wiki-data.ts
+++ b/backoffice/src/app/gc-fitness/wiki/wiki-data.ts
@@ -478,6 +478,7 @@ export const WIKI_COPY = {
     en: "We're still recording this one. Check back soon.",
   },
   copyLink: { es: "Copiar", en: "Copy" },
+  copyVideoLink: { es: "Copiar link", en: "Copy link" },
   copiedLink: { es: "¡Copiado!", en: "Copied!" },
   openLink: { es: "Abrir en una pestaña nueva", en: "Open in a new tab" },
   footer: {

--- a/backoffice/src/app/gc-fitness/wiki/wiki-hash-opener.tsx
+++ b/backoffice/src/app/gc-fitness/wiki/wiki-hash-opener.tsx
@@ -1,0 +1,43 @@
+"use client";
+
+// wiki-hash-opener.tsx
+//
+// Client island (renders nothing) that makes the per-question deep links from
+// WikiVideoShare land with the FAQ already EXPANDED. The FAQ items are native
+// <details id="faq-…"> — navigating to that anchor scrolls to them but leaves
+// them collapsed, so a shared link would drop the reader on a closed question.
+// On first paint and on every hashchange we open the targeted <details> (if the
+// anchor is one, or wraps one) and re-scroll so it lands in view after the
+// layout grows.
+
+import { useEffect } from "react";
+
+export function WikiHashOpener() {
+  useEffect(() => {
+    function openFromHash() {
+      const id = decodeURIComponent(window.location.hash.replace(/^#/, ""));
+      if (!id) return;
+      const target = document.getElementById(id);
+      if (!target) return;
+      const details =
+        target instanceof HTMLDetailsElement
+          ? target
+          : target.querySelector("details");
+      if (details && !details.open) details.open = true;
+      // Re-scroll after expanding so the anchor (with its scroll-mt offset)
+      // ends up at the top of the viewport instead of where the collapsed
+      // layout briefly put it.
+      target.scrollIntoView({ behavior: "smooth", block: "start" });
+    }
+
+    // Defer one frame so the DOM/layout is ready on the initial load.
+    const raf = requestAnimationFrame(openFromHash);
+    window.addEventListener("hashchange", openFromHash);
+    return () => {
+      cancelAnimationFrame(raf);
+      window.removeEventListener("hashchange", openFromHash);
+    };
+  }, []);
+
+  return null;
+}

--- a/backoffice/src/app/gc-fitness/wiki/wiki-sections.tsx
+++ b/backoffice/src/app/gc-fitness/wiki/wiki-sections.tsx
@@ -86,14 +86,16 @@ function VideoCard({ video, locale }: { video: WikiVideo; locale: string }) {
       id={video.id}
       className="flex scroll-mt-24 flex-col overflow-hidden rounded-2xl border border-border bg-card shadow-sm"
     >
-      <div className="flex flex-wrap items-start justify-between gap-2 px-5 pt-5">
-        <div className="min-w-0">
+      <div className="flex items-start justify-between gap-3 px-5 pt-5">
+        <div className="min-w-0 flex-1">
           <h3 className="font-heading text-base font-bold sm:text-lg">{title}</h3>
           <p className="mt-1 text-sm text-muted-foreground">
             {pick(locale, video.description)}
           </p>
         </div>
-        <div className="flex shrink-0 items-center gap-2">
+        {/* Top-right controls, pinned (no flex-wrap) so the share button lands
+            in the same spot on every card regardless of description length. */}
+        <div className="flex shrink-0 flex-col items-end gap-2">
           {comingSoon ? (
             <Badge variant="warning">{pick(locale, WIKI_COPY.comingSoon)}</Badge>
           ) : null}

--- a/backoffice/src/app/gc-fitness/wiki/wiki-sections.tsx
+++ b/backoffice/src/app/gc-fitness/wiki/wiki-sections.tsx
@@ -10,6 +10,7 @@ import {
   type WikiVideo,
 } from "./wiki-data";
 import { WikiLinkCards } from "./wiki-link-cards";
+import { WikiVideoShare } from "./wiki-video-share";
 
 // Full-width 2-up layout. Every walkthrough renders as a live Loom embed so all
 // posters/thumbnails are visible at once — no click-to-play facade and no
@@ -92,11 +93,14 @@ function VideoCard({ video, locale }: { video: WikiVideo; locale: string }) {
             {pick(locale, video.description)}
           </p>
         </div>
-        {comingSoon ? (
-          <Badge variant="warning" className="shrink-0">
-            {pick(locale, WIKI_COPY.comingSoon)}
-          </Badge>
-        ) : null}
+        <div className="flex shrink-0 items-center gap-2">
+          {comingSoon ? (
+            <Badge variant="warning">{pick(locale, WIKI_COPY.comingSoon)}</Badge>
+          ) : null}
+          {/* Per-video deep link (#349) — copies the Wiki URL + this card's
+              anchor so a coach can share a single walkthrough. */}
+          <WikiVideoShare anchorId={video.id} locale={locale} />
+        </div>
       </div>
 
       <div className="mt-auto px-5 pb-5 pt-4">

--- a/backoffice/src/app/gc-fitness/wiki/wiki-sections.tsx
+++ b/backoffice/src/app/gc-fitness/wiki/wiki-sections.tsx
@@ -59,8 +59,13 @@ export function WikiSections({ locale }: { locale: string }) {
               className="group scroll-mt-24 rounded-2xl border border-border bg-card p-5 shadow-sm"
             >
               <summary className="flex cursor-pointer list-none items-start justify-between gap-3 font-heading text-base font-semibold [&::-webkit-details-marker]:hidden">
-                {pick(locale, item.question)}
-                <ChevronDown className="mt-0.5 h-4 w-4 shrink-0 text-muted-foreground transition-transform group-open:rotate-180" />
+                <span className="min-w-0 flex-1">{pick(locale, item.question)}</span>
+                <span className="flex shrink-0 items-center gap-2">
+                  {/* Per-question deep link (#349) — copies the Wiki URL +
+                      this FAQ's anchor without toggling the disclosure. */}
+                  <WikiVideoShare anchorId={item.id} locale={locale} />
+                  <ChevronDown className="mt-0.5 h-4 w-4 shrink-0 text-muted-foreground transition-transform group-open:rotate-180" />
+                </span>
               </summary>
               <p className="mt-3 whitespace-pre-line text-sm leading-relaxed text-muted-foreground">
                 {pick(locale, item.answer)}

--- a/backoffice/src/app/gc-fitness/wiki/wiki-sections.tsx
+++ b/backoffice/src/app/gc-fitness/wiki/wiki-sections.tsx
@@ -11,6 +11,7 @@ import {
 } from "./wiki-data";
 import { WikiLinkCards } from "./wiki-link-cards";
 import { WikiVideoShare } from "./wiki-video-share";
+import { WikiHashOpener } from "./wiki-hash-opener";
 
 // Full-width 2-up layout. Every walkthrough renders as a live Loom embed so all
 // posters/thumbnails are visible at once — no click-to-play facade and no
@@ -20,6 +21,7 @@ import { WikiVideoShare } from "./wiki-video-share";
 export function WikiSections({ locale }: { locale: string }) {
   return (
     <main className="min-w-0 space-y-12">
+      <WikiHashOpener />
       {WIKI_GROUPS.map((group) => (
         <section key={group.id} id={group.id} className="scroll-mt-24 space-y-5">
           <h2 className="font-heading text-lg font-bold sm:text-xl">

--- a/backoffice/src/app/gc-fitness/wiki/wiki-video-share.tsx
+++ b/backoffice/src/app/gc-fitness/wiki/wiki-video-share.tsx
@@ -1,0 +1,59 @@
+"use client";
+
+// wiki-video-share.tsx
+//
+// Client island for the per-video "copy deep link" control. Split out from the
+// (server) WikiSections so the copy-to-clipboard button can be interactive —
+// same split rationale as wiki-link-cards.tsx.
+//
+// The copied link is the public Wiki URL with the video's anchor appended
+// (e.g. https://…/gc-fitness/wiki#dashboard), so a coach can paste it and the
+// recipient lands directly on that walkthrough. We build it from
+// `window.location` at click time rather than hardcoding an origin, so it works
+// the same on localhost, preview deploys, and prod.
+
+import { useState } from "react";
+import { Check, Link2 } from "lucide-react";
+
+import { WIKI_COPY, pick } from "./wiki-data";
+
+export function WikiVideoShare({
+  anchorId,
+  locale,
+}: {
+  anchorId: string;
+  locale: string;
+}) {
+  const [copied, setCopied] = useState(false);
+
+  async function copy() {
+    // Strip any existing hash, then append this video's anchor.
+    const base = window.location.href.split("#")[0];
+    const deepLink = `${base}#${anchorId}`;
+    try {
+      await navigator.clipboard.writeText(deepLink);
+    } catch {
+      // Clipboard may be unavailable (insecure context / denied). Fall back to
+      // navigating to the anchor so the address bar still reflects the link.
+      window.location.hash = anchorId;
+    }
+    setCopied(true);
+    window.setTimeout(() => setCopied(false), 1500);
+  }
+
+  return (
+    <button
+      type="button"
+      onClick={copy}
+      aria-label={pick(locale, copied ? WIKI_COPY.copiedLink : WIKI_COPY.copyVideoLink)}
+      className="inline-flex shrink-0 items-center gap-1.5 rounded-md border border-border bg-background px-2.5 py-1 text-xs font-medium text-foreground transition-colors hover:border-primary hover:text-primary"
+    >
+      {copied ? (
+        <Check className="h-3.5 w-3.5 text-emerald-600" />
+      ) : (
+        <Link2 className="h-3.5 w-3.5" />
+      )}
+      {pick(locale, copied ? WIKI_COPY.copiedLink : WIKI_COPY.copyVideoLink)}
+    </button>
+  );
+}

--- a/backoffice/src/app/gc-fitness/wiki/wiki-video-share.tsx
+++ b/backoffice/src/app/gc-fitness/wiki/wiki-video-share.tsx
@@ -12,7 +12,7 @@
 // `window.location` at click time rather than hardcoding an origin, so it works
 // the same on localhost, preview deploys, and prod.
 
-import { useState } from "react";
+import { useState, type MouseEvent } from "react";
 import { Check, Link2 } from "lucide-react";
 
 import { WIKI_COPY, pick } from "./wiki-data";
@@ -26,7 +26,11 @@ export function WikiVideoShare({
 }) {
   const [copied, setCopied] = useState(false);
 
-  async function copy() {
+  async function copy(event: MouseEvent) {
+    // This control can live inside a <summary> (FAQ) — prevent the click from
+    // toggling the disclosure and from bubbling further.
+    event.preventDefault();
+    event.stopPropagation();
     // Strip any existing hash, then append this video's anchor.
     const base = window.location.href.split("#")[0];
     const deepLink = `${base}#${anchorId}`;

--- a/backoffice/src/components/gc-fitness/schedule/assign-template-modal.tsx
+++ b/backoffice/src/components/gc-fitness/schedule/assign-template-modal.tsx
@@ -59,6 +59,16 @@ import {
   END_DATE_PRESET_MONTHS,
   inferEndDatePresetMonths,
 } from "@/lib/gc-fitness/end-date-presets";
+import {
+  expandRecurrenceDates,
+  type ExpandableRecurrence,
+} from "@/lib/gc-fitness/recurrence-expansion";
+
+// #294 — class applied to every day cell the recurrence will land on, so the
+// trainer previews the series on the calendar before submitting. The anchor
+// (selected) day keeps its solid `selected` styling on top of this.
+const RECURRENCE_PREVIEW_CLASS =
+  "rounded-md bg-primary/15 font-semibold text-primary";
 
 interface AssignTemplateModalProps {
   open: boolean;
@@ -474,6 +484,45 @@ export function AssignTemplateModal({
           item !== null,
       );
   }, [overrideDrafts, templateDetail]);
+
+  // #294 — civil dates the recurrence will land on, for the calendar preview.
+  // Mirrors the rule built in `onSubmit` and expands it with the SAME
+  // `expandRecurrenceDates` the assignTemplateRecurring action uses, so the
+  // highlighted days are exactly the sessions that will be created. "once" →
+  // no extra highlight (just the single selected day).
+  const previewDates = useMemo<Date[]>(() => {
+    if (mode === "once") return [];
+    let recurrence: ExpandableRecurrence;
+    if (mode === "daily") {
+      recurrence = { kind: "daily" };
+    } else if (mode === "everyN") {
+      recurrence = { kind: "every_n_days", everyN: recurringEveryN };
+    } else if (mode === "monthly") {
+      recurrence = {
+        kind: "monthly",
+        dayOfMonth: parseCivilToLocalDate(civilDate).getDate(),
+      };
+    } else {
+      const weekdays = Array.from(recurringWeekdays).sort((a, b) => a - b);
+      recurrence =
+        weekdays.length === 1
+          ? { kind: "weekly", weekday: weekdays[0] }
+          : { kind: "weekly_days", weekdays };
+    }
+    const dates = expandRecurrenceDates(
+      recurrence,
+      civilDate,
+      recurringEndEnabled ? recurringEndDate : undefined,
+    );
+    return dates.map(parseCivilToLocalDate);
+  }, [
+    mode,
+    recurringWeekdays,
+    recurringEveryN,
+    civilDate,
+    recurringEndEnabled,
+    recurringEndDate,
+  ]);
 
   function copyFirstSetToAll(exerciseIndex: number, metric: "reps" | "time") {
     setOverrideDrafts((prev) => {
@@ -909,10 +958,17 @@ export function AssignTemplateModal({
               onSelect={(d) => {
                 if (d) setCivilDate(formatLocalDateToCivil(d));
               }}
+              modifiers={{ recurrence: previewDates }}
+              modifiersClassNames={{ recurrence: RECURRENCE_PREVIEW_CLASS }}
             />
             <p className="text-xs text-muted-foreground">
               {t("scheduledFor", { date: civilDate })}
             </p>
+            {mode !== "once" ? (
+              <p className="text-xs font-medium text-primary">
+                {t("recurrencePreviewCount", { count: previewDates.length })}
+              </p>
+            ) : null}
           </div>
 
           <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">

--- a/backoffice/src/components/gc-fitness/schedule/bulk-assign-form.tsx
+++ b/backoffice/src/components/gc-fitness/schedule/bulk-assign-form.tsx
@@ -48,9 +48,19 @@ import {
   addCivilMonths,
   END_DATE_PRESET_MONTHS,
 } from "@/lib/gc-fitness/end-date-presets";
+import {
+  expandRecurrenceDates,
+  type ExpandableRecurrence,
+} from "@/lib/gc-fitness/recurrence-expansion";
 import type { ClientRosterEntry } from "@/lib/gc-fitness/client-roster";
 
 import { BulkConfirmModal } from "./bulk-confirm-modal";
+
+// #294 — class applied to every day cell the recurrence will land on, so the
+// trainer previews the series on the calendar before submitting. The anchor
+// (selected) day keeps its solid `selected` styling on top of this.
+const RECURRENCE_PREVIEW_CLASS =
+  "rounded-md bg-primary/15 font-semibold text-primary";
 
 interface BulkAssignFormProps {
   clients: ClientRosterEntry[];
@@ -172,6 +182,29 @@ export function BulkAssignForm({
     return t("summaryWeekly", { days: labels });
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [mode, recurringEveryN, recurringWeekdays, civilDate, t]);
+
+  // #294 — civil dates the recurrence will land on, for the calendar preview.
+  // Uses the SAME `expandRecurrenceDates` the bulkAssignTemplate action uses to
+  // write the series, so what the trainer sees highlighted is exactly what gets
+  // created. "once" → just the single picked day (no extra highlight).
+  const previewDates = useMemo<Date[]>(() => {
+    const recurrence = buildRecurrence();
+    if (!recurrence) return [];
+    const dates = expandRecurrenceDates(
+      recurrence as ExpandableRecurrence,
+      civilDate,
+      recurringEndEnabled ? recurringEndDate : undefined,
+    );
+    return dates.map(parseCivilToLocalDate);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [
+    mode,
+    recurringWeekdays,
+    recurringEveryN,
+    civilDate,
+    recurringEndEnabled,
+    recurringEndDate,
+  ]);
 
   const selectedClients = useMemo(
     () => clients.filter((c) => selectedUids.has(c.uid)),
@@ -311,10 +344,17 @@ export function BulkAssignForm({
               onSelect={(d) => {
                 if (d) setCivilDate(formatLocalDateToCivil(d));
               }}
+              modifiers={{ recurrence: previewDates }}
+              modifiersClassNames={{ recurrence: RECURRENCE_PREVIEW_CLASS }}
             />
             <p className="text-xs text-muted-foreground">
               {t("scheduledFor", { date: civilDate })}
             </p>
+            {mode !== "once" ? (
+              <p className="text-xs font-medium text-primary">
+                {t("recurrencePreviewCount", { count: previewDates.length })}
+              </p>
+            ) : null}
           </div>
 
           <div className="grid grid-cols-1 gap-3">

--- a/backoffice/src/lib/gc-fitness/recurrence-expansion.ts
+++ b/backoffice/src/lib/gc-fitness/recurrence-expansion.ts
@@ -1,0 +1,102 @@
+// recurrence-expansion.ts
+//
+// Pure (no "use server", no Firebase) recurrence date-expansion. This is the
+// SINGLE SOURCE OF TRUTH for turning a RecurrenceRule + start/end civil dates
+// into the concrete set of civil dates an assignment series lands on.
+//
+// 260618 (#294): extracted out of workout-assignment-actions.ts so BOTH the
+// server write path (assignTemplateRecurring / bulkAssignTemplate) AND the
+// client-side calendar PREVIEW import the exact same matcher. Previously the
+// matcher lived inside the "use server" actions file and could not be imported
+// by client components — a client preview would have had to duplicate it and
+// could silently drift from what actually gets written. Keep all behavioral
+// changes here; both call sites pick them up automatically.
+//
+// CIVIL-DATE CONTRACT (Pitfall 1): every date here is a "YYYY-MM-DD" civil-date
+// string, never a Timestamp/instant. Day arithmetic is UTC-anchored so it is
+// exact-day and DST-free.
+
+import { civilDateFormat } from "./civil-date";
+
+export const MAX_RECURRING_OCCURRENCES = 104; // ~2 years weekly cap
+export const NO_END_HORIZON_DAYS = 365; // "no end" operational horizon (rolling)
+
+export type ExpandableRecurrence =
+  | { kind: "single" }
+  | { kind: "daily" }
+  | { kind: "weekly"; weekday: number }
+  | { kind: "weekly_days"; weekdays: number[] }
+  | { kind: "every_n_days"; everyN: number }
+  | { kind: "monthly"; dayOfMonth: number };
+
+/** Add whole calendar days to a civil date string (UTC-anchored, no DST drift). */
+export function addCivilDays(civilDate: string, days: number): string {
+  const [y, m, d] = civilDate.split("-").map(Number);
+  // Construct at UTC midnight so the arithmetic is exact-day.
+  const utcMidnight = Date.UTC(y, m - 1, d);
+  const shifted = new Date(utcMidnight + days * 86_400_000);
+  return civilDateFormat(shifted, "UTC");
+}
+
+/** Local-time weekday index (0=Sun … 6=Sat) for a civil date. */
+export function dayOfWeekFromCivil(civilDate: string): number {
+  const [y, m, d] = civilDate.split("-").map(Number);
+  return new Date(y, m - 1, d).getDay();
+}
+
+/** True when `date` (a civil-date string) matches `recurrence` anchored at `startDate`. */
+export function matchesRecurrence(
+  recurrence: ExpandableRecurrence,
+  startDate: string,
+  date: string,
+  dayIndex: number,
+): boolean {
+  switch (recurrence.kind) {
+    case "single":
+      return date === startDate;
+    case "daily":
+      return true;
+    case "weekly":
+      return dayIndex === recurrence.weekday;
+    case "weekly_days":
+      return recurrence.weekdays.includes(dayIndex);
+    case "every_n_days": {
+      const [y0, m0, d0] = startDate.split("-").map(Number);
+      const [y1, m1, d1] = date.split("-").map(Number);
+      const diff =
+        (Date.UTC(y1, m1 - 1, d1) - Date.UTC(y0, m0 - 1, d0)) / 86_400_000;
+      return diff >= 0 && diff % recurrence.everyN === 0;
+    }
+    case "monthly": {
+      const [y, m, d] = date.split("-").map(Number);
+      const target = recurrence.dayOfMonth;
+      const lastDayOfMonth = new Date(y, m, 0).getDate();
+      const clamped = Math.min(target, lastDayOfMonth);
+      return d === clamped;
+    }
+  }
+}
+
+/**
+ * Expand a recurrence rule into the matching civil dates in
+ * `[startDate, endDate ?? startDate + NO_END_HORIZON_DAYS]`, capped at
+ * `MAX_RECURRING_OCCURRENCES`. Returns the dates in ascending order.
+ */
+export function expandRecurrenceDates(
+  recurrence: ExpandableRecurrence,
+  startDate: string,
+  endDate?: string,
+): string[] {
+  const hardWindowEnd = addCivilDays(startDate, NO_END_HORIZON_DAYS);
+  const windowEnd = endDate ?? hardWindowEnd;
+  const dates: string[] = [];
+  for (let date = startDate; date <= windowEnd; date = addCivilDays(date, 1)) {
+    if (
+      matchesRecurrence(recurrence, startDate, date, dayOfWeekFromCivil(date))
+    ) {
+      dates.push(date);
+      if (dates.length >= MAX_RECURRING_OCCURRENCES) break;
+    }
+  }
+  return dates;
+}

--- a/backoffice/src/lib/gc-fitness/workout-assignment-actions.ts
+++ b/backoffice/src/lib/gc-fitness/workout-assignment-actions.ts
@@ -65,12 +65,16 @@ import {
   tallyTemplateAssignments,
   type AssignmentForUsage,
 } from "./library-usage-counts";
+import {
+  MAX_RECURRING_OCCURRENCES,
+  NO_END_HORIZON_DAYS,
+  expandRecurrenceDates,
+  type ExpandableRecurrence,
+} from "./recurrence-expansion";
 
 const TEMPLATES = FirestoreCollections.workoutTemplates;
 const ASSIGNMENTS = FirestoreCollections.workoutAssignments;
 const LOGS = FirestoreCollections.workoutLogs;
-const MAX_RECURRING_OCCURRENCES = 104; // ~2 years weekly cap
-const NO_END_HORIZON_DAYS = 365; // "no end" operational horizon (rolling)
 
 /**
  * Row shape returned by the list queries. Firestore Timestamps are converted
@@ -332,76 +336,12 @@ function nextCivilForWeekdayOnOrAfter(civilDate: string, weekday: number): strin
 //
 // 260612-e9t (#175): `assignTemplateRecurring` and `bulkAssignTemplate` must
 // expand a `RecurrenceRule` into the SAME set of civil dates for the SAME
-// startDate/endDate — otherwise the two surfaces would silently drift. The
-// matcher + civil-day walk below is the SINGLE source of truth; both client
-// call sites invoke `expandRecurrenceDates`. (The inline matcher inside
-// `assignTemplateRecurring*ToPending` is a separate pending-mirror path; this
-// shared helper covers the canonical client paths.)
-
-type ExpandableRecurrence =
-  | { kind: "single" }
-  | { kind: "daily" }
-  | { kind: "weekly"; weekday: number }
-  | { kind: "weekly_days"; weekdays: number[] }
-  | { kind: "every_n_days"; everyN: number }
-  | { kind: "monthly"; dayOfMonth: number };
-
-/** True when `date` (a civil-date string) matches `recurrence` anchored at `startDate`. */
-function matchesRecurrence(
-  recurrence: ExpandableRecurrence,
-  startDate: string,
-  date: string,
-  dayIndex: number,
-): boolean {
-  switch (recurrence.kind) {
-    case "single":
-      return date === startDate;
-    case "daily":
-      return true;
-    case "weekly":
-      return dayIndex === recurrence.weekday;
-    case "weekly_days":
-      return recurrence.weekdays.includes(dayIndex);
-    case "every_n_days": {
-      const [y0, m0, d0] = startDate.split("-").map(Number);
-      const [y1, m1, d1] = date.split("-").map(Number);
-      const diff =
-        (Date.UTC(y1, m1 - 1, d1) - Date.UTC(y0, m0 - 1, d0)) / 86_400_000;
-      return diff >= 0 && diff % recurrence.everyN === 0;
-    }
-    case "monthly": {
-      const [y, m, d] = date.split("-").map(Number);
-      const target = recurrence.dayOfMonth;
-      const lastDayOfMonth = new Date(y, m, 0).getDate();
-      const clamped = Math.min(target, lastDayOfMonth);
-      return d === clamped;
-    }
-  }
-}
-
-/**
- * Expand a recurrence rule into the matching civil dates in
- * `[startDate, endDate ?? startDate + NO_END_HORIZON_DAYS]`, capped at
- * `MAX_RECURRING_OCCURRENCES`. Returns the dates in ascending order.
- */
-function expandRecurrenceDates(
-  recurrence: ExpandableRecurrence,
-  startDate: string,
-  endDate?: string,
-): string[] {
-  const hardWindowEnd = addCivilDays(startDate, NO_END_HORIZON_DAYS);
-  const windowEnd = endDate ?? hardWindowEnd;
-  const dates: string[] = [];
-  for (let date = startDate; date <= windowEnd; date = addCivilDays(date, 1)) {
-    if (
-      matchesRecurrence(recurrence, startDate, date, dayOfWeekFromCivil(date))
-    ) {
-      dates.push(date);
-      if (dates.length >= MAX_RECURRING_OCCURRENCES) break;
-    }
-  }
-  return dates;
-}
+// startDate/endDate. 260618 (#294): the matcher + civil-day walk now lives in
+// the pure `./recurrence-expansion` module (imported above) so the client-side
+// calendar PREVIEW expands dates identically to what these actions write — one
+// source of truth across the server write path and the form preview. (The
+// inline matcher inside `assignTemplateRecurring*ToPending` is a separate
+// pending-mirror path; this shared helper covers the canonical client paths.)
 
 /**
  * Hard ceiling on total docs a single bulk-recurring submit may write


### PR DESCRIPTION
Closes #349 and #294. Two GC Fitness backoffice features (cleanly disjoint files; bundled into one PR per request).

## #349 — Wiki: shareable per-section deep links
- Every Coach Wiki **video card** and **FAQ** gets a "Copiar link" button that copies the public Wiki URL plus that item's anchor (e.g. `…/gc-fitness/wiki#dashboard`, `…/wiki#faq-prellenado-pesos`), so a coach can share a single walkthrough/answer.
- The button is pinned **top-right** on every card (no more wrapping below long descriptions).
- Clicking the button inside a FAQ `<summary>` copies the link **without** toggling the disclosure.
- Opening a copied FAQ link now lands with that question **already expanded** (`WikiHashOpener` expands the targeted `<details>` on load + hashchange, then re-scrolls).

## #294 — Calendar preview of recurring schedules
- **Workout assign** (single-client modal + bulk-assign form): picking a cadence (weekly / daily / every-N / monthly) now **highlights every date the series will land on**, with a live count, before submitting.
- **Habit schedule form** (Cronograma del hábito): added the missing calendar — a read-only preview that highlights every active day with a live count.
- Refactor: extracted the recurrence matcher/expander out of the `"use server"` `workout-assignment-actions.ts` into a pure `recurrence-expansion.ts` that both the server write path and the client preview import — so the highlighted days are **exactly** what gets written (single source of truth, no twin drift). The habit preview reuses the existing `isHabitScheduledOn` predicate for the same reason.

## Tests
- `tsc --noEmit`: clean.
- `jest`: 705 pass. The 2 failures (`workout-assignment-actions` read-count, `client-activity-time`) are **pre-existing/known** — both fail on `main` too (the latter is the documented non-en-US locale flake, green in CI). No new failures introduced.
- No `firestore.rules` changes.
