### PR TITLE
fix(calendar): surface client self-assigned workouts with created-by-client badge

### DIFF
--- a/backoffice/messages/en.json
+++ b/backoffice/messages/en.json
@@ -390,6 +390,7 @@
         "loading": "Loading schedule...",
         "loadFailed": "Could not load this week.",
         "emptyDay": "No workouts or habits",
+        "clientCreated": "Created by the client",
         "workoutStatus": {
           "scheduled": "scheduled",
           "started": "in progress",

--- a/backoffice/messages/es.json
+++ b/backoffice/messages/es.json
@@ -390,6 +390,7 @@
         "loading": "Cargando agenda...",
         "loadFailed": "No se pudo cargar esta semana.",
         "emptyDay": "Sin entrenamientos ni hábitos",
+        "clientCreated": "Creado por el cliente",
         "workoutStatus": {
           "scheduled": "programado",
           "started": "en curso",

--- a/backoffice/src/app/gc-fitness/clients/[id]/_components/ClientCalendarPeek.tsx
+++ b/backoffice/src/app/gc-fitness/clients/[id]/_components/ClientCalendarPeek.tsx
@@ -11,6 +11,7 @@ import {
   ChevronRightIcon,
   Dumbbell,
   Loader2,
+  User,
   XCircle,
 } from "lucide-react";
 
@@ -33,6 +34,10 @@ type PeekItem = {
   name: string;
   status: MonthWorkoutChip["status"];
   detail: string | null;
+  /** Issue #449 — true when the client created this workout for themselves
+   * (issue #392: `trainerId === clientId`). Renders a User icon beside the
+   * name, mirroring the Agenda calendar's client-created badge. */
+  selfAssigned: boolean;
 };
 
 export function ClientCalendarPeek({
@@ -221,6 +226,7 @@ export function ClientCalendarPeek({
 }
 
 function PeekItemRow({ item }: { item: PeekItem }) {
+  const t = useTranslations("clients.detail.calendarPeek");
   const Icon = itemIcon(item);
   return (
     <div
@@ -230,8 +236,20 @@ function PeekItemRow({ item }: { item: PeekItem }) {
       )}
     >
       <Icon className="mt-0.5 size-3.5 shrink-0" />
-      <div className="min-w-0">
-        <p className="truncate font-medium">{item.name}</p>
+      <div className="min-w-0 flex-1">
+        <p className="flex min-w-0 items-center gap-1">
+          <span className="truncate font-medium">{item.name}</span>
+          {/* Issue #449 — client self-assigned workout marker (same User
+              icon the Agenda calendar's chips use). */}
+          {item.selfAssigned ? (
+            <span title={t("clientCreated")} className="inline-flex shrink-0">
+              <User
+                className="size-3 shrink-0 opacity-70"
+                aria-label={t("clientCreated")}
+              />
+            </span>
+          ) : null}
+        </p>
         {item.detail ? (
           <p className="truncate text-[10px] opacity-75">{item.detail}</p>
         ) : null}
@@ -251,6 +269,7 @@ function buildWorkoutItems(
     detail: workout.templateTag
       ? `${t(`workoutStatus.${workout.status}`)} · ${workout.templateTag}`
       : t(`workoutStatus.${workout.status}`),
+    selfAssigned: workout.selfAssigned,
   }));
 }
 

--- a/backoffice/src/components/gc-fitness/schedule/habit-chip.tsx
+++ b/backoffice/src/components/gc-fitness/schedule/habit-chip.tsx
@@ -28,8 +28,10 @@ function HabitStatusGlyph({ status }: { status: MonthHabitChip["status"] }) {
 }
 
 /** Issue #437: marks a habit the client created for themselves (vs. one the
- * trainer assigned). Rendered on the calendar habit chip. */
-function ClientOwnedBadge() {
+ * trainer assigned). Rendered on the calendar habit chip. Issue #449: also
+ * exported for the month calendar's WORKOUT chips, marking self-assigned
+ * workouts (issue #392 — `trainerId === clientId`) with the same User icon. */
+export function ClientOwnedBadge() {
   const t = useTranslations("schedule.calendar");
   return (
     <span title={t("clientCreatedBadge")} className="inline-flex shrink-0">

--- a/backoffice/src/components/gc-fitness/schedule/month-calendar.tsx
+++ b/backoffice/src/components/gc-fitness/schedule/month-calendar.tsx
@@ -63,7 +63,7 @@ import {
 } from "@/components/ui/popover";
 
 import { AssignTemplateModal } from "./assign-template-modal";
-import { HabitChip } from "./habit-chip";
+import { ClientOwnedBadge, HabitChip } from "./habit-chip";
 import { MoveAssignmentDialog } from "./move-assignment-dialog";
 import { NewHabitDialog } from "./new-habit-dialog";
 import { WorkoutDetailDialog } from "./workout-detail-dialog";
@@ -1207,6 +1207,8 @@ function DayCell({
   onClickHabit,
   onClickAdd,
 }: DayCellProps) {
+  // Issue #449 — chip tooltip suffix for client self-assigned workouts.
+  const t = useTranslations("schedule.calendar");
   return (
     <div
       onDragOver={onDragOver}
@@ -1309,8 +1311,12 @@ function DayCell({
                     <button
                       key={w.id}
                       type="button"
-                      draggable
+                      // Issue #449 — self-assigned chips are NOT draggable:
+                      // dropping would hit moveAssignment's ownership throw
+                      // (the coach must not move a client's own workout).
+                      draggable={!w.selfAssigned}
                       onDragStart={(e) => {
+                        if (w.selfAssigned) return;
                         e.dataTransfer.effectAllowed = "move";
                         e.dataTransfer.setData("text/plain", w.id);
                         onDragStartChip(w);
@@ -1320,16 +1326,19 @@ function DayCell({
                         "group/chip relative flex w-full min-w-0 items-center gap-1.5 overflow-hidden rounded border px-1.5 py-1 pr-3 text-left text-[11px] leading-tight hover:brightness-95",
                         workoutChipClass(w.status),
                       )}
-                      title={
-                        movedFromLabel
-                          ? `${w.templateName} — ${movedFromLabel}`
-                          : w.templateName
-                      }
+                      title={[
+                        w.templateName,
+                        movedFromLabel,
+                        w.selfAssigned ? t("clientCreatedBadge") : null,
+                      ]
+                        .filter(Boolean)
+                        .join(" — ")}
                     >
                       <Dumbbell className="size-3 shrink-0 opacity-80" />
                       <span className="min-w-0 flex-1 truncate font-medium">
                         {w.templateName}
                       </span>
+                      {w.selfAssigned ? <ClientOwnedBadge /> : null}
                       {movedFromLabel ? (
                         <ArrowRightLeft
                           className="size-3 shrink-0 opacity-70"
@@ -1410,6 +1419,8 @@ function ClientDayCell({
   onClickHabit,
   onClickAdd,
 }: ClientDayCellProps) {
+  // Issue #449 — chip tooltip suffix for client self-assigned workouts.
+  const t = useTranslations("schedule.calendar");
   const isEmpty = workouts.length === 0 && habits.length === 0;
   return (
     <td
@@ -1437,8 +1448,12 @@ function ClientDayCell({
             <button
               key={w.id}
               type="button"
-              draggable
+              // Issue #449 — self-assigned chips are NOT draggable: dropping
+              // would hit moveAssignment's ownership throw (the coach must
+              // not move a client's own workout).
+              draggable={!w.selfAssigned}
               onDragStart={(e) => {
+                if (w.selfAssigned) return;
                 e.dataTransfer.effectAllowed = "move";
                 e.dataTransfer.setData("text/plain", w.id);
                 onDragStartChip(w);
@@ -1451,16 +1466,19 @@ function ClientDayCell({
                 "group/chip relative flex w-full min-w-0 items-center gap-1.5 overflow-hidden rounded border px-1.5 py-1 pr-3 text-left text-[11px] leading-tight hover:brightness-95",
                 workoutChipClass(w.status),
               )}
-              title={
-                movedFromLabel
-                  ? `${w.templateName} — ${movedFromLabel}`
-                  : w.templateName
-              }
+              title={[
+                w.templateName,
+                movedFromLabel,
+                w.selfAssigned ? t("clientCreatedBadge") : null,
+              ]
+                .filter(Boolean)
+                .join(" — ")}
             >
               <Dumbbell className="size-3 shrink-0 opacity-80" />
               <span className="min-w-0 flex-1 truncate font-medium">
                 {w.templateName}
               </span>
+              {w.selfAssigned ? <ClientOwnedBadge /> : null}
               {movedFromLabel ? (
                 <ArrowRightLeft
                   className="size-3 shrink-0 opacity-70"

--- a/backoffice/src/components/gc-fitness/schedule/workout-detail-dialog.tsx
+++ b/backoffice/src/components/gc-fitness/schedule/workout-detail-dialog.tsx
@@ -108,6 +108,9 @@ export function WorkoutDetailDialog({
   const [deleteOpen, setDeleteOpen] = useState(false);
   const [editOpen, setEditOpen] = useState(false);
   const [recurrenceOpen, setRecurrenceOpen] = useState(false);
+  // Issue #449 — same key the calendar chips' badge uses, so the wording
+  // stays identical ("Created by the client" / "Creado por el cliente").
+  const tCal = useTranslations("schedule.calendar");
 
   const { data, isLoading, error } = useQuery({
     queryKey: ["assignment-detail", assignmentId],
@@ -139,10 +142,17 @@ export function WorkoutDetailDialog({
     }
   }, [open]);
 
+  // Issue #449 — client self-assigned workouts (trainerId === clientId) open
+  // READ-ONLY: the coach views the prescription but does not manage it, so
+  // every mutating CTA (edit / recurrence / delete) and the coach-owned
+  // "Iniciar entrenamiento" live-session entry are hidden.
+  const isSelfAssigned = data?.selfAssigned === true;
+
   // "Editar recurrencia" only applies to a recurring series (seriesId set) that
   // still has upcoming occurrences — i.e. scheduled or started, not a finished
   // (completed/missed) one. Single assignments have no recurrence to change.
   const canEditRecurrence =
+    !isSelfAssigned &&
     Boolean(data?.seriesId) &&
     data?.status !== "completed" &&
     data?.status !== "missed";
@@ -177,6 +187,14 @@ export function WorkoutDetailDialog({
                       Abrir chat
                     </Link>
                   </Button>
+                ) : null}
+                {isSelfAssigned ? (
+                  // Issue #449 — marks the workout as client-created (same
+                  // wording as the calendar chip's User badge).
+                  <span className="inline-flex shrink-0 items-center gap-1 rounded-full bg-muted px-2 py-0.5 text-[10px] font-medium text-muted-foreground">
+                    <User className="size-3" />
+                    {tCal("clientCreatedBadge")}
+                  </span>
                 ) : null}
                 {data ? (
                   <span
@@ -226,7 +244,10 @@ export function WorkoutDetailDialog({
             >
               Cerrar
             </Button>
-            {data && data.status !== "completed" && data.status !== "missed" ? (
+            {data &&
+            !isSelfAssigned &&
+            data.status !== "completed" &&
+            data.status !== "missed" ? (
               <Button asChild className="gap-1">
                 <Link
                   href={`/gc-fitness/clients/${data.clientId}/sessions/${data.id}/run`}
@@ -249,24 +270,28 @@ export function WorkoutDetailDialog({
                 Editar recurrencia
               </Button>
             ) : null}
-            <Button
-              variant="outline"
-              disabled={!data || isLoading}
-              onClick={() => setEditOpen(true)}
-              className="gap-1"
-            >
-              <Pencil className="size-4" />
-              Editar
-            </Button>
-            <Button
-              variant="destructive"
-              disabled={!data || isLoading}
-              onClick={() => setDeleteOpen(true)}
-              className="gap-1"
-            >
-              <Trash2 className="size-4" />
-              Eliminar
-            </Button>
+            {!isSelfAssigned ? (
+              <Button
+                variant="outline"
+                disabled={!data || isLoading}
+                onClick={() => setEditOpen(true)}
+                className="gap-1"
+              >
+                <Pencil className="size-4" />
+                Editar
+              </Button>
+            ) : null}
+            {!isSelfAssigned ? (
+              <Button
+                variant="destructive"
+                disabled={!data || isLoading}
+                onClick={() => setDeleteOpen(true)}
+                className="gap-1"
+              >
+                <Trash2 className="size-4" />
+                Eliminar
+              </Button>
+            ) : null}
           </DialogFooter>
         </DialogContent>
       </Dialog>

--- a/backoffice/src/lib/gc-fitness/__tests__/schedule-month-actions.test.ts
+++ b/backoffice/src/lib/gc-fitness/__tests__/schedule-month-actions.test.ts
@@ -56,6 +56,17 @@ function makeDb() {
               templateSnapshot: { name: "New workout" },
               status: "scheduled",
             }),
+            // Issue #449: client self-assigned workout (issue #392 shape —
+            // trainerId === clientId + selfAssigned: true). Must surface on
+            // the coach's calendar, tagged selfAssigned.
+            doc("self-assignment", {
+              trainerId: "c1",
+              clientId: "c1",
+              scheduledFor: "2026-06-10",
+              selfAssigned: true,
+              templateSnapshot: { name: "Self workout" },
+              status: "scheduled",
+            }),
           ]);
         }
         if (collectionName === FirestoreCollections.habits) {
@@ -129,12 +140,23 @@ describe("listMonthForClients", () => {
       todayCivil: "2026-06-08",
     });
 
+    // Chips sort by templateName: "New workout" < "Self workout". The
+    // old-coach doc (trainerId "old-coach" !== clientId) must NOT surface
+    // (#446); the client self-assigned doc MUST (#449), tagged selfAssigned.
     expect(result.workoutsByDay["2026-06-10"]).toEqual([
       expect.objectContaining({
         id: "new-assignment",
         templateName: "New workout",
+        selfAssigned: false,
+      }),
+      expect.objectContaining({
+        id: "self-assignment",
+        templateName: "Self workout",
+        selfAssigned: true,
       }),
     ]);
+    const workoutIds = result.workoutsByDay["2026-06-10"].map((w) => w.id);
+    expect(workoutIds).not.toContain("old-assignment");
     expect(result.habitsByDay["2026-06-10"]).toEqual([
       expect.objectContaining({
         id: "client-habit:2026-06-10",

--- a/backoffice/src/lib/gc-fitness/schedule-month-actions.ts
+++ b/backoffice/src/lib/gc-fitness/schedule-month-actions.ts
@@ -56,6 +56,11 @@ export interface MonthWorkoutChip {
   status: "scheduled" | "started" | "completed" | "missed";
   seriesId: string | null;
   recurrenceKind: string | null;
+  /** Issue #449 — true when the client created this workout for themselves
+   * (issue #392 shape: `trainerId === clientId` + `selfAssigned: true`).
+   * Drives the calendar's "created by the client" badge and disables the
+   * drag/edit affordances (the coach views but does not manage it). */
+  selfAssigned: boolean;
 }
 
 export interface MonthHabitChip {
@@ -279,6 +284,10 @@ export interface AssignmentDetail {
     string,
     Array<{ weightKg: number; reps: number }>
   >;
+  /** Issue #449 — true when the client created this workout for themselves
+   * (issue #392 shape: `trainerId === clientId`). The detail dialog renders
+   * read-only for these (no edit / recurrence / delete CTAs). */
+  selfAssigned: boolean;
 }
 
 export async function getAssignmentDetail(id: string): Promise<AssignmentDetail> {
@@ -288,7 +297,26 @@ export async function getAssignmentDetail(id: string): Promise<AssignmentDetail>
   const snap = await ref.get();
   if (!snap.exists) throw new Error("Not found");
   const data = snap.data() as Record<string, unknown>;
-  if (data.trainerId !== trainer.uid) throw new Error("Not your assignment.");
+  // Issue #449 — mirror `coachCanAccessLog` (recent-logs-actions): the coach
+  // may open the detail when they own the assignment OR when it's a client
+  // self-assigned workout (issue #392: `trainerId === clientId`) belonging to
+  // one of THEIR clients (point-read `users/{clientId}.coachId`). Anything
+  // else — including a previous coach's docs (#446) — still throws.
+  const isSelfAssigned =
+    typeof data.clientId === "string" &&
+    data.clientId.length > 0 &&
+    data.trainerId === data.clientId;
+  if (data.trainerId !== trainer.uid) {
+    let allowed = false;
+    if (isSelfAssigned) {
+      const clientSnap = await db
+        .collection(FirestoreCollections.users)
+        .doc(data.clientId as string)
+        .get();
+      allowed = clientSnap.exists && clientSnap.get("coachId") === trainer.uid;
+    }
+    if (!allowed) throw new Error("Not your assignment.");
+  }
 
   const clientId = typeof data.clientId === "string" ? data.clientId : "";
   let clientName = clientId;
@@ -470,6 +498,7 @@ export async function getAssignmentDetail(id: string): Promise<AssignmentDetail>
       };
     }),
     lastLoggedSetsByExerciseId,
+    selfAssigned: isSelfAssigned,
   };
 }
 
@@ -646,8 +675,22 @@ export async function listMonthForClients(input: {
       seriesId?: string | null;
       recurrence?: { kind?: string };
       status?: string;
+      selfAssigned?: unknown;
     };
-    if (data.trainerId !== trainer.uid) continue;
+    // Issue #449 — client self-assigned workouts (issue #392) carry
+    // `trainerId === clientId` (both = client uid). The canonical predicate is
+    // that id equality, NOT the `selfAssigned` boolean, so legacy docs without
+    // the flag still qualify. Roster scoping still holds: both callers derive
+    // `clientIds` from the coach's CURRENT roster (schedule page validates
+    // against listClients' `coachId ==` query; getClientCalendarPeek checks
+    // `client.coachId === trainer.uid`), so admitting these docs never leaks
+    // another coach's clients. Docs from a PREVIOUS coach have
+    // `trainerId === oldCoachUid !== clientId` and stay excluded (#446).
+    const isSelfAssigned =
+      typeof data.clientId === "string" &&
+      data.clientId.length > 0 &&
+      data.trainerId === data.clientId;
+    if (data.trainerId !== trainer.uid && !isSelfAssigned) continue;
     const clientId = typeof data.clientId === "string" ? data.clientId : "";
     const civil = typeof data.scheduledFor === "string" ? data.scheduledFor : "";
     if (!clientId || !civil) continue;
@@ -685,6 +728,7 @@ export async function listMonthForClients(input: {
         data.recurrence && typeof data.recurrence.kind === "string"
           ? data.recurrence.kind
           : null,
+      selfAssigned: isSelfAssigned,
     };
     (workoutsByDay[civil] ??= []).push(chip);
   }


### PR DESCRIPTION
Fixes https://github.com/mdb1/gc-fitness/issues/449

> **Stacked on #237** — targets `fix/447-mini-calendar-habit-chips`; GitHub will retarget to `main` when #237 merges.

## Root cause

`listMonthForClients` (`schedule-month-actions.ts`) queries assignments with `where("clientId", "in", clientIds)` — so client self-assigned workouts (issue #392 shape: `trainerId === clientId` + `selfAssigned: true`) ARE returned by Firestore — but the in-memory filter `if (data.trainerId !== trainer.uid) continue;` dropped them. Result: a coach had a blind spot — workouts a client scheduled for themselves never appeared on any coach calendar surface.

## What changed

**One data fix covers both surfaces** — the client-profile mini calendar (`ClientCalendarPeek` → `getClientCalendarPeek`) delegates to the same `listMonthForClients`.

- **`schedule-month-actions.ts`**
  - The in-memory filter now admits `trainerId === clientId` docs; new `selfAssigned` flag on `MonthWorkoutChip` + `AssignmentDetail`.
  - `getAssignmentDetail` no longer throws "Not your assignment." for self-assigned docs: a `coachCanAccessLog`-style fallback (mirrors `recent-logs-actions.ts`) point-reads `users/{clientId}` and allows only when `coachId === trainer.uid`.
- **`month-calendar.tsx`** — both workout-chip render sites (DayCell + ClientDayCell) render the `ClientOwnedBadge` User icon (now exported from `habit-chip.tsx`, the same badge #437 gave client-created habits); tooltip appends "Creado por el cliente"; chips are **not draggable** (`moveAssignment` stays coach-owned — untouched).
- **`workout-detail-dialog.tsx`** — opens **read-only** for self-assigned workouts: edit / recurrence / delete AND the coach-owned "Iniciar entrenamiento" CTA are hidden; a User-icon marker in the header explains why.
- **`ClientCalendarPeek.tsx`** — workout rows carry the same User icon with a `clientCreated` title/aria-label (new en/es keys, identical wording to `schedule.calendar.clientCreatedBadge`).

## Roster scoping (#446 semantics preserved)

Both callers already restrict `clientIds` to the coach's CURRENT roster (schedule page validates against `listClients()`'s `coachId ==` query; `getClientCalendarPeek` checks `client.coachId === trainer.uid`), so admitting `trainerId === clientId` docs cannot leak other coaches' clients. Docs from a **previous** coach have `trainerId === oldCoachUid !== clientId` and stay excluded — pinned by the extended regression test (old-coach doc still absent, self-assigned doc present with `selfAssigned: true`).

## Cost / infra

No query changes, no new composite indexes, no rules changes (Admin SDK reads). Only one extra point-read (`users/{clientId}`) inside `getAssignmentDetail`'s fallback path.

## Tests

- `npx jest`: 751/752 — the single failure is the known pre-existing local locale flake (`client-activity-time` date-format, green in CI).
- `npx tsc --noEmit` clean.

## Note

Built on top of quick task #447's habit-chip refactor (PR #237) — `ClientOwnedBadge` had moved from `month-calendar.tsx` into the shared `habit-chip.tsx`, so this PR exports and reuses it instead of duplicating.