### PR TITLE
Add client calendar peek

### DIFF
--- a/backoffice/messages/en.json
+++ b/backoffice/messages/en.json
@@ -365,6 +365,29 @@
         "progressPhotoAlt": "Progress photo",
         "photoAngleFallback": "photo"
       },
+      "calendarPeek": {
+        "title": "Mini calendar",
+        "rangeSummary": "{workouts, plural, one {# workout} other {# workouts}} · {habits, plural, one {# habit} other {# habits}}",
+        "previousWeek": "Previous week",
+        "nextWeek": "Next week",
+        "today": "Today",
+        "openSchedule": "Open schedule",
+        "loading": "Loading schedule...",
+        "loadFailed": "Could not load this week.",
+        "emptyDay": "No workouts or habits",
+        "moreItems": "+{count} more",
+        "workoutStatus": {
+          "scheduled": "scheduled",
+          "started": "in progress",
+          "completed": "done",
+          "missed": "missed"
+        },
+        "habitStatus": {
+          "scheduled": "pending",
+          "done": "done",
+          "missed": "missed"
+        }
+      },
       "goals": {
         "title": "Goals",
         "subtitle": "Short, medium, and long-term goals visible to the client.",

--- a/backoffice/messages/es.json
+++ b/backoffice/messages/es.json
@@ -365,6 +365,29 @@
         "progressPhotoAlt": "Foto de progreso",
         "photoAngleFallback": "foto"
       },
