### PR TITLE
fix(calendar): show client-created habits + badge (#437)

### DIFF
--- a/backoffice/messages/en.json
+++ b/backoffice/messages/en.json
@@ -353,6 +353,7 @@
         "habitStatusFuture": "future",
         "habitStatusDone": "done",
         "habitStatusPending": "pending",
+        "habitClientCreated": "Created by the client",
         "reminderStatusFutureValue": "visual only",
         "reminderStatusDone": "done",
         "reminderStatusPending": "pending",
@@ -1497,6 +1498,7 @@
       "workouts": "Workouts",
       "habits": "Habits",
       "birthdayBadge": "Birthday",
+      "clientCreatedBadge": "Created by the client",
       "pickClientsPrompt": "Pick one or more clients above to see their agenda.",
       "pickClientFirstToast": "Pick at least one client first",
       "bulkAssignHabit": "Assign habit"

--- a/backoffice/messages/es.json
+++ b/backoffice/messages/es.json
@@ -353,6 +353,7 @@
         "habitStatusFuture": "futuro",
         "habitStatusDone": "hecho",
         "habitStatusPending": "pendiente",
+        "habitClientCreated": "Creado por el cliente",
         "reminderStatusFutureValue": "solo visual",
         "reminderStatusDone": "hecho",
         "reminderStatusPending": "pendiente",
@@ -1497,6 +1498,7 @@
       "workouts": "Entrenamientos",
       "habits": "Hábitos",
       "birthdayBadge": "Cumpleaños",
+      "clientCreatedBadge": "Creado por el cliente",
       "pickClientsPrompt": "Elegí uno o más clientes arriba para ver su agenda.",
       "pickClientFirstToast": "Elegí al menos un cliente primero",
       "bulkAssignHabit": "Asignar hábito"

--- a/backoffice/src/app/gc-fitness/clients/[id]/_components/ClientDailyTimeline.tsx
+++ b/backoffice/src/app/gc-fitness/clients/[id]/_components/ClientDailyTimeline.tsx
@@ -15,6 +15,7 @@ import {
   NotebookText,
   Plus,
   Trash2,
+  User,
 } from "lucide-react";
 import { useLocale, useTranslations } from "next-intl";
 
@@ -344,7 +345,18 @@ export function ClientDailyTimeline({
                     ].join(" ")}
                   >
                     <div className="flex flex-col">
-                      <span className="font-medium">{habit.name}</span>
+                      <span className="flex items-center gap-1 font-medium">
+                        {habit.name}
+                        {habit.clientOwned ? (
+                          <span
+                            className="inline-flex items-center gap-0.5 rounded-full bg-background px-1.5 py-0.5 text-[10px] font-medium text-muted-foreground"
+                            title={t("habitClientCreated")}
+                          >
+                            <User className="size-2.5" />
+                            {t("habitClientCreated")}
+                          </span>
+                        ) : null}
+                      </span>
                       <span className="text-xs text-muted-foreground">
                         {habit.future
                           ? t("habitStatusFuture")

--- a/backoffice/src/components/gc-fitness/schedule/month-calendar.tsx
+++ b/backoffice/src/components/gc-fitness/schedule/month-calendar.tsx
@@ -37,6 +37,7 @@ import {
   Circle,
   Dumbbell,
   PlusIcon,
+  User,
   XCircle,
 } from "lucide-react";
 import { toast } from "sonner";
@@ -1354,6 +1355,7 @@ function DayCell({
                         <span className="min-w-0 max-w-full truncate">
                           {h.habitName}
                         </span>
+                        {h.clientOwned ? <ClientOwnedBadge /> : null}
                       </button>
                     ))}
                   </div>
@@ -1498,6 +1500,7 @@ function ClientDayCell({
                 <span className="min-w-0 max-w-full truncate">
                   {h.habitName}
                 </span>
+                {h.clientOwned ? <ClientOwnedBadge /> : null}
               </button>
             ))}
           </div>
@@ -1769,4 +1772,15 @@ function HabitStatusGlyph({ status }: { status: MonthHabitChip["status"] }) {
     return <XCircle className="size-2.5 text-rose-600 dark:text-rose-400" />;
   }
   return <Circle className="size-2.5 opacity-60" />;
