### PR TITLE
fix(picker): exercise picker cut off below viewport + double search icon (#412)

### DIFF
--- a/backoffice/src/components/gc-fitness/__tests__/exercise-picker-popover.test.tsx
+++ b/backoffice/src/components/gc-fitness/__tests__/exercise-picker-popover.test.tsx
@@ -440,6 +440,35 @@ describe("ExercisePickerPopover search-before-cap (issue #291 Case 6)", () => {
 });
 
 // ---------------------------------------------------------------------------
+// Issue #412 (report 2) — double-lupa regression guard. The picker's search
+// input must render EXACTLY ONE magnifying-glass icon. cmdk's CommandInput
+// already draws its own SearchIcon inside `data-slot="command-input-wrapper"`;
+// a previous manual <Search/> wrapper drew a second one. Assert the wrapper
+// holds a single svg.
+// ---------------------------------------------------------------------------
+
+describe("ExercisePickerPopover single search icon (issue #412 report 2)", () => {
+  it("renders exactly one search-icon svg in the command input", () => {
+    mockUseExercisesQuery.mockReturnValue({
+      data: [makeRow()],
+      isLoading: false,
+      error: null,
+      hasSnapshot: true,
+    });
+
+    render(<ExercisePickerPopover value="" onChange={() => {}} />);
+    openPicker();
+
+    const wrapper = document.querySelector(
+      '[data-slot="command-input-wrapper"]',
+    );
+    expect(wrapper).not.toBeNull();
+    const icons = wrapper!.querySelectorAll("svg");
+    expect(icons.length).toBe(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
 // Legacy exercise retirement — isPickableExercise filter.
 //
 // (A) A legacy catalog row (source "wger", no standard-library tag) must NOT

--- a/backoffice/src/components/gc-fitness/exercise-picker-popover.tsx
+++ b/backoffice/src/components/gc-fitness/exercise-picker-popover.tsx
@@ -56,7 +56,7 @@
 // a redundant duplicate line).
 
 import { useEffect, useMemo, useRef, useState } from "react";
-import { ChevronsUpDown, Copy, Search, X } from "lucide-react";
+import { ChevronsUpDown, Copy, X } from "lucide-react";
 import { useTranslations } from "next-intl";
 
 import { Button } from "@/components/ui/button";
@@ -415,8 +415,9 @@ export function ExercisePickerPopover({
         </Button>
       </PopoverTrigger>
       <PopoverContent
-        className="flex max-h-[min(80vh,720px)] w-[--radix-popover-trigger-width] flex-col overflow-y-auto p-0"
+        className="flex max-h-[min(var(--radix-popover-content-available-height),720px)] w-[--radix-popover-trigger-width] flex-col overflow-y-auto p-0"
         align="start"
+        collisionPadding={8}
       >
         {/* Phase 24-06 Task 3 — filter chip row. Renders ABOVE the
             search input so the trainer narrows by FEXD enrichment
@@ -441,15 +442,11 @@ export function ExercisePickerPopover({
           // cmdk render exactly `visible`.
           shouldFilter={false}
         >
-          <div className="flex items-center border-b px-3">
-            <Search className="mr-2 h-4 w-4 shrink-0 opacity-50" />
-            <CommandInput
-              value={search}
-              onValueChange={setSearch}
-              placeholder={t("searchPlaceholder")}
-              className="h-10 border-0 focus:ring-0"
-            />
-          </div>
+          <CommandInput
+            value={search}
+            onValueChange={setSearch}
+            placeholder={t("searchPlaceholder")}
+          />
           <CommandList ref={listRef}>
             {isLoading || !hasSnapshot ? (
               <CommandEmpty>{t("loadingExercises")}</CommandEmpty>


### PR DESCRIPTION
Fixes the two reports in mdb1/gc-fitness#412 — both in the single-add exercise picker (`ExercisePickerPopover`).

## 1. "Crear ejercicio se corta" — picker cut off below the viewport

`PopoverContent` capped its height with `max-h-[min(80vh,720px)]`, which ignores where the popover actually renders. Opened from the assignment-edit dialog (trigger low on screen), the content extended past the viewport bottom — and since the 80vh cap wasn't reached, the internal scroll never engaged, leaving the bottom `QuickCreateExercise` panel unreachable (the amber panel cut off in the screenshot).

Now the cap uses Radix's positioning-aware var — `max-h-[min(var(--radix-popover-content-available-height),720px)]` plus `collisionPadding={8}` — the same pattern `dropdown-menu.tsx` already uses. The popover sizes to the space actually available, so the quick-create panel is always reachable by scrolling.

## 2. "Doble lupa" — duplicated search icon

The picker wrapped shadcn's `CommandInput` in a manual `<div>` with its own `<Search>` icon — but this repo's `CommandInput` already renders a `SearchIcon` internally (via `InputGroupAddon`). Removed the manual wrapper and icon; `CommandInput` renders alone.

Scope fence: the search boxes in the multi-add dialog, bulk-assign-habit and new-habit dialogs keep their manual icon — those use a plain `<input>` (no built-in icon), so they were never duplicated.

## Tests

- New regression test: exactly one search icon renders in the open picker.
- `npx tsc --noEmit` clean; `npx jest` 756/757 (sole failure = documented pre-existing `client-activity-time` locale flake, green in CI).