### PR TITLE
feat(compare-photos): before/after picker guards + elapsed labels (#435) [backoffice]

### DIFF
--- a/backoffice/src/app/gc-fitness/clients/[id]/compare-photos/photo-compare-editor.tsx
+++ b/backoffice/src/app/gc-fitness/clients/[id]/compare-photos/photo-compare-editor.tsx
@@ -9,7 +9,14 @@ import type { ProgressPhotoRow } from "@/lib/gc-fitness/progress-photo-actions";
 import {
   formatClientActivityFullDate,
 } from "@/lib/gc-fitness/client-activity-time";
-import { formatCivilDateLabel } from "@/lib/gc-fitness/civil-date";
+import {
+  civilDateFormat,
+  formatCivilDateLabel,
+  parseCivilYMD,
+  photoCompareElapsed,
+  type CivilYMD,
+  type PhotoCompareElapsed,
+} from "@/lib/gc-fitness/civil-date";
 
 type Angle = "front" | "side" | "back";
 type Transform = { scale: number; x: number; y: number };
@@ -44,6 +51,32 @@ export function ProgressPhotoCompareEditor({
 
   const before = angled.find((p) => p.id === beforeId);
   const after = angled.find((p) => p.id === afterId);
+
+  // `angled` is sorted newest→oldest (the loader sorts descending by
+  // checkInDate), so the first entry is the most recent photo and the last is
+  // the oldest. The picker forbids picking the newest as "before" and the
+  // oldest as "after" (issue #435 rules 3 & 4) and forbids an "after" that is
+  // not strictly later than the selected "before" (rule 1).
+  const newestId = angled[0]?.id;
+  const oldestId = angled[angled.length - 1]?.id;
+  const beforeYMD = before ? photoYMD(before, timezone) : null;
+
+  // Selecting "before" can invalidate the current "after" (e.g. before moves
+  // past after). Snap after back to the newest photo so the pair always stays
+  // before < after. The newest is always a valid "after" because it can never
+  // be the "before" (it is disabled in the before picker).
+  function selectBefore(nextBeforeId: string) {
+    setBeforeId(nextBeforeId);
+    const nextBefore = angled.find((p) => p.id === nextBeforeId);
+    const nextBeforeYMD = nextBefore ? photoYMD(nextBefore, timezone) : null;
+    const afterYMD = after ? photoYMD(after, timezone) : null;
+    const stillValid =
+      afterId !== oldestId &&
+      nextBeforeYMD != null &&
+      afterYMD != null &&
+      photoCompareElapsed(nextBeforeYMD, afterYMD) != null;
+    if (!stillValid && newestId) setAfterId(newestId);
+  }
   const downloadFileName = before && after
     ? buildCompareDownloadName({
         clientName,
@@ -96,11 +129,28 @@ export function ProgressPhotoCompareEditor({
         >
           <option value="front">Front</option><option value="side">Side</option><option value="back">Back</option>
         </select>
-        <select className="h-10 rounded-md border px-2" value={beforeId} onChange={(e) => setBeforeId(e.target.value)}>
-          <option value="">Before</option>{angled.map((p) => <option key={p.id} value={p.id}>{photoDisplayDate(p, timezone, locale)}</option>)}
+        <select className="h-10 rounded-md border px-2" value={beforeId} onChange={(e) => selectBefore(e.target.value)}>
+          <option value="">Before</option>
+          {angled.map((p) => (
+            <option key={p.id} value={p.id} disabled={p.id === newestId}>
+              {photoDisplayDate(p, timezone, locale)}
+            </option>
+          ))}
         </select>
         <select className="h-10 rounded-md border px-2" value={afterId} onChange={(e) => setAfterId(e.target.value)}>
-          <option value="">After</option>{angled.map((p) => <option key={p.id} value={p.id}>{photoDisplayDate(p, timezone, locale)}</option>)}
+          <option value="">After</option>
+          {angled.map((p) => {
+            const elapsed = beforeYMD ? elapsedFromBefore(beforeYMD, p, timezone) : null;
+            const disabled = p.id === oldestId || elapsed === null;
+            const label = elapsed
+              ? `${photoDisplayDate(p, timezone, locale)} (${formatElapsed(elapsed, locale)})`
+              : photoDisplayDate(p, timezone, locale);
+            return (
+              <option key={p.id} value={p.id} disabled={disabled}>
+                {label}
+              </option>
+            );
+          })}
         </select>
       </div>
       {before?.url && after?.url ? (
@@ -212,6 +262,49 @@ function CompareStaticImage({ url, alt, date }: { url: string; alt: string; date
       </div>
     </div>
   );
+}
+
+/** The civil day (Y/M/D) a photo belongs to — its `checkInDate` when present,
+ * else the timezone-resolved `takenAt`/`createdAt` instant. Feeds the
+ * before/after elapsed calc. */
+function photoYMD(photo: ProgressPhotoRow, timezone: string): CivilYMD | null {
+  if (photo.checkInDate) return parseCivilYMD(photo.checkInDate);
+  const source = photo.takenAt ?? photo.createdAt;
+  if (!source) return null;
+  const date = new Date(source);
+  if (Number.isNaN(date.getTime())) return null;
+  return parseCivilYMD(civilDateFormat(date, timezone));
+}
+
+/** Elapsed span from the selected "before" YMD to a candidate "after" photo,
+ * or null when the candidate is not strictly later (→ not selectable as after). */
+function elapsedFromBefore(
+  beforeYMD: CivilYMD,
+  photo: ProgressPhotoRow,
+  timezone: string,
+): PhotoCompareElapsed | null {
+  const ymd = photoYMD(photo, timezone);
+  return ymd ? photoCompareElapsed(beforeYMD, ymd) : null;
+}
+
+/** Renders an elapsed span as a short parenthetical: "1 mes", "~2 meses",
+ * "3 semanas", "5 días" (es) / "1 month", "~2 months" … (en). Twin of the
+ * iOS `compare.elapsed.*` / Android `compare_elapsed_*` string tables. */
+function formatElapsed(elapsed: PhotoCompareElapsed, locale: string): string {
+  const es = locale.toLowerCase().startsWith("es");
+  const one = elapsed.value === 1;
+  const unitWord = es
+    ? elapsed.unit === "month"
+      ? one ? "mes" : "meses"
+      : elapsed.unit === "week"
+        ? one ? "semana" : "semanas"
+        : one ? "día" : "días"
+    : elapsed.unit === "month"
+      ? one ? "month" : "months"
+      : elapsed.unit === "week"
+        ? one ? "week" : "weeks"
+        : one ? "day" : "days";
+  return `${elapsed.approximate ? "~" : ""}${elapsed.value} ${unitWord}`;
 }
 
 function photoDisplayDate(photo: ProgressPhotoRow, timezone: string, locale: string): string {

--- a/backoffice/src/lib/gc-fitness/__tests__/civil-date.test.ts
+++ b/backoffice/src/lib/gc-fitness/__tests__/civil-date.test.ts
@@ -32,6 +32,8 @@ import {
   civilDateFormat,
   civilDateToday,
   formatCivilDateLabel,
+  parseCivilYMD,
+  photoCompareElapsed,
 } from "../civil-date";
 
 // Shared fixture epochs (seconds).
@@ -142,6 +144,51 @@ describe("formatCivilDateLabel(civilDate, options)", () => {
 
   it("returns the original string for malformed civil dates", () => {
     expect(formatCivilDateLabel("not-a-date")).toBe("not-a-date");
+  });
+});
+
+// photoCompareElapsed — twin of PhotoCompareElapsedTests.swift /
+// PhotoCompareElapsedTest.kt.
+//
+// SHARED CROSS-SURFACE FIXTURES: these before→after pairs and their expected
+// {value, unit, approximate} are referenced verbatim by the Swift and Kotlin
+// twins. Change one, change all three in the same PR.
+//
+//   before      | after       | expected
+//   ------------|-------------|-------------------------------
+//   2026-03-01  | 2026-04-01  | 1 month  exact   ("1 mes")
+//   2026-03-01  | 2026-05-20  | 2 months approx  ("~2 meses")
+//   2026-01-31  | 2026-03-31  | 2 months exact
+//   2026-01-31  | 2026-02-28  | 4 weeks  exact   (28d, month decremented)
+//   2026-03-01  | 2026-03-15  | 2 weeks  exact   (14d)
+//   2026-03-01  | 2026-03-10  | 1 week   approx  (9d)
+//   2026-03-01  | 2026-03-06  | 5 days   exact
+//   2026-03-01  | 2026-03-01  | null (same day)
+//   2026-04-01  | 2026-03-01  | null (after < before)
+//   2025-12-15  | 2026-01-10  | 3 weeks  approx  (26d, year boundary)
+describe("photoCompareElapsed", () => {
+  const ymd = (s: string) => parseCivilYMD(s)!;
+  const cases: Array<[string, string, ReturnType<typeof photoCompareElapsed>]> = [
+    ["2026-03-01", "2026-04-01", { value: 1, unit: "month", approximate: false }],
+    ["2026-03-01", "2026-05-20", { value: 2, unit: "month", approximate: true }],
+    ["2026-01-31", "2026-03-31", { value: 2, unit: "month", approximate: false }],
+    ["2026-01-31", "2026-02-28", { value: 4, unit: "week", approximate: false }],
+    ["2026-03-01", "2026-03-15", { value: 2, unit: "week", approximate: false }],
+    ["2026-03-01", "2026-03-10", { value: 1, unit: "week", approximate: true }],
+    ["2026-03-01", "2026-03-06", { value: 5, unit: "day", approximate: false }],
+    ["2026-03-01", "2026-03-01", null],
+    ["2026-04-01", "2026-03-01", null],
+    ["2025-12-15", "2026-01-10", { value: 3, unit: "week", approximate: true }],
+  ];
+  it.each(cases)("%s → %s", (before, after, expected) => {
+    expect(photoCompareElapsed(ymd(before), ymd(after))).toEqual(expected);
+  });
+
+  it("parseCivilYMD rejects malformed strings", () => {
+    expect(parseCivilYMD("not-a-date")).toBeNull();
+    expect(parseCivilYMD("2026-13-01")).toBeNull();
+    expect(parseCivilYMD("2026-01-32")).toBeNull();
+    expect(parseCivilYMD("2026-03-01")).toEqual({ year: 2026, month: 3, day: 1 });
   });
 });
 

--- a/backoffice/src/lib/gc-fitness/civil-date.ts
+++ b/backoffice/src/lib/gc-fitness/civil-date.ts
@@ -98,6 +98,100 @@ export function formatCivilDateLabel(
   }
 }
 
+// MARK: - Photo-comparator elapsed span (twin of PhotoCompareElapsed.swift /
+//         PhotoCompareElapsed.kt)
+//
+// SAME-SOURCE-OF-TRUTH CONTRACT: any behavioral change to `photoCompareElapsed`
+// (or `daysFromCivil`) MUST be matched in:
+//   gc-fitness/iOS/Packages/GCFitnessCore/Sources/GCFitnessCore/Schema/PhotoCompareElapsed.swift
+//   gc-fitness/android/core/src/main/kotlin/com/goldencrow/fitness/core/schema/PhotoCompareElapsed.kt
+// and the shared fixture block in the three test files must keep agreeing.
+//
+// Why a shared calculator: the before/after photo picker labels the "after"
+// options with the elapsed time since the selected "before" (e.g. "1 mes",
+// "~2 meses"). iOS, Android and the backoffice must produce the SAME buckets
+// for the same pair of civil days, so the pure math lives in one place per
+// platform.
+
+export type PhotoCompareElapsedUnit = "day" | "week" | "month";
+
+export interface PhotoCompareElapsed {
+  value: number;
+  unit: PhotoCompareElapsedUnit;
+  /** True when the span does not land exactly on the unit boundary (renders a
+   * leading "~"): e.g. 2-months-and-19-days → `{value: 2, unit: "month",
+   * approximate: true}` → "~2 meses". */
+  approximate: boolean;
+}
+
+/** A civil day as its calendar components (proleptic Gregorian). */
+export interface CivilYMD {
+  year: number;
+  month: number;
+  day: number;
+}
+
+/**
+ * Splits a `"YYYY-MM-DD"` civil string into its calendar components, or returns
+ * `null` if the string is not a well-formed civil date. Used by the photo
+ * comparator to feed `photoCompareElapsed`.
+ */
+export function parseCivilYMD(civil: string): CivilYMD | null {
+  const match = /^(\d{4})-(\d{2})-(\d{2})$/.exec(civil);
+  if (!match) return null;
+  const year = Number.parseInt(match[1]!, 10);
+  const month = Number.parseInt(match[2]!, 10);
+  const day = Number.parseInt(match[3]!, 10);
+  if (month < 1 || month > 12 || day < 1 || day > 31) return null;
+  return { year, month, day };
+}
+
+/**
+ * Serial day number for a civil date (days since 1970-01-01), via Howard
+ * Hinnant's `days_from_civil`. Pure integer math — no `Date`, no timezone —
+ * so the three platform twins stay bit-identical.
+ */
+function daysFromCivil({ year, month, day }: CivilYMD): number {
+  const y = month <= 2 ? year - 1 : year;
+  const era = Math.floor((y >= 0 ? y : y - 399) / 400);
+  const yoe = y - era * 400;
+  const doy = Math.floor((153 * (month + (month > 2 ? -3 : 9)) + 2) / 5) + day - 1;
+  const doe = yoe * 365 + Math.floor(yoe / 4) - Math.floor(yoe / 100) + doy;
+  return era * 146097 + doe - 719468;
+}
+
+/**
+ * Elapsed span between two civil days, bucketed to the coarsest sensible unit
+ * (months ≥ 1 → months; else weeks ≥ 1 → weeks; else days).
+ *
+ * Returns `null` when `after` is not strictly after `before` (same day or
+ * earlier) — the picker treats that as "not selectable as the after photo".
+ *
+ * Month counting is calendar-based ("1 mes" for Mar 1 → Apr 1) so it matches a
+ * human reading of the dates rather than a 30-day approximation. `approximate`
+ * is true whenever there is a leftover remainder past the whole unit.
+ */
+export function photoCompareElapsed(
+  before: CivilYMD,
+  after: CivilYMD,
+): PhotoCompareElapsed | null {
+  const beforeSerial = daysFromCivil(before);
+  const afterSerial = daysFromCivil(after);
+  if (afterSerial <= beforeSerial) return null;
+
+  let months = (after.year - before.year) * 12 + (after.month - before.month);
+  if (after.day < before.day) months -= 1;
+  if (months >= 1) {
+    return { value: months, unit: "month", approximate: after.day !== before.day };
+  }
+
+  const days = afterSerial - beforeSerial;
+  if (days >= 7) {
+    return { value: Math.floor(days / 7), unit: "week", approximate: days % 7 !== 0 };
+  }
+  return { value: days, unit: "day", approximate: false };
+}
+
 // MARK: - Helpers
 
 /**


### PR DESCRIPTION
Closes #435 (backoffice side). Apps (iOS + Android) ship in a separate PR on \`gc-fitness\` (#440).

## What
Improves the trainer/admin **Comparador de fotos** before/after `<select>` pickers (`ProgressPhotoCompareEditor`, used by both the coach and admin photo pages):

1. **Before < After enforced** — *After* options earlier than (or equal to) the selected *Before* are disabled.
2. **Elapsed labels** — each *After* option is labelled with the time since *Before*: `1 de abril de 2026 (1 mes)`, `20 de mayo de 2026 (~2 meses)`, etc.
3. **No latest-as-Before** — the most recent photo is disabled in the *Before* picker.
4. **No oldest-as-After** — the oldest photo is disabled in the *After* picker.

Plus: changing *Before* past the current *After* snaps *After* back to the newest photo.

## How
New pure **`photoCompareElapsed`** in `lib/gc-fitness/civil-date.ts` — the TS twin of the Swift/Kotlin calculators shipping in the apps PR (calendar-month counting via Hinnant's `days_from_civil`, shared cross-surface fixtures).

## Tests / gate
- `npx jest` — only the pre-existing `client-activity-time` locale flake fails (green in CI); **all others pass**, incl. 11 new `photoCompareElapsed` cases.
- `npx tsc --noEmit` — clean.
- No backend / rules changes.