### PR TITLE
Fix superset group sequencing

### DIFF
--- a/backoffice/src/components/gc-fitness/template-form.tsx
+++ b/backoffice/src/components/gc-fitness/template-form.tsx
@@ -27,7 +27,7 @@
 
 import { useEffect, useMemo, useRef, useState, useTransition } from "react";
 import { useRouter } from "next/navigation";
-import { useForm, useFieldArray, Controller } from "react-hook-form";
+import { useForm, useFieldArray, Controller, useWatch } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import {
   ArrowUp,
@@ -101,10 +101,11 @@ import {
   type WorkoutTemplateInput,
 } from "@/lib/gc-fitness/workout-template-schema";
 import {
+  compactSupersetGroupLabelsAfterRemoval,
   getSupersetGroupMemberIndexes,
   getSupersetGroupRest,
   getSupersetMembership,
-  listSupersetGroupOptions,
+  listSupersetGroupPillLabels,
   normalizeSupersetGroup,
 } from "@/lib/gc-fitness/superset-groups";
 
@@ -473,18 +474,14 @@ export function TemplateForm({
     }
     return s;
   }, [exerciseLibrary]);
-  const watchedExercises = form.watch("exercises") ?? [];
-  const supersetGroupOptions = useMemo(
-    () => listSupersetGroupOptions(watchedExercises),
+  const watchedExercises =
+    useWatch({ control: form.control, name: "exercises" }) ?? [];
+  // Fixed A/B/C pills + any existing labels, and once the highest visible
+  // sequence is in use, one extra letter so trainers can keep adding groups.
+  const supersetPillLabels = useMemo(
+    () => listSupersetGroupPillLabels(watchedExercises),
     [watchedExercises],
   );
-  // Fixed A/B/C pills + any legacy labels already in use beyond A-C (rendered as
-  // their own pills so existing docs stay editable). D9.
-  const supersetPillLabels = useMemo(() => {
-    const fixed = ["A", "B", "C"];
-    const extras = supersetGroupOptions.filter((g) => !fixed.includes(g));
-    return [...fixed, ...extras];
-  }, [supersetGroupOptions]);
   // Live estimated duration (work + rest + per-set setup overhead + transitions),
   // matching the iOS-twin estimator. 0 while no exercises are configured.
   const estimatedDurationMinutes = useMemo(
@@ -709,12 +706,41 @@ export function TemplateForm({
 
   function applySupersetGroup(index: number, nextGroupRaw: string) {
     const nextGroup = normalizeSupersetGroup(nextGroupRaw);
+    const previousGroup = normalizeSupersetGroup(
+      form.getValues(`exercises.${index}.supersetGroup` as const),
+    );
     form.setValue(
       `exercises.${index}.supersetGroup` as const,
       nextGroup,
       { shouldDirty: true },
     );
-    if (!nextGroup) return;
+    if (!nextGroup) {
+      if (!previousGroup) return;
+      const snapshot = watchedExercises.map((exercise, exerciseIndex) =>
+        exerciseIndex === index ? { ...exercise, supersetGroup: "" } : exercise,
+      );
+      if (getSupersetGroupMemberIndexes(snapshot, previousGroup).length >= 2) {
+        return;
+      }
+      const compacted = compactSupersetGroupLabelsAfterRemoval(
+        snapshot,
+        previousGroup,
+      );
+      compacted.forEach((exercise, exerciseIndex) => {
+        const compactedGroup = normalizeSupersetGroup(exercise.supersetGroup);
+        const currentGroup = normalizeSupersetGroup(
+          form.getValues(`exercises.${exerciseIndex}.supersetGroup` as const),
+        );
+        if (compactedGroup !== currentGroup) {
+          form.setValue(
+            `exercises.${exerciseIndex}.supersetGroup` as const,
+            compactedGroup,
+            { shouldDirty: true },
+          );
+        }
+      });
+      return;
+    }
 
     const snapshot = watchedExercises.map((exercise, exerciseIndex) =>
       exerciseIndex === index
@@ -2445,10 +2471,11 @@ export function TemplateForm({
                     </div>
                     )}
 
-                    {/* D9 — fixed A/B/C group pills (plus any legacy label
-                        already in use). Tap a pill to assign the exercise to
-                        that superset; tap the active pill to remove it. Writes
-                        through applySupersetGroup (set-count locking preserved). */}
+                    {/* D9/454 — A/B/C group pills plus the next available
+                        letter once the visible sequence is in use. Tap a pill
+                        to assign the exercise to that superset; tap the active
+                        pill to remove it. Writes through applySupersetGroup
+                        (set-count locking preserved). */}
                     <FormField
                       control={form.control}
                       name={`exercises.${index}.supersetGroup` as const}

--- a/backoffice/src/lib/app-version.ts
+++ b/backoffice/src/lib/app-version.ts
@@ -1,1 +1,1 @@
-export const BACKOFFICE_VERSION = "2.251";
+export const BACKOFFICE_VERSION = "2.252";

--- a/backoffice/src/lib/gc-fitness/__tests__/superset-groups.test.ts
+++ b/backoffice/src/lib/gc-fitness/__tests__/superset-groups.test.ts
@@ -1,5 +1,7 @@
 import {
+  compactSupersetGroupLabelsAfterRemoval,
   getSupersetGroupMemberIndexes,
+  listSupersetGroupPillLabels,
   getSupersetGroupRest,
   getSupersetMembership,
   listSupersetGroupOptions,
@@ -24,6 +26,96 @@ describe("superset-groups", () => {
 
   it("lists unique superset pills in order", () => {
     expect(listSupersetGroupOptions(exercises)).toEqual(["A", "B"]);
+  });
+
+  it("keeps A/B/C visible before the first three groups are all used", () => {
+    expect(listSupersetGroupPillLabels([])).toEqual(["A", "B", "C"]);
+    expect(listSupersetGroupPillLabels([{ supersetGroup: "A" }])).toEqual([
+      "A",
+      "B",
+      "C",
+    ]);
+    expect(listSupersetGroupPillLabels([{ supersetGroup: "C" }])).toEqual([
+      "A",
+      "B",
+      "C",
+    ]);
+    expect(
+      listSupersetGroupPillLabels([
+        { supersetGroup: "A" },
+        { supersetGroup: "C" },
+      ]),
+    ).toEqual(["A", "B", "C"]);
+    expect(
+      listSupersetGroupPillLabels([
+        { supersetGroup: "A" },
+        { supersetGroup: "A" },
+        { supersetGroup: "B" },
+        { supersetGroup: "B" },
+        { supersetGroup: "C" },
+      ]),
+    ).toEqual(["A", "B", "C"]);
+    expect(
+      listSupersetGroupPillLabels([
+        { supersetGroup: "A" },
+        { supersetGroup: "A" },
+        { supersetGroup: "B" },
+        { supersetGroup: "B" },
+        { supersetGroup: "C" },
+        { supersetGroup: "C" },
+        { supersetGroup: "D" },
+      ]),
+    ).toEqual(["A", "B", "C", "D"]);
+  });
+
+  it("adds the next superset letter once the visible sequence is used", () => {
+    expect(
+      listSupersetGroupPillLabels([
+        { supersetGroup: "A" },
+        { supersetGroup: "A" },
+        { supersetGroup: "B" },
+        { supersetGroup: "B" },
+        { supersetGroup: "C" },
+        { supersetGroup: "C" },
+      ]),
+    ).toEqual(["A", "B", "C", "D"]);
+    expect(
+      listSupersetGroupPillLabels([
+        { supersetGroup: "A" },
+        { supersetGroup: "A" },
+        { supersetGroup: "B" },
+        { supersetGroup: "B" },
+        { supersetGroup: "C" },
+        { supersetGroup: "C" },
+        { supersetGroup: "D" },
+        { supersetGroup: "D" },
+      ]),
+    ).toEqual(["A", "B", "C", "D", "E"]);
+  });
+
+  it("compacts later labels when a superset group is removed", () => {
+    expect(
+      compactSupersetGroupLabelsAfterRemoval(
+        [
+          { supersetGroup: "A" },
+          { supersetGroup: "B" },
+          { supersetGroup: "C" },
+          { supersetGroup: "E" },
+          { supersetGroup: "E" },
+        ],
+        "D",
+      ).map((exercise) => exercise.supersetGroup),
+    ).toEqual(["A", "B", "C", "D", "D"]);
+    expect(
+      compactSupersetGroupLabelsAfterRemoval(
+        [
+          { supersetGroup: "A" },
+          { supersetGroup: "C" },
+          { supersetGroup: "D" },
+        ],
+        "B",
+      ).map((exercise) => exercise.supersetGroup),
+    ).toEqual(["A", "B", "C"]);
   });
 
   it("finds all members for a group", () => {

--- a/backoffice/src/lib/gc-fitness/superset-groups.ts
+++ b/backoffice/src/lib/gc-fitness/superset-groups.ts
@@ -21,6 +21,8 @@ export interface SupersetGroupRest {
   afterRestSeconds: number | null;
 }
 
+const DEFAULT_SUPERSET_PILL_LABELS = ["A", "B", "C"] as const;
+
 export function normalizeSupersetGroup(value: unknown): string {
   return typeof value === "string" ? value.trim() : "";
 }
@@ -36,6 +38,32 @@ export function listSupersetGroupOptions(
   return Array.from(groups).sort((a, b) => a.localeCompare(b));
 }
 
+export function listSupersetGroupPillLabels(
+  exercises: SupersetGroupExerciseLike[],
+): string[] {
+  const used = listSupersetGroupOptions(exercises);
+  const labels = new Set<string>(DEFAULT_SUPERSET_PILL_LABELS);
+  for (const group of used) labels.add(group);
+
+  const selectedValues = new Set(
+    Array.from(countAlphabeticSupersetGroups(exercises))
+      .filter(([, count]) => count >= 2)
+      .map(([value]) => value),
+  );
+  const defaultMax = alphabeticLabelValue(
+    DEFAULT_SUPERSET_PILL_LABELS[DEFAULT_SUPERSET_PILL_LABELS.length - 1],
+  );
+  if (defaultMax !== null) {
+    let contiguous = 0;
+    while (selectedValues.has(contiguous + 1)) contiguous += 1;
+    if (contiguous >= defaultMax) {
+      labels.add(alphabeticLabelFromValue(contiguous + 1));
+    }
+  }
+
+  return Array.from(labels).sort(compareSupersetGroupLabels);
+}
+
 export function getSupersetGroupMemberIndexes(
   exercises: SupersetGroupExerciseLike[],
   group: string,
@@ -49,6 +77,88 @@ export function getSupersetGroupMemberIndexes(
     }
   });
   return members;
+}
+
+export function compactSupersetGroupLabelsAfterRemoval<
+  T extends SupersetGroupExerciseLike,
+>(exercises: T[], removedGroup: string): T[] {
+  const removedValue = alphabeticLabelValue(normalizeSupersetGroup(removedGroup));
+  if (removedValue === null) return exercises;
+
+  const usedAfterRemoval = Array.from(
+    new Set(
+      exercises
+        .map((exercise) =>
+          alphabeticLabelValue(normalizeSupersetGroup(exercise.supersetGroup)),
+        )
+        .filter(
+          (value): value is number =>
+            value !== null && value > removedValue,
+        ),
+    ),
+  ).sort((a, b) => a - b);
+  if (usedAfterRemoval.length === 0) return exercises;
+
+  const remapped = new Map<number, string>();
+  usedAfterRemoval.forEach((value, offset) => {
+    const nextValue = removedValue + offset;
+    if (nextValue !== value) {
+      remapped.set(value, alphabeticLabelFromValue(nextValue));
+    }
+  });
+  if (remapped.size === 0) return exercises;
+
+  return exercises.map((exercise) => {
+    const value = alphabeticLabelValue(
+      normalizeSupersetGroup(exercise.supersetGroup),
+    );
+    const nextGroup = value === null ? undefined : remapped.get(value);
+    return nextGroup ? { ...exercise, supersetGroup: nextGroup } : exercise;
+  });
+}
+
+function compareSupersetGroupLabels(a: string, b: string): number {
+  const left = alphabeticLabelValue(a);
+  const right = alphabeticLabelValue(b);
+  if (left !== null && right !== null) return left - right;
+  if (left !== null) return -1;
+  if (right !== null) return 1;
+  return a.localeCompare(b);
+}
+
+function countAlphabeticSupersetGroups(
+  exercises: SupersetGroupExerciseLike[],
+): Map<number, number> {
+  const counts = new Map<number, number>();
+  for (const exercise of exercises) {
+    const value = alphabeticLabelValue(
+      normalizeSupersetGroup(exercise.supersetGroup),
+    );
+    if (value === null) continue;
+    counts.set(value, (counts.get(value) ?? 0) + 1);
+  }
+  return counts;
+}
+
+function alphabeticLabelValue(label: string): number | null {
+  const normalized = label.trim().toUpperCase();
+  if (!/^[A-Z]+$/.test(normalized)) return null;
+  let value = 0;
+  for (const char of normalized) {
+    value = value * 26 + char.charCodeAt(0) - 64;
+  }
+  return value;
+}
+
+function alphabeticLabelFromValue(value: number): string {
+  let remaining = Math.max(1, Math.floor(value));
+  let label = "";
+  while (remaining > 0) {
+    remaining -= 1;
+    label = String.fromCharCode(65 + (remaining % 26)) + label;
+    remaining = Math.floor(remaining / 26);
+  }
+  return label;
 }
 
 /**


### PR DESCRIPTION
## Summary

- Fixes superset letter sequencing in the workout/template editor.
- Keeps `A`, `B`, and `C` visible by default.
- Shows the next letter only when all previous letters are valid supersets, meaning each has at least 2 exercises.
- Compacts later superset letters when a previous group is no longer a valid superset, so labels stay consecutive without gaps.
- Updates the form to react immediately when superset assignments change.
- Bumps backoffice version to `2.252`.

## Screenshot

<img width="663" height="122" alt="Screenshot 2026-07-14 at 4 06 21 PM" src="https://github.com/user-attachments/assets/b323ab0f-269d-472e-b244-4f56603d79f3" />
