### PR TITLE
Fix time-based workout detail metrics

### DIFF
--- a/backoffice/messages/en.json
+++ b/backoffice/messages/en.json
@@ -1817,6 +1817,7 @@
       "columnHash": "#",
       "columnExercise": "Exercise",
       "columnReps": "Reps",
+      "columnDuration": "Sec",
       "columnWeight": "Weight",
       "columnCompletedAt": "Completed At",
       "weightUnit": "kg",

--- a/backoffice/messages/es.json
+++ b/backoffice/messages/es.json
@@ -1817,6 +1817,7 @@
       "columnHash": "#",
       "columnExercise": "Ejercicio",
       "columnReps": "Reps",
+      "columnDuration": "Seg",
       "columnWeight": "Peso",
       "columnCompletedAt": "Completada",
       "weightUnit": "kg",

--- a/backoffice/src/app/gc-fitness/clients/[id]/_components/PersonalRecordsWidget.tsx
+++ b/backoffice/src/app/gc-fitness/clients/[id]/_components/PersonalRecordsWidget.tsx
@@ -33,8 +33,8 @@ export async function PersonalRecordsWidget({ clientId }: { clientId: string }) 
           sortLabel: t("sortLabel"),
           sortRecent: t("sortRecent"),
           sortMostCommon: t("sortMostCommon"),
-          previousLabel: t("previousLabel"),
-          estOneRm: t("estOneRm"),
+          previousLabel: t.raw("previousLabel"),
+          estOneRm: t.raw("estOneRm"),
           noDate: t("noDate"),
         }}
       />

