### PR TITLE
fix(notifications+mini-calendar): prev-PR line, client link, clickable cards, Agenda week nav

### DIFF
--- a/backoffice/messages/en.json
+++ b/backoffice/messages/en.json
@@ -183,6 +183,7 @@
     "noPrs": "No recent PRs to review.",
     "prsCardTitle": "{client} hit {count, plural, one {# PR} other {# PRs}}",
     "prsCardDetail": "{workout} · {count, plural, one {# personal record} other {# personal records}}",
+    "prsPreviousInline": "(prev {value})",
     "activationsTitle": "Recent activations",
     "activationsDescription": "New client sign-ins that are worth following up.",
     "birthdayCardTitle": "{client}'s birthday",

--- a/backoffice/messages/es.json
+++ b/backoffice/messages/es.json
@@ -183,6 +183,7 @@
     "noPrs": "No hay PRs recientes para revisar.",
     "prsCardTitle": "{client} metió {count, plural, one {# PR} other {# PRs}}",
     "prsCardDetail": "{workout} · {count, plural, one {# récord personal} other {# récords personales}}",
+    "prsPreviousInline": "(antes {value})",
     "activationsTitle": "Activaciones recientes",
     "activationsDescription": "Nuevos ingresos de clientes para hacer seguimiento.",
     "birthdayCardTitle": "Cumpleaños de {client}",