+}
+
+/** Issue #437: marks a habit the client created for themselves (vs. one the
+ * trainer assigned). Rendered on the calendar habit chip. */
+function ClientOwnedBadge() {
+  const t = useTranslations("schedule.calendar");
+  return (
+    <span title={t("clientCreatedBadge")} className="inline-flex shrink-0">
+      <User className="size-2.5 opacity-70" aria-label={t("clientCreatedBadge")} />
+    </span>
+  );
 }

--- a/backoffice/src/lib/gc-fitness/__tests__/client-daily-timeline-actions.test.ts
+++ b/backoffice/src/lib/gc-fitness/__tests__/client-daily-timeline-actions.test.ts
@@ -97,6 +97,30 @@ function makeDb() {
         if (collName === FirestoreCollections.habits) {
           return snap([
             makeDoc("habit-1", habit),
+            // Issue #437: client-created habit (clientOwned, trainerId ===
+            // clientId, NO `deleted` field). Same monthly-22 schedule so it
+            // shares the day-22 assertion window and never lands on day 21.
+            makeDoc("habit-client", {
+              id: "habit-client",
+              clientId: "client-1",
+              trainerId: "client-1",
+              clientOwned: true,
+              name: { en: "Client self habit", es: "Hábito propio" },
+              scheduleType: "recurring",
+              scheduleCadence: "monthly",
+              scheduleMonthDays: [22],
+            }),
+            // Soft-deleted habit — must be filtered out in memory.
+            makeDoc("habit-gone", {
+              id: "habit-gone",
+              clientId: "client-1",
+              trainerId: "trainer-1",
+              deleted: true,
+              name: { en: "Deleted habit" },
+              scheduleType: "recurring",
+              scheduleCadence: "monthly",
+              scheduleMonthDays: [22],
+            }),
           ]);
         }
         if (collName === FirestoreCollections.habitLogs) {
@@ -163,8 +187,14 @@ describe("client-daily-timeline-actions — habit schedule filtering", () => {
 
     expect(day21?.habits).toEqual([]);
     expect(day21?.reminders).toEqual([]);
-    expect(day22?.habits).toHaveLength(1);
-    expect(day22?.habits[0]?.name).toBe("Monthly check");
+    // Issue #437: trainer-assigned + client-created habits both show; the
+    // soft-deleted one does not.
+    expect(day22?.habits).toHaveLength(2);
+    const trainerHabit = day22?.habits.find((h) => h.name === "Monthly check");
+    const clientHabit = day22?.habits.find((h) => h.name === "Client self habit");
+    expect(trainerHabit?.clientOwned).toBe(false);
+    expect(clientHabit?.clientOwned).toBe(true);
+    expect(day22?.habits.some((h) => h.name === "Deleted habit")).toBe(false);
   });
 
   it("hides unscheduled habits from the single-day view", async () => {

--- a/backoffice/src/lib/gc-fitness/__tests__/schedule-month-actions.test.ts
+++ b/backoffice/src/lib/gc-fitness/__tests__/schedule-month-actions.test.ts
@@ -80,6 +80,30 @@ function makeDb() {
               scheduleCadence: "daily",
               startsOn: "2026-06-01",
             }),
+            // Issue #437: client-created habit. trainerId === clientId, marked
+            // clientOwned, and crucially NO `deleted` field (rules forbid it at
+            // create) — it must still surface, tagged clientOwned.
+            doc("client-habit", {
+              trainerId: "c1",
+              clientId: "c1",
+              clientOwned: true,
+              name: { en: "Client self habit" },
+              type: "binary",
+              scheduleType: "recurring",
+              scheduleCadence: "daily",
+              startsOn: "2026-06-01",
+            }),
+            // Soft-deleted habit must NOT surface (in-memory filter).
+            doc("gone-habit", {
+              trainerId: "t1",
+              clientId: "c1",
+              deleted: true,
+              name: { en: "Deleted habit" },
+              type: "binary",
+              scheduleType: "recurring",
+              scheduleCadence: "daily",
+              startsOn: "2026-06-01",
+            }),
           ]);
         }
         return snap([]);
@@ -113,13 +137,23 @@ describe("listMonthForClients", () => {
     ]);
     expect(result.habitsByDay["2026-06-10"]).toEqual([
       expect.objectContaining({
+        id: "client-habit:2026-06-10",
+        habitName: "Client self habit",
+        clientOwned: true,
+      }),
+      expect.objectContaining({
         id: "new-habit:2026-06-10",
         habitName: "New coach habit",
+        clientOwned: false,
       }),
       expect.objectContaining({
         id: "old-habit:2026-06-10",
         habitName: "Old coach habit",
+        clientOwned: false,
       }),
     ]);
