### PR TITLE
Backoffice: allow editing recurrence end date

### DIFF
--- a/backoffice/src/components/gc-fitness/schedule/workout-detail-dialog.tsx
+++ b/backoffice/src/components/gc-fitness/schedule/workout-detail-dialog.tsx
@@ -291,6 +291,7 @@ export function WorkoutDetailDialog({
           assignmentId={data.id}
           scheduledFor={data.scheduledFor}
           recurrence={data.recurrence}
+          seriesEndDate={data.seriesEndDate}
           onSaved={() => {
             setRecurrenceOpen(false);
             onOpenChange(false);

--- a/backoffice/src/components/gc-fitness/schedule/workout-recurrence-edit-dialog.tsx
+++ b/backoffice/src/components/gc-fitness/schedule/workout-recurrence-edit-dialog.tsx
@@ -11,8 +11,8 @@
 // (mode + weekday chips + every-N + monthly) but is standalone and seeded from
 // the occurrence's current recurrence rule. On save it calls
 // editAssignmentRecurrence, which deletes the future scheduled docs in the
-// series and re-expands the new rule over the same window (preserving past /
-// completed occurrences). Copy is hardcoded Spanish to match the detail
+// series and re-expands the new rule up to the selected end date (preserving
+// past / completed occurrences). Copy is hardcoded Spanish to match the detail
 // dialog's existing convention (the 26-07 i18n pass will lift both together).
 
 import { useMemo, useState } from "react";
@@ -35,6 +35,11 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { editAssignmentRecurrence } from "@/lib/gc-fitness/workout-assignment-actions";
+import {
+  addCivilMonths,
+  END_DATE_PRESET_MONTHS,
+  inferEndDatePresetMonths,
+} from "@/lib/gc-fitness/end-date-presets";
 
 type Mode = "weekly" | "daily" | "everyN" | "monthly";
 
@@ -53,6 +58,8 @@ interface WorkoutRecurrenceEditDialogProps {
   scheduledFor: string;
   /** The occurrence's current recurrence rule (used to seed the picker). */
   recurrence: Record<string, unknown> | null;
+  /** Latest scheduled date in the current series, used as the editable end. */
+  seriesEndDate: string | null;
   onSaved: () => void;
 }
 
@@ -65,6 +72,19 @@ function dayOfMonthFromCivil(civil: string): number {
   const parts = civil.split("-");
   const d = Number(parts[2]);
   return Number.isFinite(d) && d >= 1 && d <= 31 ? d : 1;
+}
+
+const CIVIL_DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
+
+function initialEndDateForSeries(
+  scheduledFor: string,
+  seriesEndDate: string | null,
+): string {
+  return seriesEndDate &&
+    CIVIL_DATE_RE.test(seriesEndDate) &&
+    seriesEndDate >= scheduledFor
+    ? seriesEndDate
+    : scheduledFor;
 }
 
 /** Derive the initial picker state from the occurrence's current recurrence. */
@@ -119,16 +139,25 @@ export function WorkoutRecurrenceEditDialog({
   assignmentId,
   scheduledFor,
   recurrence,
+  seriesEndDate,
   onSaved,
 }: WorkoutRecurrenceEditDialogProps) {
   const seed = useMemo(
     () => seedFromRecurrence(recurrence, scheduledFor),
     [recurrence, scheduledFor],
   );
+  const initialEndDate = useMemo(
+    () => initialEndDateForSeries(scheduledFor, seriesEndDate),
+    [scheduledFor, seriesEndDate],
+  );
   const [mode, setMode] = useState<Mode>(seed.mode);
   const [weekdays, setWeekdays] = useState<Set<number>>(seed.weekdays);
   const [everyN, setEveryN] = useState<number>(seed.everyN);
   const [everyNDraft, setEveryNDraft] = useState<string>(String(seed.everyN));
+  const [endDate, setEndDate] = useState<string>(initialEndDate);
+  const [endPresetMonths, setEndPresetMonths] = useState<number | null>(() =>
+    inferEndDatePresetMonths(scheduledFor, initialEndDate),
+  );
   const [pending, setPending] = useState(false);
 
   function toggleWeekday(idx: number) {
@@ -163,10 +192,19 @@ export function WorkoutRecurrenceEditDialog({
       toast.error("Elegí al menos un día de la semana.");
       return;
     }
+    if (!CIVIL_DATE_RE.test(endDate)) {
+      toast.error("Elegí una fecha de fin válida.");
+      return;
+    }
+    if (endDate < scheduledFor) {
+      toast.error("La fecha de fin debe ser igual o posterior a esta fecha.");
+      return;
+    }
     setPending(true);
     try {
       const result = await editAssignmentRecurrence(assignmentId, {
         recurrence: rule,
+        endDate,
       });
       toast.success(
         `Recurrencia actualizada · ${result.createdCount} ${
@@ -279,6 +317,52 @@ export function WorkoutRecurrenceEditDialog({
               </div>
             </div>
           ) : null}
+
+          <div className="flex flex-col gap-1.5">
+            <label className="text-sm font-medium" htmlFor="recur-end-date">
+              Fecha de fin
+            </label>
+            <div className="flex flex-wrap gap-2">
+              {END_DATE_PRESET_MONTHS.map((months) => {
+                const presetDate = addCivilMonths(scheduledFor, months);
+                const active =
+                  endPresetMonths === months && endDate === presetDate;
+                return (
+                  <Button
+                    key={months}
+                    type="button"
+                    variant={active ? "default" : "outline"}
+                    size="sm"
+                    className="rounded-full"
+                    aria-pressed={active}
+                    onClick={() => {
+                      setEndPresetMonths(months);
+                      setEndDate(presetDate);
+                    }}
+                  >
+                    {months} meses
+                  </Button>
+                );
+              })}
+            </div>
+            <input
+              id="recur-end-date"
+              type="date"
+              value={endDate}
+              min={scheduledFor}
+              onChange={(event) => {
+                const next = event.target.value;
+                setEndDate(next);
+                setEndPresetMonths(
+                  inferEndDatePresetMonths(scheduledFor, next),
+                );
+              }}
+              className="h-10 rounded-md border bg-background px-3 text-sm"
+            />
+            <p className="text-xs text-muted-foreground">
+              Se reprograma hasta esta fecha inclusive.
+            </p>
+          </div>
 
           {mode === "monthly" ? (
             <p className="text-xs text-muted-foreground">

--- a/backoffice/src/lib/app-version.ts
+++ b/backoffice/src/lib/app-version.ts
@@ -1,1 +1,1 @@
-export const BACKOFFICE_VERSION = "2.248";
+export const BACKOFFICE_VERSION = "2.249";

--- a/backoffice/src/lib/gc-fitness/__tests__/workout-assignment-actions.recurrence.test.ts
+++ b/backoffice/src/lib/gc-fitness/__tests__/workout-assignment-actions.recurrence.test.ts
@@ -191,6 +191,63 @@ describe("editAssignmentRecurrence", () => {
     expect(result).toEqual({ ok: true, removedCount: 3, createdCount: 2 });
   });
 
+  it("uses endDate to extend the edited recurrence window", async () => {
+    mockedGetTokens.mockResolvedValue(fakeTokens());
+    mockGet.mockResolvedValue(anchorSnap());
+    mockQueryGet.mockResolvedValue(monWedFriSeriesDocs());
+
+    const result = await editAssignmentRecurrence("asg-1", {
+      recurrence: { kind: "weekly_days", weekdays: [1, 5] },
+      endDate: "2026-06-29",
+    });
+
+    expect(mockBatchDelete).toHaveBeenCalledTimes(3);
+    const newDates = mockBatchSet.mock.calls
+      .map((c) => c[1].scheduledFor)
+      .sort();
+    expect(newDates).toEqual([
+      "2026-06-15",
+      "2026-06-19",
+      "2026-06-22",
+      "2026-06-26",
+      "2026-06-29",
+    ]);
+    expect(result).toEqual({ ok: true, removedCount: 3, createdCount: 5 });
+  });
+
+  it("uses endDate to shorten the edited recurrence window", async () => {
+    mockedGetTokens.mockResolvedValue(fakeTokens());
+    mockGet.mockResolvedValue(anchorSnap());
+    mockQueryGet.mockResolvedValue(monWedFriSeriesDocs());
+
+    const result = await editAssignmentRecurrence("asg-1", {
+      recurrence: { kind: "weekly_days", weekdays: [1, 5] },
+      endDate: "2026-06-15",
+    });
+
+    expect(mockBatchDelete).toHaveBeenCalledTimes(3);
+    const newDates = mockBatchSet.mock.calls
+      .map((c) => c[1].scheduledFor)
+      .sort();
+    expect(newDates).toEqual(["2026-06-15"]);
+    expect(result).toEqual({ ok: true, removedCount: 3, createdCount: 1 });
+  });
+
+  it("rejects endDate before the edited occurrence date", async () => {
+    mockedGetTokens.mockResolvedValue(fakeTokens());
+    mockGet.mockResolvedValue(anchorSnap());
+
+    await expect(
+      editAssignmentRecurrence("asg-1", {
+        recurrence: { kind: "daily" },
+        endDate: "2026-06-14",
+      }),
+    ).rejects.toThrow(/endDate must be on or after/i);
+    expect(mockQueryGet).not.toHaveBeenCalled();
+    expect(mockBatchSet).not.toHaveBeenCalled();
+    expect(mockBatchDelete).not.toHaveBeenCalled();
+  });
+
   it("new doc ids follow asg-{clientId}-{YYYYMMDD}-{uuid}", async () => {
     mockedGetTokens.mockResolvedValue(fakeTokens());
     mockGet.mockResolvedValue(anchorSnap());

--- a/backoffice/src/lib/gc-fitness/schedule-month-actions.ts
+++ b/backoffice/src/lib/gc-fitness/schedule-month-actions.ts
@@ -27,6 +27,7 @@ import { FirestoreCollections } from "./collections";
 import { civilDateFormat } from "./civil-date";
 import { coachVisibleClientName } from "./client-name";
 import { resolveExerciseDocsById } from "./exercise-resolution";
+import { CIVIL_DATE_REGEX } from "./workout-assignment-schema";
 import {
   coerceLegacyHabitLogValue,
   logCountsAsCompleted,
@@ -260,6 +261,7 @@ export interface AssignmentDetail {
   meetingNotes: string | null;
   seriesId: string | null;
   recurrence: Record<string, unknown> | null;
+  seriesEndDate: string | null;
   exercises: AssignmentExercise[];
   /**
    * The client's MOST RECENT completed set values, per exerciseId — used by the
@@ -332,6 +334,28 @@ export async function getAssignmentDetail(id: string): Promise<AssignmentDetail>
   const templateTag =
     typeof snapshot.tag === "string" ? snapshot.tag : null;
   const exercises = Array.isArray(snapshot.exercises) ? snapshot.exercises : [];
+  const seriesId = typeof data.seriesId === "string" ? data.seriesId : null;
+  let seriesEndDate: string | null = null;
+  if (seriesId) {
+    // Recurring workout series are write-capped in the assignment actions
+    // (MAX_RECURRING_OCCURRENCES), so reading the sibling docs here is bounded.
+    const seriesSnap = await db
+      .collection(ASSIGNMENTS)
+      .where("trainerId", "==", trainer.uid)
+      .where("seriesId", "==", seriesId)
+      .get();
+    for (const seriesDoc of seriesSnap.docs) {
+      const seriesData = seriesDoc.data() as { scheduledFor?: unknown };
+      const scheduledFor =
+        typeof seriesData.scheduledFor === "string"
+          ? seriesData.scheduledFor
+          : "";
+      if (!CIVIL_DATE_REGEX.test(scheduledFor)) continue;
+      if (!seriesEndDate || scheduledFor > seriesEndDate) {
+        seriesEndDate = scheduledFor;
+      }
+    }
+  }
   const exerciseIds = exercises
     .map((exercise) => exercise.exerciseId)
     .filter((id): id is string => typeof id === "string" && id.length > 0);
@@ -359,12 +383,12 @@ export async function getAssignmentDetail(id: string): Promise<AssignmentDetail>
     templateTag,
     meetingNotes:
       typeof data.meetingNotes === "string" ? data.meetingNotes : null,
-    seriesId:
-      typeof data.seriesId === "string" ? data.seriesId : null,
+    seriesId,
     recurrence:
       data.recurrence && typeof data.recurrence === "object"
         ? (data.recurrence as Record<string, unknown>)
         : null,
+    seriesEndDate,
     exercises: exercises.map((ex, idx) => {
       const exId = typeof ex.exerciseId === "string" ? ex.exerciseId : "";
       const source = exerciseMap.get(exId);

--- a/backoffice/src/lib/gc-fitness/workout-assignment-actions.ts
+++ b/backoffice/src/lib/gc-fitness/workout-assignment-actions.ts
@@ -1949,9 +1949,9 @@ export async function editAssignmentExercises(
 //                  occurrences, so the cutoff is today-or-future in practice.
 //   seriesStart  = earliest scheduledFor in the series — the anchor that keeps
 //                  every_n_days phase stable across the edit.
-//   windowEnd    = latest scheduledFor in the series — preserves the original
-//                  horizon (no endDate is persisted on the docs, so the existing
-//                  span IS the source of truth for "how far out").
+//   windowEnd    = input endDate when provided, otherwise latest scheduledFor in
+//                  the series — preserving the original horizon for legacy
+//                  callers.
 //
 // Past / started / completed / missed docs are never touched (status filter,
 // exactly like the cascade delete). Per-occurrence exercise edits on future
@@ -1962,6 +1962,13 @@ export async function editAssignmentExercises(
 // unchanged prescription does NOT reset the client's per-exercise weight prefill.
 const editAssignmentRecurrenceSchema = z.object({
   recurrence: recurrenceSchema,
+  endDate: z
+    .string()
+    .regex(
+      CIVIL_DATE_REGEX,
+      "endDate must be a 'YYYY-MM-DD' civil-date string.",
+    )
+    .optional(),
 });
 
 export async function editAssignmentRecurrence(
@@ -2007,6 +2014,9 @@ export async function editAssignmentRecurrence(
   if (!CIVIL_DATE_REGEX.test(cutoff)) {
     throw new Error("Assignment is missing a valid scheduled date.");
   }
+  if (input.endDate && input.endDate < cutoff) {
+    throw new Error("endDate must be on or after the edited occurrence date.");
+  }
 
   // Load the whole series for this trainer to derive the original window AND the
   // set of future-scheduled docs to replace.
@@ -2037,12 +2047,14 @@ export async function editAssignmentRecurrence(
     }
   }
 
-  // Re-expand the NEW rule over the original span, anchored at the series start
-  // (keeps every_n_days phase), then keep only dates at/after the cutoff.
+  // Re-expand the NEW rule over the selected span, anchored at the series start
+  // (keeps every_n_days phase), then keep only dates at/after the cutoff. When
+  // omitted, preserve the existing series horizon for legacy callers.
+  const nextWindowEnd = input.endDate ?? windowEnd;
   const newDates = expandRecurrenceDates(
     recurrence,
     seriesStart,
-    windowEnd,
+    nextWindowEnd,
   ).filter((date) => date >= cutoff);
   if (newDates.length === 0) {
     throw new Error(


### PR DESCRIPTION
## Summary

- Adds an editable end date to the GC Fitness workout recurrence edit dialog.
- Allows trainers to shorten or extend recurring workout series from the selected occurrence onward.
- Updates the recurrence edit server action to use the selected end date when re-expanding future scheduled assignments.
- Keeps past, completed, missed, and started occurrences untouched.

## Screenshot

<img width="914" height="652" alt="Screenshot 2026-07-13 at 1 03 21 PM" src="https://github.com/user-attachments/assets/769fab68-3adb-4740-a60a-7bf11fc95230" />
