### PR TITLE
Hide orphaned users from admin search

### DIFF
--- a/backoffice/src/lib/app-version.ts
+++ b/backoffice/src/lib/app-version.ts
@@ -1,1 +1,1 @@
-export const BACKOFFICE_VERSION = "2.249";
+export const BACKOFFICE_VERSION = "2.250";

--- a/backoffice/src/lib/gc-fitness/__tests__/admin-user-search.test.ts
+++ b/backoffice/src/lib/gc-fitness/__tests__/admin-user-search.test.ts
@@ -211,12 +211,40 @@ describe("searchUsersByEmailForAdmin", () => {
     ]);
   });
 
-  it("does not throw when getUser fails for a doc (tolerant role merge)", async () => {
+  it("filters orphaned user docs when Firebase Auth says the uid is missing", async () => {
+    const docs = [
+      mockDoc("uid-orphan", {
+        email: "duplicate@example.com",
+        displayName: "Ghost Client",
+        role: "client",
+      }),
+      mockDoc("uid-live", {
+        email: "duplicate@example.com",
+        displayName: "Live Client",
+        role: "client",
+      }),
+    ];
+    mockGet.mockResolvedValueOnce({ docs });
+    mockGetUser.mockImplementation((uid: string) => {
+      if (uid === "uid-orphan") {
+        return Promise.reject({ code: "auth/user-not-found" });
+      }
+      return Promise.resolve({ customClaims: {} });
+    });
+
+    const rows = await searchUsersByEmailForAdmin("duplicate@example.com");
+
+    expect(rows).toHaveLength(1);
+    expect(rows[0].uid).toBe("uid-live");
+    expect(rows[0].displayName).toBe("Live Client");
+  });
+
+  it("does not throw on non-not-found getUser failures (tolerant role merge)", async () => {
     const docs = [
       mockDoc("uid-x", { email: "x@example.com", displayName: "X", role: "trainer" }),
     ];
     mockGet.mockResolvedValueOnce({ docs });
-    mockGetUser.mockRejectedValueOnce(new Error("auth/user-not-found"));
+    mockGetUser.mockRejectedValueOnce(new Error("auth/network-request-failed"));
 
     const rows = await searchUsersByEmailForAdmin("x");
     expect(rows).toHaveLength(1);

--- a/backoffice/src/lib/gc-fitness/admin-actions.ts
+++ b/backoffice/src/lib/gc-fitness/admin-actions.ts
@@ -127,6 +127,14 @@ function rolesFromClaims(claims: Record<string, unknown> | undefined): string[] 
   return Array.from(result);
 }
 
+function isAuthUserNotFound(error: unknown): boolean {
+  if (!error || typeof error !== "object") return false;
+  const code = (error as { code?: unknown }).code;
+  if (code === "auth/user-not-found") return true;
+  const message = (error as { message?: unknown }).message;
+  return typeof message === "string" && message.includes("auth/user-not-found");
+}
+
 export async function listCoachesForAdmin(): Promise<CoachAdminRow[]> {
   await getCurrentAdmin();
   const db = gcFitnessFirestore();
@@ -215,11 +223,17 @@ export async function searchUsersByEmailForAdmin(
 
   // (4) Map each doc; merge doc.role with claim roles. Tolerant — a single bad
   // doc never throws (missing field → "" / null / false; getUser failure → []).
-  const rows = await Promise.all(
+  const rowsWithOrphans = await Promise.all(
     matches.map(async (doc) => {
       const data = doc.data() as Record<string, unknown>;
       const uid = doc.id;
-      const authUser = await gcFitnessAuth().getUser(uid).catch(() => null);
+      const authUser = await gcFitnessAuth().getUser(uid).catch((error) => {
+        if (isAuthUserNotFound(error)) return "not-found" as const;
+        return null;
+      });
+      if (authUser === "not-found") {
+        return null;
+      }
 
       const roles = new Set<string>(
         rolesFromClaims(authUser?.customClaims as Record<string, unknown> | undefined),
@@ -239,6 +253,10 @@ export async function searchUsersByEmailForAdmin(
         coachId: typeof data.coachId === "string" ? data.coachId : null,
       } satisfies UserSearchResultRow;
     }),
+  );
+
+  const rows = rowsWithOrphans.filter(
+    (row): row is UserSearchResultRow => row !== null,
   );
 
   rows.sort((a, b) => a.email.localeCompare(b.email));


### PR DESCRIPTION
## Summary

- Hides orphaned Firestore `/users/{uid}` docs from the GC Fitness admin user search when the UID no longer exists in Firebase Auth.
- Aligns `/gc-fitness/admin/users` with the existing “My clients” roster behavior, which already filters out Auth-missing user docs.
- Adds regression coverage for duplicated emails where one UID is orphaned, while keeping non-`user-not-found` Auth failures fail-open/tolerant.

## Manual QA

Not manually tested in the browser because this flow requires a GC Fitness admin account/claim. A coach/trainer account cannot access `/gc-fitness/admin/users`.