### PR TITLE
fix(calendar): keep date controls readable on mobile (#394)

### DIFF
--- a/backoffice/src/components/gc-fitness/schedule/month-calendar.tsx
+++ b/backoffice/src/components/gc-fitness/schedule/month-calendar.tsx
@@ -562,42 +562,51 @@ export function MonthCalendar({
           Restructured for mobile (~390px): the view switcher, month nav,
           "Hoy" and "Asignación masiva" controls live in their own wrapping
           toolbar instead of the PageHeader actions row, so they stack/wrap
-          cleanly on a phone instead of overflowing horizontally. */}
+          cleanly on a phone instead of overflowing horizontally.
+
+          #394: the date nav + "Hoy" keep their OWN row and get width priority
+          so the month/range label never collapses to "J.." on a phone; the
+          bulk-action buttons drop to a separate full-width row below on mobile
+          (all inline on ≥sm). */}
       <div className="flex flex-wrap items-center gap-2">
         <div className="w-full overflow-x-auto sm:w-auto sm:overflow-visible">
           {viewSwitcher}
         </div>
-        <div className="min-w-0 flex-1 sm:flex-none">{rangeNav}</div>
-        <Button
-          type="button"
-          variant="outline"
-          size="sm"
-          className="min-h-[40px] rounded-full"
-          onClick={goToday}
-        >
-          {t("today")}
-        </Button>
-        <Button
-          variant="outline"
-          size="sm"
-          className="min-h-[40px] rounded-full"
-          asChild
-        >
-          <Link href="/gc-fitness/schedule/bulk">{t("bulkAssign")}</Link>
-        </Button>
-        {/* 260612-e9t (#176): bulk habit assignment from the Agenda. The
-            assigned habit carries its template's recurring schedule (the dialog
-            copies scheduleCadence/Weekdays/etc. server-side). */}
-        <Button
-          type="button"
-          variant="outline"
-          size="sm"
-          className="min-h-[40px] rounded-full"
-          onClick={() => setBulkHabitOpen(true)}
-          disabled={clients.length === 0}
-        >
-          {t("bulkAssignHabit")}
-        </Button>
+        <div className="flex min-w-0 flex-1 items-center gap-2 sm:flex-none">
+          <div className="min-w-0 flex-1 sm:flex-none">{rangeNav}</div>
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            className="min-h-[40px] shrink-0 rounded-full"
+            onClick={goToday}
+          >
+            {t("today")}
+          </Button>
+        </div>
+        <div className="flex w-full flex-wrap items-center gap-2 sm:w-auto">
+          <Button
+            variant="outline"
+            size="sm"
+            className="min-h-[40px] rounded-full"
+            asChild
+          >
+            <Link href="/gc-fitness/schedule/bulk">{t("bulkAssign")}</Link>
+          </Button>
+          {/* 260612-e9t (#176): bulk habit assignment from the Agenda. The
+              assigned habit carries its template's recurring schedule (the dialog
+              copies scheduleCadence/Weekdays/etc. server-side). */}
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            className="min-h-[40px] rounded-full"
+            onClick={() => setBulkHabitOpen(true)}
+            disabled={clients.length === 0}
+          >
+            {t("bulkAssignHabit")}
+          </Button>
+        </div>
       </div>
 
       {/* ── Client filter bar ─────────────────────────────────────────── */}


### PR DESCRIPTION
Closes #394.

## Problem
On a phone, the Agenda (`/gc-fitness/schedule`) calendar's **month/range label collapsed to "J.."** — the coach couldn't tell which period they were viewing. (Confirmed from the issue screenshot: the circled `‹ J.. ›` control.)

## Cause
The date nav (`rangeNav`, `flex-1`) shared its toolbar row with the **Hoy / Asignación masiva / Asignar hábito** buttons. Those buttons took their natural width, starving the `flex-1` date nav so its `truncate` label shrank to ~2 characters.

## Fix
Restructure the toolbar so the **date controls keep width priority on mobile**:
- The date nav + **Hoy** now live in their own flex group that takes the row on mobile (`flex-1`), so the month/range label gets the full width and stays readable.
- The two bulk-action buttons drop to a **separate full-width row** below on mobile (`w-full sm:w-auto`).
- On ≥`sm` everything stays inline (`sm:flex-none` / `sm:w-auto`) — **desktop layout unchanged**.

Mobile rows now read: `[3 Días · Semana · Mes]` / `[‹ Junio 2026 › · Hoy]` / `[Asignación masiva · Asignar hábito]`.

## Gate
- `npx tsc --noEmit` clean. Pure JSX/Tailwind layout change (no logic), so `npx jest` is unaffected (green except the pre-existing `client-activity-time` locale flake).
- Worth a quick eyeball on a ~390px viewport to confirm the label reads fully; desktop is untouched.