### PR TITLE
fix(prs): scope coach PR/log visibility to current roster, not stale trainerId

### DIFF
--- a/backoffice/src/app/gc-fitness/notifications/page.tsx
+++ b/backoffice/src/app/gc-fitness/notifications/page.tsx
@@ -33,6 +33,7 @@ import {
   listActiveWorkoutSessionsForTrainer,
 } from "@/lib/gc-fitness/live-workout-actions";
 import type { ActiveWorkoutSummary } from "@/lib/gc-fitness/live-workout-types";
+import { filterPrLogsToRoster } from "@/lib/gc-fitness/personal-records";
 import { listRecentLogsForTrainerPage } from "@/lib/gc-fitness/recent-logs-actions";
 import { UpcomingWorkoutAlerts } from "@/components/gc-fitness/upcoming-workout-alerts";
 import { sectionMetadata } from "@/lib/gc-fitness/page-metadata";
@@ -146,14 +147,19 @@ export default async function NotificationsPage({
   const todayCivil = civilDateToday(trainerTimezone);
   const renewalWindowEnd = addCivilDays(todayCivil, 14);
 
-  const [activeWorkoutSummaries, workoutActivity, habits, activations, clients, prNotificationsRaw] =
+  // Roster first: workout_logs.trainerId goes stale on coach transfer, so the
+  // PR feed must be scoped to the CURRENT roster (users.coachId) — issue #446.
+  // listClients() is cached (unstable_cache + per-request dedupe), so awaiting
+  // it before the Promise.all costs nothing.
+  const clients = await listClients();
+  const rosterUids = new Set(clients.map((client) => client.uid));
+  const [activeWorkoutSummaries, workoutActivity, habits, activations, prNotificationsRaw] =
     await Promise.all([
     listActiveWorkoutSessionsForTrainer(),
     listMyCoachActivityPage(null, 100, null, "workout_assignment"),
     listHabitsForTrainer(),
     listRecentLogsForTrainerPage(null, 20, null, "signup"),
-    listClients(),
-    listRecentPrWorkoutNotifications(trainer.uid),
+    listRecentPrWorkoutNotifications(trainer.uid, rosterUids),
   ]);
   const birthdayNotificationsRaw = await listBirthdayNotificationsForTrainer(trainer.uid, todayCivil);
 
@@ -595,17 +601,27 @@ function NotificationRow({
 
 async function listRecentPrWorkoutNotifications(
   trainerUid: string,
+  rosterUids: ReadonlySet<string>,
 ): Promise<PrNotification[]> {
   const db = gcFitnessFirestore();
+  // The trainerId query stays as the cheap fetch (existing single-field index,
+  // no cost change), but trainerId is stamped at log creation and never updated
+  // on coach transfer — so the rows MUST be re-scoped to the current roster
+  // before rendering, or the former coach keeps seeing transferred clients'
+  // PRs (issue #446).
   const snap = await db
     .collection(FirestoreCollections.workoutLogs)
     .where("trainerId", "==", trainerUid)
     .limit(150)
     .get();
 
-  return snap.docs
-    .map((doc): PrNotification | null => {
-      const data = doc.data() as Record<string, unknown>;
+  const rows = snap.docs.map((doc) => {
+    const data = doc.data() as Record<string, unknown>;
+    return { doc, data, clientId: data.clientId };
+  });
+
+  return filterPrLogsToRoster(rows, rosterUids)
+    .map(({ doc, data }): PrNotification | null => {
       if (data.deleted === true) return null;
       const completedAt = toIso(data.completedAt);
       if (data.status !== "completed" && !completedAt) return null;

--- a/backoffice/src/lib/gc-fitness/__tests__/personal-records.test.ts
+++ b/backoffice/src/lib/gc-fitness/__tests__/personal-records.test.ts
@@ -1,5 +1,6 @@
 import {
   buildPersonalRecords,
+  filterPrLogsToRoster,
   flattenLogPRs,
   previousRecordsByExercise,
   type PRExerciseMeta,
@@ -130,6 +131,51 @@ describe("flattenLogPRs", () => {
 
   it("returns [] when the log has no prs", () => {
     expect(flattenLogPRs({})).toEqual([]);
+  });
+});
+
+describe("filterPrLogsToRoster", () => {
+  const roster = new Set(["client-a", "client-b"]);
+
+  it("keeps rows whose clientId is on the roster", () => {
+    const rows = [
+      { clientId: "client-a", trainerId: "coach-1" },
+      { clientId: "client-b", trainerId: "coach-1" },
+    ];
+    expect(filterPrLogsToRoster(rows, roster)).toEqual(rows);
+  });
+
+  it("drops a transferred client even when trainerId still equals the coach (issue #446)", () => {
+    const rows = [
+      { clientId: "client-a", trainerId: "coach-1" },
+      // Transferred away: users/{uid}.coachId now points at another coach, but
+      // the historical log keeps the stale trainerId stamp.
+      { clientId: "client-transferred", trainerId: "coach-1" },
+    ];
+    expect(filterPrLogsToRoster(rows, roster)).toEqual([
+      { clientId: "client-a", trainerId: "coach-1" },
+    ]);
+  });
+
+  it("keeps a self-assigned-shaped row when the client is on the roster", () => {
+    const rows = [{ clientId: "client-a", trainerId: "client-a" }];
+    expect(filterPrLogsToRoster(rows, roster)).toEqual(rows);
+  });
+
+  it("drops rows with missing or empty clientId", () => {
+    const rows = [
+      { trainerId: "coach-1" },
+      { clientId: "", trainerId: "coach-1" },
+      { clientId: 42, trainerId: "coach-1" },
+      { clientId: null, trainerId: "coach-1" },
+    ];
+    expect(filterPrLogsToRoster(rows, roster)).toEqual([]);
+  });
+
+  it("returns [] against an empty roster", () => {
+    expect(
+      filterPrLogsToRoster([{ clientId: "client-a" }], new Set<string>()),
+    ).toEqual([]);
   });
 });
 

--- a/backoffice/src/lib/gc-fitness/coach-pulse-actions.ts
+++ b/backoffice/src/lib/gc-fitness/coach-pulse-actions.ts
@@ -111,6 +111,11 @@ export async function getCoachPulse(): Promise<CoachPulse> {
   const activeClients = clients
     .filter((c) => !c.pendingProvisioning)
     .slice(0, 50);
+  // workout_assignments/workout_logs below are fetched via the trainerId
+  // stamp, which is set at creation and never updated on coach transfer —
+  // transferred clients would otherwise inflate BOTH sides of the workout
+  // metric. Re-scope those rows in memory to the CURRENT roster (issue #446).
+  const rosterUids = new Set(activeClients.map((c) => c.uid));
   const trainerTz = await getTrainerTimezone();
   const windowDays = buildWindowDays(trainerTz);
   const windowStart = windowDays[0]!;
@@ -311,6 +316,7 @@ export async function getCoachPulse(): Promise<CoachPulse> {
         typeof data.scheduledFor === "string" ? data.scheduledFor : "";
       const clientId = typeof data.clientId === "string" ? data.clientId : "";
       if (!scheduledFor || !clientId) return null;
+      if (!rosterUids.has(clientId)) return null; // stale trainerId — issue #446
       if (scheduledFor < windowStart || scheduledFor > windowEnd) return null;
       return { clientId, scheduledFor };
     })
@@ -337,6 +343,7 @@ export async function getCoachPulse(): Promise<CoachPulse> {
       const clientId =
         typeof data.clientId === "string" ? data.clientId : "";
       if (!clientId) return null;
+      if (!rosterUids.has(clientId)) return null; // stale trainerId — issue #446
       const startedAt = asDate(data.startedAt) ?? asDate(data.createdAt);
       if (!startedAt) return null;
       const civilDate = civilDateFormat(startedAt, trainerTz);

--- a/backoffice/src/lib/gc-fitness/personal-records.ts
+++ b/backoffice/src/lib/gc-fitness/personal-records.ts
@@ -109,6 +109,28 @@ export function flattenLogPRs(logData: Record<string, unknown>): RawPersonalReco
   return out;
 }
 
+/**
+ * Keeps only rows that belong to a client on the coach's CURRENT roster
+ * (issue #446). `workout_logs.trainerId` is stamped at log-creation time and is
+ * never updated when a client is transferred to another coach, so any
+ * `trainerId == coach` query keeps returning the transferred client's
+ * historical logs to the FORMER coach. The current `users/{uid}.coachId`
+ * (i.e. roster membership via listClients()) is the only valid visibility
+ * scope — apply this filter to every coach-facing read built on a stale
+ * trainerId query. Rows with a missing/empty/non-string clientId are dropped.
+ */
+export function filterPrLogsToRoster<T extends { clientId?: unknown }>(
+  rows: T[],
+  rosterUids: ReadonlySet<string>,
+): T[] {
+  return rows.filter(
+    (row) =>
+      typeof row.clientId === "string" &&
+      row.clientId.length > 0 &&
+      rosterUids.has(row.clientId),
+  );
+}
+
 function metricOf(pr: { durationSeconds: number | null }): PRMetric {
   return pr.durationSeconds != null && pr.durationSeconds > 0 ? "time" : "reps";
 }


### PR DESCRIPTION
Fixes https://github.com/mdb1/gc-fitness/issues/446 — the backoffice "PRs recientes" feed (notifications page, `?type=prs`) kept showing PRs from clients who had been **transferred to another coach**.

## Root cause

`workout_logs.trainerId` is stamped at log-creation time and is **never updated on coach transfer**. `listRecentPrWorkoutNotifications` queried `workout_logs.where("trainerId","==",coach)`, so the former coach kept receiving the transferred client's historical PR logs; the `clientNameById.get(...) ?? item.clientName` fallback then rendered the stamped name even though the client is no longer on the roster. The current `users/{uid}.coachId` (roster membership via `listClients()`) is the only valid visibility scope.

## Changes

1. **`lib/gc-fitness/personal-records.ts`** — new pure, unit-tested `filterPrLogsToRoster(rows, rosterUids)` helper: keeps only rows whose `clientId` is on the coach's CURRENT roster; drops missing/empty/non-string `clientId`. Comment documents the stale-trainerId pattern for future coach-scoped reads.
2. **`app/gc-fitness/notifications/page.tsx`** — `listRecentPrWorkoutNotifications` now takes the roster uid set (from the already-fetched, cached `listClients()`) and applies the filter to the fetched rows **before** mapping to `PrNotification`. The existing `trainerId ==` query stays as the cheap fetch — no new index, no cost increase.
3. **`lib/gc-fitness/coach-pulse-actions.ts`** — same stale-trainerId pattern inflated **both** sides of the dashboard workout pulse (assignments denominator + completed-logs numerator). Added in-memory `rosterUids` membership checks to both mappings. Firestore queries and their load-bearing index/fallback comments untouched.
4. **`lib/gc-fitness/recent-logs-actions.ts`** — **verified, no change needed**: the reschedule and reminder rows built from the `trainerId`-scoped assignments scan are already roster-gated by `nameByClientId.has(clientId)` (built from `listClients()`), so non-roster clientIds are dropped by the consumer.

**Not affected (verified):** `listClientPersonalRecords` in `personal-records-actions.ts` already gates on the client doc's current `coachId`.

## Explicit non-goal

Self-assigned workouts (`clientId === trainerId` = the client's own uid) were **never** returned by the `trainerId == coach` query, so they still don't surface in this PR feed. Surfacing a roster client's self-assigned PRs here would be a new feature — track separately if desired.

## Tests

- `npx jest personal-records` — 16/16 green (5 new cases: transferred client dropped even with matching trainerId, roster client kept, self-assigned shape kept, missing/empty clientId dropped, empty roster).
- `npx tsc --noEmit` — clean.
- Full `npx jest` — 751/752; the single failure is the pre-existing locale-dependent date-format flake in `client-activity-time.test.ts` (fails locally on non-en-US locale, green in CI — not touched by this change).