### PR TITLE
fix(recent-logs): coach can open client-created (self) workout logs (#434)

### DIFF
--- a/backoffice/src/lib/gc-fitness/__tests__/recent-logs-actions.self-workout-feed.test.ts
+++ b/backoffice/src/lib/gc-fitness/__tests__/recent-logs-actions.self-workout-feed.test.ts
@@ -1,0 +1,128 @@
+// __tests__/recent-logs-actions.self-workout-feed.test.ts
+//
+// Issue #434 follow-up: the LEGACY dashboard/recent-logs branch
+// (`listRecentLogsForTrainer`, no page arg) queried workout_logs by
+// `trainerId == coach`, so CLIENT-CREATED ("self") workouts — whose trainerId
+// is the client's own uid — never appeared in that feed. The branch now fans
+// out per roster client by `clientId` (like the paginated branch). This test
+// locks that a self-log for a roster client shows up, and that its assignment
+// (never in the trainer-scoped assignment set) survives the orphan filter via
+// the point-read existence check.
+
+const mockState: { db: unknown } = { db: null };
+
+jest.mock("@/lib/firebase/gc-fitness-admin", () => ({
+  gcFitnessFirestore: () => mockState.db,
+}));
+jest.mock("@/lib/gc-fitness/auth-helpers", () => ({
+  getCurrentTrainer: jest.fn(async () => ({ uid: "t1", email: "t@x.com" })),
+}));
+jest.mock("@/lib/gc-fitness/client-roster", () => ({
+  listClients: jest.fn(async () => [
+    {
+      uid: "c1",
+      email: "c1@x.com",
+      displayName: "Client One",
+      createdAt: null,
+      timezone: null,
+      photoURL: null,
+      pendingProvisioning: false,
+    },
+  ]),
+}));
+jest.mock("@/lib/gc-fitness/trainer-timezone", () => ({
+  getTrainerTimezone: jest.fn(async () => "UTC"),
+}));
+
+import { listRecentLogsForTrainer } from "../recent-logs-actions";
+import { FirestoreCollections } from "../collections";
+
+function snap(docs: unknown[]) {
+  return {
+    docs,
+    size: docs.length,
+    empty: docs.length === 0,
+    forEach: (cb: (d: unknown) => void) => docs.forEach(cb),
+  };
+}
+
+function doc(id: string, data: Record<string, unknown>) {
+  return { id, exists: true, data: () => data, get: (f: string) => data[f] };
+}
+
+const SELF_ASSIGNMENT_ID = "asg-c1-20260710-self-xyz";
+const SELF_LOG_ID = "log-asg-c1-20260710-self-abc-123";
+
+// A client-created ("self") completed workout: trainerId === clientId === c1.
+const selfLog = doc(SELF_LOG_ID, {
+  clientId: "c1",
+  trainerId: "c1",
+  assignment_id: SELF_ASSIGNMENT_ID,
+  status: "completed",
+  startedAt: "2026-07-10T10:00:00.000Z",
+  completedAt: "2026-07-10T10:45:00.000Z",
+  sets: [{ id: "s1", exerciseId: "e1", reps: 10, weight_kg: 50 }],
+  templateSnapshot: { name: "Resistiré", exercises: [] },
+});
+
+const clientUser = doc("c1", {
+  email: "c1@x.com",
+  displayName: "Client One",
+  role: "client",
+  coachId: "t1",
+  timezone: null,
+});
+
+function makeDb() {
+  function makeQuery(collName: string): Record<string, unknown> {
+    const q: Record<string, unknown> = {
+      where: () => q,
+      orderBy: () => q,
+      limit: () => q,
+      get: async () => {
+        if (collName === FirestoreCollections.workoutLogs) return snap([selfLog]);
+        if (collName === FirestoreCollections.users) return snap([clientUser]);
+        // workout_assignments (trainer-scoped), habits, habit_logs, photos,
+        // body_weight_logs, profile events → empty.
+        return snap([]);
+      },
+      doc: (id: string) => makeDocRef(collName, id),
+    };
+    return q;
+  }
+
+  function makeDocRef(collName: string, id: string) {
+    return {
+      id,
+      // The orphan filter point-reads the self-assignment by id — it exists.
+      get: async () =>
+        collName === FirestoreCollections.workoutAssignments && id === SELF_ASSIGNMENT_ID
+          ? doc(id, { clientId: "c1", trainerId: "c1" })
+          : { exists: false, id, data: () => ({}), get: () => undefined },
+      collection: (sub: string) => makeQuery(`${collName}/${id}/${sub}`),
+    };
+  }
+
+  return {
+    collection: (name: string) => makeQuery(name),
+    getAll: async () => [],
+  };
+}
+
+describe("listRecentLogsForTrainer — client-created (self) workouts in the feed (#434)", () => {
+  let errSpy: jest.SpyInstance;
+  beforeEach(() => {
+    mockState.db = makeDb();
+    errSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+  });
+  afterEach(() => errSpy.mockRestore());
+
+  it("surfaces a self-log for a roster client (survives the orphan filter)", async () => {
+    const result = await listRecentLogsForTrainer();
+    const workoutRows = result.logs.filter((r) => r.category === "workout");
+    expect(workoutRows).toHaveLength(1);
+    expect(workoutRows[0]).toEqual(
+      expect.objectContaining({ clientId: "c1", workoutLogId: SELF_LOG_ID }),
+    );
+  });
+});

--- a/backoffice/src/lib/gc-fitness/__tests__/recent-logs-actions.self-workout.test.ts
+++ b/backoffice/src/lib/gc-fitness/__tests__/recent-logs-actions.self-workout.test.ts
@@ -1,0 +1,122 @@
+// __tests__/recent-logs-actions.self-workout.test.ts
+//
+// Issue #434: a coach opening a CLIENT-CREATED ("self") workout log 404'd.
+// Self-assigned workouts (issue #392) carry trainerId === clientId === the
+// client's own uid, so the old `data.trainerId !== trainer.uid` gate in
+// getWorkoutLogDetail always threw "Forbidden" → notFound(). The fix resolves
+// the client's coachId (like habits' currentTrainerCanManageHabit).
+//
+// These tests lock: (1) a self-log whose client belongs to the coach is
+// accessible, (2) a plain trainer-owned log stays accessible, (3) a log whose
+// client is NOT the coach's is still rejected (no cross-coach leak).
+
+const mockState: { db: unknown } = { db: null };
+
+jest.mock("@/lib/firebase/gc-fitness-admin", () => ({
+  gcFitnessFirestore: () => mockState.db,
+}));
+jest.mock("@/lib/gc-fitness/auth-helpers", () => ({
+  getCurrentTrainer: jest.fn(async () => ({ uid: "coach1", email: "coach@x.com" })),
+}));
+jest.mock("@/lib/gc-fitness/trainer-timezone", () => ({
+  getTrainerTimezone: jest.fn(async () => "UTC"),
+}));
+
+import { getWorkoutLogDetail } from "../recent-logs-actions";
+import { FirestoreCollections } from "../collections";
+
+function docSnap(exists: boolean, data: Record<string, unknown>) {
+  return {
+    exists,
+    id: (data.__id as string) ?? "",
+    data: () => data,
+    get: (field: string) => data[field],
+  };
+}
+
+/**
+ * Minimal Firestore mock: resolves `collection(name).doc(id).get()` from a
+ * fixture map keyed by `${name}/${id}`.
+ */
+function makeDb(fixtures: Record<string, Record<string, unknown> | null>) {
+  return {
+    collection: (name: string) => ({
+      doc: (id: string) => ({
+        get: async () => {
+          const data = fixtures[`${name}/${id}`];
+          return data ? docSnap(true, data) : docSnap(false, {});
+        },
+      }),
+    }),
+  };
+}
+
+const WL = FirestoreCollections.workoutLogs;
+const USERS = FirestoreCollections.users;
+
+const SELF_LOG_ID = "log-asg-client1-20260710-self-abc-123";
+const selfLog = {
+  __id: SELF_LOG_ID,
+  clientId: "client1",
+  trainerId: "client1", // self-assigned: trainerId === clientId
+  status: "completed",
+  sets: [],
+  templateSnapshot: { name: "Resistiré", exercises: [] },
+  startedAt: null,
+  completedAt: null,
+};
+
+describe("getWorkoutLogDetail — client-created (self) workouts (#434)", () => {
+  it("lets the coach open a self-log for their own client", async () => {
+    mockState.db = makeDb({
+      [`${WL}/${SELF_LOG_ID}`]: selfLog,
+      [`${USERS}/client1`]: {
+        displayName: "Client One",
+        email: "client1@x.com",
+        coachId: "coach1",
+        timezone: "UTC",
+      },
+      [`${USERS}/coach1`]: { displayName: "Coach One" },
+    });
+
+    const detail = await getWorkoutLogDetail(SELF_LOG_ID);
+    expect(detail.workoutName).toBe("Resistiré");
+    expect(detail.clientName).toBeTruthy();
+  });
+
+  it("still lets the coach open a normal trainer-owned log", async () => {
+    const id = "log-normal-1";
+    mockState.db = makeDb({
+      [`${WL}/${id}`]: {
+        __id: id,
+        clientId: "client1",
+        trainerId: "coach1", // trainer-owned
+        status: "completed",
+        sets: [],
+        templateSnapshot: { name: "Pecho", exercises: [] },
+      },
+      [`${USERS}/client1`]: { displayName: "Client One", coachId: "coach1" },
+      [`${USERS}/coach1`]: { displayName: "Coach One" },
+    });
+
+    const detail = await getWorkoutLogDetail(id);
+    expect(detail.workoutName).toBe("Pecho");
+  });
+
+  it("rejects a log whose client is not the coach's (no cross-coach leak)", async () => {
+    const id = "log-foreign-1";
+    mockState.db = makeDb({
+      [`${WL}/${id}`]: {
+        __id: id,
+        clientId: "clientX",
+        trainerId: "clientX", // self-log, but of another coach's client
+        status: "completed",
+        sets: [],
+        templateSnapshot: { name: "Ajena", exercises: [] },
+      },
+      [`${USERS}/clientX`]: { displayName: "Other", coachId: "someoneElse" },
+    });
+
+    await expect(getWorkoutLogDetail(id)).rejects.toThrow("Forbidden");
+  });
+});

--- a/backoffice/src/lib/gc-fitness/recent-logs-actions.ts
+++ b/backoffice/src/lib/gc-fitness/recent-logs-actions.ts
@@ -1531,6 +1531,35 @@ export async function listRecentLogsForClientAsAdmin(
   });
 }
 
