### PR TITLE
feat(prs): previous-PR on log detail + client Personal Records section (#405)

### DIFF
--- a/backoffice/messages/en.json
+++ b/backoffice/messages/en.json
@@ -321,7 +321,21 @@
         "habitTrends": "Habits",
         "recentMessages": "Recent messages",
         "bodyWeight": "Body weight (30 days)",
-        "recentLogs": "Recent activity"
+        "recentLogs": "Recent activity",
+        "personalRecords": "Personal records"
+      },
+      "personalRecords": {
+        "title": "Personal records",
+        "subtitle": "The client's best lifts and how they've progressed.",
+        "empty": "No personal records yet.",
+        "muscleGroupLabel": "Muscle group",
+        "muscleGroupAll": "All",
+        "sortLabel": "Sort",
+        "sortRecent": "Most recent",
+        "sortMostCommon": "Most common",
+        "previousLabel": "Previous: {value}",
+        "estOneRm": "Est. 1RM {value} kg",
+        "noDate": "—"
       },
       "timeline": {
         "title": "Daily client view",
@@ -1805,6 +1819,7 @@
       "noAthleteNotes": "No client notes.",
       "prBadge": "PR",
       "prBadgeTitle": "New personal record · estimated 1RM {value} kg",
+      "prPreviousLabel": "prev {value}",
       "exerciseSetCount": "{count, plural, one {# set} other {# sets}}",
       "exerciseTopWeight": "Top: {weight} kg",
       "exerciseNoWeight": "No weight logged",

--- a/backoffice/messages/es.json
+++ b/backoffice/messages/es.json
@@ -321,7 +321,21 @@
         "habitTrends": "Hábitos",
         "recentMessages": "Mensajes recientes",
         "bodyWeight": "Peso corporal (30 días)",
-        "recentLogs": "Actividad reciente"
+        "recentLogs": "Actividad reciente",
+        "personalRecords": "Récords personales"
+      },
+      "personalRecords": {
+        "title": "Récords personales",
+        "subtitle": "Las mejores marcas del cliente y su progresión.",
+        "empty": "Todavía no hay récords.",
+        "muscleGroupLabel": "Grupo muscular",
+        "muscleGroupAll": "Todos",
+        "sortLabel": "Ordenar",
+        "sortRecent": "Más recientes",
+        "sortMostCommon": "Más comunes",
+        "previousLabel": "Anterior: {value}",
+        "estOneRm": "1RM est. {value} kg",
+        "noDate": "—"
       },
       "timeline": {
         "title": "Vista diaria del cliente",
@@ -1805,6 +1819,7 @@
       "noAthleteNotes": "Sin notas del cliente.",
       "prBadge": "PR",
       "prBadgeTitle": "Nuevo récord personal · 1RM estimado {value} kg",
+      "prPreviousLabel": "ant. {value}",
       "exerciseSetCount": "{count, plural, one {# serie} other {# series}}",
       "exerciseTopWeight": "Tope: {weight} kg",
       "exerciseNoWeight": "Sin peso registrado",

--- a/backoffice/src/app/gc-fitness/clients/[id]/_components/PersonalRecordsClient.tsx
+++ b/backoffice/src/app/gc-fitness/clients/[id]/_components/PersonalRecordsClient.tsx
@@ -1,0 +1,204 @@
+"use client";
+
+// PersonalRecordsClient.tsx — issue #405 part (b). Renders a client's personal
+// records with the record each one beat ("previous PR") and how long ago it was
+// set, filterable by muscle group and sortable by "most recent" / "most common"
+// (most-trained exercises first). Pure client filtering over a server-provided
+// list — no extra fetches.
+
+import { useMemo, useState } from "react";
+import { useLocale } from "next-intl";
+import { Trophy } from "lucide-react";
+
+import type { PersonalRecordEntry } from "@/lib/gc-fitness/personal-records";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+
+export interface PersonalRecordsLabels {
+  empty: string;
+  muscleGroupLabel: string;
+  muscleGroupAll: string;
+  sortLabel: string;
+  sortRecent: string;
+  sortMostCommon: string;
+  previousLabel: string; // "Previous: {value}"
+  estOneRm: string; // "Est. 1RM {value} kg"
+  noDate: string;
+}
+
+type SortKey = "recent" | "common";
+
+// "pull_up_bar" → "Pull up bar" — mirrors the exercise-progress filter casing.
+function formatMuscleGroup(group: string): string {
+  return group.replace(/_/g, " ").replace(/^[a-z]/, (c) => c.toUpperCase());
+}
+
+/** Compact record value: duration for time PRs, "{w} kg × {r}" for weighted,
+ * "{r} reps" for bodyweight. */
+function recordValue(
+  snap: { weightKg: number; reps: number; durationSeconds: number | null },
+  metric: "reps" | "time",
+): string {
+  if (metric === "time" && snap.durationSeconds != null) return `${snap.durationSeconds}s`;
+  if (snap.weightKg > 0) return `${snap.weightKg} kg × ${snap.reps}`;
+  return `${snap.reps} reps`;
+}
+
+function formatAgo(ms: number | null, locale: string, noDate: string): string {
+  if (ms == null) return noDate;
+  const diff = ms - Date.now(); // negative → in the past
+  const abs = Math.abs(diff);
+  const rtf = new Intl.RelativeTimeFormat(locale, { numeric: "auto" });
+  const minute = 60_000;
+  const hour = 60 * minute;
+  const day = 24 * hour;
+  const month = 30 * day;
+  const year = 365 * day;
+  if (abs < hour) return rtf.format(Math.round(diff / minute), "minute");
+  if (abs < day) return rtf.format(Math.round(diff / hour), "hour");
+  if (abs < month) return rtf.format(Math.round(diff / day), "day");
+  if (abs < year) return rtf.format(Math.round(diff / month), "month");
+  return rtf.format(Math.round(diff / year), "year");
+}
+
+export function PersonalRecordsClient({
+  records,
+  labels,
+}: {
+  records: PersonalRecordEntry[];
+  labels: PersonalRecordsLabels;
+}) {
+  const locale = useLocale();
+  const [muscleGroup, setMuscleGroup] = useState<string>("all");
+  const [sort, setSort] = useState<SortKey>("recent");
+
+  const muscleGroups = useMemo(() => {
+    const set = new Set<string>();
+    for (const r of records) for (const g of r.muscleGroups) set.add(g);
+    return Array.from(set).sort((a, b) =>
+      formatMuscleGroup(a).localeCompare(formatMuscleGroup(b)),
+    );
+  }, [records]);
+
+  const visible = useMemo(() => {
+    const filtered =
+      muscleGroup === "all"
+        ? records
+        : records.filter((r) => r.muscleGroups.includes(muscleGroup));
+    const sorted = [...filtered];
+    if (sort === "common") {
+      sorted.sort(
+        (a, b) =>
+          b.sessionCount - a.sessionCount ||
+          a.exerciseName.localeCompare(b.exerciseName),
+      );
+    }
+    // "recent" keeps the server order (most-recent PR first).
+    return sorted;
+  }, [records, muscleGroup, sort]);
+
+  if (records.length === 0) {
+    return (
+      <div className="flex h-32 items-center justify-center rounded-md border border-dashed text-sm text-muted-foreground">
+        {labels.empty}
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-3">
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-end">
+        {muscleGroups.length >= 2 ? (
+          <div className="flex flex-col gap-1.5 sm:w-44">
+            <label
+              htmlFor="pr-muscle"
+              className="text-xs font-medium uppercase tracking-wide text-muted-foreground"
+            >
+              {labels.muscleGroupLabel}
+            </label>
+            <Select value={muscleGroup} onValueChange={setMuscleGroup}>
+              <SelectTrigger id="pr-muscle" className="w-full">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="all">{labels.muscleGroupAll}</SelectItem>
+                {muscleGroups.map((g) => (
+                  <SelectItem key={g} value={g}>
+                    {formatMuscleGroup(g)}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+        ) : null}
+        <div className="flex flex-col gap-1.5 sm:w-44">
+          <label
+            htmlFor="pr-sort"
+            className="text-xs font-medium uppercase tracking-wide text-muted-foreground"
+          >
+            {labels.sortLabel}
+          </label>
+          <Select value={sort} onValueChange={(v) => setSort(v as SortKey)}>
+            <SelectTrigger id="pr-sort" className="w-full">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="recent">{labels.sortRecent}</SelectItem>
+              <SelectItem value="common">{labels.sortMostCommon}</SelectItem>
+            </SelectContent>
+          </Select>
+        </div>
+      </div>
+
+      <ul className="space-y-2">
+        {visible.map((r) => (
+          <li
+            key={r.exerciseId}
+            className="rounded-lg border border-border bg-background px-3 py-2.5"
+          >
+            <div className="flex items-start justify-between gap-3">
+              <div className="min-w-0">
+                <p className="truncate font-medium">{r.exerciseName}</p>
+                {r.muscleGroups.length > 0 ? (
+                  <p className="mt-0.5 truncate text-xs text-muted-foreground">
+                    {r.muscleGroups.map(formatMuscleGroup).join(" · ")}
+                  </p>
+                ) : null}
+              </div>
+              <div className="shrink-0 text-right">
+                <p className="flex items-center justify-end gap-1 font-semibold">
+                  <Trophy className="h-3.5 w-3.5 text-amber-600 dark:text-amber-400" />
+                  {recordValue(r.current, r.metric)}
+                </p>
+                {r.metric === "reps" && r.current.estimatedOneRM > 0 ? (
+                  <p className="text-xs text-muted-foreground">
+                    {labels.estOneRm.replace(
+                      "{value}",
+                      String(Math.round(r.current.estimatedOneRM * 10) / 10),
+                    )}
+                  </p>
+                ) : null}
+                <p className="text-xs text-muted-foreground">
+                  {formatAgo(r.current.achievedAtMs, locale, labels.noDate)}
+                </p>
+              </div>
+            </div>
+            {r.previous ? (
+              <p className="mt-1.5 border-t border-dashed border-border pt-1.5 text-xs text-muted-foreground">
+                {labels.previousLabel.replace(
+                  "{value}",
+                  recordValue(r.previous, r.metric),
+                )}
+              </p>
+            ) : null}
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/backoffice/src/app/gc-fitness/clients/[id]/_components/PersonalRecordsWidget.tsx
+++ b/backoffice/src/app/gc-fitness/clients/[id]/_components/PersonalRecordsWidget.tsx
@@ -1,0 +1,43 @@
+// PersonalRecordsWidget.tsx — issue #405 part (b). Async server component that
+// loads a client's personal records and renders the filterable list.
+
+import { Trophy } from "lucide-react";
+import { getTranslations } from "next-intl/server";
+
+import { listClientPersonalRecords } from "@/lib/gc-fitness/personal-records-actions";
+import { PersonalRecordsClient } from "./PersonalRecordsClient";
+
+export async function PersonalRecordsWidget({ clientId }: { clientId: string }) {
+  const t = await getTranslations("clients.detail.personalRecords");
+  const { records } = await listClientPersonalRecords(clientId);
+
+  return (
+    <section
+      id="personal-records"
+      className="rounded-[1.25rem] border border-border bg-card p-5 shadow-sm"
+    >
+      <div className="mb-3">
+        <h2 className="flex items-center gap-2 font-medium">
+          <Trophy className="size-4" />
+          {t("title")}
+        </h2>
+        <p className="text-sm text-muted-foreground">{t("subtitle")}</p>
+      </div>
+
+      <PersonalRecordsClient
+        records={records}
+        labels={{
+          empty: t("empty"),
+          muscleGroupLabel: t("muscleGroupLabel"),
+          muscleGroupAll: t("muscleGroupAll"),
+          sortLabel: t("sortLabel"),
+          sortRecent: t("sortRecent"),
+          sortMostCommon: t("sortMostCommon"),
+          previousLabel: t("previousLabel"),
+          estOneRm: t("estOneRm"),
+          noDate: t("noDate"),
+        }}
+      />
+    </section>
+  );
+}

--- a/backoffice/src/app/gc-fitness/clients/[id]/page.tsx
+++ b/backoffice/src/app/gc-fitness/clients/[id]/page.tsx
@@ -43,6 +43,7 @@ import { ChatHistoryWidget } from "./_components/ChatHistoryWidget";
 import { BodyWeightTrendChart } from "./_components/BodyWeightTrendChart";
 import { ClientNotesCard } from "./_components/ClientNotesCard";
 import { ProgressPhotosWidget } from "./_components/ProgressPhotosWidget";
+import { PersonalRecordsWidget } from "./_components/PersonalRecordsWidget";
 import { ClientRecentLogsWidget } from "./_components/ClientRecentLogsWidget";
 import ClientRequestActionsCard from "./_components/ClientRequestActionsCard";
 import { listClientGoals } from "@/lib/gc-fitness/client-goal-actions";
@@ -252,6 +253,10 @@ export default async function ClientDetailPage({
         />
 
         <ProgressPhotosWidget photos={progressPhotos} clientId={id} timezone={timezone} />
+
+        <Suspense fallback={<WidgetSkeleton title={tSkeleton("personalRecords")} />}>
+          <PersonalRecordsWidget clientId={id} />
+        </Suspense>
 
         <Suspense fallback={<WidgetSkeleton title={tSkeleton("recentLogs")} />}>
           <ClientRecentLogsWidget clientId={id} timezone={timezone} />

--- a/backoffice/src/components/gc-fitness/workout-log-detail-view.tsx
+++ b/backoffice/src/components/gc-fitness/workout-log-detail-view.tsx
@@ -24,6 +24,15 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import type { WorkoutLogDetail } from "@/lib/gc-fitness/recent-logs-actions";
 
+/** Compact "previous PR" value for the PR row: duration for time PRs, else
+ * "{weight} kg × {reps}" (issue #405). */
+function prPreviousText(
+  prev: NonNullable<WorkoutLogDetail["sets"][number]["prPrevious"]>,
+): string {
+  if (prev.durationSeconds !== null) return `${prev.durationSeconds}s`;
+  return `${prev.weightKg} kg × ${prev.reps}`;
+}
+
 // Stable HSL palette — assigns each distinct exerciseId a recognisable
 // accent so the per-exercise blocks read at a glance.
 const EXERCISE_COLORS = [
@@ -236,7 +245,7 @@ export function WorkoutLogDetailView({ detail }: { detail: WorkoutLogDetail }) {
                               }
                             >
                               <td className="py-2 pr-3">
-                                <div className="flex items-center gap-1.5">
+                                <div className="flex flex-wrap items-center gap-x-1.5 gap-y-0.5">
                                   <span>{set.index}</span>
                                   {set.isPR ? (
                                     <span
@@ -252,6 +261,13 @@ export function WorkoutLogDetailView({ detail }: { detail: WorkoutLogDetail }) {
                                         className="h-3.5 w-3.5 text-amber-600 dark:text-amber-400"
                                         aria-label={t("prBadge")}
                                       />
+                                    </span>
+                                  ) : null}
+                                  {set.isPR && set.prPrevious ? (
+                                    <span className="whitespace-nowrap text-[10px] text-muted-foreground">
+                                      {t("prPreviousLabel", {
+                                        value: prPreviousText(set.prPrevious),
+                                      })}
                                     </span>
                                   ) : null}
                                 </div>

--- a/backoffice/src/lib/gc-fitness/__tests__/personal-records.test.ts
+++ b/backoffice/src/lib/gc-fitness/__tests__/personal-records.test.ts
@@ -1,0 +1,152 @@
+import {
+  buildPersonalRecords,
+  flattenLogPRs,
+  previousRecordsByExercise,
+  type PRExerciseMeta,
+  type RawPersonalRecord,
+} from "../personal-records";
+
+function pr(over: Partial<RawPersonalRecord> & { exerciseId: string; setLogId: string }): RawPersonalRecord {
+  return {
+    weightKg: 100,
+    reps: 5,
+    estimatedOneRM: 116.7,
+    durationSeconds: null,
+    achievedAtMs: 0,
+    ...over,
+  };
+}
+
+const meta = new Map<string, PRExerciseMeta>([
+  ["bench", { name: "Bench Press", muscleGroups: ["chest"], sessionCount: 12 }],
+  ["squat", { name: "Squat", muscleGroups: ["legs"], sessionCount: 20 }],
+  ["plank", { name: "Plank", muscleGroups: ["core"], sessionCount: 4 }],
+]);
+
+describe("buildPersonalRecords", () => {
+  it("returns current + previous PR per exercise (newest is current)", () => {
+    const rows = [
+      pr({ exerciseId: "bench", setLogId: "b1", estimatedOneRM: 100, achievedAtMs: 1000 }),
+      pr({ exerciseId: "bench", setLogId: "b2", estimatedOneRM: 110, achievedAtMs: 2000 }),
+      pr({ exerciseId: "bench", setLogId: "b3", estimatedOneRM: 120, achievedAtMs: 3000 }),
+    ];
+    const [entry] = buildPersonalRecords(rows, meta);
+    expect(entry.exerciseId).toBe("bench");
+    expect(entry.exerciseName).toBe("Bench Press");
+    expect(entry.muscleGroups).toEqual(["chest"]);
+    expect(entry.metric).toBe("reps");
+    expect(entry.current.estimatedOneRM).toBe(120);
+    expect(entry.current.achievedAtMs).toBe(3000);
+    expect(entry.previous?.estimatedOneRM).toBe(110);
+  });
+
+  it("has null previous when there is only one PR", () => {
+    const rows = [pr({ exerciseId: "squat", setLogId: "s1", estimatedOneRM: 150, achievedAtMs: 5000 })];
+    const [entry] = buildPersonalRecords(rows, meta);
+    expect(entry.previous).toBeNull();
+    expect(entry.current.estimatedOneRM).toBe(150);
+  });
+
+  it("detects time-based PRs and orders by duration", () => {
+    const rows = [
+      pr({ exerciseId: "plank", setLogId: "p1", reps: 0, estimatedOneRM: 0, durationSeconds: 60, achievedAtMs: 1000 }),
+      pr({ exerciseId: "plank", setLogId: "p2", reps: 0, estimatedOneRM: 0, durationSeconds: 90, achievedAtMs: 2000 }),
+    ];
+    const [entry] = buildPersonalRecords(rows, meta);
+    expect(entry.metric).toBe("time");
+    expect(entry.current.durationSeconds).toBe(90);
+    expect(entry.previous?.durationSeconds).toBe(60);
+  });
+
+  it("orders entries by most-recent PR first", () => {
+    const rows = [
+      pr({ exerciseId: "bench", setLogId: "b1", achievedAtMs: 1000 }),
+      pr({ exerciseId: "squat", setLogId: "s1", achievedAtMs: 9000 }),
+    ];
+    const entries = buildPersonalRecords(rows, meta);
+    expect(entries.map((e) => e.exerciseId)).toEqual(["squat", "bench"]);
+  });
+
+  it("falls back to magnitude when achievedAt is missing", () => {
+    const rows = [
+      pr({ exerciseId: "bench", setLogId: "b1", estimatedOneRM: 130, achievedAtMs: null }),
+      pr({ exerciseId: "bench", setLogId: "b2", estimatedOneRM: 120, achievedAtMs: null }),
+    ];
+    const [entry] = buildPersonalRecords(rows, meta);
+    expect(entry.current.estimatedOneRM).toBe(130);
+    expect(entry.previous?.estimatedOneRM).toBe(120);
+  });
+
+  it("dedupes repeated setLogId", () => {
+    const rows = [
+      pr({ exerciseId: "bench", setLogId: "b1", estimatedOneRM: 100, achievedAtMs: 1000 }),
+      pr({ exerciseId: "bench", setLogId: "b1", estimatedOneRM: 100, achievedAtMs: 1000 }),
+    ];
+    const [entry] = buildPersonalRecords(rows, meta);
+    expect(entry.previous).toBeNull();
+  });
+});
+
+describe("flattenLogPRs", () => {
+  it("maps snake_case wire keys and resolves achieved_at", () => {
+    const rows = flattenLogPRs({
+      completedAt: { toDate: () => new Date(5000) },
+      prs: [
+        {
+          exerciseId: "bench",
+          weight_kg: 100,
+          reps: 5,
+          estimated_one_rm: 116.7,
+          set_log_id: "b1",
+          achieved_at: { toDate: () => new Date(4000) },
+        },
+      ],
+    });
+    expect(rows).toEqual([
+      {
+        exerciseId: "bench",
+        weightKg: 100,
+        reps: 5,
+        estimatedOneRM: 116.7,
+        durationSeconds: null,
+        setLogId: "b1",
+        achievedAtMs: 4000,
+      },
+    ]);
+  });
+
+  it("falls back to the log timestamp when a PR has no achieved_at, and skips PRs missing ids", () => {
+    const rows = flattenLogPRs({
+      startedAt: { toDate: () => new Date(7000) },
+      prs: [
+        { exerciseId: "plank", reps: 0, duration_seconds: 90, set_log_id: "p1" },
+        { weight_kg: 50, reps: 5, set_log_id: "no-exercise" },
+        { exerciseId: "x", reps: 5 },
+      ],
+    });
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({ exerciseId: "plank", durationSeconds: 90, achievedAtMs: 7000 });
+  });
+
+  it("returns [] when the log has no prs", () => {
+    expect(flattenLogPRs({})).toEqual([]);
+  });
+});
+
+describe("previousRecordsByExercise", () => {
+  it("returns the latest earlier PR per requested exercise", () => {
+    const earlier = [
+      pr({ exerciseId: "bench", setLogId: "b1", estimatedOneRM: 100, achievedAtMs: 1000 }),
+      pr({ exerciseId: "bench", setLogId: "b2", estimatedOneRM: 110, achievedAtMs: 2000 }),
+      pr({ exerciseId: "squat", setLogId: "s1", estimatedOneRM: 140, achievedAtMs: 1500 }),
+    ];
+    const prev = previousRecordsByExercise(earlier, new Set(["bench"]));
+    expect(prev.get("bench")?.estimatedOneRM).toBe(110);
+    expect(prev.has("squat")).toBe(false);
+  });
+
+  it("returns empty when no earlier PR exists for the exercise", () => {
+    const prev = previousRecordsByExercise([], new Set(["bench"]));
+    expect(prev.size).toBe(0);
+  });
+});

--- a/backoffice/src/lib/gc-fitness/personal-records-actions.ts
+++ b/backoffice/src/lib/gc-fitness/personal-records-actions.ts
@@ -1,0 +1,132 @@
+"use server";
+
+// personal-records-actions.ts — server reads for a client's personal records
+// (issue #405). PRs live on each workout_logs doc's `prs[]`; there is no
+// separate collection, so we scan the client's recent logs, flatten every PR,
+// and hand the rows to the pure grouping logic in personal-records.ts.
+//
+// READ-COST: ONE bounded query — `workout_logs where clientId == X orderBy
+// startedAt desc limit 300` (reuses the existing (clientId, startedAt DESC)
+// composite index; no date bound so a long-standing record still surfaces) +
+// ONE batched getAll for the PR exercises' muscle groups.
+
+import { getCurrentTrainer } from "@/lib/gc-fitness/auth-helpers";
+import { gcFitnessFirestore } from "@/lib/firebase/gc-fitness-admin";
+import { FirestoreCollections } from "@/lib/gc-fitness/collections";
+import {
+  buildPersonalRecords,
+  flattenLogPRs,
+  type PersonalRecordEntry,
+  type PRExerciseMeta,
+  type RawPersonalRecord,
+} from "@/lib/gc-fitness/personal-records";
+
+const LOG_FETCH_LIMIT = 300;
+
+export interface ClientPersonalRecords {
+  clientId: string;
+  records: PersonalRecordEntry[];
+}
+
+function localizedName(value: unknown, fallback: string): string {
+  if (typeof value === "string" && value.trim()) return value.trim();
+  if (value && typeof value === "object") {
+    const loc = value as { es?: unknown; en?: unknown };
+    if (typeof loc.es === "string" && loc.es.trim()) return loc.es.trim();
+    if (typeof loc.en === "string" && loc.en.trim()) return loc.en.trim();
+  }
+  return fallback;
+}
+
+/**
+ * Read-only: all of a client's personal records with the record each one beat,
+ * plus exercise name / muscle groups / session count for the coach's filters.
+ * Trainer-auth gated + per-client ownership checked.
+ */
+export async function listClientPersonalRecords(
+  clientId: string,
+): Promise<ClientPersonalRecords> {
+  const trainer = await getCurrentTrainer();
+  const db = gcFitnessFirestore();
+
+  const clientSnap = await db
+    .collection(FirestoreCollections.users)
+    .doc(clientId)
+    .get();
+  if (!clientSnap.exists || clientSnap.get("coachId") !== trainer.uid) {
+    return { clientId, records: [] };
+  }
+
+  const snap = await db
+    .collection(FirestoreCollections.workoutLogs)
+    .where("clientId", "==", clientId)
+    .orderBy("startedAt", "desc")
+    .limit(LOG_FETCH_LIMIT)
+    .get();
+
+  const allPrs: RawPersonalRecord[] = [];
+  const nameById = new Map<string, string>();
+  const sessionCountById = new Map<string, number>();
+
+  for (const doc of snap.docs) {
+    const data = doc.data() as Record<string, unknown>;
+
+    // Names from the log's templateSnapshot (same source the detail builder uses).
+    const templateExercises =
+      (data.templateSnapshot as { exercises?: Array<Record<string, unknown>> } | undefined)
+        ?.exercises ?? [];
+    for (const ex of templateExercises) {
+      const exId = typeof ex.exerciseId === "string" ? ex.exerciseId : "";
+      if (exId && !nameById.has(exId)) nameById.set(exId, localizedName(ex.name, exId));
+    }
+
+    // Session count = # of sessions with a completed set for the exercise
+    // (matches the "most common" ordering in exercise-progress).
+    const rawSets = Array.isArray(data.sets)
+      ? (data.sets as Array<Record<string, unknown>>)
+      : [];
+    const exercisesThisSession = new Set<string>();
+    for (const s of rawSets) {
+      const exId = typeof s.exerciseId === "string" ? s.exerciseId : "";
+      if (!exId) continue;
+      if (Boolean(s.completed_at ?? s.completedAt)) exercisesThisSession.add(exId);
+    }
+    for (const exId of exercisesThisSession) {
+      sessionCountById.set(exId, (sessionCountById.get(exId) ?? 0) + 1);
+    }
+
+    allPrs.push(...flattenLogPRs(data));
+  }
+
+  // Resolve muscle groups for the exercises that actually have a PR — one
+  // batched getAll (bounded by the client's PR variety).
+  const prExerciseIds = Array.from(new Set(allPrs.map((p) => p.exerciseId)));
+  const muscleById = new Map<string, string[]>();
+  if (prExerciseIds.length > 0) {
+    const refs = prExerciseIds.map((exId) =>
+      db.collection(FirestoreCollections.exercises).doc(exId),
+    );
+    const exerciseDocs = await db.getAll(...refs);
+    for (const exDoc of exerciseDocs) {
+      if (!exDoc.exists) continue;
+      const mg = exDoc.get("muscleGroups");
+      if (Array.isArray(mg)) {
+        muscleById.set(exDoc.id, mg.filter((v): v is string => typeof v === "string"));
+      }
+      // Prefer the canonical exercise-doc name over the snapshot when present.
+      const docName = localizedName(exDoc.get("name"), "");
+      if (docName) nameById.set(exDoc.id, docName);
+    }
+  }
+
+  const meta = new Map<string, PRExerciseMeta>();
+  for (const exId of prExerciseIds) {
+    meta.set(exId, {
+      name: nameById.get(exId) ?? exId,
+      muscleGroups: muscleById.get(exId) ?? [],
+      sessionCount: sessionCountById.get(exId) ?? 0,
+    });
+  }
+
+  return { clientId, records: buildPersonalRecords(allPrs, meta) };
+}

--- a/backoffice/src/lib/gc-fitness/personal-records.ts
+++ b/backoffice/src/lib/gc-fitness/personal-records.ts
@@ -1,0 +1,222 @@
+// personal-records.ts — PURE grouping logic for a client's personal records
+// (issue #405). No Firestore / no React here so it is unit-testable; the server
+// action (personal-records-actions.ts) does the I/O and feeds these functions.
+//
+// PRs live as a `prs[]` array on each workout_logs doc (there is no separate
+// collection). PRDetector only appends a PR when it strictly beats the previous
+// best for that exercise, so an exercise's PRs form a strictly-increasing
+// sequence over time — the newest PR is the current record and the one before
+// it is the "previous PR" the coach wants to see (issue #405 part a).
+
+export type PRMetric = "reps" | "time";
+
+/** One raw PR row flattened from a workout_logs `prs[]` entry. */
+export interface RawPersonalRecord {
+  exerciseId: string;
+  weightKg: number;
+  reps: number;
+  estimatedOneRM: number;
+  /** Present (seconds) only for time-based PRs (plank, wall-sit); else null. */
+  durationSeconds: number | null;
+  setLogId: string;
+  /** Epoch ms when the PR was achieved, or null when the doc lacks a date. */
+  achievedAtMs: number | null;
+}
+
+/** A single record snapshot (current or previous). */
+export interface PRSnapshot {
+  weightKg: number;
+  reps: number;
+  estimatedOneRM: number;
+  durationSeconds: number | null;
+  achievedAtMs: number | null;
+}
+
+/** Metadata for an exercise, resolved from the logs + exercise docs. */
+export interface PRExerciseMeta {
+  name: string;
+  muscleGroups: string[];
+  /** How many of the client's sessions logged this exercise — drives the
+   * "most common" ordering in the UI. */
+  sessionCount: number;
+}
+
+/** The current PR for one exercise plus the record it beat (if any). */
+export interface PersonalRecordEntry {
+  exerciseId: string;
+  exerciseName: string;
+  muscleGroups: string[];
+  sessionCount: number;
+  metric: PRMetric;
+  current: PRSnapshot;
+  /** The record the current PR beat — null when this is the first PR. */
+  previous: PRSnapshot | null;
+}
+
+function prToMs(v: unknown): number | null {
+  if (v && typeof (v as { toDate?: () => Date }).toDate === "function") {
+    const d = (v as { toDate: () => Date }).toDate();
+    return Number.isNaN(d.getTime()) ? null : d.getTime();
+  }
+  if (v instanceof Date) return Number.isNaN(v.getTime()) ? null : v.getTime();
+  if (typeof v === "string") {
+    const t = new Date(v).getTime();
+    return Number.isNaN(t) ? null : t;
+  }
+  return null;
+}
+
+function prNumeric(v: unknown): number {
+  const n = typeof v === "number" ? v : Number(v);
+  return Number.isFinite(n) ? n : 0;
+}
+
+/**
+ * Flattens one workout_logs `prs[]` array into RawPersonalRecord rows, resolving
+ * each PR's achieved-at (falling back to the log's completedAt/startedAt). Pure
+ * (duck-typed Firestore Timestamp via `.toDate()`) so both the server action and
+ * the workout-log detail builder can reuse it (issue #405).
+ */
+export function flattenLogPRs(logData: Record<string, unknown>): RawPersonalRecord[] {
+  const rawPrs = Array.isArray(logData.prs)
+    ? (logData.prs as Array<Record<string, unknown>>)
+    : [];
+  if (rawPrs.length === 0) return [];
+  const logFallbackMs = prToMs(logData.completedAt) ?? prToMs(logData.startedAt);
+  const out: RawPersonalRecord[] = [];
+  for (const pr of rawPrs) {
+    const exerciseId = typeof pr.exerciseId === "string" ? pr.exerciseId : "";
+    const setLogId =
+      typeof pr.set_log_id === "string"
+        ? pr.set_log_id
+        : typeof pr.setLogId === "string"
+          ? pr.setLogId
+          : "";
+    if (!exerciseId || !setLogId) continue;
+    const durationRaw = pr.duration_seconds ?? pr.durationSeconds;
+    const durationSeconds =
+      typeof durationRaw === "number" && durationRaw > 0 ? durationRaw : null;
+    out.push({
+      exerciseId,
+      weightKg: prNumeric(pr.weight_kg ?? pr.weightKg),
+      reps: prNumeric(pr.reps),
+      estimatedOneRM: prNumeric(pr.estimated_one_rm ?? pr.estimatedOneRM),
+      durationSeconds,
+      setLogId,
+      achievedAtMs: prToMs(pr.achieved_at ?? pr.achievedAt) ?? logFallbackMs,
+    });
+  }
+  return out;
+}
+
+function metricOf(pr: { durationSeconds: number | null }): PRMetric {
+  return pr.durationSeconds != null && pr.durationSeconds > 0 ? "time" : "reps";
+}
+
+/** Sort magnitude for a PR — duration for time PRs, else Epley e1RM. */
+function magnitude(pr: RawPersonalRecord): number {
+  return metricOf(pr) === "time" ? pr.durationSeconds ?? 0 : pr.estimatedOneRM;
+}
+
+function toSnapshot(pr: RawPersonalRecord): PRSnapshot {
+  return {
+    weightKg: pr.weightKg,
+    reps: pr.reps,
+    estimatedOneRM: pr.estimatedOneRM,
+    durationSeconds: pr.durationSeconds,
+    achievedAtMs: pr.achievedAtMs,
+  };
+}
+
+/**
+ * Groups raw PRs by exercise and returns, per exercise, the current record and
+ * the one it beat. Within an exercise, PRs are ordered oldest→newest by
+ * `achievedAtMs` (falling back to magnitude when a date is missing), so the
+ * last entry is the current record and the second-to-last is "previous".
+ *
+ * The returned list is ordered most-recent-PR first; callers (the client UI)
+ * re-sort for the "most common" view and filter by muscle group.
+ */
+export function buildPersonalRecords(
+  prs: RawPersonalRecord[],
+  meta: Map<string, PRExerciseMeta>,
+): PersonalRecordEntry[] {
+  const byExercise = new Map<string, RawPersonalRecord[]>();
+  for (const pr of prs) {
+    if (!pr.exerciseId || !pr.setLogId) continue;
+    const list = byExercise.get(pr.exerciseId);
+    if (list) list.push(pr);
+    else byExercise.set(pr.exerciseId, [pr]);
+  }
+
+  const entries: PersonalRecordEntry[] = [];
+  for (const [exerciseId, list] of byExercise) {
+    // Oldest → newest. Primary key is the achieved date; magnitude is the
+    // tiebreaker (and the fallback when dates are missing on legacy docs).
+    const sorted = [...list].sort((a, b) => {
+      const ta = a.achievedAtMs ?? Number.NEGATIVE_INFINITY;
+      const tb = b.achievedAtMs ?? Number.NEGATIVE_INFINITY;
+      if (ta !== tb) return ta - tb;
+      return magnitude(a) - magnitude(b);
+    });
+    // Dedupe identical setLogId (a log read more than once) — keep first.
+    const seen = new Set<string>();
+    const deduped = sorted.filter((pr) => {
+      if (seen.has(pr.setLogId)) return false;
+      seen.add(pr.setLogId);
+      return true;
+    });
+    if (deduped.length === 0) continue;
+
+    const currentPr = deduped[deduped.length - 1]!;
+    const previousPr = deduped.length >= 2 ? deduped[deduped.length - 2]! : null;
+    const m = meta.get(exerciseId);
+    entries.push({
+      exerciseId,
+      exerciseName: m?.name ?? exerciseId,
+      muscleGroups: m?.muscleGroups ?? [],
+      sessionCount: m?.sessionCount ?? 0,
+      metric: metricOf(currentPr),
+      current: toSnapshot(currentPr),
+      previous: previousPr ? toSnapshot(previousPr) : null,
+    });
+  }
+
+  // Default order: most recently set PR first (nulls last).
+  entries.sort((a, b) => {
+    const ta = a.current.achievedAtMs ?? Number.NEGATIVE_INFINITY;
+    const tb = b.current.achievedAtMs ?? Number.NEGATIVE_INFINITY;
+    if (ta !== tb) return tb - ta;
+    return a.exerciseName.localeCompare(b.exerciseName);
+  });
+  return entries;
+}
+
+/**
+ * The previous PR (the record it beat) for each of `exerciseIds`, given the raw
+ * PRs from logs that came BEFORE the log in question. Returns the latest PR per
+ * exercise (max `achievedAtMs`, magnitude tiebreak) — that is the record the
+ * new PR beat. Used by the workout-log detail view (issue #405 part a).
+ */
+export function previousRecordsByExercise(
+  earlierPrs: RawPersonalRecord[],
+  exerciseIds: Set<string>,
+): Map<string, PRSnapshot> {
+  const best = new Map<string, RawPersonalRecord>();
+  for (const pr of earlierPrs) {
+    if (!exerciseIds.has(pr.exerciseId) || !pr.setLogId) continue;
+    const cur = best.get(pr.exerciseId);
+    if (!cur) {
+      best.set(pr.exerciseId, pr);
+      continue;
+    }
+    const ta = pr.achievedAtMs ?? Number.NEGATIVE_INFINITY;
+    const tc = cur.achievedAtMs ?? Number.NEGATIVE_INFINITY;
+    if (ta > tc || (ta === tc && magnitude(pr) > magnitude(cur))) {
+      best.set(pr.exerciseId, pr);
+    }
+  }
+  const out = new Map<string, PRSnapshot>();
+  for (const [exId, pr] of best) out.set(exId, toSnapshot(pr));
+  return out;
+}

--- a/backoffice/src/lib/gc-fitness/recent-logs-actions.ts
+++ b/backoffice/src/lib/gc-fitness/recent-logs-actions.ts
@@ -14,6 +14,7 @@ import {
 } from "./client-roster";
 import { coachVisibleClientName } from "./client-name";
 import { resolveExerciseDocsById } from "./exercise-resolution";
+import { flattenLogPRs, previousRecordsByExercise } from "./personal-records";
 import { isHabitScheduledOn } from "./habit-schedule";
 import { getTrainerTimezone } from "./trainer-timezone";
 
@@ -140,6 +141,17 @@ export interface WorkoutLogDetail {
     isPR: boolean;
     /** Stored Epley estimated 1RM (kg) when isPR === true. */
     prEstimatedOneRM: number | null;
+    /**
+     * The record this PR beat (issue #405) — the client's most recent PR for
+     * this exercise from a session BEFORE this one. Null when this is the
+     * exercise's first PR or when `isPR` is false.
+     */
+    prPrevious: {
+      weightKg: number;
+      reps: number;
+      estimatedOneRM: number;
+      durationSeconds: number | null;
+    } | null;
     /** Snapshot superset label (e.g. "A"); null for standalone exercises. */
     supersetGroup: string | null;
   }>;
@@ -1817,6 +1829,55 @@ async function buildWorkoutLogDetail(
     prBySetLogId.set(setLogId, { estimatedOneRM: e1rm });
   }
 
+  // #405 part (a): for every PR in THIS log, find the record it beat — the
+  // client's most recent PR for the same exercise from an EARLIER session. Only
+  // runs when the log actually has PRs (keeps the extra read off non-PR logs).
+  const prPrevBySetLogId = new Map<
+    string,
+    { weightKg: number; reps: number; estimatedOneRM: number; durationSeconds: number | null }
+  >();
+  if (rawPrs.length > 0) {
+    const clientId = typeof data.clientId === "string" ? data.clientId : "";
+    const startedAt = asDate(data.startedAt) ?? asDate(data.createdAt);
+    const prExerciseIds = new Set(
+      rawPrs
+        .map((pr) => (typeof pr.exerciseId === "string" ? pr.exerciseId : ""))
+        .filter((id) => id.length > 0),
+    );
+    if (clientId && startedAt && prExerciseIds.size > 0) {
+      // Earlier logs only (startedAt <) — reuses the (clientId, startedAt) index.
+      const earlierSnap = await db
+        .collection(FirestoreCollections.workoutLogs)
+        .where("clientId", "==", clientId)
+        .where("startedAt", "<", startedAt)
+        .orderBy("startedAt", "desc")
+        .limit(200)
+        .get();
+      const earlierPrs = earlierSnap.docs.flatMap((d) =>
+        flattenLogPRs(d.data() as Record<string, unknown>),
+      );
+      const prevByExercise = previousRecordsByExercise(earlierPrs, prExerciseIds);
+      for (const pr of rawPrs) {
+        const exId = typeof pr.exerciseId === "string" ? pr.exerciseId : "";
+        const setLogId =
+          typeof pr.set_log_id === "string"
+            ? pr.set_log_id
+            : typeof pr.setLogId === "string"
+              ? pr.setLogId
+              : "";
+        const prev = exId ? prevByExercise.get(exId) : undefined;
+        if (setLogId && prev) {
+          prPrevBySetLogId.set(setLogId, {
+            weightKg: prev.weightKg,
+            reps: prev.reps,
+            estimatedOneRM: prev.estimatedOneRM,
+            durationSeconds: prev.durationSeconds,
+          });
+        }
+      }
+    }
+  }
+
   const sets = rawSets.map((set, index) => {
     const exerciseId = typeof set.exerciseId === "string" ? set.exerciseId : "";
     const templateExercise = exerciseId
@@ -1852,6 +1913,7 @@ async function buildWorkoutLogDetail(
       isWarmup: Boolean(set.is_warmup ?? set.isWarmup),
       isPR: Boolean(pr),
       prEstimatedOneRM: pr?.estimatedOneRM ?? null,
+      prPrevious: pr ? (prPrevBySetLogId.get(setLogId) ?? null) : null,
       supersetGroup:
         typeof templateExercise?.supersetGroup === "string" &&
         (templateExercise.supersetGroup as string).trim().length > 0


### PR DESCRIPTION
Closes #405.

Two parts.

## Part (a) — show the previous PR
The workout-log detail view now shows, next to each PR row, the **previous PR** for that exercise — the record the new one beat (e.g. `PR 🏆 · prev 100 kg × 5`). `buildWorkoutLogDetail` computes it by scanning the client's **earlier** logs' `prs[]` for the same exercise and taking the latest prior record. The extra query only runs when the log actually has PRs, and reuses the existing `(clientId, startedAt)` index.

## Part (b) — client-profile "Personal records" section
A new section on the client profile listing **every** PR with **how long ago** it was set and the record it beat, with two filters:
- **Muscle group** (All / chest / back / legs …) — from each exercise's `muscleGroups`.
- **Sort**: "Most recent" (default) / "Most common" (most-trained exercises first, by session count).

## How PRs work here
PRs are stored as a `prs[]` array on each `workout_logs` doc (no separate collection). `PRDetector` only appends a PR when it strictly beats the prior best, so each exercise's PRs are strictly increasing → newest = current record, the one before = "previous". The section does **one** bounded query (`workout_logs where clientId == X orderBy startedAt desc limit 300`) + one batched `getAll` for the PR exercises' muscle groups.

## Files
- `personal-records.ts` — pure, unit-tested: `flattenLogPRs`, `buildPersonalRecords`, `previousRecordsByExercise`.
- `personal-records-actions.ts` — `listClientPersonalRecords` (trainer-auth + per-client ownership gated).
- `recent-logs-actions.ts` — inject `prPrevious` into `WorkoutLogDetail` sets.
- `workout-log-detail-view.tsx` — render the previous PR.
- `_components/PersonalRecordsWidget.tsx` (server) + `PersonalRecordsClient.tsx` (client filters) + wired into the client page grid.
- EN/ES strings. `achievedAt` crosses to the client as epoch ms so "how long ago" is locale-aware via `Intl.RelativeTimeFormat`.

## Notes / scope
- **No index / rules / functions changes** (Admin SDK reads; existing indexes only).
- "Most common" = per-client most-trained ordering (there's no global canonical squat/bench list; this matches the existing exercise-progress ordering).
- PR history is scoped to the client's most recent 300 sessions (bounded read) — covers any realistic client.

## Gate
- `npx tsc --noEmit` clean.
- `npx jest` all green except the pre-existing `client-activity-time` locale flake (passes in CI). New `personal-records.test.ts` (11 cases): current/previous grouping, time PRs, most-recent ordering, missing-date fallback, dedupe, `flattenLogPRs` wire-key mapping + achieved-at fallback, `previousRecordsByExercise`.
- Resolved the Next `"use server"` constraint (kept `flattenLogPRs` in the pure module, not the actions file).
- Recommend a manual pass on a client with real PRs (needs prod data) to confirm the section + previous-PR render as expected.