### PR TITLE
backoffice: localize Categoría/Equipo columns in exercises library table

### DIFF
--- a/backoffice/messages/en.json
+++ b/backoffice/messages/en.json
@@ -1248,6 +1248,15 @@
         "rope": "Rope",
         "smith": "Smith machine",
         "swiss_ball": "Swiss ball"
+      },
+      "category": {
+        "strength": "Strength",
+        "powerlifting": "Powerlifting",
+        "plyometrics": "Plyometrics",
+        "cardio": "Cardio",
+        "olympic_weightlifting": "Olympic weightlifting",
+        "stretching": "Stretching",
+        "strongman": "Strongman"
       }
     },
     "mediaUpload": {

--- a/backoffice/messages/es.json
+++ b/backoffice/messages/es.json
@@ -1248,6 +1248,15 @@
         "rope": "Soga",
         "smith": "Máquina Smith",
         "swiss_ball": "Pelota suiza"
+      },
+      "category": {
+        "strength": "Fuerza",
+        "powerlifting": "Powerlifting",
+        "plyometrics": "Pliometría",
+        "cardio": "Cardio",
+        "olympic_weightlifting": "Halterofilia",
+        "stretching": "Estiramiento",
+        "strongman": "Strongman"
       }
     },
     "mediaUpload": {

--- a/backoffice/src/app/gc-fitness/exercises/client.tsx
+++ b/backoffice/src/app/gc-fitness/exercises/client.tsx
@@ -216,10 +216,13 @@ export function ExerciseLibraryClient({
   );
 
   const columnsT = useTranslations("exercises.columns");
+  // Localized muscle/equipment/category labels for the table's Categoría +
+  // Equipo columns (same catalog the picker + exercise form use).
+  const vocabT = useTranslations("exercises.vocabulary");
   const locale = useLocale();
   const columns = useMemo(
-    () => makeColumns(handlers, columnsT, usageCounts, locale),
-    [handlers, columnsT, usageCounts, locale],
+    () => makeColumns(handlers, columnsT, vocabT, usageCounts, locale),
+    [handlers, columnsT, vocabT, usageCounts, locale],
   );
 
   const table = useReactTable({

--- a/backoffice/src/app/gc-fitness/exercises/columns.tsx
+++ b/backoffice/src/app/gc-fitness/exercises/columns.tsx
@@ -30,6 +30,23 @@ import {
 import { ExercisePreviewThumb } from "@/components/gc-fitness/exercise-preview-thumb";
 import { FavoriteStarButton } from "@/components/gc-fitness/favorite-star-button";
 import type { ExerciseRow } from "@/lib/gc-fitness/exercises-listener";
+import {
+  isMuscleGroup,
+  isEquipment,
+} from "@/lib/gc-fitness/exercise-vocabulary";
+
+// FEXD exercise `category` enum values that have a dedicated label in the
+// exercises.vocabulary.category catalog. Anything outside this set (and not a
+// muscle-group fallback) falls back to the humanized English title-caser.
+const KNOWN_CATEGORIES = new Set([
+  "strength",
+  "powerlifting",
+  "plyometrics",
+  "cardio",
+  "olympic_weightlifting",
+  "stretching",
+  "strongman",
+]);
 
 // Difficulty level → semantic Badge variant per the redesign doc
 // (beginner → success, intermediate → brand, expert/advanced → violet).
@@ -83,9 +100,25 @@ function formatLabel(s: string): string {
 
 type TFn = ReturnType<typeof useTranslations>;
 
+// Localize a "category" cell value. It is either a muscle-group key (the
+// fallback for rows without a FEXD category) or a FEXD category enum. Unknown
+// legacy values keep the English humanized form.
+function categoryLabel(raw: string, tVocab: TFn): string {
+  if (isMuscleGroup(raw)) return tVocab(`muscle.${raw}`);
+  if (KNOWN_CATEGORIES.has(raw)) return tVocab(`category.${raw}`);
+  return formatLabel(raw);
+}
+
+// Localize an equipment key. Unknown legacy values (e.g. the raw FEXD
+// "body only") keep the English humanized form.
+function equipmentLabel(raw: string, tVocab: TFn): string {
+  return isEquipment(raw) ? tVocab(`equipment.${raw}`) : formatLabel(raw);
+}
+
 export function makeColumns(
   handlers: ExerciseColumnHandlers,
   t: TFn,
+  tVocab: TFn,
   usageCounts?: Record<string, number>,
   locale?: string,
 ): ColumnDef<ExerciseRow>[] {
@@ -190,7 +223,7 @@ export function makeColumns(
         }
         return (
           <Badge variant="brand" className="font-medium">
-            {formatLabel(raw)}
+            {categoryLabel(raw, tVocab)}
           </Badge>
         );
       },
@@ -206,7 +239,7 @@ export function makeColumns(
           <div className="flex flex-wrap gap-1">
             {visible.map((e) => (
               <Badge key={e} variant="outline" className="font-normal">
-                {formatLabel(e)}
+                {equipmentLabel(e, tVocab)}
               </Badge>
             ))}
             {overflow > 0 && (


### PR DESCRIPTION
## Problem
In the **Ejercicios** library table, the **CATEGORÍA** (Legs, Back, Chest, Core…) and **EQUIPO** (Barbell, Bodyweight…) columns rendered in English regardless of locale — same `formatLabel()` English-only gap as the picker filter (mdb1/gc-fitness#360), but in `columns.tsx`.

## Fix
Localize both columns from the shared `exercises.vocabulary` catalog:

- **Categoría** — the cell value is either a muscle-group key (the fallback for rows without a FEXD `category`, which is what the standard-library rows in the screenshot show) or a FEXD `category` enum. Muscle keys resolve via `vocabulary.muscle`; category enums via a **new `vocabulary.category`** subsection (`strength`→Fuerza, `powerlifting`, `plyometrics`→Pliometría, plus cardio/olympic_weightlifting/stretching/strongman for completeness). Unknown legacy values keep the humanized fallback.
- **Equipo** — `vocabulary.equipment`, guarded by `isEquipment()` so legacy raw values (e.g. the FEXD `body only`) keep the humanized fallback.

`makeColumns` gains a vocabulary translator; `client.tsx` passes `useTranslations("exercises.vocabulary")`.

New strings: only the `vocabulary.category.*` keys (EN + ES). Muscle/equipment keys already existed.

## Testing
- `tsc --noEmit` clean for `columns.tsx` / `client.tsx`; both message catalogs parse.
- Full `npx jest` → 710 passed; the 1 failure is the pre-existing `client-activity-time` locale flake (green in CI), unrelated.