--- a/backoffice/src/components/gc-fitness/schedule/workout-detail-dialog.tsx
+++ b/backoffice/src/components/gc-fitness/schedule/workout-detail-dialog.tsx
@@ -534,7 +534,7 @@ function ExerciseSetTable({
   // no-weight sentinel (weightBySetKg was an empty array = reps-only /
   // bodyweight), drop the Peso column entirely so the detail reads reps-only
   // with NO "kg" label. Legacy (nil) + weighted exercises keep the column.
-  const noWeight = ex.hasExplicitNoWeightPrescription;
+  const noWeight = ex.metric === "time" || ex.hasExplicitNoWeightPrescription;
   const rows = Array.from({ length: ex.sets }, (_, i) => ({
     setNumber: i + 1,
     reps: ex.repsBySet[i] ?? ex.reps,

--- a/backoffice/src/components/gc-fitness/share-workout-card.tsx
+++ b/backoffice/src/components/gc-fitness/share-workout-card.tsx
@@ -119,8 +119,8 @@ function weightString(kg: number): string {
 
 /**
  * v2.2 per-set chip text — mirrors iOS `ShareCardView.setChipText`:
- *   - weighted (weight > 0): "{w} kg × {reps}"
  *   - time-based (durationSeconds present): "{n}s"
+ *   - weighted (weight > 0): "{w} kg × {reps}"
  *   - bodyweight (weight 0, no duration): "{reps}"
  */
 function setChipText(
@@ -128,11 +128,11 @@ function setChipText(
   reps: number | null,
   durationSeconds: number | null,
 ): string {
-  if (weight !== null && weight > 0) {
-    return `${weightString(weight)} kg × ${reps ?? 0}`;
-  }
   if (durationSeconds !== null) {
     return `${durationSeconds}s`;
+  }
+  if (weight !== null && weight > 0) {
+    return `${weightString(weight)} kg × ${reps ?? 0}`;
   }
   return `${reps ?? 0}`;
 }
@@ -494,7 +494,7 @@ function buildSuccessModel(
     let topVolume = 0;
     let topIdx = -1;
     working.forEach((s, i) => {
-      if (s.weight !== null && s.weight > 0) {
+      if (s.metric !== "time" && s.weight !== null && s.weight > 0) {
         const vol = s.weight * (s.reps ?? 0);
         if (vol > topVolume) {
           topVolume = vol;
@@ -511,7 +511,7 @@ function buildSuccessModel(
 
     const oneRMLabel = bestEstimatedOneRM(
       working
-        .filter((s) => s.weight !== null && s.weight > 0)
+        .filter((s) => s.metric !== "time" && s.weight !== null && s.weight > 0)
         .map((s) => ({ weight: s.weight as number, reps: s.reps ?? 0 })),
     );
 
@@ -521,7 +521,7 @@ function buildSuccessModel(
 
   // Volumen total = Σ(weight × reps) over working (non-warmup) sets.
   const totalVolume = detail.sets
-    .filter((s) => !s.isWarmup)
+    .filter((s) => !s.isWarmup && s.metric !== "time")
     .reduce((acc, s) => acc + (s.weight ?? 0) * (s.reps ?? 0), 0);
   const seriesCount = detail.sets.filter((s) => !s.isWarmup).length;
   const exerciseCount = detail.exerciseCount || order.length;
@@ -612,14 +612,15 @@ function buildAssignmentModel(
 
     // Per-set normalized rows from the prescription. reps_i = repsBySet[i] ?? reps.
     const perSet = Array.from({ length: setCount }, (_, i) => {
+      const isTimeExercise = ex.metric === "time";
       const weight =
-        i < ex.weightBySetKg.length && ex.weightBySetKg[i] > 0
+        !isTimeExercise && i < ex.weightBySetKg.length && ex.weightBySetKg[i] > 0
           ? ex.weightBySetKg[i]
           : null;
       const reps =
-        i < ex.repsBySet.length ? ex.repsBySet[i] : ex.reps;
+        isTimeExercise ? null : i < ex.repsBySet.length ? ex.repsBySet[i] : ex.reps;
       const durationSeconds =
-        ex.metric === "time"
+        isTimeExercise
           ? i < ex.durationBySetSeconds.length
             ? ex.durationBySetSeconds[i]
             : ex.durationSeconds

--- a/backoffice/src/components/gc-fitness/workout-log-detail-view.tsx
+++ b/backoffice/src/components/gc-fitness/workout-log-detail-view.tsx
@@ -76,7 +76,7 @@ function groupSetsByExercise(sets: WorkoutLogDetail["sets"]): ExerciseGroup[] {
       order.push(key);
     }
     bucket.sets.push(set);
-    if (set.weight !== null) {
+    if (set.metric !== "time" && set.weight !== null) {
       bucket.topWeight =
         bucket.topWeight === null ? set.weight : Math.max(bucket.topWeight, set.weight);
     }
@@ -181,6 +181,9 @@ export function WorkoutLogDetailView({ detail }: { detail: WorkoutLogDetail }) {
             <div className="flex flex-col gap-3">
               {groups.map((group, gIdx) => {
                 const palette = EXERCISE_COLORS[gIdx % EXERCISE_COLORS.length];
+                const isTimeGroup =
+                  group.sets.length > 0 &&
+                  group.sets.every((set) => set.metric === "time");
                 return (
                   <div
                     key={group.exerciseId}
@@ -228,72 +231,81 @@ export function WorkoutLogDetailView({ detail }: { detail: WorkoutLogDetail }) {
                         <thead className="border-b text-left text-xs uppercase tracking-wide text-muted-foreground">
                           <tr>
                             <th className="py-1.5 pr-3">{t("columnHash")}</th>
-                            <th className="py-1.5 pr-3">{t("columnReps")}</th>
-                            <th className="py-1.5 pr-3">{t("columnWeight")}</th>
+                            <th className="py-1.5 pr-3">
+                              {isTimeGroup ? t("columnDuration") : t("columnReps")}
+                            </th>
+                            {!isTimeGroup ? (
+                              <th className="py-1.5 pr-3">{t("columnWeight")}</th>
+                            ) : null}
                             <th className="py-1.5 pr-3">{t("columnCompletedAt")}</th>
                             <th className="py-1.5 pr-3">Descanso</th>
                           </tr>
                         </thead>
                         <tbody>
-                          {group.sets.map((set) => (
-                            <tr
-                              key={`${set.index}-${set.setLogId}`}
-                              className={
-                                set.isPR
-                                  ? "border-b bg-amber-100/40 last:border-b-0 dark:bg-amber-900/20"
-                                  : "border-b last:border-b-0"
-                              }
-                            >
-                              <td className="py-2 pr-3">
-                                <div className="flex flex-wrap items-center gap-x-1.5 gap-y-0.5">
-                                  <span>{set.index}</span>
-                                  {set.isPR ? (
-                                    <span
-                                      title={
-                                        set.prEstimatedOneRM !== null
-                                          ? t("prBadgeTitle", {
-                                              value: Math.round(set.prEstimatedOneRM * 10) / 10,
-                                            })
-                                          : t("prBadge")
-                                      }
-                                    >
-                                      <Trophy
-                                        className="h-3.5 w-3.5 text-amber-600 dark:text-amber-400"
-                                        aria-label={t("prBadge")}
-                                      />
-                                    </span>
-                                  ) : null}
-                                  {set.isPR && set.prPrevious ? (
-                                    <span className="whitespace-nowrap text-[10px] text-muted-foreground">
-                                      {t("prPreviousLabel", {
-                                        value: prPreviousText(set.prPrevious),
-                                      })}
-                                    </span>
-                                  ) : null}
-                                </div>
-                              </td>
-                              <td className="py-2 pr-3">
-                                {/* Time-set rendering: surface `{N}s` when the
-                                    log carries a duration; otherwise reps. */}
-                                {set.durationSeconds !== null
-                                  ? `${set.durationSeconds}s`
-                                  : (set.reps ?? t("emptyDash"))}
-                              </td>
-                              <td className="py-2 pr-3">
-                                {set.weight !== null
-                                  ? `${set.weight} ${t("weightUnit")}`
-                                  : t("emptyDash")}
-                              </td>
-                              <td className="py-2 pr-3 text-muted-foreground">
-                                {formatTimeOnly(set.completedAt, detail.clientTimezone)}
-                              </td>
-                              <td className="py-2 pr-3 text-muted-foreground">
-                                {restMap.has(set.setLogId)
-                                  ? formatRest(restMap.get(set.setLogId)!)
-                                  : t("emptyDash")}
-                              </td>
-                            </tr>
-                          ))}
+                          {group.sets.map((set) => {
+                            const isTimeSet = set.metric === "time";
+                            return (
+                              <tr
+                                key={`${set.index}-${set.setLogId}`}
+                                className={
+                                  set.isPR
+                                    ? "border-b bg-amber-100/40 last:border-b-0 dark:bg-amber-900/20"
+                                    : "border-b last:border-b-0"
+                                }
+                              >
+                                <td className="py-2 pr-3">
+                                  <div className="flex flex-wrap items-center gap-x-1.5 gap-y-0.5">
+                                    <span>{set.index}</span>
+                                    {set.isPR ? (
+                                      <span
+                                        title={
+                                          set.prEstimatedOneRM !== null
+                                            ? t("prBadgeTitle", {
+                                                value: Math.round(set.prEstimatedOneRM * 10) / 10,
+                                              })
+                                            : t("prBadge")
+                                        }
+                                      >
+                                        <Trophy
+                                          className="h-3.5 w-3.5 text-amber-600 dark:text-amber-400"
+                                          aria-label={t("prBadge")}
+                                        />
+                                      </span>
+                                    ) : null}
+                                    {set.isPR && set.prPrevious ? (
+                                      <span className="whitespace-nowrap text-[10px] text-muted-foreground">
+                                        {t("prPreviousLabel", {
+                                          value: prPreviousText(set.prPrevious),
+                                        })}
+                                      </span>
+                                    ) : null}
+                                  </div>
+                                </td>
+                                <td className="py-2 pr-3">
+                                  {isTimeSet
+                                    ? set.durationSeconds !== null
+                                      ? `${set.durationSeconds}s`
+                                      : t("emptyDash")
+                                    : (set.reps ?? t("emptyDash"))}
+                                </td>
+                                {!isTimeGroup ? (
+                                  <td className="py-2 pr-3">
+                                    {!isTimeSet && set.weight !== null
+                                      ? `${set.weight} ${t("weightUnit")}`
+                                      : t("emptyDash")}
+                                  </td>
+                                ) : null}
+                                <td className="py-2 pr-3 text-muted-foreground">
+                                  {formatTimeOnly(set.completedAt, detail.clientTimezone)}
+                                </td>
+                                <td className="py-2 pr-3 text-muted-foreground">
+                                  {restMap.has(set.setLogId)
+                                    ? formatRest(restMap.get(set.setLogId)!)
+                                    : t("emptyDash")}
+                                </td>
+                              </tr>
+                            );
+                          })}
                         </tbody>
                       </table>
                     </div>

--- a/backoffice/src/lib/app-version.ts
+++ b/backoffice/src/lib/app-version.ts
@@ -1,1 +1,1 @@
-export const BACKOFFICE_VERSION = "2.253";
+export const BACKOFFICE_VERSION = "2.254";

--- a/backoffice/src/lib/app-version.ts
+++ b/backoffice/src/lib/app-version.ts
@@ -1,1 +1,1 @@
-export const BACKOFFICE_VERSION = "2.252";
+export const BACKOFFICE_VERSION = "2.253";

--- a/backoffice/src/lib/gc-fitness/__tests__/recent-logs-actions.self-workout.test.ts
+++ b/backoffice/src/lib/gc-fitness/__tests__/recent-logs-actions.self-workout.test.ts
@@ -25,10 +25,10 @@ jest.mock("@/lib/gc-fitness/trainer-timezone", () => ({
 import { getWorkoutLogDetail } from "../recent-logs-actions";
 import { FirestoreCollections } from "../collections";
 
-function docSnap(exists: boolean, data: Record<string, unknown>) {
+function docSnap(exists: boolean, data: Record<string, unknown>, id = "") {
   return {
     exists,
-    id: (data.__id as string) ?? "",
+    id: (data.__id as string) ?? id,
     data: () => data,
     get: (field: string) => data[field],
   };
@@ -44,7 +44,7 @@ function makeDb(fixtures: Record<string, Record<string, unknown> | null>) {
       doc: (id: string) => ({
         get: async () => {
           const data = fixtures[`${name}/${id}`];
-          return data ? docSnap(true, data) : docSnap(false, {});
+          return data ? docSnap(true, data, id) : docSnap(false, {}, id);
         },
       }),
     }),
@@ -53,6 +53,7 @@ function makeDb(fixtures: Record<string, Record<string, unknown> | null>) {
 
 const WL = FirestoreCollections.workoutLogs;
 const USERS = FirestoreCollections.users;
+const EXERCISES = FirestoreCollections.exercises;
 
 const SELF_LOG_ID = "log-asg-client1-20260710-self-abc-123";
 const selfLog = {
@@ -101,6 +102,55 @@ describe("getWorkoutLogDetail — client-created (self) workouts (#434)", () => 
 
     const detail = await getWorkoutLogDetail(id);
     expect(detail.workoutName).toBe("Pecho");
+  });
+
+  it("marks legacy time-exercise set logs as time and falls back to prescribed duration", async () => {
+    const id = "log-time-legacy-1";
+    mockState.db = makeDb({
+      [`${WL}/${id}`]: {
+        __id: id,
+        clientId: "client1",
+        trainerId: "coach1",
+        status: "completed",
+        sets: [
+          {
+            id: "set-plank-1",
+            exerciseId: "plank",
+            set_index: 0,
+            reps: 10,
+            weight_kg: 20,
+            completed_at: "2026-07-14T15:00:00.000Z",
+          },
+        ],
+        templateSnapshot: {
+          name: "Core",
+          exercises: [
+            {
+              exerciseId: "plank",
+              sets: 1,
+              reps: 0,
+              durationSeconds: 45,
+            },
+          ],
+        },
+      },
+      [`${USERS}/client1`]: { displayName: "Client One", coachId: "coach1" },
+      [`${USERS}/coach1`]: { displayName: "Coach One" },
+      [`${EXERCISES}/plank`]: {
+        name: { en: "Plank", es: "Plancha" },
+        metric: "time",
+      },
+    });
+
+    const detail = await getWorkoutLogDetail(id);
+
+    expect(detail.sets[0]).toMatchObject({
+      exerciseName: "Plank",
+      metric: "time",
+      reps: 10,
+      weight: 20,
+      durationSeconds: 45,
+    });
   });
 
   it("rejects a log whose client is not the coach's (no cross-coach leak)", async () => {

--- a/backoffice/src/lib/gc-fitness/recent-logs-actions.ts
+++ b/backoffice/src/lib/gc-fitness/recent-logs-actions.ts
@@ -117,6 +117,14 @@ export interface WorkoutLogDetail {
     setLogId: string;
     exerciseId: string;
     exerciseName: string;
+    /**
+     * Effective exercise metric for rendering logged actuals. Prefer the
+     * template snapshot, then the exercise library, and finally a logged or
+     * prescribed duration. Legacy logs may still carry reps/weight fields for
+     * time exercises, so consumers must branch on this instead of field
+     * presence alone.
+     */
+    metric: "reps" | "time";
     reps: number | null;
     weight: number | null;
     /**
@@ -221,6 +229,47 @@ function numeric(value: unknown): number | null {
     if (Number.isFinite(parsed)) return parsed;
   }
   return null;
+}
+
+function numericArray(value: unknown): number[] {
+  return Array.isArray(value)
+    ? value.filter((n): n is number => typeof n === "number" && Number.isFinite(n))
+    : [];
+}
+
+function setIndexFromLog(set: Record<string, unknown>): number | null {
+  const raw = numeric(set.set_index ?? set.setIndex);
+  return raw !== null ? Math.max(0, Math.floor(raw)) : null;
+}
+
+function prescribedDurationForSet(
+  templateExercise: Record<string, unknown> | undefined,
+  setIndex: number,
+): number | null {
+  if (!templateExercise) return null;
+  const bySet = numericArray(templateExercise.durationBySetSeconds);
+  return bySet[setIndex] ?? numeric(templateExercise.durationSeconds);
+}
+
+function effectiveSetMetric(opts: {
+  templateExercise: Record<string, unknown> | undefined;
+  sourceExercise: Record<string, unknown> | undefined;
+  loggedDurationSeconds: number | null;
+  prescribedDurationSeconds: number | null;
+}): "reps" | "time" {
+  if (opts.loggedDurationSeconds !== null && opts.loggedDurationSeconds > 0) {
+    return "time";
+  }
+  if (opts.templateExercise?.metric === "time") return "time";
+  if (opts.templateExercise?.metric === "reps") return "reps";
+  if (opts.sourceExercise?.metric === "time") return "time";
+  if (
+    opts.prescribedDurationSeconds !== null &&
+    opts.prescribedDurationSeconds > 0
+  ) {
+    return "time";
+  }
+  return "reps";
 }
 
 function boolCompleted(value: unknown): boolean {
@@ -1878,8 +1927,13 @@ async function buildWorkoutLogDetail(
     }
   }
 
+  const nextSetIndexByExercise = new Map<string, number>();
   const sets = rawSets.map((set, index) => {
     const exerciseId = typeof set.exerciseId === "string" ? set.exerciseId : "";
+    const fallbackSetKey = exerciseId || `row-${index}`;
+    const fallbackSetIndex = nextSetIndexByExercise.get(fallbackSetKey) ?? 0;
+    nextSetIndexByExercise.set(fallbackSetKey, fallbackSetIndex + 1);
+    const setIndex = setIndexFromLog(set) ?? fallbackSetIndex;
     const templateExercise = exerciseId
       ? templateExerciseById.get(exerciseId)
       : undefined;
@@ -1890,11 +1944,25 @@ async function buildWorkoutLogDetail(
     );
     const setLogId = typeof set.id === "string" ? set.id : "";
     const pr = setLogId ? prBySetLogId.get(setLogId) : undefined;
+    const loggedDurationSeconds = numeric(set.duration_seconds ?? set.durationSeconds);
+    const prescribedDurationSeconds = prescribedDurationForSet(
+      templateExercise,
+      setIndex,
+    );
+    const metric = effectiveSetMetric({
+      templateExercise,
+      sourceExercise,
+      loggedDurationSeconds,
+      prescribedDurationSeconds,
+    });
+    const durationSeconds =
+      loggedDurationSeconds ?? (metric === "time" ? prescribedDurationSeconds : null);
     return {
       index: index + 1,
       setLogId,
       exerciseId,
       exerciseName,
+      metric,
       reps: numeric(set.reps),
       // Wire field is `weight_kg` (iOS); keep `weight` as a legacy fallback.
       weight: numeric(set.weight_kg ?? set.weight),
@@ -1903,7 +1971,7 @@ async function buildWorkoutLogDetail(
       // legacy/camel fallback mirroring the weight_kg ?? weight pattern
       // above. Null when the set was reps-based or pre-26-04 (no field
       // on the doc).
-      durationSeconds: numeric(set.duration_seconds ?? set.durationSeconds),
+      durationSeconds,
       // Wire field is `completed_at` (iOS); keep `completedAt` as a legacy fallback.
       completedAt: asIso(set.completed_at ?? set.completedAt),
       // 260529-mrp — Wire field is `is_warmup` (iOS, snake_case); keep

--- a/backoffice/src/lib/gc-fitness/schedule-month-actions.ts
+++ b/backoffice/src/lib/gc-fitness/schedule-month-actions.ts
@@ -128,6 +128,30 @@ function statusFromAssignment(
   return "scheduled";
 }
 
+function finiteNumber(value: unknown): number | null {
+  return typeof value === "number" && Number.isFinite(value) ? value : null;
+}
+
+function finiteNumberArray(value: unknown): number[] {
+  return Array.isArray(value)
+    ? value.filter((n): n is number => typeof n === "number" && Number.isFinite(n))
+    : [];
+}
+
+function effectiveAssignmentMetric(opts: {
+  snapshotExercise: Record<string, unknown>;
+  sourceExercise: Record<string, unknown> | undefined;
+  durationBySetSeconds: number[];
+  durationSeconds: number | null;
+}): "reps" | "time" {
+  if (opts.snapshotExercise.metric === "time") return "time";
+  if (opts.snapshotExercise.metric === "reps") return "reps";
+  if (opts.sourceExercise?.metric === "time") return "time";
+  if (opts.durationBySetSeconds.length > 0) return "time";
+  if (opts.durationSeconds !== null && opts.durationSeconds > 0) return "time";
+  return "reps";
+}
+
 /**
  * Computes which civil-dates in [monthStart, monthEnd] a habit is
  * scheduled on, based on its `scheduleType` + cadence fields. Mirrors the
@@ -433,6 +457,14 @@ export async function getAssignmentDetail(id: string): Promise<AssignmentDetail>
         (typeof nameField === "string"
           ? nameField
           : nameField?.en ?? nameField?.es ?? exId ?? `Exercise ${idx + 1}`);
+      const durationBySetSeconds = finiteNumberArray(ex.durationBySetSeconds);
+      const durationSeconds = finiteNumber(ex.durationSeconds);
+      const metric = effectiveAssignmentMetric({
+        snapshotExercise: ex,
+        sourceExercise: source,
+        durationBySetSeconds,
+        durationSeconds,
+      });
       return {
         index: idx,
         exerciseId: exId,
@@ -481,20 +513,12 @@ export async function getAssignmentDetail(id: string): Promise<AssignmentDetail>
           ex.supersetGroup.trim().length > 0
             ? ex.supersetGroup.trim()
             : null,
-        // 26-03 — Forgiving metric decode (PATTERNS.md §18 + Shared 5).
-        // Unknown / absent values fall back to "reps" so every legacy
-        // assignment doc renders the existing Reps column unchanged.
-        metric: ex.metric === "time" ? "time" : "reps",
-        durationBySetSeconds: Array.isArray(ex.durationBySetSeconds)
-          ? (ex.durationBySetSeconds as number[]).filter((n) =>
-              Number.isFinite(n),
-            )
-          : [],
-        durationSeconds:
-          typeof ex.durationSeconds === "number" &&
-          Number.isFinite(ex.durationSeconds)
-            ? ex.durationSeconds
-            : null,
+        // 26-03 + #455 — Forgiving metric decode. Snapshot wins when explicit;
+        // otherwise inherit time from the source exercise or duration fields so
+        // legacy assignment docs don't render time prescriptions as reps/weight.
+        metric,
+        durationBySetSeconds,
+        durationSeconds,
       };
     }),
     lastLoggedSetsByExerciseId,


### PR DESCRIPTION
## Summary
- Detect time-based exercises in workout log details from snapshot metric, source exercise metric, logged duration, or prescribed duration fallback
- Render time-based workout sets with a seconds column and hide weight/reps-style weight display
- Keep scheduled workout detail and share card consistent for time-based exercises
- Add locale copy for the duration column and regression coverage for legacy time-exercise logs

## Screenshot

<img width="1196" height="233" alt="Screenshot 2026-07-14 at 6 59 24 PM" src="https://github.com/user-attachments/assets/e469beae-5c3f-4e1a-bb97-649947bcade6" />
