### PR TITLE
#361 backoffice: pre-fill generator swap picker with the routine's filters

### DIFF
--- a/backoffice/src/components/gc-fitness/exercise-picker-popover.tsx
+++ b/backoffice/src/components/gc-fitness/exercise-picker-popover.tsx
@@ -100,6 +100,7 @@ import {
   useExerciseFilters,
   applyFilters,
   type ExerciseFilters,
+  type InitialExerciseFilters,
 } from "@/lib/gc-fitness/exercise-filter-state";
 import { MUSCLE_GROUPS, EQUIPMENT } from "@/lib/gc-fitness/exercise-vocabulary";
 import { useFavorites } from "@/lib/gc-fitness/use-favorites";
@@ -143,6 +144,13 @@ export interface ExercisePickerPopoverProps {
   className?: string;
   /** Optional aria-label for the trigger (a11y in dense rows). */
   ariaLabel?: string;
+  /**
+   * Optional initial muscle/equipment filter selection applied when the
+   * popover first mounts. The workout generator passes the routine's selected
+   * equipment + muscle groups so a swap opens already scoped to the same
+   * filters (issue #361). Omitted in the normal create/edit flow → unfiltered.
+   */
+  initialFilters?: InitialExerciseFilters;
 }
 
 function formatLabel(s: string): string {
@@ -197,6 +205,7 @@ export function ExercisePickerPopover({
   disabled,
   className,
   ariaLabel,
+  initialFilters,
 }: ExercisePickerPopoverProps) {
   const t = useTranslations("picker");
   const effectivePlaceholder = placeholder ?? t("triggerPlaceholder");
@@ -224,7 +233,7 @@ export function ExercisePickerPopover({
   // Hook owns the immutable Set update contract (Codex MEDIUM); every
   // chip click below goes through setFilters() with `new Set(...)`.
   const { filters, setFilters, isEmpty: filtersEmpty, clear: clearFilters } =
-    useExerciseFilters();
+    useExerciseFilters(initialFilters);
 
   // Filter soft-deleted out + apply the chip filters. The trainer's
   // previously-selected exercise (if it has since been deleted) still

--- a/backoffice/src/components/gc-fitness/generator/workout-generator-wizard.tsx
+++ b/backoffice/src/components/gc-fitness/generator/workout-generator-wizard.tsx
@@ -390,6 +390,12 @@ export function WorkoutGeneratorWizard({ clients, trainerTimezone }: Props) {
             setStep(6);
           }}
           renderExerciseExtras={renderExerciseExtras}
+          // #361 — opening the picker to swap an exercise pre-applies the
+          // routine's own equipment + muscle-group selection as filters.
+          pickerInitialFilters={{
+            muscles: [...muscles],
+            equipment: [...equipment],
+          }}
         />
       </div>
     );

--- a/backoffice/src/components/gc-fitness/template-form.tsx
+++ b/backoffice/src/components/gc-fitness/template-form.tsx
@@ -167,6 +167,14 @@ export interface TemplateFormProps {
    * create flow. The pre-filled other-language value is preserved until edited.
    */
   initialShowTranslation?: boolean;
+  /**
+   * Optional initial muscle/equipment filters for the per-exercise picker
+   * popover. The workout generator passes the routine's selected equipment +
+   * muscle groups so swapping an exercise opens the picker already scoped to
+   * the same filters (issue #361). Omitted in the normal create/edit flow →
+   * the picker opens unfiltered as before.
+   */
+  pickerInitialFilters?: { muscles?: string[]; equipment?: string[] };
 }
 
 const DRAFT_STORAGE_PREFIX = "gc-fitness:template-draft:";
@@ -338,6 +346,7 @@ export function TemplateForm({
   onCreated,
   renderExerciseExtras,
   initialShowTranslation,
+  pickerInitialFilters,
 }: TemplateFormProps) {
   const t = useTranslations("templates.form");
   const router = useRouter();
@@ -1279,6 +1288,7 @@ export function TemplateForm({
                               value={pickerField.value ?? ""}
                               onChange={pickerField.onChange}
                               ariaLabel={t("pickExerciseAria", { index: index + 1 })}
+                              initialFilters={pickerInitialFilters}
                             />
                           </FormControl>
                           <FormMessage />

--- a/backoffice/src/lib/gc-fitness/__tests__/exercise-filter-state.test.ts
+++ b/backoffice/src/lib/gc-fitness/__tests__/exercise-filter-state.test.ts
@@ -280,4 +280,35 @@ describe("applyFilters (Phase 24-06 Task 2)", () => {
     // The OLD Set must NOT have been mutated to size 0.
     expect(oneMuscle.size).toBe(1);
   });
+
+  // Issue #361 — the generator passes the routine's muscle/equipment
+  // selection so a swap opens the picker already scoped to those filters.
+  it("#361: seeds muscles + equipment from initialFilters on mount", () => {
+    const { result } = renderHook(() =>
+      useExerciseFilters({ muscles: ["shoulders"], equipment: ["dumbbell"] }),
+    );
+
+    expect([...result.current.filters.muscles]).toEqual(["shoulders"]);
+    expect([...result.current.filters.equipment]).toEqual(["dumbbell"]);
+    expect(result.current.isEmpty).toBe(false);
+  });
+
+  // The trainer can still fully clear a pre-seeded picker.
+  it("#361: clear() resets a pre-seeded picker to empty", () => {
+    const { result } = renderHook(() =>
+      useExerciseFilters({ muscles: ["shoulders"], equipment: ["dumbbell"] }),
+    );
+
+    act(() => result.current.clear());
+
+    expect(result.current.filters.muscles.size).toBe(0);
+    expect(result.current.filters.equipment.size).toBe(0);
+    expect(result.current.isEmpty).toBe(true);
+  });
+
+  // Backwards compatible: no argument → empty filters, as before.
+  it("#361: defaults to empty when no initialFilters is passed", () => {
+    const { result } = renderHook(() => useExerciseFilters());
+    expect(result.current.isEmpty).toBe(true);
+  });
 });

--- a/backoffice/src/lib/gc-fitness/exercise-filter-state.ts
+++ b/backoffice/src/lib/gc-fitness/exercise-filter-state.ts
@@ -60,6 +60,28 @@ const EMPTY: ExerciseFilters = {
   mechanic: null,
 };
 
+/**
+ * Optional seed for the picker's filter chips. The workout generator passes
+ * the routine's selected muscle groups + equipment so that swapping an
+ * exercise opens the picker already scoped to the same filters (issue #361).
+ * Array-shaped (not Set) so callers can pass plain serializable values.
+ */
+export interface InitialExerciseFilters {
+  muscles?: string[];
+  equipment?: string[];
+  level?: string | null;
+  mechanic?: string | null;
+}
+
+function fromInitial(initial: InitialExerciseFilters): ExerciseFilters {
+  return {
+    muscles: new Set(initial.muscles ?? []),
+    equipment: new Set(initial.equipment ?? []),
+    level: initial.level ?? null,
+    mechanic: initial.mechanic ?? null,
+  };
+}
+
 const MUSCLE_FILTER_ALIASES: Record<string, string[]> = {
   legs: ["legs", "quadriceps", "hamstrings", "glutes", "calves"],
 };
@@ -76,8 +98,13 @@ const MUSCLE_FILTER_ALIASES: Record<string, string[]> = {
  *   - `isEmpty`: true when ALL fields are at their default (no chips active)
  *   - `clear`: resets to EMPTY in a single state transition
  */
-export function useExerciseFilters() {
-  const [filters, setFilters] = useState<ExerciseFilters>(EMPTY);
+export function useExerciseFilters(initial?: InitialExerciseFilters) {
+  // Seed once on mount via the lazy initializer; later edits (chip toggles,
+  // clear) own the state. `clear` always resets to EMPTY so a pre-seeded
+  // picker can still be fully cleared by the trainer.
+  const [filters, setFilters] = useState<ExerciseFilters>(() =>
+    initial ? fromInitial(initial) : EMPTY,
+  );
 
   const isEmpty = useMemo(
     () =>


### PR DESCRIPTION
Fixes mdb1/gc-fitness#361

## Problem
On the workout generator's last (review) step, swapping an exercise opened the exercise picker with **no filters** — so a routine generated for e.g. *dumbbells + shoulders* dropped the trainer into the full library, forcing them to re-select the same equipment and muscle they'd already chosen.

## Fix
Thread the generator's selected equipment + muscle groups down to the per-exercise picker so a swap opens already scoped to them:

```
wizard ─pickerInitialFilters→ TemplateForm ─initialFilters→ ExercisePickerPopover ─→ useExerciseFilters(seed)
```

- `useExerciseFilters(initial?)` gains an optional seed applied via a **lazy `useState` initializer** (seeded once on mount). `clear()` still resets to empty, so the trainer can fully clear a pre-seeded picker.
- The normal create/edit flow passes nothing → picker opens unfiltered, exactly as before (backwards compatible).

## Testing
- New hook tests: seeds muscles+equipment from `initialFilters`; `clear()` resets a pre-seeded picker; no-arg defaults to empty.
- `npx jest exercise-filter-state exercise-picker-popover template-form` → 43 passed.
- `tsc --noEmit` clean for the touched files.
- Full `npx jest` → 713 passed; the 1 failure is the pre-existing `client-activity-time` locale flake (green in CI), unrelated.