+      "calendarPeek": {
+        "title": "Mini calendario",
+        "rangeSummary": "{workouts, plural, one {# entrenamiento} other {# entrenamientos}} · {habits, plural, one {# hábito} other {# hábitos}}",
+        "previousWeek": "Semana anterior",
+        "nextWeek": "Semana siguiente",
+        "today": "Hoy",
+        "openSchedule": "Abrir agenda",
+        "loading": "Cargando agenda...",
+        "loadFailed": "No se pudo cargar esta semana.",
+        "emptyDay": "Sin entrenamientos ni hábitos",
+        "moreItems": "+{count} más",
+        "workoutStatus": {
+          "scheduled": "programado",
+          "started": "en curso",
+          "completed": "hecho",
+          "missed": "vencido"
+        },
+        "habitStatus": {
+          "scheduled": "pendiente",
+          "done": "hecho",
+          "missed": "vencido"
+        }
+      },
       "goals": {
         "title": "Objetivos",
         "subtitle": "Objetivos de corto, mediano y largo plazo visibles para el cliente.",

--- a/backoffice/src/app/gc-fitness/clients/[id]/_components/ClientCalendarPeek.tsx
+++ b/backoffice/src/app/gc-fitness/clients/[id]/_components/ClientCalendarPeek.tsx
@@ -1,0 +1,333 @@
+"use client";
+
+import Link from "next/link";
+import { useMemo, useState } from "react";
+import { useLocale, useTranslations } from "next-intl";
+import {
+  ArrowUpRight,
+  CalendarDays,
+  CheckCircle2,
+  ChevronLeftIcon,
+  ChevronRightIcon,
+  Circle,
+  Dumbbell,
+  ListChecks,
+  Loader2,
+  XCircle,
+} from "lucide-react";
+
+import {
+  getClientCalendarPeek,
+  type ClientCalendarPeekPayload,
+} from "@/lib/gc-fitness/client-calendar-peek-actions";
+import type {
+  MonthHabitChip,
+  MonthWorkoutChip,
+} from "@/lib/gc-fitness/schedule-month-actions";
+import { formatCivilDateLabel } from "@/lib/gc-fitness/civil-date";
+import { cn } from "@/lib/utils";
+import { Button } from "@/components/ui/button";
+
+const DAY_MS = 86_400_000;
+const MAX_VISIBLE_ITEMS = 4;
+
+type PeekItem =
+  | {
+      id: string;
+      kind: "workout";
+      name: string;
+      status: MonthWorkoutChip["status"];
+      detail: string | null;
+    }
+  | {
+      id: string;
+      kind: "habit";
+      name: string;
+      status: MonthHabitChip["status"];
+      detail: string | null;
+    };
+
+export function ClientCalendarPeek({
+  clientId,
+  initialPayload,
+}: {
+  clientId: string;
+  initialPayload: ClientCalendarPeekPayload;
+}) {
+  const locale = useLocale();
+  const t = useTranslations("clients.detail.calendarPeek");
+  const [peek, setPeek] = useState(initialPayload);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const days = useMemo(
+    () => civilDaysInRange(peek.startCivil, peek.endCivil),
+    [peek.startCivil, peek.endCivil],
+  );
+  const totals = useMemo(
+    () =>
+      days.reduce(
+        (acc, day) => {
+          acc.workouts += peek.calendar.workoutsByDay[day]?.length ?? 0;
+          acc.habits += peek.calendar.habitsByDay[day]?.length ?? 0;
+          return acc;
+        },
+        { workouts: 0, habits: 0 },
+      ),
+    [days, peek.calendar.habitsByDay, peek.calendar.workoutsByDay],
+  );
+
+  const scheduleHref = `/gc-fitness/schedule?month=${peek.anchorCivil.slice(
+    0,
+    7,
+  )}&clientIds=${encodeURIComponent(clientId)}`;
+
+  async function loadAnchor(anchorCivil: string) {
+    setLoading(true);
+    setError(null);
+    try {
+      const next = await getClientCalendarPeek({ clientId, anchorCivil });
+      setPeek(next);
+    } catch {
+      setError(t("loadFailed"));
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <section className="rounded-xl border bg-card p-4">
+      <div className="mb-4 flex flex-col gap-3 lg:flex-row lg:items-start lg:justify-between">
+        <div className="min-w-0">
+          <h2 className="flex items-center gap-2 font-medium">
+            <CalendarDays className="size-4" />
+            {t("title")}
+          </h2>
+          <p className="text-sm text-muted-foreground">
+            {formatRange(peek.startCivil, peek.endCivil, locale)} ·{" "}
+            {t("rangeSummary", totals)}
+          </p>
+        </div>
+
+        <div className="flex flex-wrap items-center gap-2">
+          <div className="flex items-center gap-1 rounded-full border bg-background p-1">
+            <Button
+              type="button"
+              variant="ghost"
+              size="icon"
+              className="size-8 rounded-full"
+              disabled={loading}
+              onClick={() => void loadAnchor(addCivilDays(peek.anchorCivil, -7))}
+              aria-label={t("previousWeek")}
+              title={t("previousWeek")}
+            >
+              <ChevronLeftIcon className="size-4" />
+            </Button>
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              className="h-8 rounded-full px-3"
+              disabled={loading || peek.anchorCivil === peek.todayCivil}
+              onClick={() => void loadAnchor(peek.todayCivil)}
+            >
+              {t("today")}
+            </Button>
+            <Button
+              type="button"
+              variant="ghost"
+              size="icon"
+              className="size-8 rounded-full"
+              disabled={loading}
+              onClick={() => void loadAnchor(addCivilDays(peek.anchorCivil, 7))}
+              aria-label={t("nextWeek")}
+              title={t("nextWeek")}
+            >
+              <ChevronRightIcon className="size-4" />
+            </Button>
+          </div>
+
+          <Button variant="outline" size="sm" className="h-9 rounded-full" asChild>
+            <Link href={scheduleHref}>
+              {t("openSchedule")}
+              <ArrowUpRight className="ml-1.5 size-3.5" />
+            </Link>
+          </Button>
+        </div>
+      </div>
+
+      {loading ? (
+        <div className="mb-3 flex items-center gap-2 text-xs text-muted-foreground">
+          <Loader2 className="size-3.5 animate-spin" />
+          {t("loading")}
+        </div>
+      ) : null}
+
+      {error ? (
+        <div className="mb-3 rounded-md border border-destructive/30 bg-destructive/10 px-3 py-2 text-sm text-destructive">
+          {error}
+        </div>
+      ) : null}
+
+      <div className="overflow-x-auto pb-1">
+        <div className="grid min-w-[780px] grid-cols-7 gap-2 xl:min-w-0">
+          {days.map((day) => {
+            const workouts = peek.calendar.workoutsByDay[day] ?? [];
+            const habits = peek.calendar.habitsByDay[day] ?? [];
+            const items = buildItems(workouts, habits, t);
+            const visibleItems = items.slice(0, MAX_VISIBLE_ITEMS);
+            const hiddenCount = Math.max(0, items.length - visibleItems.length);
+            const isToday = day === peek.todayCivil;
+
+            return (
+              <div
+                key={day}
+                className={cn(
+                  "flex min-h-48 flex-col rounded-lg border bg-background p-2",
+                  isToday && "border-primary bg-primary/5",
+                )}
+              >
+                <div className="mb-2 flex items-start justify-between gap-2">
+                  <div className="min-w-0">
+                    <p className="truncate text-xs text-muted-foreground">
+                      {formatCivilDateLabel(day, { weekday: "short" }, locale)}
+                    </p>
+                    <p className="text-base font-semibold tabular-nums">
+                      {day.slice(8, 10)}
+                    </p>
+                  </div>
+                  {isToday ? (
+                    <span className="rounded-full bg-primary px-2 py-0.5 text-[10px] font-medium text-primary-foreground">
+                      {t("today")}
+                    </span>
+                  ) : null}
+                </div>
+
+                {visibleItems.length === 0 ? (
+                  <div className="flex flex-1 items-center justify-center rounded-md border border-dashed px-2 text-center text-xs text-muted-foreground">
+                    {t("emptyDay")}
+                  </div>
+                ) : (
+                  <div className="flex flex-1 flex-col gap-1.5">
+                    {visibleItems.map((item) => (
+                      <PeekItemRow key={item.id} item={item} />
+                    ))}
+                    {hiddenCount > 0 ? (
+                      <p className="px-1 text-[11px] text-muted-foreground">
+                        {t("moreItems", { count: hiddenCount })}
+                      </p>
+                    ) : null}
+                  </div>
+                )}
+              </div>
+            );
+          })}
+        </div>
+      </div>
+    </section>
+  );
+}
+
+function PeekItemRow({ item }: { item: PeekItem }) {
+  const Icon = itemIcon(item);
+  return (
+    <div
+      className={cn(
+        "flex min-w-0 items-start gap-1.5 rounded-md border px-2 py-1.5 text-[11px]",
+        itemClassName(item),
+      )}
+    >
+      <Icon className="mt-0.5 size-3.5 shrink-0" />
+      <div className="min-w-0">
+        <p className="truncate font-medium">{item.name}</p>
+        {item.detail ? (
+          <p className="truncate text-[10px] opacity-75">{item.detail}</p>
+        ) : null}
+      </div>
+    </div>
+  );
+}
+
+function buildItems(
+  workouts: MonthWorkoutChip[],
+  habits: MonthHabitChip[],
+  t: ReturnType<typeof useTranslations>,
+): PeekItem[] {
+  return [
+    ...workouts.map((workout): PeekItem => ({
+      id: `workout:${workout.id}`,
+      kind: "workout",
+      name: workout.templateName,
+      status: workout.status,
+      detail: workout.templateTag
+        ? `${t(`workoutStatus.${workout.status}`)} · ${workout.templateTag}`
+        : t(`workoutStatus.${workout.status}`),
+    })),
+    ...habits.map((habit): PeekItem => ({
+      id: `habit:${habit.id}`,
+      kind: "habit",
+      name: habit.habitName,
+      status: habit.status,
+      detail: t(`habitStatus.${habit.status}`),
+    })),
+  ];
+}
+
+function itemIcon(item: PeekItem) {
+  if (item.status === "completed" || item.status === "done") return CheckCircle2;
+  if (item.status === "missed") return XCircle;
+  if (item.kind === "workout") return Dumbbell;
+  if (item.status === "scheduled") return Circle;
+  return ListChecks;
+}
+
+function itemClassName(item: PeekItem): string {
+  if (item.status === "completed" || item.status === "done") {
+    return "border-emerald-500/40 bg-emerald-500/10 text-emerald-900 dark:text-emerald-200";
+  }
+  if (item.status === "missed") {
+    return "border-rose-400/40 bg-rose-500/10 text-rose-900 dark:text-rose-200";
+  }
+  if (item.status === "started") {
+    return "border-sky-500/40 bg-sky-500/10 text-sky-900 dark:text-sky-200";
+  }
+  return "border-border bg-muted/40 text-foreground";
+}
+
+function civilDaysInRange(startCivil: string, endCivil: string): string[] {
+  const days: string[] = [];
+  for (
+    let day = startCivil;
+    day <= endCivil && days.length < 14;
+    day = addCivilDays(day, 1)
+  ) {
+    days.push(day);
+  }
+  return days;
+}
+
+function addCivilDays(civilDate: string, days: number): string {
+  return formatCivilDate(
+    new Date(parseCivilDate(civilDate).getTime() + days * DAY_MS),
+  );
+}
+
+function formatRange(startCivil: string, endCivil: string, locale: string): string {
+  return `${formatCivilDateLabel(startCivil, { day: "numeric", month: "short" }, locale)} - ${formatCivilDateLabel(
+    endCivil,
+    { day: "numeric", month: "short" },
+    locale,
+  )}`;
+}
+
+function parseCivilDate(civilDate: string): Date {
+  const [year, month, day] = civilDate.split("-").map(Number);
+  return new Date(Date.UTC(year, month - 1, day));
+}
+
+function formatCivilDate(date: Date): string {
+  const year = date.getUTCFullYear();
+  const month = String(date.getUTCMonth() + 1).padStart(2, "0");
+  const day = String(date.getUTCDate()).padStart(2, "0");
+  return `${year}-${month}-${day}`;
+}

--- a/backoffice/src/app/gc-fitness/clients/[id]/page.tsx
+++ b/backoffice/src/app/gc-fitness/clients/[id]/page.tsx
@@ -48,12 +48,14 @@ import ClientRequestActionsCard from "./_components/ClientRequestActionsCard";
 import { listClientGoals } from "@/lib/gc-fitness/client-goal-actions";
 import { getClientNotes } from "@/lib/gc-fitness/client-notes-actions";
 import { listProgressPhotosForClient } from "@/lib/gc-fitness/progress-photo-actions";
+import { getClientCalendarPeek } from "@/lib/gc-fitness/client-calendar-peek-actions";
 import {
   bodyWeightFulfillment,
   progressPhotosFulfillment,
 } from "@/lib/gc-fitness/client-request-fulfillment";
 import { PendingClientPreload } from "./_components/PendingClientPreload";
 import { ClientSummaryCard } from "./_components/ClientSummaryCard";
+import { ClientCalendarPeek } from "./_components/ClientCalendarPeek";
 import { sectionMetadata } from "@/lib/gc-fitness/page-metadata";
 
 // Tab title: "GC Fitness - <clients>" (issue #170).
@@ -146,7 +148,7 @@ export default async function ClientDetailPage({
   // Contract: every client activity surface below reads this explicit IANA
   // timezone. Leaf components must not infer UTC or the host timezone.
   const todayCivil = civilDateToday(timezone);
-  const [notes, progressPhotos, goals, bodyWeightFulfilled] = await Promise.all([
+  const [notes, progressPhotos, goals, bodyWeightFulfilled, calendarPeek] = await Promise.all([
     getClientNotes(id).catch(() => ({ notes: "", updatedAt: null, entries: [] })),
     listProgressPhotosForClient(id),
     listClientGoals(id),
@@ -156,6 +158,7 @@ export default async function ClientDetailPage({
     bodyWeightFulfillment(id, client.bodyWeightRequestedAt ?? null).catch(
       () => ({ fulfilled: false, fulfilledAt: null }),
     ),
+    getClientCalendarPeek({ clientId: id, anchorCivil: todayCivil }),
   ]);
   // Header "Peso" = the client's most recent weigh-in BY MEASUREMENT DATE.
   // On a transient read error fall back to NULL (em dash), never to the
@@ -208,6 +211,7 @@ export default async function ClientDetailPage({
         timezone={timezone}
         goals={goals}
       />
+      <ClientCalendarPeek clientId={id} initialPayload={calendarPeek} />
 
       <ClientRequestActionsCard
         clientId={id}

--- a/backoffice/src/lib/app-version.ts
+++ b/backoffice/src/lib/app-version.ts
@@ -1,1 +1,1 @@
-export const BACKOFFICE_VERSION = "2.250";
+export const BACKOFFICE_VERSION = "2.251";

--- a/backoffice/src/lib/gc-fitness/__tests__/client-calendar-peek-actions.test.ts
+++ b/backoffice/src/lib/gc-fitness/__tests__/client-calendar-peek-actions.test.ts
@@ -1,0 +1,104 @@
+const mockGetCurrentTrainer = jest.fn();
+const mockClientGet = jest.fn();
+const mockClientDoc = jest.fn(() => ({ get: mockClientGet }));
+const mockCollection = jest.fn(() => ({ doc: mockClientDoc }));
+const mockListMonthForClients = jest.fn();
+
+jest.mock("@/lib/firebase/gc-fitness-admin", () => ({
+  gcFitnessFirestore: () => ({ collection: mockCollection }),
+}));
+
+jest.mock("@/lib/gc-fitness/auth-helpers", () => ({
+  getCurrentTrainer: () => mockGetCurrentTrainer(),
+}));
+
+jest.mock("@/lib/gc-fitness/civil-date", () => ({
+  civilDateToday: jest.fn(() => "2026-07-13"),
+}));
+
+jest.mock("../schedule-month-actions", () => ({
+  listMonthForClients: (input: unknown) => mockListMonthForClients(input),
+}));
+
+import { getClientCalendarPeek } from "../client-calendar-peek-actions";
+
+describe("getClientCalendarPeek", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetCurrentTrainer.mockResolvedValue({
+      uid: "trainer-1",
+      email: "trainer@example.com",
+    });
+    mockClientGet.mockResolvedValue({
+      exists: true,
+      data: () => ({
+        coachId: "trainer-1",
+        timezone: "America/Argentina/Buenos_Aires",
+      }),
+    });
+    mockListMonthForClients.mockResolvedValue({
+      monthStart: "2026-07-10",
+      monthEnd: "2026-07-16",
+      workoutsByDay: {},
+      habitsByDay: {},
+    });
+  });
+
+  it("loads a 7-day window centered on the requested anchor for the owned client", async () => {
+    const result = await getClientCalendarPeek({
+      clientId: "client-1",
+      anchorCivil: "2026-07-13",
+    });
+
+    expect(mockCollection).toHaveBeenCalledWith("users");
+    expect(mockClientDoc).toHaveBeenCalledWith("client-1");
+    expect(mockListMonthForClients).toHaveBeenCalledWith({
+      startCivil: "2026-07-10",
+      endCivil: "2026-07-16",
+      clientIds: ["client-1"],
+      todayCivil: "2026-07-13",
+    });
+    expect(result).toEqual({
+      anchorCivil: "2026-07-13",
+      startCivil: "2026-07-10",
+      endCivil: "2026-07-16",
+      todayCivil: "2026-07-13",
+      calendar: {
+        monthStart: "2026-07-10",
+        monthEnd: "2026-07-16",
+        workoutsByDay: {},
+        habitsByDay: {},
+      },
+    });
+  });
+
+  it("falls back to today when the anchor is malformed", async () => {
+    await getClientCalendarPeek({
+      clientId: "client-1",
+      anchorCivil: "not-a-date",
+    });
+
+    expect(mockListMonthForClients).toHaveBeenCalledWith(
+      expect.objectContaining({
+        startCivil: "2026-07-10",
+        endCivil: "2026-07-16",
+        todayCivil: "2026-07-13",
+      }),
+    );
+  });
+
+  it("rejects clients owned by a different coach before reading calendar data", async () => {
+    mockClientGet.mockResolvedValueOnce({
+      exists: true,
+      data: () => ({ coachId: "other-trainer", timezone: "UTC" }),
+    });
+
+    await expect(
+      getClientCalendarPeek({
+        clientId: "client-1",
+        anchorCivil: "2026-07-13",
+      }),
+    ).rejects.toThrow("Forbidden");
+    expect(mockListMonthForClients).not.toHaveBeenCalled();
+  });
+});

--- a/backoffice/src/lib/gc-fitness/client-calendar-peek-actions.ts
+++ b/backoffice/src/lib/gc-fitness/client-calendar-peek-actions.ts
@@ -1,0 +1,96 @@
+"use server";
+
+import { gcFitnessFirestore } from "@/lib/firebase/gc-fitness-admin";
+
+import { getCurrentTrainer } from "./auth-helpers";
+import { civilDateToday } from "./civil-date";
+import { FirestoreCollections } from "./collections";
+import {
+  listMonthForClients,
+  type MonthCalendarPayload,
+} from "./schedule-month-actions";
+
+const DAY_MS = 86_400_000;
+const CIVIL_DATE_PATTERN = /^\d{4}-\d{2}-\d{2}$/;
+
+export interface ClientCalendarPeekPayload {
+  anchorCivil: string;
+  startCivil: string;
+  endCivil: string;
+  todayCivil: string;
+  calendar: MonthCalendarPayload;
+}
+
+export async function getClientCalendarPeek(input: {
+  clientId: string;
+  anchorCivil?: string;
+}): Promise<ClientCalendarPeekPayload> {
+  const trainer = await getCurrentTrainer();
+  const db = gcFitnessFirestore();
+
+  const clientSnap = await db
+    .collection(FirestoreCollections.users)
+    .doc(input.clientId)
+    .get();
+  if (!clientSnap.exists) {
+    throw new Error("Not found");
+  }
+
+  const client = clientSnap.data() as {
+    coachId?: string;
+    timezone?: string;
+  };
+  if (client.coachId !== trainer.uid) {
+    throw new Error("Forbidden");
+  }
+
+  const timezone =
+    typeof client.timezone === "string" && client.timezone.length > 0
+      ? client.timezone
+      : "UTC";
+  const todayCivil = civilDateToday(timezone);
+  const anchorCivil = isValidCivilDate(input.anchorCivil)
+    ? input.anchorCivil
+    : todayCivil;
+  const startCivil = addCivilDays(anchorCivil, -3);
+  const endCivil = addCivilDays(anchorCivil, 3);
+  const calendar = await listMonthForClients({
+    startCivil,
+    endCivil,
+    clientIds: [input.clientId],
+    todayCivil,
+  });
+
+  return {
+    anchorCivil,
+    startCivil,
+    endCivil,
+    todayCivil,
+    calendar,
+  };
+}
+
+function isValidCivilDate(value: unknown): value is string {
+  if (typeof value !== "string" || !CIVIL_DATE_PATTERN.test(value)) {
+    return false;
+  }
+  return formatCivilDate(parseCivilDate(value)) === value;
+}
+
+function addCivilDays(civilDate: string, days: number): string {
+  return formatCivilDate(
+    new Date(parseCivilDate(civilDate).getTime() + days * DAY_MS),
+  );
+}
+
+function parseCivilDate(civilDate: string): Date {
+  const [year, month, day] = civilDate.split("-").map(Number);
+  return new Date(Date.UTC(year, month - 1, day));
+}
+
+function formatCivilDate(date: Date): string {
+  const year = date.getUTCFullYear();
+  const month = String(date.getUTCMonth() + 1).padStart(2, "0");
+  const day = String(date.getUTCDate()).padStart(2, "0");
+  return `${year}-${month}-${day}`;
+}


### PR DESCRIPTION
## Summary

- Adds a mini calendar to the GC Fitness client profile.
- Shows a 7-day window centered on today: previous 3 days, today, and next 3 days.
- Adds previous/next week navigation plus a “Today” reset.
- Reuses the existing schedule data path for workouts and habits, with a client-profile wrapper that validates the coach owns the client.
- Links from the mini calendar to the full schedule filtered to that client.
- Bumps backoffice version to `2.251`.

## Screenshot

<img width="1212" height="357" alt="Screenshot 2026-07-13 at 5 59 49 PM" src="https://github.com/user-attachments/assets/17c734b4-7084-4c7d-b740-22d8e3da53bb" />
