### PR TITLE
fix(gc-fitness): mobile backoffice — Brave login, admin mode, calendar nav

### DIFF
--- a/backoffice/.env.example
+++ b/backoffice/.env.example
@@ -28,6 +28,14 @@ NEXT_PUBLIC_GC_FITNESS_FIREBASE_PROJECT_ID=gcfitness-3476b
 NEXT_PUBLIC_GC_FITNESS_FIREBASE_STORAGE_BUCKET=
 NEXT_PUBLIC_GC_FITNESS_FIREBASE_MESSAGING_SENDER_ID=
 NEXT_PUBLIC_GC_FITNESS_FIREBASE_APP_ID=
+# #378 — Brave / privacy-browser sign-in fix. Set to "true" in PRODUCTION only.
+# When enabled, the gc-fitness Web SDK authDomain becomes the app's own origin
+# and the Firebase Auth handler is served same-origin via the /__/auth/* +
+# /__/firebase/* rewrites in next.config.ts (fixes Brave/Safari/Firefox blocking
+# the cross-origin handler). REQUIRES the production domain to be added to the
+# gcfitness-3476b project's Firebase Auth → Settings → Authorized domains.
+# Leave empty on preview/localhost (keeps the default firebaseapp.com domain).
+NEXT_PUBLIC_GC_FITNESS_AUTH_SELF_HOSTED=
 
 # --- Firebase Admin SDK (server-only) -------------------------------
 # Source: Firebase console -> Project settings (gcfitness-3476b) ->

--- a/backoffice/next.config.ts
+++ b/backoffice/next.config.ts
@@ -6,6 +6,29 @@ import createNextIntlPlugin from "next-intl/plugin";
 // subtree via NextIntlClientProvider in `app/gc-fitness/layout.tsx`.
 const withNextIntl = createNextIntlPlugin("./src/i18n/request.ts");
 