--- a/backoffice/src/app/gc-fitness/clients/[id]/_components/ClientCalendarPeek.tsx
+++ b/backoffice/src/app/gc-fitness/clients/[id]/_components/ClientCalendarPeek.tsx
@@ -3,6 +3,7 @@
 import Link from "next/link";
 import { useMemo, useState } from "react";
 import { useLocale, useTranslations } from "next-intl";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import {
   ArrowUpRight,
   CalendarDays,
@@ -24,6 +25,7 @@ import { formatCivilDateLabel } from "@/lib/gc-fitness/civil-date";
 import { cn } from "@/lib/utils";
 import { Button } from "@/components/ui/button";
 import { HabitChip } from "@/components/gc-fitness/schedule/habit-chip";
+import { WorkoutDetailDialog } from "@/components/gc-fitness/schedule/workout-detail-dialog";
 
 const DAY_MS = 86_400_000;
 
@@ -31,6 +33,10 @@ const DAY_MS = 86_400_000;
 // HabitChip pills (issue #447 — same visual hierarchy as the Agenda).
 type PeekItem = {
   id: string;
+  /** Raw MonthWorkoutChip.id = the assignment doc id, used to open the
+   * WorkoutDetailDialog (issue #449 follow-up). Distinct from `id`, which is
+   * `workout:`-prefixed for React keys. */
+  assignmentId: string;
   name: string;
   status: MonthWorkoutChip["status"];
   detail: string | null;
@@ -52,6 +58,20 @@ export function ClientCalendarPeek({
   const [peek, setPeek] = useState(initialPayload);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  // The WorkoutDetailDialog uses `useQuery`, so it needs a QueryClientProvider
+  // ancestor — the client-detail route ships none. Mirror ClientSummaryLists'
+  // local provider defaults (issue #449 follow-up).
+  const [queryClient] = useState(
+    () =>
+      new QueryClient({
+        defaultOptions: {
+          queries: { staleTime: 30_000, refetchOnWindowFocus: false },
+        },
+      }),
+  );
+  const [detailAssignmentId, setDetailAssignmentId] = useState<string | null>(
+    null,
+  );
 
   const days = useMemo(
     () => civilDaysInRange(peek.startCivil, peek.endCivil),
@@ -88,7 +108,11 @@ export function ClientCalendarPeek({
     }
   }
 
+  const rangeTitle = formatRange(peek.startCivil, peek.endCivil, locale);
+  const isOnTodayWeek = peek.anchorCivil === peek.todayCivil;
+
   return (
+   <QueryClientProvider client={queryClient}>
     <section className="rounded-xl border bg-card p-4">
       <div className="mb-4 flex flex-col gap-3 lg:flex-row lg:items-start lg:justify-between">
         <div className="min-w-0">
@@ -97,12 +121,12 @@ export function ClientCalendarPeek({
             {t("title")}
           </h2>
           <p className="text-sm text-muted-foreground">
-            {formatRange(peek.startCivil, peek.endCivil, locale)} ·{" "}
-            {t("rangeSummary", totals)}
+            {rangeTitle} · {t("rangeSummary", totals)}
           </p>
         </div>
 
         <div className="flex flex-wrap items-center gap-2">
+          {/* ‹ [week range] › — mirrors the Agenda month-calendar rangeNav. */}
           <div className="flex items-center gap-1 rounded-full border bg-background p-1">
             <Button
               type="button"
@@ -116,16 +140,9 @@ export function ClientCalendarPeek({
             >
               <ChevronLeftIcon className="size-4" />
             </Button>
-            <Button
-              type="button"
-              variant="ghost"
-              size="sm"
-              className="h-8 rounded-full px-3"
-              disabled={loading || peek.anchorCivil === peek.todayCivil}
-              onClick={() => void loadAnchor(peek.todayCivil)}
-            >
-              {t("today")}
-            </Button>
+            <span className="min-w-0 flex-1 truncate px-2 text-center text-sm font-semibold tracking-tight sm:min-w-[13ch] sm:flex-none">
+              {rangeTitle}
+            </span>
             <Button
               type="button"
               variant="ghost"
@@ -139,6 +156,18 @@ export function ClientCalendarPeek({
               <ChevronRightIcon className="size-4" />
             </Button>
           </div>
+
+          {/* Separate jump-to-today button, disabled on today's week. */}
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            className="h-9 rounded-full"
+            disabled={loading || isOnTodayWeek}
+            onClick={() => void loadAnchor(peek.todayCivil)}
+          >
+            {t("today")}
+          </Button>
 
           <Button variant="outline" size="sm" className="h-9 rounded-full" asChild>
             <Link href={scheduleHref}>
@@ -201,7 +230,11 @@ export function ClientCalendarPeek({
                 ) : (
                   <div className="flex flex-1 flex-col gap-1.5">
                     {workoutItems.map((item) => (
-                      <PeekItemRow key={item.id} item={item} />
+                      <PeekItemRow
+                        key={item.id}
+                        item={item}
+                        onOpenDetail={setDetailAssignmentId}
+                      />
                     ))}
                     {habits.length > 0 ? (
                       <div className="flex min-w-0 flex-wrap gap-1">
@@ -222,16 +255,38 @@ export function ClientCalendarPeek({
         </div>
       </div>
     </section>
+
+    {detailAssignmentId ? (
+      <WorkoutDetailDialog
+        open
+        onOpenChange={(open) => !open && setDetailAssignmentId(null)}
+        assignmentId={detailAssignmentId}
+        onDeleted={() => {
+          setDetailAssignmentId(null);
+          // Refresh the currently-viewed week so an edit/delete reflects here.
+          void loadAnchor(peek.anchorCivil);
+        }}
+      />
+    ) : null}
+   </QueryClientProvider>
   );
 }
 
-function PeekItemRow({ item }: { item: PeekItem }) {
+function PeekItemRow({
+  item,
+  onOpenDetail,
+}: {
+  item: PeekItem;
+  onOpenDetail: (assignmentId: string) => void;
+}) {
   const t = useTranslations("clients.detail.calendarPeek");
   const Icon = itemIcon(item);
   return (
-    <div
+    <button
+      type="button"
+      onClick={() => onOpenDetail(item.assignmentId)}
       className={cn(
-        "flex min-w-0 items-start gap-1.5 rounded-md border px-2 py-1.5 text-[11px]",
+        "flex w-full min-w-0 items-start gap-1.5 rounded-md border px-2 py-1.5 text-left text-[11px] transition-colors hover:border-primary/50 hover:brightness-105 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
         itemClassName(item),
       )}
     >
@@ -254,7 +309,7 @@ function PeekItemRow({ item }: { item: PeekItem }) {
           <p className="truncate text-[10px] opacity-75">{item.detail}</p>
         ) : null}
       </div>
-    </div>
+    </button>
   );
 }
 
@@ -264,6 +319,7 @@ function buildWorkoutItems(
 ): PeekItem[] {
   return workouts.map((workout): PeekItem => ({
     id: `workout:${workout.id}`,
+    assignmentId: workout.id,
     name: workout.templateName,
     status: workout.status,
     detail: workout.templateTag

--- a/backoffice/src/app/gc-fitness/notifications/page.tsx
+++ b/backoffice/src/app/gc-fitness/notifications/page.tsx
@@ -33,7 +33,12 @@ import {
   listActiveWorkoutSessionsForTrainer,
 } from "@/lib/gc-fitness/live-workout-actions";
 import type { ActiveWorkoutSummary } from "@/lib/gc-fitness/live-workout-types";
-import { filterPrLogsToRoster } from "@/lib/gc-fitness/personal-records";
+import {
+  filterPrLogsToRoster,
+  flattenLogPRs,
+  previousRecordBySetLog,
+  type PRSnapshot,
+} from "@/lib/gc-fitness/personal-records";
 import { listRecentLogsForTrainerPage } from "@/lib/gc-fitness/recent-logs-actions";
 import { UpcomingWorkoutAlerts } from "@/components/gc-fitness/upcoming-workout-alerts";
 import { sectionMetadata } from "@/lib/gc-fitness/page-metadata";
@@ -102,6 +107,9 @@ type UnifiedNotification = {
   tone: keyof typeof NOTIFICATION_CHIP;
   icon: ReactNode;
   title: string;
+  /** When set, the notification headline links to this href (e.g. the PR
+   * notification's client name → client profile). */
+  titleHref?: string;
   detail: string;
   detailItems?: string[];
   meta: string;
@@ -159,7 +167,9 @@ export default async function NotificationsPage({
     listMyCoachActivityPage(null, 100, null, "workout_assignment"),
     listHabitsForTrainer(),
     listRecentLogsForTrainerPage(null, 20, null, "signup"),
-    listRecentPrWorkoutNotifications(trainer.uid, rosterUids),
+    listRecentPrWorkoutNotifications(trainer.uid, rosterUids, (value) =>
+      t("prsPreviousInline", { value }),
+    ),
   ]);
   const birthdayNotificationsRaw = await listBirthdayNotificationsForTrainer(trainer.uid, todayCivil);
 
@@ -220,6 +230,7 @@ export default async function NotificationsPage({
         client: item.clientName,
         count: item.prCount,
       }),
+      titleHref: `/gc-fitness/clients/${item.clientId}`,
       detail: item.detail,
       detailItems: item.detailItems,
       meta: formatMeta(item.occurredAtISO, item.clientName, null, locale, trainerTimezone),
@@ -380,6 +391,7 @@ export default async function NotificationsPage({
                 key={item.id}
                 tone={item.tone}
                 title={item.title}
+                titleHref={item.titleHref}
                 detail={item.detail}
                 detailItems={item.detailItems}
                 meta={item.meta}
@@ -514,6 +526,7 @@ function NotificationRow({
   icon,
   tone,
   title,
+  titleHref,
   detail,
   detailItems,
   meta,
@@ -528,6 +541,7 @@ function NotificationRow({
   icon: ReactNode;
   tone: keyof typeof NOTIFICATION_CHIP;
   title: string;
+  titleHref?: string;
   detail: string;
   detailItems?: string[];
   meta: string;
@@ -555,9 +569,18 @@ function NotificationRow({
         </div>
         <div className="min-w-0 space-y-1">
           <div className="flex items-center gap-2">
-            <p className="text-sm font-semibold leading-tight text-foreground">
-              {title}
-            </p>
+            {titleHref ? (
+              <Link
+                href={titleHref}
+                className="text-sm font-semibold leading-tight text-foreground hover:underline"
+              >
+                {title}
+              </Link>
+            ) : (
+              <p className="text-sm font-semibold leading-tight text-foreground">
+                {title}
+              </p>
+            )}
             {unread ? (
               <span
                 className="size-2 shrink-0 rounded-full bg-primary"
@@ -602,6 +625,7 @@ function NotificationRow({
 async function listRecentPrWorkoutNotifications(
   trainerUid: string,
   rosterUids: ReadonlySet<string>,
+  formatPrevious: (value: string) => string,
 ): Promise<PrNotification[]> {
   const db = gcFitnessFirestore();
   // The trainerId query stays as the cheap fetch (existing single-field index,
@@ -620,8 +644,13 @@ async function listRecentPrWorkoutNotifications(
     return { doc, data, clientId: data.clientId };
   });
 
-  return filterPrLogsToRoster(rows, rosterUids)
-    .map(({ doc, data }): PrNotification | null => {
+  // Build the base notifications (no previous-PR suffix yet), scope to roster,
+  // sort + slice to the top 10 FIRST — so the earlier-logs point query below
+  // runs at most 10 times (bounded), not once per candidate log (issue #405
+  // follow-up). Each surviving log keeps its raw `data`/`prs` for that lookup.
+  const base = filterPrLogsToRoster(rows, rosterUids)
+    .map((row) => {
+      const { doc, data } = row;
       if (data.deleted === true) return null;
       const completedAt = toIso(data.completedAt);
       if (data.status !== "completed" && !completedAt) return null;
@@ -635,12 +664,11 @@ async function listRecentPrWorkoutNotifications(
         (data.templateSnapshot as { name?: unknown } | undefined)?.name,
         "Workout",
       );
-      const prDetails = formatPrDetails(data, prs);
       const clientName =
         typeof data.clientName === "string" && data.clientName.trim()
           ? data.clientName.trim()
           : clientId;
-      return {
+      const notification: PrNotification = {
         id: `pr:${doc.id}`,
         occurredAtISO: completedAt ?? toIso(data.updatedAt) ?? toIso(data.startedAt),
         clientId,
@@ -648,19 +676,68 @@ async function listRecentPrWorkoutNotifications(
         workoutName,
         prCount: prs.length,
         detail: workoutName,
-        detailItems: prDetails,
         workoutHref: `/gc-fitness/recent-logs/workouts/${doc.id}`,
         chatHref: `/gc-fitness/chat?chatId=${clientId}`,
       };
+      return { notification, data, prs };
     })
-    .filter((item): item is PrNotification => item !== null)
-    .sort((a, b) => isoMs(b.occurredAtISO) - isoMs(a.occurredAtISO))
+    .filter(
+      (
+        item,
+      ): item is {
+        notification: PrNotification;
+        data: Record<string, unknown>;
+        prs: Array<Record<string, unknown>>;
+      } => item !== null,
+    )
+    .sort((a, b) => isoMs(b.notification.occurredAtISO) - isoMs(a.notification.occurredAtISO))
     .slice(0, 10);
+
+  // Only the ≤10 surviving PR logs hit Firestore for their earlier-log baseline
+  // (point reads only — getAll/batchGet fails on Vercel).
+  return Promise.all(
+    base.map(async ({ notification, data, prs }) => {
+      const prevBySetLogId = await resolvePreviousPrsForLog(db, data);
+      return {
+        ...notification,
+        detailItems: formatPrDetails(data, prs, prevBySetLogId, formatPrevious),
+      };
+    }),
+  );
+}
+
+/**
+ * For one PR-carrying log, resolves the record each of its PRs beat — keyed by
+ * setLogId — by point-querying the client's EARLIER logs (startedAt <). Mirrors
+ * the log-detail flow (recent-logs-actions.ts) so the feed line matches the
+ * "(antes …)" the log-detail page already shows (issue #405 follow-up).
+ */
+async function resolvePreviousPrsForLog(
+  db: ReturnType<typeof gcFitnessFirestore>,
+  data: Record<string, unknown>,
+): Promise<Map<string, PRSnapshot>> {
+  const clientId = typeof data.clientId === "string" ? data.clientId : "";
+  const startedAt = data.startedAt; // raw Firestore Timestamp value
+  const thisLogPrs = flattenLogPRs(data);
+  if (!clientId || !startedAt || thisLogPrs.length === 0) return new Map();
+  const earlierSnap = await db
+    .collection(FirestoreCollections.workoutLogs)
+    .where("clientId", "==", clientId)
+    .where("startedAt", "<", startedAt)
+    .orderBy("startedAt", "desc")
+    .limit(200)
+    .get();
+  const earlierPrs = earlierSnap.docs.flatMap((d) =>
+    flattenLogPRs(d.data() as Record<string, unknown>),
+  );
+  return previousRecordBySetLog(earlierPrs, thisLogPrs);
 }
 
 function formatPrDetails(
   data: Record<string, unknown>,
   prs: Array<Record<string, unknown>>,
+  prevBySetLogId: Map<string, PRSnapshot>,
+  formatPrevious: (value: string) => string,
 ): string[] {
   const templateExercises =
     (data.templateSnapshot as { exercises?: Array<Record<string, unknown>> } | undefined)
@@ -695,9 +772,20 @@ function formatPrDetails(
         ? exerciseNameById.get(set.exerciseId)
         : undefined) ??
       (exerciseId || "PR");
+    // #405 follow-up: append the record this PR beat, mirroring the log-detail
+    // "(antes …)" copy — duration PR → "Ns", else "W kg x R".
+    const prev = setLogId ? prevBySetLogId.get(setLogId) : undefined;
+    let previousSuffix = "";
+    if (prev) {
+      const prevValue =
+        prev.durationSeconds !== null && prev.durationSeconds > 0
+          ? `${prev.durationSeconds}s`
+          : `${formatKg(prev.weightKg)} x ${Math.round(prev.reps)}`;
+      previousSuffix = ` ${formatPrevious(prevValue)}`;
+    }
     const durationSeconds = numeric(pr.duration_seconds ?? pr.durationSeconds);
     if (durationSeconds !== null && durationSeconds > 0) {
-      return `${name}: ${formatDuration(durationSeconds)}`;
+      return `${name}: ${formatDuration(durationSeconds)}${previousSuffix}`;
     }
     const weight = numeric(pr.weight_kg ?? pr.weightKg ?? set?.weight_kg ?? set?.weight);
     const reps = numeric(pr.reps ?? set?.reps);
@@ -713,7 +801,7 @@ function formatPrDetails(
     const oneRm = estimatedOneRM !== null && estimatedOneRM > 0
       ? ` (${formatKg(estimatedOneRM)} 1RM)`
       : "";
-    return `${name}${performance ? `: ${performance}` : ""}${oneRm}`;
+    return `${name}${performance ? `: ${performance}` : ""}${oneRm}${previousSuffix}`;
   });
   const remaining = prs.length - details.length;
   if (remaining > 0) {

--- a/backoffice/src/lib/gc-fitness/__tests__/personal-records.test.ts
+++ b/backoffice/src/lib/gc-fitness/__tests__/personal-records.test.ts
@@ -2,6 +2,7 @@ import {
   buildPersonalRecords,
   filterPrLogsToRoster,
   flattenLogPRs,
+  previousRecordBySetLog,
   previousRecordsByExercise,
   type PRExerciseMeta,
   type RawPersonalRecord,
@@ -194,5 +195,54 @@ describe("previousRecordsByExercise", () => {
   it("returns empty when no earlier PR exists for the exercise", () => {
     const prev = previousRecordsByExercise([], new Set(["bench"]));
     expect(prev.size).toBe(0);
+  });
+});
+
+describe("previousRecordBySetLog", () => {
+  it("cross-log — maps this log's PR to the record it beat in an earlier log", () => {
+    const earlier = [
+      pr({ exerciseId: "bench", setLogId: "b0", weightKg: 100, reps: 8, estimatedOneRM: 124, achievedAtMs: 1000 }),
+    ];
+    const thisLog = [
+      pr({ exerciseId: "bench", setLogId: "b1", weightKg: 110, reps: 8, estimatedOneRM: 139, achievedAtMs: 2000 }),
+    ];
+    const map = previousRecordBySetLog(earlier, thisLog);
+    expect(map.get("b1")?.weightKg).toBe(100);
+    expect(map.get("b1")?.reps).toBe(8);
+  });
+
+  it("same-log double PR — the second PR's previous is the first PR of the same session, not the earlier-log baseline", () => {
+    const earlier = [
+      pr({ exerciseId: "bench", setLogId: "b0", weightKg: 90, estimatedOneRM: 100, achievedAtMs: 1000 }),
+    ];
+    const thisLog = [
+      pr({ exerciseId: "bench", setLogId: "b1", weightKg: 110, estimatedOneRM: 120, achievedAtMs: 2000 }),
+      pr({ exerciseId: "bench", setLogId: "b2", weightKg: 130, estimatedOneRM: 140, achievedAtMs: 3000 }),
+    ];
+    const map = previousRecordBySetLog(earlier, thisLog);
+    // First PR of the session beat the earlier-log baseline (90).
+    expect(map.get("b1")?.weightKg).toBe(90);
+    // Second PR of the session beat the immediately-prior in-session PR (110).
+    expect(map.get("b2")?.weightKg).toBe(110);
+  });
+
+  it("first-ever PR — no earlier logs + a single this-log PR ⇒ setLogId absent", () => {
+    const thisLog = [
+      pr({ exerciseId: "squat", setLogId: "s1", weightKg: 150, estimatedOneRM: 175, achievedAtMs: 5000 }),
+    ];
+    const map = previousRecordBySetLog([], thisLog);
+    expect(map.has("s1")).toBe(false);
+    expect(map.size).toBe(0);
+  });
+
+  it("time-based PR — previous resolves by duration ordering", () => {
+    const earlier = [
+      pr({ exerciseId: "plank", setLogId: "p0", reps: 0, estimatedOneRM: 0, durationSeconds: 60, achievedAtMs: 1000 }),
+    ];
+    const thisLog = [
+      pr({ exerciseId: "plank", setLogId: "p1", reps: 0, estimatedOneRM: 0, durationSeconds: 90, achievedAtMs: 2000 }),
+    ];
+    const map = previousRecordBySetLog(earlier, thisLog);
+    expect(map.get("p1")?.durationSeconds).toBe(60);
   });
 });

--- a/backoffice/src/lib/gc-fitness/personal-records.ts
+++ b/backoffice/src/lib/gc-fitness/personal-records.ts
@@ -242,3 +242,55 @@ export function previousRecordsByExercise(
   for (const [exId, pr] of best) out.set(exId, toSnapshot(pr));
   return out;
 }
+
+/**
+ * The record each of THIS log's PRs beat, keyed by the PR's `setLogId`
+ * (issue #405 follow-up — the notifications feed). Unlike
+ * `previousRecordsByExercise` (one previous per exercise), this resolves a
+ * previous for EVERY PR row, so a session that set two PRs for the same
+ * exercise sees the second PR's "previous" as the first PR of the SAME session
+ * (not the earlier-log baseline).
+ *
+ * Ordering rule (mirrors the existing convention): per exercise, seed the
+ * running-best from `earlierPrs` (latest by `achievedAtMs`, magnitude
+ * tiebreak); walk `thisLogPrs` oldest→newest (achievedAtMs then magnitude);
+ * for each row the previous = the current running-best (if any), then advance
+ * the running-best to that row. A row with no prior best (first-ever PR) is
+ * simply absent from the map.
+ */
+export function previousRecordBySetLog(
+  earlierPrs: RawPersonalRecord[],
+  thisLogPrs: RawPersonalRecord[],
+): Map<string, PRSnapshot> {
+  // Group this log's PRs by exercise (skip rows missing ids).
+  const byExercise = new Map<string, RawPersonalRecord[]>();
+  for (const pr of thisLogPrs) {
+    if (!pr.exerciseId || !pr.setLogId) continue;
+    const list = byExercise.get(pr.exerciseId);
+    if (list) list.push(pr);
+    else byExercise.set(pr.exerciseId, [pr]);
+  }
+  if (byExercise.size === 0) return new Map();
+
+  // Seed the running-best per exercise from the earlier-log baseline.
+  const runningBest = previousRecordsByExercise(
+    earlierPrs,
+    new Set(byExercise.keys()),
+  );
+
+  const out = new Map<string, PRSnapshot>();
+  for (const [exerciseId, list] of byExercise) {
+    const sorted = [...list].sort((a, b) => {
+      const ta = a.achievedAtMs ?? Number.NEGATIVE_INFINITY;
+      const tb = b.achievedAtMs ?? Number.NEGATIVE_INFINITY;
+      if (ta !== tb) return ta - tb;
+      return magnitude(a) - magnitude(b);
+    });
+    let best = runningBest.get(exerciseId) ?? null;
+    for (const pr of sorted) {
+      if (best) out.set(pr.setLogId, best);
+      best = toSnapshot(pr);
+    }
+  }
+  return out;
+}


### PR DESCRIPTION
Follow-up to mdb1/gc-fitness#405 (user report: the PRs notifications feed still didn't show the previous record each new PR beat) + 3 UX fixes from the same review.

## 1. Prev-PR line in the PRs notifications feed (#405 follow-up)

Each PR line now appends the record it beat, matching the log-detail copy:

> Sentadilla trasera (Smith): 130 kg x 8 (164.7 kg 1RM) **(antes 110 kg x 8)**

- New pure helper `previousRecordBySetLog(earlierPrs, thisLogPrs)` in `personal-records.ts` (jest-tested), reusing the existing PR #234 primitives. Unlike `previousRecordsByExercise` it resolves a previous for EVERY PR row, so a session with two PRs on the same exercise shows the second one beating the first (the exact case in the user's screenshot).
- Bounded reads: notifications are sorted and sliced to the top 10 BEFORE any history lookup, so at most 10 earlier-logs queries run (`clientId ==` + `startedAt <` + `orderBy startedAt desc`, limit 200 — served by the already-deployed `workout_logs (clientId, startedAt DESC)` composite index that recent-logs uses; point queries only, no `getAll`).
- First-ever PRs simply render without a suffix.
- New i18n key `notifications.prsPreviousInline`: es `"(antes {value})"` / en `"(prev {value})"`.

## 2. Client name links to the profile

The PR notification headline ("Nico Rey metió 3 PRs") now links to `/gc-fitness/clients/{clientId}` via a new optional `titleHref` on the unified notification row.

## 3. Mini calendario: workout cards open the detail

Cards in the client-detail mini calendar are now buttons that open the same `WorkoutDetailDialog` the Agenda uses (chip id = assignment doc id). Local `QueryClientProvider` added (mirroring the existing `ClientSummaryLists` pattern — the route has no react-query ancestor). `onDeleted` reloads the viewed week.

## 4. Mini calendario: week label in the nav

The middle pill no longer reads a static "Hoy" — it now shows the week range (`11 jul - 17 jul`) between the chevrons, mirroring the Agenda's rangeNav, with a separate outline "Hoy" jump button (disabled while already on today's week).

## Test gate

- `npx tsc --noEmit` clean.
- `npx jest`: 755 passed / 1 failed — the sole failure is the documented pre-existing `client-activity-time` locale flake (green in CI). No new failures.
- `npx jest personal-records`: 20/20 incl. 4 new prev-PR cases (same-session double PR, first-ever PR, duration PR, earlier-log baseline).