+    // Soft-deleted habit is filtered out.
+    const ids = result.habitsByDay["2026-06-10"].map((h) => h.id);
+    expect(ids).not.toContain("gone-habit:2026-06-10");
   });
 });

--- a/backoffice/src/lib/gc-fitness/client-daily-timeline-actions.ts
+++ b/backoffice/src/lib/gc-fitness/client-daily-timeline-actions.ts
@@ -53,6 +53,8 @@ export interface ClientDailyTimelineDay {
     completed: boolean;
     value: string;
     future: boolean;
+    /** Client created this habit for themselves (issue #400/#437). */
+    clientOwned: boolean;
   }>;
   reminders: Array<{
     id: string;
@@ -152,9 +154,10 @@ function isHabitActiveOnDate(
   habit: Record<string, unknown>,
   civilDate: string,
 ): boolean {
-  // Soft-delete is handled by the `deleted == false` query filter in this
-  // module's habit loads, so this predicate (like iOS `isActive`) only answers
-  // "scheduled on this day?".
+  // Soft-delete is filtered in memory when building `habitsById` (issue #437 —
+  // the query no longer uses `deleted == false`, which dropped client-created
+  // habits that carry no `deleted` field), so this predicate (like iOS
+  // `isActive`) only answers "scheduled on this day?".
   return isHabitScheduledOn(habit, civilDate);
 }
 
@@ -229,7 +232,6 @@ export async function getClientDailyTimeline(
     db
       .collection(FirestoreCollections.habits)
       .where("clientId", "==", clientId)
-      .where("deleted", "==", false)
       .get(),
     db
       .collection(FirestoreCollections.habitLogs)
@@ -260,6 +262,9 @@ export async function getClientDailyTimeline(
   const habitsById = new Map<string, Record<string, unknown>>();
   habitsSnap.docs.forEach((doc) => {
     const data = doc.data() as Record<string, unknown>;
+    // Issue #437: in-memory soft-delete filter (the query no longer does it, so
+    // client-created habits without a `deleted` field are not dropped).
+    if (data.deleted === true) return;
     habitNames.set(doc.id, localizedText(data.name, "Habit"));
     habitsById.set(doc.id, data);
   });
@@ -406,6 +411,7 @@ export async function getClientDailyTimeline(
         id: habitId,
         name: habitNames.get(habitId) ?? "Habit",
         completed,
+        clientOwned: habit.clientOwned === true,
         value:
           typeof log?.value === "string" || typeof log?.value === "number"
             ? String(log?.value)
@@ -495,7 +501,6 @@ export async function getClientDailyTimelineDay(
     db
       .collection(FirestoreCollections.habits)
       .where("clientId", "==", clientId)
-      .where("deleted", "==", false)
       .get(),
     db
       .collection(FirestoreCollections.habitLogs)
@@ -525,6 +530,9 @@ export async function getClientDailyTimelineDay(
   const habitsById = new Map<string, Record<string, unknown>>();
   habitsSnap.docs.forEach((doc) => {
     const data = doc.data() as Record<string, unknown>;
+    // Issue #437: in-memory soft-delete filter (the query no longer does it, so
+    // client-created habits without a `deleted` field are not dropped).
+    if (data.deleted === true) return;
     habitNames.set(doc.id, localizedText(data.name, "Habit"));
     habitsById.set(doc.id, data);
   });
@@ -657,6 +665,7 @@ export async function getClientDailyTimelineDay(
       id: habitId,
       name: habitNames.get(habitId) ?? "Habit",
       completed,
+      clientOwned: habit.clientOwned === true,
       value:
         typeof log?.value === "string" || typeof log?.value === "number"
           ? String(log?.value)

--- a/backoffice/src/lib/gc-fitness/schedule-month-actions.ts
+++ b/backoffice/src/lib/gc-fitness/schedule-month-actions.ts
@@ -64,6 +64,11 @@ export interface MonthHabitChip {
   civilDate: string;
   habitName: string;
   status: "done" | "missed" | "scheduled";
+  /** True when the client created this habit for themselves (issue #400 —
+   * `clientOwned: true`, `clientId === trainerId`) rather than the trainer
+   * assigning it. The calendar renders a "client-created" badge for these
+   * (issue #437). */
+  clientOwned: boolean;
 }
 
 export interface MonthCalendarPayload {
@@ -595,11 +600,15 @@ export async function listMonthForClients(input: {
       .orderBy("startedAt", "desc")
       .limit(200)
       .get(),
-    db
-      .collection(HABITS)
-      .where("clientId", "in", clientIds)
-      .where("deleted", "==", false)
-      .get(),
+    // Issue #437: do NOT add `.where("deleted", "==", false)` here. A Firestore
+    // equality filter only matches docs where the field EXISTS — and
+    // client-created habits (issue #400) are created WITHOUT a `deleted` field
+    // (the rules forbid it at create), so that clause silently dropped every
+    // client-created habit. We fetch all habits for the client and filter
+    // `deleted === true` in memory below instead. `clientId in` also captures
+    // client-created habits, whose `trainerId` is the client's own uid (not the
+    // coach's), so no trainerId filter is used here either.
+    db.collection(HABITS).where("clientId", "in", clientIds).get(),
   ]);
 
   // Build an assignmentId → log status map for the assignment status flip.
@@ -688,12 +697,16 @@ export async function listMonthForClients(input: {
   const habitsByClient = new Map<string, Array<Record<string, unknown>>>();
   const habitMetaById = new Map<
     string,
-    { name: string; type: HabitType; targetValue: number | undefined }
+    { name: string; type: HabitType; targetValue: number | undefined; clientOwned: boolean }
   >();
   for (const doc of habitSnap.docs) {
     const data = doc.data() as Record<string, unknown>;
     const clientId = typeof data.clientId === "string" ? data.clientId : "";
     if (!clientId) continue;
+    // Issue #437: in-memory soft-delete filter (the query no longer does it —
+    // see the habits query note above). Client-created habits have no `deleted`
+    // field, so only `deleted === true` is excluded here.
+    if (data.deleted === true) continue;
     (habitsByClient.get(clientId) ?? habitsByClient.set(clientId, []).get(clientId))!.push({
       ...data,
       __id: doc.id,
@@ -710,6 +723,7 @@ export async function listMonthForClients(input: {
       type: ((typeof data.type === "string" ? data.type : "binary") as HabitType),
       targetValue:
         typeof data.targetValue === "number" ? (data.targetValue as number) : undefined,
+      clientOwned: data.clientOwned === true,
     });
   }
 
@@ -780,6 +794,7 @@ export async function listMonthForClients(input: {
           civilDate: civil,
           habitName: meta.name,
           status,
+          clientOwned: meta.clientOwned,
         });
       }
     }


### PR DESCRIPTION
Closes #437.

## Problem
When a **client** creates a habit for themselves in the app (issue #400), it never showed up in the backoffice calendar/agenda.

## Root cause
Client-created habits are created with `clientOwned: true`, `clientId === trainerId === <client uid>`, and — per the shared `firestore.rules` create branch — **no `deleted` field**. The backoffice habits query used `.where("deleted", "==", false)`, and a Firestore equality filter only matches docs where the field **exists**, so every client-created habit was silently excluded. (Ownership was never the issue — the query already filters by `clientId`, not `trainerId`.)

## Fix
- Drop `.where("deleted", "==", false)` from the habits queries and filter `deleted === true` **in memory** instead — client-created habits (no `deleted`) now flow through, soft-deleted ones stay hidden.
- Applied to **both** trainer-facing surfaces that list a client's habits by day: the `/schedule` calendar (`schedule-month-actions.ts`) and the client daily timeline (`client-daily-timeline-actions.ts`).
- **Badge**: each client-created habit is marked with a "created by the client" person-icon badge on the calendar chip and the daily-timeline row (new `clientOwned` field on both habit projection types).
- EN/ES strings added (`schedule.calendar.clientCreatedBadge`, `clients.detail.timeline.habitClientCreated`).

## Notes
- **No index / rules / functions changes.** Both queries are now single-field filters (no composite index needed), and the backoffice reads via the Admin SDK (bypasses rules), so the existing habits read rule — which only grants the coach access via the client's `coachId` — is not a blocker. `getHabit` (used by the chip's detail dialog) already resolves client-owned habits through `currentTrainerCanManageHabit` → client's `coachId`, so clicking a client-created chip works.

## Tests / gate
- `npx tsc --noEmit` — clean.
- `npx jest` — all green except the pre-existing `client-activity-time` locale flake (passes in CI). Added twin coverage in both `schedule-month-actions.test.ts` and `client-daily-timeline-actions.test.ts` asserting: client-created habit surfaces + tagged `clientOwned`, trainer habits `clientOwned: false`, soft-deleted excluded.