+// #378 — Brave / privacy-browser sign-in. The GC Fitness Firebase Auth handler
+// normally lives on the cross-origin domain gcfitness-3476b.firebaseapp.com.
+// Brave (and Safari ITP / Firefox ETP) block that cross-origin handler's
+// storage, so signInWithPopup is blocked and signInWithRedirect's
+// getRedirectResult comes back empty — trainers bounce straight back to /login.
+//
+// Fix: serve the handler SAME-ORIGIN by proxying /__/auth/* and /__/firebase/*
+// from our domain to the project's firebaseapp.com handler, paired with the
+// gc-fitness Web SDK authDomain set to our own origin (see gc-fitness-client.ts,
+// gated by NEXT_PUBLIC_GC_FITNESS_AUTH_SELF_HOSTED). The OAuth redirect_uri sent
+// to Google stays firebaseapp.com (Firebase's internal flow), so the only extra
+// console step is adding the production domain to the project's Auth "Authorized
+// domains".
+//
+// MyDNAMap is UNAFFECTED: its authDomain stays goldencrow-pocketgenes
+// .firebaseapp.com, so its handler requests go to firebaseapp.com directly and
+// never hit our domain's /__/auth/*. When self-hosting is disabled (preview /
+// localhost) nothing requests these paths on our domain and the rewrite is
+// dormant.
+const GC_FITNESS_AUTH_HANDLER_HOST =
+  process.env.NEXT_PUBLIC_GC_FITNESS_FIREBASE_AUTH_DOMAIN ??
+  "gcfitness-3476b.firebaseapp.com";
+
 const nextConfig: NextConfig = {
   images: {
     remotePatterns: [
@@ -13,6 +36,18 @@ const nextConfig: NextConfig = {
       { protocol: "https", hostname: "storage.googleapis.com" },
       { protocol: "https", hostname: "firebasestorage.googleapis.com" },
     ],
+  },
+  async rewrites() {
+    return [
+      {
+        source: "/__/auth/:path*",
+        destination: `https://${GC_FITNESS_AUTH_HANDLER_HOST}/__/auth/:path*`,
+      },
+      {
+        source: "/__/firebase/:path*",
+        destination: `https://${GC_FITNESS_AUTH_HANDLER_HOST}/__/firebase/:path*`,
+      },
+    ];
   },
 };
 

--- a/backoffice/src/app/api/gc-fitness/login/route.ts
+++ b/backoffice/src/app/api/gc-fitness/login/route.ts
@@ -170,11 +170,18 @@ export async function POST(request: Request) {
     }
 
     try {
-      const existingClaims =
-        ((decoded as DecodedIdToken & {
-          customClaims?: Record<string, unknown>;
-        }).customClaims ??
-          {}) as Record<string, unknown>;
+      // #379: existing custom claims live on the Auth user record, NOT under a
+      // `decoded.customClaims` sub-object — Firebase spreads claims directly
+      // onto the decoded ID token (e.g. `decoded.admin`). Reading the
+      // (always-undefined) `decoded.customClaims` made `mergeRoles` see `{}`,
+      // dropping the `admin` role so `setCustomUserClaims` WIPED admin on every
+      // login — admins lost the panel on any fresh sign-in (e.g. mobile). Read
+      // the authoritative claims via getUser(), mirroring promoteUserToAdmin.
+      const userRecord = await gcFitnessAuth().getUser(decoded.uid);
+      const existingClaims = (userRecord.customClaims ?? {}) as Record<
+        string,
+        unknown
+      >;
       const roles = mergeRoles(existingClaims);
       await gcFitnessAuth().setCustomUserClaims(decoded.uid, {
         ...existingClaims,

--- a/backoffice/src/components/gc-fitness/schedule/month-calendar.tsx
+++ b/backoffice/src/components/gc-fitness/schedule/month-calendar.tsx
@@ -521,7 +521,12 @@ export function MonthCalendar({
   );
 
   const rangeNav = (
-    <div className="inline-flex min-w-0 items-center gap-1 rounded-full border bg-card p-1">
+    // #381: `flex w-full` (not `inline-flex`) so the pill fills the width its
+    // `flex-1` parent allocates on mobile. As an inline-flex it sized to its
+    // own content and overflowed the parent, painting the month label over the
+    // "Hoy" button and hiding the next-range (>) chevron. Filling the parent
+    // lets the label `truncate` instead of overflowing.
+    <div className="flex w-full min-w-0 items-center gap-1 rounded-full border bg-card p-1 sm:inline-flex sm:w-auto">
       <Button
         variant="ghost"
         size="icon"

--- a/backoffice/src/lib/firebase/gc-fitness-client.ts
+++ b/backoffice/src/lib/firebase/gc-fitness-client.ts
@@ -25,6 +25,27 @@ import { getStorage, type FirebaseStorage } from "firebase/storage";
 
 const GC_FITNESS_APP_NAME = "gc-fitness";
 
+// #378 — resolve the Firebase Auth handler domain. When self-hosting is enabled
+// (NEXT_PUBLIC_GC_FITNESS_AUTH_SELF_HOSTED=true, set in production), point
+// authDomain at OUR OWN origin so the auth handler is served same-origin via the
+// /__/auth/* + /__/firebase/* rewrites in next.config.ts. That keeps the
+// handler's storage first-party, which privacy browsers (Brave / Safari ITP /
+// Firefox ETP) allow — fixing the bounce-back-to-/login on Brave mobile.
+//
+// Gated + window-guarded so it only kicks in client-side in production. Preview
+// deploys and localhost keep the default cross-origin firebaseapp.com domain so
+// every ephemeral Vercel URL doesn't need to be added to Authorized domains.
+function resolveGCFitnessAuthDomain(): string | undefined {
+  const fallback = process.env.NEXT_PUBLIC_GC_FITNESS_FIREBASE_AUTH_DOMAIN;
+  if (
+    process.env.NEXT_PUBLIC_GC_FITNESS_AUTH_SELF_HOSTED === "true" &&
+    typeof window !== "undefined"
+  ) {
+    return window.location.host;
+  }
+  return fallback;
+}
+
 const gcFitnessConfig = {
   apiKey: process.env.NEXT_PUBLIC_GC_FITNESS_FIREBASE_API_KEY,
   authDomain: process.env.NEXT_PUBLIC_GC_FITNESS_FIREBASE_AUTH_DOMAIN,
@@ -45,7 +66,16 @@ function getGCFitnessApp(): FirebaseApp {
   // duplicate module evaluation) already initialized it. Without this guard,
   // `initializeApp(config, "gc-fitness")` would throw on the second call.
   const existing = getApps().find((a) => a.name === GC_FITNESS_APP_NAME);
-  return existing ?? initializeApp(gcFitnessConfig, GC_FITNESS_APP_NAME);
+  // Resolve authDomain at init time (not module-eval) so the client-side
+  // window.location.host override (#378 self-hosting) is in effect. Sign-in only
+  // runs client-side, so the app is first initialized with `window` present.
+  return (
+    existing ??
+    initializeApp(
+      { ...gcFitnessConfig, authDomain: resolveGCFitnessAuthDomain() },
+      GC_FITNESS_APP_NAME,
+    )
+  );
 }
 
 export function getGCFitnessAuth(): Auth {

--- a/backoffice/src/proxy.ts
+++ b/backoffice/src/proxy.ts
@@ -166,7 +166,11 @@ export const config = {
   matcher: [
     // Existing MyDNAMap / Pocket Gyms surfaces — same exclusions as pre-02-03
     // plus gc-fitness paths (handled in the branch above).
-    "/((?!login|access-denied|botfarm|api/auth|api/sdk|_next/static|_next/image|favicon.ico|gc-fitness|api/gc-fitness).*)",
+    // `__` excludes the Firebase Auth handler paths (/__/auth/*, /__/firebase/*)
+    // self-hosted via next.config rewrites (#378) — otherwise this middleware
+    // would route them through the NextAuth branch and redirect the handler to
+    // /login, breaking the proxied sign-in flow.
+    "/((?!login|access-denied|botfarm|api/auth|api/sdk|_next/static|_next/image|favicon.ico|gc-fitness|api/gc-fitness|__).*)",
     "/gc-fitness/:path*",
     "/api/gc-fitness/login",
     "/api/gc-fitness/logout",


### PR DESCRIPTION
Fixes three GC Fitness backoffice mobile issues in one PR.

## mdb1/gc-fitness#381 — visual bug: forward arrow covered on mobile
The Agenda range navigator (`< Junio 2026 >`) was an `inline-flex` pill, so it sized to its own content and **overflowed its `flex-1` parent** on a phone, painting the month label over the `Hoy` button and hiding the next-range (`>`) chevron. Changed it to `flex w-full` (with `sm:inline-flex sm:w-auto` for desktop) so the label `truncate`s within the allotted width instead of overflowing.

`backoffice/src/components/gc-fitness/schedule/month-calendar.tsx`

## mdb1/gc-fitness#379 — admin mode not shown on mobile / "no tengo permisos"
The login route read existing custom claims from `decoded.customClaims` — **a sub-object that never exists**, because Firebase spreads custom claims directly onto the decoded ID token (`decoded.admin`, `decoded.roles`, …). So `mergeRoles` always saw `{}`, dropped the `admin` role, and `setCustomUserClaims` **wiped `admin` on every login**. A desktop session minted before the wipe kept working; any fresh login (e.g. mobile) lost admin → no sidebar entry and `/admin` returned Forbidden.

Fix: read the authoritative claims via `getUser().customClaims`, mirroring `promoteUserToAdmin`.

`backoffice/src/app/api/gc-fitness/login/route.ts`

> ⚠️ **One-time data step:** prior logins already wiped the affected admin's `admin` claim from their Auth user record. After this merges, re-grant it once (admin UI "promote to admin" from a still-working desktop session, or a one-off `setCustomUserClaims`). From then on it persists.

## mdb1/gc-fitness#378 — Brave mobile can't log in (bounces to /login)
Root cause: Firebase's auth handler runs on the cross-origin `gcfitness-3476b.firebaseapp.com`. Brave (and Safari ITP / Firefox ETP) block that handler's storage, so `signInWithPopup` is blocked and the `signInWithRedirect` fallback's `getRedirectResult` returns empty → bounce to `/login`.

Fix: serve the handler **same-origin**.
- `next.config.ts`: proxy `/__/auth/*` and `/__/firebase/*` to the project's firebaseapp.com handler.
- `gc-fitness-client.ts`: when `NEXT_PUBLIC_GC_FITNESS_AUTH_SELF_HOSTED=true`, set `authDomain` to the app's own origin (`window.location.host`).
- `proxy.ts`: exclude `/__/` from the middleware matcher so it doesn't route the handler through NextAuth.

**MyDNAMap is unaffected** — its `authDomain` stays `goldencrow-pocketgenes.firebaseapp.com`, so its handler requests hit firebaseapp.com directly and never touch our domain's `/__/auth/*`. The flag is **prod-only**; preview/localhost keep the default cross-origin domain, so ephemeral Vercel URLs don't need to be authorized.

### Required to activate #378 (human/console — cannot be done in code)
1. Add the **production domain** to Firebase Console → Auth → Settings → **Authorized domains** for `gcfitness-3476b`.
2. Set `NEXT_PUBLIC_GC_FITNESS_AUTH_SELF_HOSTED=true` in **Vercel production** env.
3. Verify on a real **Brave mobile** device (this can't be reproduced locally/statically).

## Verification
- `npx tsc --noEmit` — clean
- `npm run build` — ✓ Compiled successfully
- `npx jest` — 713/714 pass; the one failure is the pre-existing `client-activity-time` locale flake (green in CI, unrelated)