### PR TITLE
Mini calendario: habit pills + show all items per day (gc-fitness #447)

### DIFF
--- a/backoffice/messages/en.json
+++ b/backoffice/messages/en.json
@@ -390,7 +390,6 @@
         "loading": "Loading schedule...",
         "loadFailed": "Could not load this week.",
         "emptyDay": "No workouts or habits",
-        "moreItems": "+{count} more",
         "workoutStatus": {
           "scheduled": "scheduled",
           "started": "in progress",

--- a/backoffice/messages/es.json
+++ b/backoffice/messages/es.json
@@ -390,7 +390,6 @@
         "loading": "Cargando agenda...",
         "loadFailed": "No se pudo cargar esta semana.",
         "emptyDay": "Sin entrenamientos ni hábitos",
-        "moreItems": "+{count} más",
         "workoutStatus": {
           "scheduled": "programado",
           "started": "en curso",

--- a/backoffice/src/app/gc-fitness/clients/[id]/_components/ClientCalendarPeek.tsx
+++ b/backoffice/src/app/gc-fitness/clients/[id]/_components/ClientCalendarPeek.tsx
@@ -9,9 +9,7 @@ import {
   CheckCircle2,
   ChevronLeftIcon,
   ChevronRightIcon,
-  Circle,
   Dumbbell,
-  ListChecks,
   Loader2,
   XCircle,
 } from "lucide-react";
@@ -20,32 +18,22 @@ import {
   getClientCalendarPeek,
   type ClientCalendarPeekPayload,
 } from "@/lib/gc-fitness/client-calendar-peek-actions";
-import type {
-  MonthHabitChip,
-  MonthWorkoutChip,
-} from "@/lib/gc-fitness/schedule-month-actions";
+import type { MonthWorkoutChip } from "@/lib/gc-fitness/schedule-month-actions";
 import { formatCivilDateLabel } from "@/lib/gc-fitness/civil-date";
 import { cn } from "@/lib/utils";
 import { Button } from "@/components/ui/button";
+import { HabitChip } from "@/components/gc-fitness/schedule/habit-chip";
 
 const DAY_MS = 86_400_000;
-const MAX_VISIBLE_ITEMS = 4;
 
-type PeekItem =
-  | {
-      id: string;
-      kind: "workout";
-      name: string;
-      status: MonthWorkoutChip["status"];
-      detail: string | null;
-    }
-  | {
-      id: string;
-      kind: "habit";
-      name: string;
-      status: MonthHabitChip["status"];
-      detail: string | null;
-    };
+// Workout-only card row data. Habits render separately as compact
+// HabitChip pills (issue #447 — same visual hierarchy as the Agenda).
+type PeekItem = {
+  id: string;
+  name: string;
+  status: MonthWorkoutChip["status"];
+  detail: string | null;
+};
 
 export function ClientCalendarPeek({
   clientId,
@@ -174,9 +162,7 @@ export function ClientCalendarPeek({
           {days.map((day) => {
             const workouts = peek.calendar.workoutsByDay[day] ?? [];
             const habits = peek.calendar.habitsByDay[day] ?? [];
-            const items = buildItems(workouts, habits, t);
-            const visibleItems = items.slice(0, MAX_VISIBLE_ITEMS);
-            const hiddenCount = Math.max(0, items.length - visibleItems.length);
+            const workoutItems = buildWorkoutItems(workouts, t);
             const isToday = day === peek.todayCivil;
 
             return (
@@ -203,19 +189,25 @@ export function ClientCalendarPeek({
                   ) : null}
                 </div>
 
-                {visibleItems.length === 0 ? (
+                {workoutItems.length === 0 && habits.length === 0 ? (
                   <div className="flex flex-1 items-center justify-center rounded-md border border-dashed px-2 text-center text-xs text-muted-foreground">
                     {t("emptyDay")}
                   </div>
                 ) : (
                   <div className="flex flex-1 flex-col gap-1.5">
-                    {visibleItems.map((item) => (
+                    {workoutItems.map((item) => (
                       <PeekItemRow key={item.id} item={item} />
                     ))}
-                    {hiddenCount > 0 ? (
-                      <p className="px-1 text-[11px] text-muted-foreground">
-                        {t("moreItems", { count: hiddenCount })}
-                      </p>
+                    {habits.length > 0 ? (
+                      <div className="flex min-w-0 flex-wrap gap-1">
+                        {habits.map((h) => (
+                          <HabitChip
+                            key={h.id}
+                            habit={h}
+                            title={`${h.habitName} · ${t(`habitStatus.${h.status}`)}`}
+                          />
+                        ))}
+                      </div>
                     ) : null}
                   </div>
                 )}
@@ -248,41 +240,28 @@ function PeekItemRow({ item }: { item: PeekItem }) {
   );
 }
 
-function buildItems(
+function buildWorkoutItems(
   workouts: MonthWorkoutChip[],
-  habits: MonthHabitChip[],
   t: ReturnType<typeof useTranslations>,
 ): PeekItem[] {
-  return [
-    ...workouts.map((workout): PeekItem => ({
-      id: `workout:${workout.id}`,
-      kind: "workout",
-      name: workout.templateName,
-      status: workout.status,
-      detail: workout.templateTag
-        ? `${t(`workoutStatus.${workout.status}`)} · ${workout.templateTag}`
-        : t(`workoutStatus.${workout.status}`),
-    })),
-    ...habits.map((habit): PeekItem => ({
-      id: `habit:${habit.id}`,
-      kind: "habit",
-      name: habit.habitName,
-      status: habit.status,
-      detail: t(`habitStatus.${habit.status}`),
-    })),
-  ];
+  return workouts.map((workout): PeekItem => ({
+    id: `workout:${workout.id}`,
+    name: workout.templateName,
+    status: workout.status,
+    detail: workout.templateTag
+      ? `${t(`workoutStatus.${workout.status}`)} · ${workout.templateTag}`
+      : t(`workoutStatus.${workout.status}`),
+  }));
 }
 
 function itemIcon(item: PeekItem) {
-  if (item.status === "completed" || item.status === "done") return CheckCircle2;
+  if (item.status === "completed") return CheckCircle2;
   if (item.status === "missed") return XCircle;
-  if (item.kind === "workout") return Dumbbell;
-  if (item.status === "scheduled") return Circle;
-  return ListChecks;
+  return Dumbbell;
 }
 
 function itemClassName(item: PeekItem): string {
-  if (item.status === "completed" || item.status === "done") {
+  if (item.status === "completed") {
     return "border-emerald-500/40 bg-emerald-500/10 text-emerald-900 dark:text-emerald-200";
   }
   if (item.status === "missed") {

--- a/backoffice/src/components/gc-fitness/schedule/habit-chip.tsx
+++ b/backoffice/src/components/gc-fitness/schedule/habit-chip.tsx
@@ -1,0 +1,91 @@
+"use client";
+
+import { CheckCircle2, Circle, User, XCircle } from "lucide-react";
+import { useTranslations } from "next-intl";
+
+import type { MonthHabitChip } from "@/lib/gc-fitness/schedule-month-actions";
+import { cn } from "@/lib/utils";
+
+// Status-only chip classes for habits. Extracted from month-calendar's
+// STATUS_PALETTE/habitChipClass (issue #447) — the class strings must stay
+// byte-identical to keep the full Agenda calendar visually unchanged.
+function habitChipClass(status: MonthHabitChip["status"]): string {
+  if (status === "scheduled")
+    return "border-border bg-card text-muted-foreground";
+  if (status === "done")
+    return "border-emerald-500/50 bg-emerald-500/15 text-emerald-900 dark:text-emerald-200";
+  return "border-rose-400/40 bg-rose-500/10 text-rose-900 dark:text-rose-200";
+}
+
+function HabitStatusGlyph({ status }: { status: MonthHabitChip["status"] }) {
+  if (status === "done") {
+    return <CheckCircle2 className="size-2.5 text-emerald-600 dark:text-emerald-400" />;
+  }
+  if (status === "missed") {
+    return <XCircle className="size-2.5 text-rose-600 dark:text-rose-400" />;
+  }
+  return <Circle className="size-2.5 opacity-60" />;
+}
+
+/** Issue #437: marks a habit the client created for themselves (vs. one the
+ * trainer assigned). Rendered on the calendar habit chip. */
+function ClientOwnedBadge() {
+  const t = useTranslations("schedule.calendar");
+  return (
+    <span title={t("clientCreatedBadge")} className="inline-flex shrink-0">
+      <User className="size-2.5 opacity-70" aria-label={t("clientCreatedBadge")} />
+    </span>
+  );
+}
+
+/**
+ * Shared compact habit "pill" used by the full Agenda calendar (DayCell +
+ * ClientDayCell) and the client-detail mini calendar (issue #447) — habits
+ * render visibly smaller/lighter than the rectangular workout cards.
+ *
+ * Renders a `<button>` when `onClick` is provided (Agenda: opens the habit
+ * dialog) and a non-interactive `<span>` otherwise (mini calendar).
+ */
+export function HabitChip({
+  habit,
+  onClick,
+  title,
+}: {
+  habit: MonthHabitChip;
+  onClick?: () => void;
+  title?: string;
+}) {
+  const chipTitle = title ?? habit.habitName;
+  const content = (
+    <>
+      <HabitStatusGlyph status={habit.status} />
+      <span className="min-w-0 max-w-full truncate">{habit.habitName}</span>
+      {habit.clientOwned ? <ClientOwnedBadge /> : null}
+    </>
+  );
+
+  const baseClass =
+    "inline-flex max-w-full items-center gap-0.5 rounded-full border px-1.5 py-0.5 text-[10px] font-medium";
+
+  if (onClick) {
+    return (
+      <button
+        type="button"
+        onClick={onClick}
+        className={cn(baseClass, "hover:brightness-95", habitChipClass(habit.status))}
+        title={chipTitle}
+      >
+        {content}
+      </button>
+    );
+  }
+
+  return (
+    <span
+      className={cn(baseClass, habitChipClass(habit.status))}
+      title={chipTitle}
+    >
+      {content}
+    </span>
+  );
+}

--- a/backoffice/src/components/gc-fitness/schedule/month-calendar.tsx
+++ b/backoffice/src/components/gc-fitness/schedule/month-calendar.tsx
@@ -37,7 +37,6 @@ import {
   Circle,
   Dumbbell,
   PlusIcon,
-  User,
   XCircle,
 } from "lucide-react";
 import { toast } from "sonner";
@@ -64,6 +63,7 @@ import {
 } from "@/components/ui/popover";
 
 import { AssignTemplateModal } from "./assign-template-modal";
+import { HabitChip } from "./habit-chip";
 import { MoveAssignmentDialog } from "./move-assignment-dialog";
 import { NewHabitDialog } from "./new-habit-dialog";
 import { WorkoutDetailDialog } from "./workout-detail-dialog";
@@ -143,12 +143,6 @@ const STATUS_PALETTE: Record<
 // Scheduled → neutral card surface; terminal states keep their status color.
 function workoutChipClass(status: MonthWorkoutChip["status"]): string {
   if (status === "scheduled") return "border-border bg-card text-foreground";
-  return STATUS_PALETTE[status];
-}
-
-function habitChipClass(status: MonthHabitChip["status"]): string {
-  if (status === "scheduled")
-    return "border-border bg-card text-muted-foreground";
   return STATUS_PALETTE[status];
 }
 
@@ -1350,22 +1344,12 @@ function DayCell({
                 {group.habits.length > 0 ? (
                   <div className="flex min-w-0 flex-wrap gap-1">
                     {group.habits.map((h) => (
-                      <button
+                      <HabitChip
                         key={h.id}
-                        type="button"
+                        habit={h}
                         onClick={() => onClickHabit(h)}
-                        className={cn(
-                          "inline-flex max-w-full items-center gap-0.5 rounded-full border px-1.5 py-0.5 text-[10px] font-medium hover:brightness-95",
-                          habitChipClass(h.status),
-                        )}
                         title={`${h.habitName} · ${h.status}`}
-                      >
-                        <HabitStatusGlyph status={h.status} />
-                        <span className="min-w-0 max-w-full truncate">
-                          {h.habitName}
-                        </span>
-                        {h.clientOwned ? <ClientOwnedBadge /> : null}
-                      </button>
+                      />
                     ))}
                   </div>
                 ) : null}
@@ -1495,22 +1479,12 @@ function ClientDayCell({
         {habits.length > 0 ? (
           <div className="flex min-w-0 flex-wrap gap-1">
             {habits.map((h) => (
-              <button
+              <HabitChip
                 key={h.id}
-                type="button"
+                habit={h}
                 onClick={() => onClickHabit(h)}
-                className={cn(
-                  "inline-flex max-w-full items-center gap-0.5 rounded-full border px-1.5 py-0.5 text-[10px] font-medium hover:brightness-95",
-                  habitChipClass(h.status),
-                )}
                 title={`${h.habitName} · ${h.status}`}
-              >
-                <HabitStatusGlyph status={h.status} />
-                <span className="min-w-0 max-w-full truncate">
-                  {h.habitName}
-                </span>
-                {h.clientOwned ? <ClientOwnedBadge /> : null}
-              </button>
+              />
             ))}
           </div>
         ) : null}
@@ -1773,23 +1747,3 @@ function LegendItem({
   );
 }
 
-function HabitStatusGlyph({ status }: { status: MonthHabitChip["status"] }) {
-  if (status === "done") {
-    return <CheckCircle2 className="size-2.5 text-emerald-600 dark:text-emerald-400" />;
-  }
-  if (status === "missed") {
-    return <XCircle className="size-2.5 text-rose-600 dark:text-rose-400" />;
-  }
-  return <Circle className="size-2.5 opacity-60" />;
-}
-
-/** Issue #437: marks a habit the client created for themselves (vs. one the
- * trainer assigned). Rendered on the calendar habit chip. */
-function ClientOwnedBadge() {
-  const t = useTranslations("schedule.calendar");
-  return (
-    <span title={t("clientCreatedBadge")} className="inline-flex shrink-0">
-      <User className="size-2.5 opacity-70" aria-label={t("clientCreatedBadge")} />
-    </span>
-  );
-}


### PR DESCRIPTION
## Summary

Adopts the full Agenda calendar's visual hierarchy in the client-detail **Mini calendario** (`ClientCalendarPeek`):

- **Before:** workouts and habits rendered at the same card size via `PeekItemRow`, and anything beyond 4 items per day collapsed behind a "+N más" pill.
- **After:** workout cards keep their current size; habits render below them as the same compact pill chips the Agenda uses (status glyph + color + client-created badge); ALL workouts and habits per day are visible — no truncation (day cells simply grow).

## Changes

- **New `schedule/habit-chip.tsx`:** shared presentational `HabitChip` extracted from `month-calendar.tsx` (status classes, `HabitStatusGlyph`, `ClientOwnedBadge` moved verbatim — class strings byte-identical). Renders a `<button>` when `onClick` is provided (Agenda) and a non-interactive `<span>` otherwise (mini calendar).
- **`month-calendar.tsx`:** pure extraction refactor — both habit render sites (`DayCell`, `ClientDayCell`) now use `HabitChip`; no visual or behavioral change in the full Agenda calendar.
- **`ClientCalendarPeek.tsx`:** habits render as `HabitChip` pills below full-size workout cards; removed `MAX_VISIBLE_ITEMS`/slicing/"+N más"; narrowed `PeekItem` plumbing to workouts only.
- **`messages/en.json` / `es.json`:** deleted the now-unused `clients.detail.calendarPeek.moreItems` key.

No data-layer changes (`client-calendar-peek-actions.ts` / `schedule-month-actions.ts` untouched — kept clear for the upcoming #449 task).

## Test gate

- `npx tsc --noEmit` clean
- `npx jest`: 751/752 — the single failure is the pre-existing locale-dependent `client-activity-time` date-format test (local-only flake, green in CI)

Ref: https://github.com/mdb1/gc-fitness/issues/447