+/**
+ * Issue #434: a coach may view a workout log when they are the log's `trainerId`
+ * OR the coach-of-record for the log's client. Client-created ("self") workouts
+ * (issue #392) carry `trainerId === clientId === <client uid>`, so the bare
+ * `trainerId === coach` equality 404s them even though the log shows up in the
+ * coach's recent-logs feed (which filters by `clientId`). Resolving the client's
+ * `coachId` — the same fallback habits use in `currentTrainerCanManageHabit` —
+ * admits them. The lookup is scoped to the coach's own clients, so no cross-coach
+ * leak. (The backoffice reads via the Admin SDK, so Firestore rules are bypassed;
+ * this app-side check is the only gate.)
+ */
+async function coachCanAccessLog(
+  db: FirebaseFirestore.Firestore,
+  coachUid: string,
+  data: { trainerId?: unknown; clientId?: unknown },
+): Promise<boolean> {
+  if (data.trainerId === coachUid) return true;
+  const clientId =
+    typeof data.clientId === "string" && data.clientId.trim().length > 0
+      ? data.clientId.trim()
+      : null;
+  if (!clientId) return false;
+  const clientSnap = await db
+    .collection(FirestoreCollections.users)
+    .doc(clientId)
+    .get();
+  return clientSnap.exists && clientSnap.get("coachId") === coachUid;
+}
+
 export async function getWorkoutLogDetail(
   workoutLogId: string,
 ): Promise<WorkoutLogDetail> {
@@ -1546,7 +1575,7 @@ export async function getWorkoutLogDetail(
   }
 
   const data = logSnap.data() as Record<string, unknown>;
-  if (data.trainerId !== trainer.uid) {
+  if (!(await coachCanAccessLog(db, trainer.uid, data))) {
     throw new Error("Forbidden");
   }
 
@@ -1574,7 +1603,7 @@ export async function getWorkoutLogDetailAsAdmin(
   }
 
   const data = logSnap.data() as Record<string, unknown>;
-  if (data.trainerId !== coachId) {
+  if (!(await coachCanAccessLog(db, coachId, data))) {
     throw new Error("Workout log not found.");
   }
 
@@ -1627,13 +1656,19 @@ export async function getWorkoutLogDetailByAssignment(
   if (docById.size === 0) return null;
   const allDocs = Array.from(docById.values());
 
-  // Trainer-ownership + completed filter in memory (see index note above).
-  const completed = allDocs.filter((d) => {
-    const data = d.data() as Record<string, unknown>;
-    if (data.trainerId !== trainer.uid) return false;
-    // A log is "completed" when it carries a completedAt (status mirrors it).
-    return data.status === "completed" || asIso(data.completedAt) !== null;
-  });
+  // Ownership + completed filter in memory (see index note above). Ownership
+  // resolves the client's coachId too (issue #434 — client-created "self"
+  // workouts carry trainerId === clientId), so the share card shows the actuals
+  // of a self-assigned workout the same way it does a trainer-assigned one.
+  const ownedAndCompleted = await Promise.all(
+    allDocs.map(async (d) => {
+      const data = d.data() as Record<string, unknown>;
+      if (!(await coachCanAccessLog(db, trainer.uid, data))) return false;
+      // A log is "completed" when it carries a completedAt (status mirrors it).
+      return data.status === "completed" || asIso(data.completedAt) !== null;
+    }),
+  );
+  const completed = allDocs.filter((_, i) => ownedAndCompleted[i]);
   if (completed.length === 0) return null;
 
   // Most recent by startedAt (fall back to completedAt), so re-logged

--- a/backoffice/src/lib/gc-fitness/recent-logs-actions.ts
+++ b/backoffice/src/lib/gc-fitness/recent-logs-actions.ts
@@ -555,11 +555,23 @@ async function buildRecentLogs(params: {
       sourceFull(weightSnapsR) ||
       sourceFull(profileSnapsR);
   } else {
-    const workoutLogsPromise = db
-      .collection(FirestoreCollections.workoutLogs)
-      .where("trainerId", "==", params.trainerId)
-      .limit(150)
-      .get();
+    // #434 follow-up: fan out workout_logs per roster client (by clientId)
+    // instead of a single `trainerId ==` query, so CLIENT-CREATED ("self")
+    // workouts — whose trainerId is the client's own uid, not the coach's —
+    // appear in the dashboard/recent-logs feed too (the paginated branch
+    // already keys off clientId). Each per-client query is bounded and
+    // .catch-guarded like the other fan-outs in this branch. No new index:
+    // single-field `clientId` is auto-indexed.
+    const workoutLogsPromise = Promise.all(
+      clients.map((client) =>
+        db
+          .collection(FirestoreCollections.workoutLogs)
+          .where("clientId", "==", client.uid)
+          .limit(150)
+          .get()
+          .catch(() => null),
+      ),
+    );
     // Trainer-scoped assignments — used to surface the "client moved
     // workout from X to Y" reschedule activity. No orderBy keeps this on
     // the existing single-field trainerId index; we filter in memory to
@@ -664,8 +676,9 @@ async function buildRecentLogs(params: {
         .catch(() => null),
     );
 
+    let workoutLogsFanout: Array<FirebaseFirestore.QuerySnapshot | null> = [];
     [
-      workoutLogsSnap,
+      workoutLogsFanout,
       usersSnap,
       habitLogsSnaps,
       photoSnaps,
@@ -683,6 +696,11 @@ async function buildRecentLogs(params: {
       Promise.all(habitsPromises),
       trainerAssignmentsPromise,
     ]);
+    // Flatten the per-client fan-out into the single `{ docs }` shape the rest
+    // of the function consumes (same shape the paginated branch produces).
+    workoutLogsSnap = {
+      docs: workoutLogsFanout.flatMap((snap) => snap?.docs ?? []),
+    };
   }
 
   // Rewrap as a flat array so the rest of the function (which expects
@@ -1320,12 +1338,23 @@ async function buildRecentLogs(params: {
     (fk) => !existingAssignmentIds.has(fk),
   );
   if (unknownFks.length > 0) {
-    const refs = unknownFks.map((fk) =>
-      db.collection(FirestoreCollections.workoutAssignments).doc(fk),
+    // Point reads, NOT db.getAll: getAll/batchGet is unreliable in this
+    // serverless (Vercel) setup (issue #166 / PR #186). This confirmation is
+    // load-bearing for #434 — a client-created ("self") workout's assignment
+    // (trainerId === clientId) is never in the trainer-scoped
+    // `trainerAssignmentsSnap`, so its FK is ALWAYS "unknown" here and would be
+    // dropped as orphaned if the existence check silently failed.
+    const docs = await Promise.all(
+      unknownFks.map((fk) =>
+        db
+          .collection(FirestoreCollections.workoutAssignments)
+          .doc(fk)
+          .get()
+          .catch(() => null),
+      ),
     );
-    const docs = await db.getAll(...refs);
     docs.forEach((d) => {
-      if (d.exists) existingAssignmentIds.add(d.id);
+      if (d?.exists) existingAssignmentIds.add(d.id);
     });
   }
 


### PR DESCRIPTION
Closes #434.

## Problem
A coach opening a **client-created ("self") workout log** got a 404 (e.g. the `…-self-…` log in the issue). Related: those self-workouts also didn't appear in the dashboard recent-logs widget.

## Root cause
Self-assigned workouts (issue #392) are written with `trainerId === clientId === <client uid>`. Backoffice workout ownership checks used a bare `trainerId === coach.uid` equality (no `coachId` fallback, unlike habits' `currentTrainerCanManageHabit`), so both the detail loader **and** the legacy feed query rejected/hid them.

## Fix
**1. Detail loaders (the 404).** New `coachCanAccessLog(db, coach, data)`: a coach may open a log when they're its `trainerId` **or** the coach-of-record for its client (`users/{clientId}.coachId === coach`). Scoped to the coach's own clients → no cross-coach leak. Applied to `getWorkoutLogDetail`, `getWorkoutLogDetailAsAdmin`, and `getWorkoutLogDetailByAssignment` (calendar share-card actuals).

**2. Legacy dashboard/recent-logs feed.** `listRecentLogsForTrainer` queried `workout_logs` by `trainerId == coach`; now it fans out per roster client by `clientId` (like the paginated branch), so self-workouts show up. Also switched the orphan-filter's assignment-existence confirmation from `db.getAll` to parallel point reads — `getAll` is unreliable in this serverless (Vercel) setup (PR #186), and that check is load-bearing here (a self-workout's assignment is never in the trainer-scoped set, so its FK is always "unknown" and the row would be dropped as orphaned if the check silently failed).

## Notes / scope
- **No index / rules / functions changes.** All queries are single-field (`clientId`) filters (auto-indexed); the backoffice reads via the Admin SDK (rules bypassed), so the app-side check is the only gate.
- `buildWorkoutLogDetail` uses the passed coach uid only for the share-card coach display-name (degrades to null), so passing the coach's uid for a self-log is correct.

## Tests / gate
- `npx tsc --noEmit` clean.
- `npx jest` all green except the pre-existing `client-activity-time` locale flake (passes in CI). New coverage:
  - `recent-logs-actions.self-workout.test.ts` — self-log for own client opens, trainer-owned log still opens, another coach's client's log rejected.
  - `recent-logs-actions.self-workout-feed.test.ts` — legacy feed surfaces a roster client's self-log and it survives the orphan filter.