### PR TITLE
feat: Hevy-style set types in template editor, live sessions y log detail (gc-fitness #403)

### DIFF
--- a/backoffice/src/app/gc-fitness/clients/[id]/sessions/[assignmentId]/run/_components/active-workout-session.tsx
+++ b/backoffice/src/app/gc-fitness/clients/[id]/sessions/[assignmentId]/run/_components/active-workout-session.tsx
@@ -237,7 +237,7 @@ export function ActiveWorkoutSession({
         onReps={(i, v) => live.setReps(ex.exerciseId, i, v)}
         onDuration={(i, v) => live.setDuration(ex.exerciseId, i, v)}
         onToggleDone={(i) => live.toggleDone(ex.exerciseId, i)}
-        onToggleWarmup={(i) => live.toggleWarmup(ex.exerciseId, i)}
+        onSetType={(i, type) => live.setSetType(ex.exerciseId, i, type)}
         onAddSet={() => live.addSet(ex.exerciseId)}
         onRemoveSet={(i) => live.removeSet(ex.exerciseId, i)}
         onMove={(dir) => live.moveExercise(ex.exerciseId, dir)}

--- a/backoffice/src/app/gc-fitness/clients/[id]/sessions/[assignmentId]/run/_components/session-exercise-card.tsx
+++ b/backoffice/src/app/gc-fitness/clients/[id]/sessions/[assignmentId]/run/_components/session-exercise-card.tsx
@@ -24,6 +24,23 @@ import {
 
 import { Button } from "@/components/ui/button";
 import { Textarea } from "@/components/ui/textarea";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { cn } from "@/lib/utils";
+// quick-260714-m57 (#403) — Hevy-style per-set types: the set-number cell is
+// the picker; W (orange) / F (red) / D (purple) render instead of the number.
+import {
+  SET_TYPES,
+  type SetType,
+  setDisplayLabels,
+  SET_TYPE_LETTERS,
+  SET_TYPE_LABELS_ES,
+  SET_TYPE_TEXT_CLASS,
+} from "@/lib/gc-fitness/set-type";
 import { setClientExerciseNote } from "@/lib/gc-fitness/live-workout-actions";
 import {
   clientExerciseNoteKey,
@@ -130,7 +147,9 @@ export interface SessionExerciseCardProps {
   onReps: (idx: number, value: number) => void;
   onDuration: (idx: number, value: number) => void;
   onToggleDone: (idx: number) => void;
-  onToggleWarmup: (idx: number) => void;
+  /** quick-260714-m57 (#403) — pick the row's set type (replaces the old
+   *  warmup-only toggle; warmup is one of the four options). */
+  onSetType: (idx: number, type: SetType) => void;
   onAddSet: () => void;
   onRemoveSet: (idx: number) => void;
   onMove: (dir: -1 | 1) => void;
@@ -149,7 +168,7 @@ export function SessionExerciseCard({
   onReps,
   onDuration,
   onToggleDone,
-  onToggleWarmup,
+  onSetType,
   onAddSet,
   onRemoveSet,
   onMove,
@@ -159,6 +178,9 @@ export function SessionExerciseCard({
   const isTime = exercise.metric === "time";
   const prevLabel = formatPrevious(previous, isTime);
   const queryClient = useQueryClient();
+  // quick-260714-m57 (#403) — Hevy numbering: normal sets numbered counting
+  // only normals; W/F/D letters for the rest.
+  const setLabels = setDisplayLabels(rows.map((r) => r.setType));
 
   const noteQuery = useClientExerciseNote(clientId, exercise.exerciseId);
   const [editingNote, setEditingNote] = useState(false);
@@ -326,18 +348,46 @@ export function SessionExerciseCard({
                     : ""
               }`}
             >
-              <button
-                type="button"
-                onClick={() => onToggleWarmup(idx)}
-                title={row.isWarmup ? "Quitar calentamiento" : "Marcar calentamiento"}
-                className={`flex h-7 w-7 items-center justify-center rounded-md text-xs font-semibold ${
-                  row.isWarmup
-                    ? "bg-amber-500/20 text-amber-600"
-                    : "text-muted-foreground hover:bg-muted"
-                }`}
-              >
-                {row.isWarmup ? "W" : idx + 1}
-              </button>
+              {/* quick-260714-m57 (#403) — set-number cell = type picker. */}
+              <DropdownMenu>
+                <DropdownMenuTrigger asChild>
+                  <button
+                    type="button"
+                    title="Cambiar tipo de serie"
+                    aria-label={`Tipo de la serie ${idx + 1}: ${SET_TYPE_LABELS_ES[row.setType]}`}
+                    className={cn(
+                      "flex h-7 w-7 items-center justify-center rounded-md text-xs font-semibold hover:bg-muted",
+                      row.setType === "normal"
+                        ? "text-muted-foreground"
+                        : cn("font-bold", SET_TYPE_TEXT_CLASS[row.setType]),
+                    )}
+                  >
+                    {setLabels[idx] ?? idx + 1}
+                  </button>
+                </DropdownMenuTrigger>
+                <DropdownMenuContent align="start">
+                  {SET_TYPES.map((type) => (
+                    <DropdownMenuItem
+                      key={type}
+                      onSelect={() => onSetType(idx, type)}
+                      className={cn(
+                        "gap-2",
+                        type === row.setType && "bg-muted",
+                      )}
+                    >
+                      <span
+                        className={cn(
+                          "w-4 text-center font-semibold",
+                          SET_TYPE_TEXT_CLASS[type],
+                        )}
+                      >
+                        {SET_TYPE_LETTERS[type] ?? "#"}
+                      </span>
+                      {SET_TYPE_LABELS_ES[type]}
+                    </DropdownMenuItem>
+                  ))}
+                </DropdownMenuContent>
+              </DropdownMenu>
               <span className="truncate text-xs text-muted-foreground">
                 {prevLabel ?? "—"}
               </span>

--- a/backoffice/src/app/gc-fitness/clients/[id]/sessions/[assignmentId]/run/_components/use-live-session.ts
+++ b/backoffice/src/app/gc-fitness/clients/[id]/sessions/[assignmentId]/run/_components/use-live-session.ts
@@ -25,6 +25,12 @@ import type {
   SessionSetLog,
 } from "@/lib/gc-fitness/live-workout-types";
 import { resolveSetPrefill } from "@/lib/gc-fitness/weight-prefill";
+// quick-260714-m57 (#403) — per-set types (normal/warmup/failure/dropset).
+import {
+  type SetType,
+  effectiveSetType,
+  plannedSetType,
+} from "@/lib/gc-fitness/set-type";
 
 export interface SetRowState {
   /** Stable lowercased UUID — the SetLog id (arrayUnion dedup key). */
@@ -32,7 +38,15 @@ export interface SetRowState {
   weightKg: number;
   reps: number;
   durationSeconds: number | null;
+  /**
+   * Legacy warmup flag — kept in LOCKSTEP with `setType` by every mutator
+   * (`isWarmup === (setType === "warmup")`), mirroring the wire sync
+   * invariant (#403).
+   */
   isWarmup: boolean;
+  /** quick-260714-m57 (#403) — per-set type; seeded from the prescription's
+   *  `setTypesBySet` and editable via the set-number picker. */
+  setType: SetType;
   done: boolean;
   /** ISO instant the row was marked done (frozen once set). */
   completedAt: string | null;
@@ -134,12 +148,16 @@ function initialRows(
       prescriptionUpdatedAt,
       lastLoggedAt,
     });
+    // quick-260714-m57 (#403) — seed the planned type from the prescription
+    // (missing / short / unknown ⇒ normal); isWarmup stays in lockstep.
+    const planned = plannedSetType(idx, ex.setTypesBySet);
     return {
       id: newId(),
       weightKg: resolved.weightKg,
       reps: resolved.reps,
       durationSeconds: time ? resolved.durationSeconds : null,
-      isWarmup: false,
+      isWarmup: planned === "warmup",
+      setType: planned,
       done: false,
       completedAt: null,
     };
@@ -156,12 +174,16 @@ function hydrateLoggedSets(
   for (const set of loggedSets) {
     const rows = next[set.exerciseId];
     if (!rows || !rows[set.setIndex]) continue;
+    // quick-260714-m57 (#403) — effective type resolves setType ?? legacy
+    // isWarmup, keeping the row's flag/type pair in lockstep.
+    const eff = effectiveSetType(set);
     rows[set.setIndex] = {
       id: set.id,
       weightKg: set.weightKg,
       reps: set.reps,
       durationSeconds: set.durationSeconds ?? null,
-      isWarmup: set.isWarmup,
+      isWarmup: eff === "warmup",
+      setType: eff,
       done: true,
       completedAt: set.completedAt,
     };
@@ -183,6 +205,8 @@ export interface LiveSessionApi {
   setReps: (exerciseId: string, idx: number, value: number) => void;
   setDuration: (exerciseId: string, idx: number, value: number) => void;
   toggleWarmup: (exerciseId: string, idx: number) => void;
+  /** quick-260714-m57 (#403) — set the row's type (keeps isWarmup synced). */
+  setSetType: (exerciseId: string, idx: number, type: SetType) => void;
   toggleDone: (exerciseId: string, idx: number) => boolean;
   addSet: (exerciseId: string) => void;
   removeSet: (exerciseId: string, idx: number) => void;
@@ -305,7 +329,10 @@ export function useLiveSession(
             weightKg: row.weightKg,
             reps: row.reps,
             completedAt: row.completedAt ?? new Date().toISOString(),
-            isWarmup: row.isWarmup,
+            // quick-260714-m57 (#403) — setType is authoritative; the wire
+            // bridge (sessionSetToWire) re-derives is_warmup from it.
+            isWarmup: row.setType === "warmup",
+            setType: row.setType === "normal" ? null : row.setType,
             clientLoggedAt: row.completedAt ?? new Date().toISOString(),
             durationSeconds: row.durationSeconds,
           });
@@ -368,7 +395,32 @@ export function useLiveSession(
   );
   const toggleWarmup = useCallback(
     (exerciseId: string, idx: number) =>
-      mutateRow(exerciseId, idx, (r) => ({ ...r, isWarmup: !r.isWarmup }), true),
+      mutateRow(
+        exerciseId,
+        idx,
+        (r) => {
+          // quick-260714-m57 (#403) — the quick toggle flips warmup ↔ normal,
+          // keeping setType and isWarmup in lockstep.
+          const nextWarmup = r.setType !== "warmup";
+          return {
+            ...r,
+            isWarmup: nextWarmup,
+            setType: nextWarmup ? "warmup" : "normal",
+          };
+        },
+        true,
+      ),
+    [mutateRow],
+  );
+  // quick-260714-m57 (#403) — explicit 4-type picker write.
+  const setSetType = useCallback(
+    (exerciseId: string, idx: number, type: SetType) =>
+      mutateRow(
+        exerciseId,
+        idx,
+        (r) => ({ ...r, setType: type, isWarmup: type === "warmup" }),
+        true,
+      ),
     [mutateRow],
   );
 
@@ -421,7 +473,10 @@ export function useLiveSession(
               weightKg: last?.weightKg ?? 0,
               reps: last?.reps ?? 0,
               durationSeconds: last?.durationSeconds ?? null,
+              // quick-260714-m57 (#403) — a new set starts "normal" (values
+              // copy from the last row, the type does not).
               isWarmup: false,
+              setType: "normal" as const,
               done: false,
               completedAt: null,
             },
@@ -485,6 +540,9 @@ export function useLiveSession(
                   supersetGroup: ex.supersetGroup ?? null,
                   repsBySet: rows.map((r) => r.reps),
                   weightBySetKg: rows.map((r) => r.weightKg),
+                  // quick-260714-m57 (#403) — the future prescription keeps
+                  // the performed set types (server omits all-normal arrays).
+                  setTypesBySet: rows.map((r) => r.setType),
                   metric: ex.metric ?? null,
                   durationBySetSeconds: isTime
                     ? rows.map((r) => r.durationSeconds ?? 0)
@@ -550,6 +608,7 @@ export function useLiveSession(
     setReps,
     setDuration,
     toggleWarmup,
+    setSetType,
     toggleDone,
     addSet,
     removeSet,

--- a/backoffice/src/components/gc-fitness/schedule/workout-assignment-edit-dialog.tsx
+++ b/backoffice/src/components/gc-fitness/schedule/workout-assignment-edit-dialog.tsx
@@ -24,12 +24,29 @@ import {
 import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
 import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import {
   Tooltip,
   TooltipContent,
   TooltipProvider,
   TooltipTrigger,
 } from "@/components/ui/tooltip";
 import { cn } from "@/lib/utils";
+// quick-260714-m57 (#403) — Hevy-style per-set types on the assignment's
+// frozen snapshot (same picker as the template editor).
+import {
+  SET_TYPES,
+  type SetType,
+  plannedSetType,
+  setDisplayLabels,
+  SET_TYPE_LETTERS,
+  SET_TYPE_LABELS_ES,
+  SET_TYPE_TEXT_CLASS,
+} from "@/lib/gc-fitness/set-type";
 import { ExercisePickerPopover } from "@/components/gc-fitness/exercise-picker-popover";
 import { useExercisesQuery } from "@/lib/gc-fitness/exercises-listener";
 import {
@@ -73,6 +90,12 @@ interface ExerciseDraftRow {
   durationBySetSeconds: number[];
   durationSeconds: number | null;
   supersetGroup: string | null;
+  /**
+   * quick-260714-m57 (#403) — per-set types, ALWAYS aligned 1:1 with
+   * `setRows` (add/remove set keeps them in lockstep). Payload emits
+   * `setTypesBySet`; the server drops it when all-normal.
+   */
+  setTypes: SetType[];
 }
 
 function InfoTooltip({ text, label }: { text: string; label: string }) {
@@ -116,6 +139,7 @@ function seedDraftRows(exercises: AssignmentDetail["exercises"]): ExerciseDraftR
           ? String(ex.weightBySetKg[i])
           : "",
     }));
+    const rows = setRows.length > 0 ? setRows : [{ reps: "0", kg: "" }];
     return {
       rowId: makeRowId(),
       exerciseId: ex.exerciseId,
@@ -124,13 +148,16 @@ function seedDraftRows(exercises: AssignmentDetail["exercises"]): ExerciseDraftR
       rest: String(ex.rest_seconds ?? 60),
       transitionRest: String(ex.transition_rest_seconds ?? 60),
       notes: ex.notes ?? "",
-      setRows: setRows.length > 0 ? setRows : [{ reps: "0", kg: "" }],
+      setRows: rows,
       // 260610-j67 — preserve the no-weight sentinel across edits.
       noWeight: ex.hasExplicitNoWeightPrescription === true,
       metric: ex.metric,
       durationBySetSeconds: ex.durationBySetSeconds ?? [],
       durationSeconds: ex.durationSeconds ?? null,
       supersetGroup: ex.supersetGroup ?? null,
+      // quick-260714-m57 (#403) — aligned 1:1 with setRows; missing / short /
+      // unknown entries coerce to "normal" (forgiving decode).
+      setTypes: rows.map((_, i) => plannedSetType(i, ex.setTypesBySet)),
     };
   });
 }
@@ -234,8 +261,22 @@ export function WorkoutAssignmentEditDialog({
         durationBySetSeconds: [],
         durationSeconds: null,
         supersetGroup: null,
+        setTypes: ["normal"],
       },
     ]);
+  }
+
+  // quick-260714-m57 (#403) — per-set type mutation (aligned with setRows).
+  function setRowType(rowId: string, rowIdx: number, type: SetType) {
+    setDrafts((prev) =>
+      prev.map((row) => {
+        if (row.rowId !== rowId) return row;
+        const setTypes = row.setRows.map(
+          (_, i) => (i === rowIdx ? type : row.setTypes[i] ?? "normal"),
+        );
+        return { ...row, setTypes };
+      }),
+    );
   }
 
   function removeExerciseRow(rowId: string) {
@@ -297,6 +338,12 @@ export function WorkoutAssignmentEditDialog({
         durationSeconds: draft.durationSeconds,
         supersetGroup: draft.supersetGroup,
         noWeight: draft.noWeight,
+        // quick-260714-m57 (#403) — always send the FULL aligned array; the
+        // server normalizes (writes only when some entry is non-normal, and
+        // deletes the stale key otherwise).
+        setTypesBySet: (repsBySet.length > 0 ? repsBySet : [0]).map(
+          (_, i) => draft.setTypes[i] ?? "normal",
+        ),
       };
     });
   }
@@ -538,6 +585,15 @@ export function WorkoutAssignmentEditDialog({
                           data.lastLoggedSetsByExerciseId?.[draft.exerciseId]?.[
                             rowIdx
                           ];
+                        // quick-260714-m57 (#403) — Hevy label: colored
+                        // letter for non-normal; number counting ONLY
+                        // normal sets otherwise.
+                        const rowType = draft.setTypes[rowIdx] ?? "normal";
+                        const rowLabel = setDisplayLabels(
+                          draft.setRows.map(
+                            (_, i) => draft.setTypes[i] ?? "normal",
+                          ),
+                        )[rowIdx];
                         return (
                           <div
                             key={`${draft.rowId}-${rowIdx}`}
@@ -547,9 +603,51 @@ export function WorkoutAssignmentEditDialog({
                                 : "grid-cols-[28px_minmax(80px,1fr)_minmax(80px,1fr)_max-content]"
                             }`}
                           >
-                            <span className="pt-2 text-xs text-muted-foreground">
-                              {rowIdx + 1}
-                            </span>
+                            <DropdownMenu>
+                              <DropdownMenuTrigger asChild>
+                                <button
+                                  type="button"
+                                  tabIndex={-1}
+                                  aria-label={`Tipo de la serie ${rowIdx + 1}: ${SET_TYPE_LABELS_ES[rowType]}`}
+                                  title="Cambiar tipo de serie"
+                                  className={cn(
+                                    "mt-1 inline-flex h-7 w-7 items-center justify-center rounded-md text-xs hover:bg-muted",
+                                    rowType === "normal"
+                                      ? "text-muted-foreground"
+                                      : cn(
+                                          "font-bold",
+                                          SET_TYPE_TEXT_CLASS[rowType],
+                                        ),
+                                  )}
+                                >
+                                  {rowLabel}
+                                </button>
+                              </DropdownMenuTrigger>
+                              <DropdownMenuContent align="start">
+                                {SET_TYPES.map((type) => (
+                                  <DropdownMenuItem
+                                    key={type}
+                                    onSelect={() =>
+                                      setRowType(draft.rowId, rowIdx, type)
+                                    }
+                                    className={cn(
+                                      "gap-2",
+                                      type === rowType && "bg-muted",
+                                    )}
+                                  >
+                                    <span
+                                      className={cn(
+                                        "w-4 text-center font-semibold",
+                                        SET_TYPE_TEXT_CLASS[type],
+                                      )}
+                                    >
+                                      {SET_TYPE_LETTERS[type] ?? "#"}
+                                    </span>
+                                    {SET_TYPE_LABELS_ES[type]}
+                                  </DropdownMenuItem>
+                                ))}
+                              </DropdownMenuContent>
+                            </DropdownMenu>
                             <input
                               type="text"
                               inputMode="numeric"
@@ -604,6 +702,14 @@ export function WorkoutAssignmentEditDialog({
                                     setRows: draft.setRows.filter(
                                       (_, i) => i !== rowIdx,
                                     ),
+                                    // quick-260714-m57 (#403) — keep types
+                                    // aligned with setRows.
+                                    setTypes: draft.setRows
+                                      .map(
+                                        (_, i) =>
+                                          draft.setTypes[i] ?? "normal",
+                                      )
+                                      .filter((_, i) => i !== rowIdx),
                                   })
                                 }
                                 className="inline-flex h-7 w-7 items-center justify-center rounded-md border border-transparent text-muted-foreground hover:border-border hover:text-foreground disabled:opacity-30"
@@ -624,6 +730,15 @@ export function WorkoutAssignmentEditDialog({
                             setRows: [
                               ...draft.setRows,
                               { reps: last?.reps ?? "0", kg: last?.kg ?? "" },
+                            ],
+                            // quick-260714-m57 (#403) — a new set starts as
+                            // "normal" (values copy from the last row, the
+                            // type does not).
+                            setTypes: [
+                              ...draft.setRows.map(
+                                (_, i) => draft.setTypes[i] ?? "normal",
+                              ),
+                              "normal",
                             ],
                           });
                         }}

--- a/backoffice/src/components/gc-fitness/template-form.tsx
+++ b/backoffice/src/components/gc-fitness/template-form.tsx
@@ -94,7 +94,27 @@ import {
   AlertDialogHeader,
   AlertDialogTitle,
 } from "@/components/ui/alert-dialog";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
 import { cn } from "@/lib/utils";
+
+// quick-260714-m57 (#403) — Hevy-style per-set types (normal / warm-up /
+// failure / drop set). TS twin helpers of iOS SetType.swift; the picker
+// writes `setTypesBySet` next to repsBySet / weightBySetKg.
+import {
+  SET_TYPES,
+  type SetType,
+  isSetType,
+  plannedSetType,
+  setDisplayLabels,
+  SET_TYPE_LETTERS,
+  SET_TYPE_LABELS_ES,
+  SET_TYPE_TEXT_CLASS,
+} from "@/lib/gc-fitness/set-type";
 
 import {
   workoutTemplateSchema,
@@ -251,13 +271,32 @@ function withTransitionRestDefault(
     | Array<Partial<WorkoutTemplateInput["exercises"][number]>>
     | undefined,
 ): WorkoutTemplateInput["exercises"] {
-  return (exercises ?? []).map((exercise) => ({
-    ...exercise,
-    transition_rest_seconds:
-      typeof exercise.transition_rest_seconds === "number"
-        ? exercise.transition_rest_seconds
-        : 60,
-  })) as WorkoutTemplateInput["exercises"];
+  return (exercises ?? []).map((exercise) => {
+    const next: Record<string, unknown> = {
+      ...exercise,
+      transition_rest_seconds:
+        typeof exercise.transition_rest_seconds === "number"
+          ? exercise.transition_rest_seconds
+          : 60,
+    };
+    // quick-260714-m57 (#403) — sanitize per-set types on LOAD: keep only
+    // known wire strings ("normal"/"warmup"/"failure"/"dropset") so the
+    // submit-time Zod enum can't reject a stale/foreign doc. All-normal (or
+    // fully-invalid) arrays are dropped entirely — the wire contract omits
+    // the field when nothing is non-normal.
+    const rawTypes = (exercise as { setTypesBySet?: unknown }).setTypesBySet;
+    if (Array.isArray(rawTypes)) {
+      // POSITIONAL coercion (never filter — dropping an entry would shift
+      // every later set's type to the wrong row).
+      const clean = rawTypes.map((t): SetType => (isSetType(t) ? t : "normal"));
+      if (clean.some((t) => t !== "normal")) {
+        next.setTypesBySet = clean;
+      } else {
+        delete next.setTypesBySet;
+      }
+    }
+    return next;
+  }) as WorkoutTemplateInput["exercises"];
 }
 
 function clearDraft(key: string) {
@@ -691,6 +730,38 @@ export function TemplateForm({
     if (nextDurations !== undefined) {
       form.setValue(durationPath, nextDurations, { shouldDirty: true });
     }
+    // quick-260714-m57 (#403) — keep setTypesBySet aligned with the set
+    // count: pad new sets with "normal", truncate removed ones. Only when
+    // the trainer already picked a type (never fabricate the field).
+    const typesPath = `exercises.${index}.setTypesBySet` as const;
+    const currentTypes = form.getValues(typesPath);
+    if (Array.isArray(currentTypes) && currentTypes.length > 0) {
+      const nextTypes = Array.from({ length: safeSets }, (_, i) =>
+        plannedSetType(i, currentTypes),
+      );
+      form.setValue(typesPath, nextTypes, { shouldDirty: true });
+    }
+  }
+
+  // quick-260714-m57 (#403) — per-set type picker write. Reads the current
+  // array (padded to the set count with "normal"), swaps one entry, writes
+  // back. Emission is normalized on submit (field omitted when all-normal).
+  function setSetType(index: number, setIdx: number, type: SetType) {
+    const typesPath = `exercises.${index}.setTypesBySet` as const;
+    const totalSets = Math.max(
+      1,
+      Math.min(
+        10,
+        Number(form.getValues(`exercises.${index}.sets` as const) ?? 1),
+      ),
+    );
+    const current = form.getValues(typesPath);
+    const next = Array.from(
+      { length: Math.max(totalSets, setIdx + 1) },
+      (_, i) => plannedSetType(i, current),
+    );
+    next[setIdx] = type;
+    form.setValue(typesPath, next, { shouldDirty: true });
   }
 
   function syncSupersetGroupSets(group: string, nextSets: number) {
@@ -878,7 +949,23 @@ export function TemplateForm({
                       : durationFallbackForAlign ?? 60,
                   )
                 : undefined;
-            return {
+            // quick-260714-m57 (#403) — align per-set types to canonicalLen
+            // (pad "normal", truncate) like reps/weights above. The field is
+            // persisted ONLY when some entry is non-normal (wire contract:
+            // writers omit all-normal arrays). On update the whole
+            // `exercises` array is replaced, so omission also CLEARS stale
+            // types on Firestore.
+            const cleanedTypes: SetType[] = Array.isArray(ex.setTypesBySet)
+              ? ex.setTypesBySet.map((t): SetType =>
+                  isSetType(t) ? t : "normal",
+                )
+              : [];
+            const alignedTypes = Array.from(
+              { length: canonicalLen },
+              (_, i): SetType => cleanedTypes[i] ?? "normal",
+            );
+            const hasNonNormalTypes = alignedTypes.some((t) => t !== "normal");
+            const normalizedExercise: WorkoutTemplateInput["exercises"][number] = {
               ...ex,
               sets: canonicalLen,
               reps: alignedReps[0] ?? repsFallback,
@@ -902,6 +989,15 @@ export function TemplateForm({
                 : {}),
               order: idx + 1,
             };
+            if (hasNonNormalTypes) {
+              normalizedExercise.setTypesBySet = alignedTypes;
+            } else {
+              // NEVER leave the key as `undefined` — the Admin SDK rejects
+              // undefined values ("Cannot use 'undefined' as a Firestore
+              // value"); deleting the key omits it from the payload.
+              delete normalizedExercise.setTypesBySet;
+            }
+            return normalizedExercise;
           }),
         };
         const result = await onSubmit(normalized);
@@ -1812,6 +1908,20 @@ export function TemplateForm({
                             const weightValue = weightArray[setIdx];
                             const durationValue =
                               setDurationDraft[setKey] ?? (durationArray[setIdx] ?? durationFallback);
+                            // quick-260714-m57 (#403) — Hevy-style per-set
+                            // type. Non-normal rows render the colored letter
+                            // (W/F/D); normal rows render a number counting
+                            // ONLY normal sets (preceding rows decide it, so
+                            // slicing to setIdx+1 is sufficient).
+                            const typesRaw = form.getValues(
+                              `exercises.${index}.setTypesBySet` as const,
+                            );
+                            const rowType = plannedSetType(setIdx, typesRaw);
+                            const rowLabel = setDisplayLabels(
+                              Array.from({ length: setIdx + 1 }, (_, i) =>
+                                plannedSetType(i, typesRaw),
+                              ),
+                            )[setIdx];
 
                             return (
                               <div
@@ -1827,9 +1937,59 @@ export function TemplateForm({
                                     : "grid-cols-[52px_minmax(0,1fr)_minmax(0,1fr)_28px] sm:grid-cols-[84px_minmax(140px,1fr)_minmax(140px,1fr)_28px]",
                                 )}
                               >
-                                <span className="text-xs text-muted-foreground">
-                                  {t("setNumber", { count: setIdx + 1 })}
-                                </span>
+                                {/* quick-260714-m57 (#403) — the set-number
+                                    cell is the type picker trigger: Normal /
+                                    Calentamiento (W) / Al fallo (F) / Drop
+                                    set (D). */}
+                                <DropdownMenu>
+                                  <DropdownMenuTrigger asChild>
+                                    <button
+                                      type="button"
+                                      tabIndex={-1}
+                                      aria-label={`Tipo de la serie ${setIdx + 1}: ${SET_TYPE_LABELS_ES[rowType]}`}
+                                      title="Cambiar tipo de serie"
+                                      className={cn(
+                                        "inline-flex h-8 items-center justify-start rounded-md px-1 text-xs hover:bg-muted",
+                                        rowType === "normal"
+                                          ? "text-muted-foreground"
+                                          : cn(
+                                              "font-bold",
+                                              SET_TYPE_TEXT_CLASS[rowType],
+                                            ),
+                                      )}
+                                    >
+                                      {rowType === "normal"
+                                        ? t("setNumber", {
+                                            count: Number(rowLabel),
+                                          })
+                                        : rowLabel}
+                                    </button>
+                                  </DropdownMenuTrigger>
+                                  <DropdownMenuContent align="start">
+                                    {SET_TYPES.map((type) => (
+                                      <DropdownMenuItem
+                                        key={type}
+                                        onSelect={() =>
+                                          setSetType(index, setIdx, type)
+                                        }
+                                        className={cn(
+                                          "gap-2",
+                                          type === rowType && "bg-muted",
+                                        )}
+                                      >
+                                        <span
+                                          className={cn(
+                                            "w-4 text-center font-semibold",
+                                            SET_TYPE_TEXT_CLASS[type],
+                                          )}
+                                        >
+                                          {SET_TYPE_LETTERS[type] ?? "#"}
+                                        </span>
+                                        {SET_TYPE_LABELS_ES[type]}
+                                      </DropdownMenuItem>
+                                    ))}
+                                  </DropdownMenuContent>
+                                </DropdownMenu>
                                 {/* 26-03 — Per-set primary input. When the
                                     effective metric is "time", the field
                                     binds to durationBySetSeconds with bounds

--- a/backoffice/src/components/gc-fitness/workout-log-detail-view.tsx
+++ b/backoffice/src/components/gc-fitness/workout-log-detail-view.tsx
@@ -23,6 +23,12 @@ import { useTranslations } from "next-intl";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import type { WorkoutLogDetail } from "@/lib/gc-fitness/recent-logs-actions";
+// quick-260714-m57 (#403) — W/F/D badge on logged sets in "Detalle de series".
+import {
+  SET_TYPE_BADGE_CLASS,
+  SET_TYPE_LABELS_ES,
+  SET_TYPE_LETTERS,
+} from "@/lib/gc-fitness/set-type";
 
 /** Compact "previous PR" value for the PR row: duration for time PRs, else
  * "{weight} kg × {reps}" (issue #405). */
@@ -247,6 +253,17 @@ export function WorkoutLogDetailView({ detail }: { detail: WorkoutLogDetail }) {
                               <td className="py-2 pr-3">
                                 <div className="flex flex-wrap items-center gap-x-1.5 gap-y-0.5">
                                   <span>{set.index}</span>
+                                  {/* quick-260714-m57 (#403) — logged set
+                                      type badge (W/F/D + name tooltip). */}
+                                  {set.setType !== "normal" ? (
+                                    <span
+                                      title={SET_TYPE_LABELS_ES[set.setType]}
+                                      aria-label={SET_TYPE_LABELS_ES[set.setType]}
+                                      className={`inline-flex items-center rounded-full px-1.5 py-0.5 text-[10px] font-bold ${SET_TYPE_BADGE_CLASS[set.setType]}`}
+                                    >
+                                      {SET_TYPE_LETTERS[set.setType]}
+                                    </span>
+                                  ) : null}
                                   {set.isPR ? (
                                     <span
                                       title={

--- a/backoffice/src/lib/gc-fitness/__tests__/live-workout-volume.test.ts
+++ b/backoffice/src/lib/gc-fitness/__tests__/live-workout-volume.test.ts
@@ -93,3 +93,36 @@ describe("countWorkingSets", () => {
     ).toBe(2);
   });
 });
+
+// quick-260714-m57 (#403) — twin vectors shared with iOS SetTypeTests +
+// Android WorkoutVolumeTest: set-type-aware warmup exclusion.
+describe("set-type aware volume (quick-260714-m57 #403)", () => {
+  it("warmup excluded, failure + dropset included ⇒ 450.0 exactly", () => {
+    const sets = [
+      set({ weightKg: 20, reps: 10, setType: "warmup", isWarmup: true }), // excluded
+      set({ weightKg: 20, reps: 10 }), // 200
+      set({ weightKg: 30, reps: 5, setType: "failure" }), // 150
+      set({ weightKg: 10, reps: 10, setType: "dropset" }), // 100
+    ];
+    expect(computeTotalVolumeKg(sets)).toBe(450);
+  });
+
+  it("a set_type-only warmup (isWarmup false) is ALSO excluded", () => {
+    const sets = [
+      set({ weightKg: 20, reps: 10, setType: "warmup", isWarmup: false }),
+      set({ weightKg: 20, reps: 10 }),
+    ];
+    expect(computeTotalVolumeKg(sets)).toBe(200);
+    expect(countWorkingSets(sets)).toBe(1);
+  });
+
+  it("failure/dropset sets count as working sets", () => {
+    expect(
+      countWorkingSets([
+        set({ setType: "failure" }),
+        set({ setType: "dropset" }),
+        set({ setType: "warmup", isWarmup: true }),
+      ]),
+    ).toBe(2);
+  });
+});

--- a/backoffice/src/lib/gc-fitness/__tests__/set-type.test.ts
+++ b/backoffice/src/lib/gc-fitness/__tests__/set-type.test.ts
@@ -1,0 +1,107 @@
+// set-type.test.ts
+//
+// quick-260714-m57 (issue #403) — twin vectors for the Hevy-style per-set
+// types (normal / warmup / failure / dropset). The SAME vectors run on:
+//   - iOS:     GCFitnessCoreTests/SetTypeTests.swift
+//   - Android: core/src/test/kotlin/.../schema/SetTypeTest.kt
+// A drift between the three suites means the twins have diverged — fix the
+// implementation, not the test.
+
+import {
+  SET_TYPES,
+  type SetType,
+  effectiveSetType,
+  plannedSetType,
+  setDisplayLabels,
+  SET_TYPE_LETTERS,
+} from "../set-type";
+
+describe("SET_TYPES wire strings", () => {
+  it("matches the canonical iOS raw values verbatim", () => {
+    expect(SET_TYPES).toEqual(["normal", "warmup", "failure", "dropset"]);
+  });
+});
+
+describe("effectiveSetType (reader-side decode)", () => {
+  it("legacy set: no set_type + is_warmup true ⇒ warmup", () => {
+    expect(effectiveSetType({ is_warmup: true })).toBe("warmup");
+    expect(effectiveSetType({ isWarmup: true })).toBe("warmup");
+  });
+
+  it("legacy set: no set_type + is_warmup false/absent ⇒ normal", () => {
+    expect(effectiveSetType({ is_warmup: false })).toBe("normal");
+    expect(effectiveSetType({})).toBe("normal");
+  });
+
+  it("set_type 'failure' ⇒ failure regardless of is_warmup", () => {
+    expect(effectiveSetType({ set_type: "failure", is_warmup: false })).toBe(
+      "failure",
+    );
+    // Explicit non-warmup type overrides a stale warmup flag (sync invariant
+    // means writers never produce this, but readers stay deterministic).
+    expect(effectiveSetType({ set_type: "failure", is_warmup: true })).toBe(
+      "failure",
+    );
+    // camelCase session shape too.
+    expect(effectiveSetType({ setType: "dropset", isWarmup: false })).toBe(
+      "dropset",
+    );
+  });
+
+  it("unknown set_type 'xyz' ⇒ falls back to is_warmup", () => {
+    expect(effectiveSetType({ set_type: "xyz", is_warmup: true })).toBe(
+      "warmup",
+    );
+    expect(effectiveSetType({ set_type: "xyz", is_warmup: false })).toBe(
+      "normal",
+    );
+  });
+
+  it("set_type-only warmup (is_warmup absent) ⇒ warmup", () => {
+    expect(effectiveSetType({ set_type: "warmup" })).toBe("warmup");
+  });
+
+  it("explicit set_type 'normal' behaves like absent (twin normalization)", () => {
+    // iOS/Android normalize "normal" to nil/null and fall back to the flag.
+    expect(effectiveSetType({ set_type: "normal", is_warmup: false })).toBe(
+      "normal",
+    );
+    expect(effectiveSetType({ set_type: "normal", is_warmup: true })).toBe(
+      "warmup",
+    );
+  });
+});
+
+describe("plannedSetType (template setTypesBySet resolution)", () => {
+  const types = ["warmup", "xyz", "failure"];
+
+  it("resolves known entries; unknown/short/missing coerce to normal", () => {
+    expect(plannedSetType(0, types)).toBe("warmup");
+    expect(plannedSetType(1, types)).toBe("normal"); // unknown raw
+    expect(plannedSetType(2, types)).toBe("failure");
+    expect(plannedSetType(3, types)).toBe("normal"); // short array
+    expect(plannedSetType(0, null)).toBe("normal"); // missing array
+    expect(plannedSetType(0, undefined)).toBe("normal");
+    expect(plannedSetType(-1, types)).toBe("normal");
+  });
+});
+
+describe("setDisplayLabels (Hevy numbering rule)", () => {
+  it("[warmup, normal, normal, dropset, normal] ⇒ [W, 1, 2, D, 3]", () => {
+    const input: SetType[] = ["warmup", "normal", "normal", "dropset", "normal"];
+    expect(setDisplayLabels(input)).toEqual(["W", "1", "2", "D", "3"]);
+  });
+
+  it("edge cases", () => {
+    expect(setDisplayLabels(["failure"])).toEqual(["F"]);
+    expect(setDisplayLabels([])).toEqual([]);
+    expect(setDisplayLabels(["normal", "normal"])).toEqual(["1", "2"]);
+  });
+
+  it("letters map: W / F / D, null for normal", () => {
+    expect(SET_TYPE_LETTERS.warmup).toBe("W");
+    expect(SET_TYPE_LETTERS.failure).toBe("F");
+    expect(SET_TYPE_LETTERS.dropset).toBe("D");
+    expect(SET_TYPE_LETTERS.normal).toBeNull();
+  });
+});

--- a/backoffice/src/lib/gc-fitness/__tests__/workout-template-schema.set-types.test.ts
+++ b/backoffice/src/lib/gc-fitness/__tests__/workout-template-schema.set-types.test.ts
@@ -1,0 +1,60 @@
+// workout-template-schema.set-types.test.ts
+//
+// quick-260714-m57 (issue #403) — Zod boundary for the per-set type
+// prescription `setTypesBySet` on template exercises (threat T-m57-02:
+// the server-action boundary is the guard for trainer-authored templates,
+// which bypass Firestore rules via the Admin SDK).
+
+import { exerciseRefSchema } from "../workout-template-schema";
+
+const baseExercise = {
+  exerciseId: "wger-bench-press",
+  sets: 3,
+  reps: 10,
+  rest_seconds: 90,
+  order: 1,
+};
+
+describe("exerciseRefSchema.setTypesBySet (quick-260714-m57 #403)", () => {
+  it("accepts a valid setTypesBySet array and preserves it", () => {
+    const parsed = exerciseRefSchema.parse({
+      ...baseExercise,
+      setTypesBySet: ["warmup", "normal", "failure", "dropset"],
+    });
+    expect(parsed.setTypesBySet).toEqual([
+      "warmup",
+      "normal",
+      "failure",
+      "dropset",
+    ]);
+  });
+
+  it("is optional — absent field parses to undefined (legacy docs)", () => {
+    const parsed = exerciseRefSchema.parse(baseExercise);
+    expect(parsed.setTypesBySet).toBeUndefined();
+  });
+
+  it("rejects unknown set-type strings (T-m57-02)", () => {
+    const result = exerciseRefSchema.safeParse({
+      ...baseExercise,
+      setTypesBySet: ["warmup", "xyz"],
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects more than 10 entries", () => {
+    const result = exerciseRefSchema.safeParse({
+      ...baseExercise,
+      setTypesBySet: Array(11).fill("normal"),
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects non-string entries", () => {
+    const result = exerciseRefSchema.safeParse({
+      ...baseExercise,
+      setTypesBySet: [1, 2],
+    });
+    expect(result.success).toBe(false);
+  });
+});

--- a/backoffice/src/lib/gc-fitness/live-workout-actions.ts
+++ b/backoffice/src/lib/gc-fitness/live-workout-actions.ts
@@ -46,6 +46,9 @@ import {
   computeTotalVolumeKg,
 } from "./live-workout-volume";
 import { resolveExerciseDocsById } from "./exercise-resolution";
+// quick-260714-m57 (#403) — per-set types. `isSetType` gates the forgiving
+// wire decode; `effectiveSetType` powers the warmup exclusions.
+import { effectiveSetType, isSetType } from "./set-type";
 import type {
   ActiveSession,
   ActiveWorkoutSummary,
@@ -91,6 +94,26 @@ function numArrayOrNull(v: unknown): number[] | null {
   if (!Array.isArray(v)) return null;
   const out = v.filter((n): n is number => typeof n === "number");
   return out.length > 0 ? out : null;
+}
+
+/** quick-260714-m57 (#403) — raw string array (setTypesBySet). POSITIONAL
+ *  coercion: non-string entries become "normal" (never filtered — dropping
+ *  an entry would shift later sets' types). Null when absent/not-a-list. */
+function strArrayOrNull(v: unknown): string[] | null {
+  if (!Array.isArray(v)) return null;
+  if (v.length === 0) return null;
+  return v.map((s) => (typeof s === "string" ? s : "normal"));
+}
+
+/** quick-260714-m57 (#403) — effective-warmup predicate on a RAW wire set
+ *  (`set_type` / `is_warmup`, snake_case). */
+function isEffectiveWarmupWire(s: Record<string, unknown>): boolean {
+  return (
+    effectiveSetType({
+      set_type: typeof s.set_type === "string" ? s.set_type : null,
+      is_warmup: s.is_warmup === true,
+    }) === "warmup"
+  );
 }
 
 // ── media resolution (gs:// → 1h signed URL; https passes through) ─────────
@@ -184,6 +207,9 @@ async function buildSessionExercises(
             : null,
         repsBySet: numArrayOrNull(e.repsBySet),
         weightBySetKg: numArrayOrNull(e.weightBySetKg),
+        // quick-260714-m57 (#403) — per-set type prescription from the
+        // snapshot; the UI resolves per index via plannedSetType.
+        setTypesBySet: strArrayOrNull(e.setTypesBySet),
         metric,
         durationBySetSeconds: numArrayOrNull(e.durationBySetSeconds),
         durationSeconds:
@@ -209,10 +235,24 @@ function wireSetToSession(s: Record<string, unknown>): SessionSetLog {
     clientLoggedAt: toIso(s.client_logged_at) ?? new Date(0).toISOString(),
     durationSeconds:
       typeof s.duration_seconds === "number" ? s.duration_seconds : null,
+    // quick-260714-m57 (#403) — forgiving decode: unknown/absent/"normal"
+    // wire strings coerce to null (effective type then falls back to
+    // is_warmup, matching the iOS/Android twins).
+    setType:
+      isSetType(s.set_type) && s.set_type !== "normal" ? s.set_type : null,
   };
 }
 
 function sessionSetToWire(s: SessionSetLog): Record<string, unknown> {
+  // quick-260714-m57 (#403) — SYNC INVARIANT at the encode boundary: every
+  // encoded set satisfies `is_warmup == (set_type == "warmup")`. A non-null
+  // non-normal setType is authoritative; legacy/normal sets keep the caller's
+  // isWarmup flag. `set_type` is omitted when null/normal (writers never
+  // store "normal"), mirroring SetLog.swift / SetLog.kt.
+  const setType =
+    s.setType && isSetType(s.setType) && s.setType !== "normal"
+      ? s.setType
+      : null;
   const wire: Record<string, unknown> = {
     id: s.id,
     exerciseId: s.exerciseId,
@@ -220,9 +260,12 @@ function sessionSetToWire(s: SessionSetLog): Record<string, unknown> {
     weight_kg: s.weightKg,
     reps: s.reps,
     completed_at: new Date(s.completedAt),
-    is_warmup: s.isWarmup,
+    is_warmup: setType !== null ? setType === "warmup" : s.isWarmup === true,
     client_logged_at: new Date(s.clientLoggedAt),
   };
+  if (setType !== null) {
+    wire.set_type = setType;
+  }
   // Firestore rejects `undefined`; iOS omits the field on reps-based sets.
   if (typeof s.durationSeconds === "number" && s.durationSeconds > 0) {
     wire.duration_seconds = s.durationSeconds;
@@ -803,6 +846,13 @@ async function enrichEditedExercises(
     if (e.supersetGroup) out.supersetGroup = e.supersetGroup;
     if (e.repsBySet) out.repsBySet = e.repsBySet;
     if (e.weightBySetKg) out.weightBySetKg = e.weightBySetKg;
+    // quick-260714-m57 (#403) — carry the per-set types into the propagated
+    // future snapshots, omitting all-normal arrays (wire contract). The
+    // conditional spread pattern also keeps `undefined` out of the Admin SDK
+    // payload.
+    if (e.setTypesBySet && e.setTypesBySet.some((t) => t !== "normal")) {
+      out.setTypesBySet = e.setTypesBySet;
+    }
     if (e.metric) out.metric = e.metric;
     if (e.durationBySetSeconds) out.durationBySetSeconds = e.durationBySetSeconds;
     if (typeof e.durationSeconds === "number") {
@@ -890,12 +940,14 @@ export async function getPreviousSessionForClient(
     // Logs are newest-first; first time we see an exercise wins. Within a log
     // keep the heaviest working set as the representative "last time".
     for (const raw of sets) {
-      if (raw.is_warmup === true) continue;
+      // quick-260714-m57 (#403) — a set_type-only warmup (is_warmup absent)
+      // must be excluded from the ANTERIOR column/prefill too.
+      if (isEffectiveWarmupWire(raw)) continue;
       const exerciseId = String(raw.exerciseId ?? "");
       if (!exerciseId || map[exerciseId]) continue;
       // find heaviest set for this exercise in this (most recent) log
       const sameExercise = sets.filter(
-        (s) => s.exerciseId === exerciseId && s.is_warmup !== true,
+        (s) => s.exerciseId === exerciseId && !isEffectiveWarmupWire(s),
       );
       const best = sameExercise.reduce((acc, s) =>
         num(s.weight_kg, 0) > num(acc.weight_kg, 0) ? s : acc,

--- a/backoffice/src/lib/gc-fitness/live-workout-schema.ts
+++ b/backoffice/src/lib/gc-fitness/live-workout-schema.ts
@@ -7,6 +7,8 @@
 
 import { z } from "zod";
 
+import { SET_TYPES } from "./set-type";
+
 /** Lowercased UUID-ish id; loose on format, strict on emptiness. */
 const idSchema = z.string().min(1).max(128);
 
@@ -26,6 +28,9 @@ export const sessionSetLogSchema = z.object({
   isWarmup: z.boolean(),
   clientLoggedAt: isoDateSchema,
   durationSeconds: z.number().int().min(1).max(86_400).nullish(),
+  // quick-260714-m57 (#403) — optional richer set type. Writers keep
+  // isWarmup === (setType === "warmup") in sync (see live-workout-types).
+  setType: z.enum(SET_TYPES).nullish(),
 });
 
 export const startSessionSchema = z.object({
@@ -55,6 +60,9 @@ export const sessionExerciseSnapshotSchema = z.object({
   supersetGroup: z.string().max(8).nullish(),
   repsBySet: z.array(z.number().int().min(0).max(100)).max(20).nullish(),
   weightBySetKg: z.array(z.number().min(0).max(2000)).max(20).nullish(),
+  // quick-260714-m57 (#403) — per-set type prescription carried through
+  // finalize / future-recurrence propagation of coach-edited snapshots.
+  setTypesBySet: z.array(z.enum(SET_TYPES)).max(20).nullish(),
   metric: z.enum(["reps", "time"]).nullish(),
   durationBySetSeconds: z.array(z.number().int().min(1).max(86_400)).max(20).nullish(),
   durationSeconds: z.number().int().min(1).max(86_400).nullish(),

--- a/backoffice/src/lib/gc-fitness/live-workout-types.ts
+++ b/backoffice/src/lib/gc-fitness/live-workout-types.ts
@@ -13,6 +13,7 @@
 // to what the iOS app writes (SetLog.swift / WorkoutLog.swift CodingKeys).
 
 import type { ExerciseMetric } from "./live-workout-supersets";
+import type { SetType } from "./set-type";
 
 /** A localized string as stored on exercise/template docs. */
 export interface LocalizedString {
@@ -38,6 +39,14 @@ export interface SessionSetLog {
   clientLoggedAt: string;
   /** Seconds, time-based sets only (plank/wall-sit/dead-hang). */
   durationSeconds?: number | null;
+  /**
+   * quick-260714-m57 (#403) — optional richer set type (warmup / failure /
+   * dropset). Wire: `set_type` (snake_case sibling of `is_warmup`). Writers
+   * MUST keep `isWarmup === (setType === "warmup")` in sync so old readers
+   * keep excluding warm-ups. Absent/null = legacy doc or normal set —
+   * resolve via `effectiveSetType()` from ./set-type.
+   */
+  setType?: SetType | null;
 }
 
 /**
@@ -66,6 +75,12 @@ export interface SessionExercise {
   repsBySet?: number[] | null;
   /** Per-set weight pre-fill, kg. */
   weightBySetKg?: number[] | null;
+  /**
+   * quick-260714-m57 (#403) — per-set type prescription (raw wire strings
+   * "normal" | "warmup" | "failure" | "dropset"). Resolve per set index via
+   * `plannedSetType()` from ./set-type (missing / short / unknown ⇒ normal).
+   */
+  setTypesBySet?: string[] | null;
   /** reps | time. Defaults to reps when absent. */
   metric?: ExerciseMetric | null;
   /** Per-set durations (time exercises), seconds. */

--- a/backoffice/src/lib/gc-fitness/live-workout-volume.ts
+++ b/backoffice/src/lib/gc-fitness/live-workout-volume.ts
@@ -5,19 +5,24 @@
 // No I/O; unit-tested in __tests__/live-workout-volume.test.ts.
 //
 // Volume contract (mirrors iOS):
-//   - WARMUP sets are EXCLUDED from total volume.
+//   - WARMUP sets are EXCLUDED from total volume — via the HARDENED
+//     effective predicate (quick-260714-m57 #403): a set is a warmup when
+//     EITHER the richer setType === "warmup" OR the legacy isWarmup flag
+//     says so (effectiveSetType from ./set-type). Failure / drop sets
+//     count normally.
 //   - reps-based set:  weightKg * reps
 //   - time-based set:  weightKg * (durationSeconds / 60)   — a bodyweight
 //     plank (weightKg = 0) contributes 0, which is correct.
 //   A set counts as time-based when it carries a positive durationSeconds.
 
 import type { SessionSetLog } from "./live-workout-types";
+import { effectiveSetType } from "./set-type";
 
 /** Σ working volume in kg. Warmups excluded; time sets use weight·minutes. */
 export function computeTotalVolumeKg(sets: SessionSetLog[]): number {
   let total = 0;
   for (const set of sets) {
-    if (set.isWarmup) continue;
+    if (effectiveSetType(set) === "warmup") continue;
     const duration = set.durationSeconds ?? 0;
     if (duration > 0) {
       total += set.weightKg * (duration / 60);
@@ -49,5 +54,5 @@ export function computeDurationSeconds(
 
 /** Count of completed (non-warmup) working sets — for the progress header. */
 export function countWorkingSets(sets: SessionSetLog[]): number {
-  return sets.filter((s) => !s.isWarmup).length;
+  return sets.filter((s) => effectiveSetType(s) !== "warmup").length;
 }

--- a/backoffice/src/lib/gc-fitness/recent-logs-actions.ts
+++ b/backoffice/src/lib/gc-fitness/recent-logs-actions.ts
@@ -17,6 +17,9 @@ import { resolveExerciseDocsById } from "./exercise-resolution";
 import { flattenLogPRs, previousRecordsByExercise } from "./personal-records";
 import { isHabitScheduledOn } from "./habit-schedule";
 import { getTrainerTimezone } from "./trainer-timezone";
+// quick-260714-m57 (#403) — effective per-set type (setType ?? is_warmup) for
+// the "Detalle de series" badges + warmup exclusions.
+import { effectiveSetType, type SetType } from "./set-type";
 
 export type RecentLogCategory =
   | "habit"
@@ -137,6 +140,13 @@ export interface WorkoutLogDetail {
      * Defaults to false when absent (pre-warmup-flag logs).
      */
     isWarmup: boolean;
+    /**
+     * quick-260714-m57 (#403) — EFFECTIVE set type resolved via
+     * `effectiveSetType` (valid non-normal `set_type` wins; else the legacy
+     * warmup flag). Powers the W/F/D badge in "Detalle de series". Always
+     * consistent with `isWarmup` (`isWarmup === (setType === "warmup")`).
+     */
+    setType: SetType;
     /** True when this set matches a PR row in the parent workout log's prs[]. */
     isPR: boolean;
     /** Stored Epley estimated 1RM (kg) when isPR === true. */
@@ -1890,6 +1900,14 @@ async function buildWorkoutLogDetail(
     );
     const setLogId = typeof set.id === "string" ? set.id : "";
     const pr = setLogId ? prBySetLogId.get(setLogId) : undefined;
+    // quick-260714-m57 (#403) — effective type: a valid non-normal
+    // `set_type` wins; unknown strings and legacy docs fall back to the
+    // warmup flag. Hardens the share-card warmup exclusion too (a
+    // set_type-only warmup now resolves isWarmup=true).
+    const setTypeEffective = effectiveSetType({
+      set_type: typeof set.set_type === "string" ? set.set_type : null,
+      is_warmup: set.is_warmup === true || set.isWarmup === true,
+    });
     return {
       index: index + 1,
       setLogId,
@@ -1906,11 +1924,12 @@ async function buildWorkoutLogDetail(
       durationSeconds: numeric(set.duration_seconds ?? set.durationSeconds),
       // Wire field is `completed_at` (iOS); keep `completedAt` as a legacy fallback.
       completedAt: asIso(set.completed_at ?? set.completedAt),
-      // 260529-mrp — Wire field is `is_warmup` (iOS, snake_case); keep
-      // `isWarmup` as a camel fallback mirroring the weight_kg ?? weight
-      // pattern. The share card excludes warmups from Volumen / Series /
-      // top-set / 1RM, matching the iOS twin.
-      isWarmup: Boolean(set.is_warmup ?? set.isWarmup),
+      // 260529-mrp — the share card excludes warmups from Volumen / Series /
+      // top-set / 1RM, matching the iOS twin. quick-260714-m57 (#403):
+      // derived from the EFFECTIVE type so `set_type:"warmup"`-only sets are
+      // excluded too (sync invariant holds by construction).
+      isWarmup: setTypeEffective === "warmup",
+      setType: setTypeEffective,
       isPR: Boolean(pr),
       prEstimatedOneRM: pr?.estimatedOneRM ?? null,
       prPrevious: pr ? (prPrevBySetLogId.get(setLogId) ?? null) : null,

--- a/backoffice/src/lib/gc-fitness/schedule-month-actions.ts
+++ b/backoffice/src/lib/gc-fitness/schedule-month-actions.ts
@@ -34,6 +34,9 @@ import {
   type HabitLogRow,
 } from "./habit-compliance";
 import type { HabitType } from "./habit-schema";
+// quick-260714-m57 (#403) — effective set type for warmup exclusion (a
+// set_type-only warmup must be skipped like an is_warmup one).
+import { effectiveSetType } from "./set-type";
 
 const ASSIGNMENTS = FirestoreCollections.workoutAssignments;
 const LOGS = FirestoreCollections.workoutLogs;
@@ -252,6 +255,14 @@ export interface AssignmentExercise {
   /** 26-03 — Exercise-level duration fallback (seconds). Null when not
    *  prescribed (reps-based) or unset on a time exercise. */
   durationSeconds: number | null;
+  /**
+   * quick-260714-m57 (#403) — per-set type prescription (raw wire strings
+   * "normal" | "warmup" | "failure" | "dropset"). Positionally coerced on
+   * read (unknown entry → "normal"), never filtered — dropping an entry
+   * would shift later sets' types to the wrong row. Empty array for legacy
+   * docs (all-normal).
+   */
+  setTypesBySet: string[];
 }
 
 export interface AssignmentDetail {
@@ -495,6 +506,12 @@ export async function getAssignmentDetail(id: string): Promise<AssignmentDetail>
           Number.isFinite(ex.durationSeconds)
             ? ex.durationSeconds
             : null,
+        // quick-260714-m57 (#403) — POSITIONAL coercion (map, never filter).
+        setTypesBySet: Array.isArray(ex.setTypesBySet)
+          ? (ex.setTypesBySet as unknown[]).map((t) =>
+              typeof t === "string" ? t : "normal",
+            )
+          : [],
       };
     }),
     lastLoggedSetsByExerciseId,
@@ -538,7 +555,16 @@ async function fetchLastLoggedSetsByExercise(
         Array<{ setIndex: number; weightKg: number; reps: number }>
       >();
       for (const raw of sets) {
-        if (raw.is_warmup === true) continue;
+        // quick-260714-m57 (#403) — effective-warmup exclusion: a warmup can
+        // arrive as `is_warmup:true` (legacy) or as `set_type:"warmup"`.
+        if (
+          effectiveSetType({
+            set_type: typeof raw.set_type === "string" ? raw.set_type : null,
+            is_warmup: raw.is_warmup === true,
+          }) === "warmup"
+        ) {
+          continue;
+        }
         const exerciseId =
           typeof raw.exerciseId === "string" ? raw.exerciseId : "";
         if (!exerciseId) continue;

--- a/backoffice/src/lib/gc-fitness/set-type.ts
+++ b/backoffice/src/lib/gc-fitness/set-type.ts
@@ -1,0 +1,119 @@
+// set-type.ts
+//
+// quick-260714-m57 (issue #403) — Hevy-style per-set types. TypeScript twin
+// of iOS `GCFitnessCore/Schema/SetType.swift` (the canonical source of truth
+// for the wire strings) and Android `core/.../schema/SetType.kt`. Any change
+// to the raw values or the display-label rule MUST be co-shipped on all three
+// surfaces in the same change set.
+//
+// Plain module (NOT "use server") so both Server Actions and client
+// components can import it — unit-tested in __tests__/set-type.test.ts.
+//
+// WIRE CONTRACT (additive, forgiving):
+//   - Template/snapshot exercises carry `setTypesBySet: string[]?` (camelCase
+//     wire key, sibling of repsBySet / weightBySetKg). Missing / short /
+//     unknown entry ⇒ effective "normal" (see plannedSetType).
+//   - Logged sets carry `set_type: string?` (snake_case, sibling of
+//     `is_warmup`). Writers ALWAYS keep `is_warmup == (set_type === "warmup")`
+//     in sync so old readers keep excluding warm-ups from volume/PR math.
+//
+// DISPLAY RULE (Hevy semantics): non-normal sets render a colored letter
+// instead of the set number — W = warm-up (orange), F = failure (red),
+// D = drop set (purple). Normal sets render a 1-based number counting ONLY
+// normal sets (non-normal sets do not consume a number).
+
+/** Canonical wire strings — order matters only for UI pickers. */
+export const SET_TYPES = ["normal", "warmup", "failure", "dropset"] as const;
+
+export type SetType = (typeof SET_TYPES)[number];
+
+/** Type guard for a raw wire string. */
+export function isSetType(raw: unknown): raw is SetType {
+  return (
+    typeof raw === "string" && (SET_TYPES as readonly string[]).includes(raw)
+  );
+}
+
+/**
+ * Reader-side effective type for a logged set. Accepts BOTH the snake_case
+ * Firestore wire shape (`set_type` / `is_warmup`) and the camelCase
+ * session shape (`setType` / `isWarmup`).
+ *
+ * Twin semantics (iOS/Android normalization): a valid NON-normal `set_type`
+ * wins; `"normal"`, unknown strings, and absent values all fall back to the
+ * legacy warmup flag — old documents resolve exactly as before.
+ */
+export function effectiveSetType(set: {
+  set_type?: string | null;
+  setType?: string | null;
+  is_warmup?: boolean | null;
+  isWarmup?: boolean | null;
+}): SetType {
+  const raw = set.set_type ?? set.setType;
+  if (isSetType(raw) && raw !== "normal") return raw;
+  return (set.is_warmup ?? set.isWarmup) === true ? "warmup" : "normal";
+}
+
+/**
+ * Effective-type resolution for a template/snapshot `setTypesBySet` entry.
+ * Missing array, out-of-range index, or unknown raw entry all coerce to
+ * "normal" (store raw, coerce on read — decode-everything philosophy, same
+ * as the repsBySet fallbacks).
+ */
+export function plannedSetType(
+  setIndex: number,
+  setTypesBySet: readonly string[] | null | undefined,
+): SetType {
+  const raw = setTypesBySet?.[setIndex];
+  return isSetType(raw) ? raw : "normal";
+}
+
+/** Single-letter marker for non-normal sets; null for "normal". */
+export const SET_TYPE_LETTERS: Record<SetType, string | null> = {
+  normal: null,
+  warmup: "W",
+  failure: "F",
+  dropset: "D",
+};
+
+/**
+ * Hevy numbering rule: normal sets are numbered 1-based counting ONLY normal
+ * sets; warm-up/failure/drop sets render their letter and do not consume a
+ * number.
+ *
+ *     setDisplayLabels(["warmup", "normal", "normal", "dropset", "normal"])
+ *     // ["W", "1", "2", "D", "3"]
+ */
+export function setDisplayLabels(types: readonly SetType[]): string[] {
+  let normalCount = 0;
+  return types.map((type) => {
+    const letter = SET_TYPE_LETTERS[type];
+    if (letter) return letter;
+    normalCount += 1;
+    return String(normalCount);
+  });
+}
+
+/** Spanish display names (matches the backoffice form's inline-Spanish copy). */
+export const SET_TYPE_LABELS_ES: Record<SetType, string> = {
+  normal: "Normal",
+  warmup: "Calentamiento",
+  failure: "Al fallo",
+  dropset: "Drop set",
+};
+
+/** Tailwind text-color classes for the letter markers (W/F/D). */
+export const SET_TYPE_TEXT_CLASS: Record<SetType, string> = {
+  normal: "",
+  warmup: "text-orange-500",
+  failure: "text-red-500",
+  dropset: "text-purple-500",
+};
+
+/** Tailwind badge classes (bg + text) for log-detail type badges. */
+export const SET_TYPE_BADGE_CLASS: Record<SetType, string> = {
+  normal: "",
+  warmup: "bg-orange-100 text-orange-700",
+  failure: "bg-red-100 text-red-700",
+  dropset: "bg-purple-100 text-purple-700",
+};

--- a/backoffice/src/lib/gc-fitness/workout-assignment-actions.ts
+++ b/backoffice/src/lib/gc-fitness/workout-assignment-actions.ts
@@ -51,6 +51,8 @@ import {
   changedWeightExerciseIds,
   exercisesOf,
 } from "./weight-diff";
+// quick-260714-m57 (#403) — per-set type helpers (TS twin of iOS SetType).
+import { plannedSetType, type SetType } from "./set-type";
 import {
   recordCoachActivityEvent,
   markCoachActivityDeleted,
@@ -142,6 +144,12 @@ function jsonSafe(value: unknown): unknown {
   return value;
 }
 
+// quick-260714-m57 (#403) — NOTE on `setTypesBySet`: every snapshot-build
+// site (assignTemplate single/bulk/recurring, duplicate, fork, recurrence
+// re-expansion, propagateTemplateToFutureAssignments) flows through this
+// function, which copies each template exercise VERBATIM via `...exercise`.
+// `setTypesBySet` therefore rides template → templateSnapshot without an
+// explicit key, exactly like repsBySet / weightBySetKg.
 async function templateSnapshotForAssignment(
   template: Record<string, unknown>,
 ): Promise<Record<string, unknown>> {
@@ -275,6 +283,27 @@ function applyExerciseOverrides(
     ...templateSnapshot,
     exercises,
   };
+}
+
+/**
+ * quick-260714-m57 (#403) — normalize per-set types coming from the edit
+ * dialog (or realigned from the existing snapshot when the edit doesn't
+ * carry them). Coerces unknown entries POSITIONALLY to "normal" (never
+ * filters — dropping an entry would shift later sets' types), aligns to
+ * `setCount`, and returns null when every entry is normal: the wire
+ * contract omits all-normal arrays, and callers DELETE the key so a stale
+ * non-normal array can't survive an all-normal edit.
+ */
+function normalizeEditedSetTypes(
+  raw: unknown,
+  setCount: number,
+): SetType[] | null {
+  if (!Array.isArray(raw)) return null;
+  const length = Math.max(1, Math.min(20, setCount || raw.length || 1));
+  const aligned = Array.from({ length }, (_, i) =>
+    plannedSetType(i, raw as readonly string[]),
+  );
+  return aligned.some((t) => t !== "normal") ? aligned : null;
 }
 
 function normalizeEditedWeights(opts: {
@@ -1733,7 +1762,14 @@ export async function editAssignmentExercises(
             ? Number(edit.transition_rest_seconds)
             : undefined;
         const notes = typeof edit.notes === "string" ? edit.notes : "";
-        exercises[index] = {
+        // quick-260714-m57 (#403) — legacy index edits don't carry types:
+        // realign the snapshot's existing setTypesBySet to the new set count
+        // (pad "normal" / truncate); delete when all-normal.
+        const realignedTypes = normalizeEditedSetTypes(
+          (current as { setTypesBySet?: unknown }).setTypesBySet,
+          repsBySet.length,
+        );
+        const nextExercise: Record<string, unknown> = {
           ...current,
           sets: repsBySet.length,
           reps: repsBySet[0] ?? 0,
@@ -1745,6 +1781,12 @@ export async function editAssignmentExercises(
             : {}),
           notes,
         };
+        if (realignedTypes) {
+          nextExercise.setTypesBySet = realignedTypes;
+        } else {
+          delete nextExercise.setTypesBySet;
+        }
+        exercises[index] = nextExercise;
       }
       return { ...base, exercises };
     }
@@ -1812,6 +1854,15 @@ export async function editAssignmentExercises(
           : null;
       const supersetGroup =
         typeof edit.supersetGroup === "string" ? edit.supersetGroup : null;
+      // quick-260714-m57 (#403) — prefer the dialog's explicit types; fall
+      // back to realigning what the snapshot already had (an older dialog
+      // build won't send the field). Null ⇒ all-normal ⇒ key deleted below.
+      const setTypesBySet = normalizeEditedSetTypes(
+        edit.setTypesBySet !== undefined
+          ? edit.setTypesBySet
+          : (current as { setTypesBySet?: unknown } | undefined)?.setTypesBySet,
+        repsBySet.length,
+      );
       const merged: Record<string, unknown> = {
         ...(current ?? {}),
         exerciseId,
@@ -1844,6 +1895,13 @@ export async function editAssignmentExercises(
         merged.hasExplicitNoWeightPrescription = true;
       } else {
         delete merged.hasExplicitNoWeightPrescription;
+      }
+      // quick-260714-m57 (#403) — explicit set-or-delete: `...current` above
+      // carries a stale setTypesBySet that must not survive an all-normal edit.
+      if (setTypesBySet) {
+        merged.setTypesBySet = setTypesBySet;
+      } else {
+        delete merged.setTypesBySet;
       }
       return merged;
     },

--- a/backoffice/src/lib/gc-fitness/workout-template-schema.ts
+++ b/backoffice/src/lib/gc-fitness/workout-template-schema.ts
@@ -31,6 +31,8 @@
 
 import { z } from "zod";
 
+import { SET_TYPES } from "./set-type";
+
 // Tags are trainer-defined free text in v1. We still keep the canonical
 // defaults in the UI, but the schema no longer hard-codes a closed enum.
 export const workoutTagSchema = z
@@ -118,6 +120,15 @@ export const exerciseRefSchema = z
         z.number().min(0, "Weight per set cannot be negative.").max(500, "Weight per set max is 500kg."),
       )
       .max(10, "Maximum 10 weight entries.")
+      .optional(),
+    // quick-260714-m57 (#403) — per-set type prescription (Hevy-style
+    // warmup / failure / dropset markers). Enum literals MUST stay aligned
+    // with the iOS SetType raw values + Android SetType.wire (Pitfall-7
+    // contract surface). Threat T-m57-02: this Zod boundary is the guard
+    // for trainer-authored templates (Admin SDK bypasses Firestore rules).
+    setTypesBySet: z
+      .array(z.enum(SET_TYPES))
+      .max(10, "Maximum 10 set-type entries.")
       .optional(),
     supersetGroup: z
       .string()


### PR DESCRIPTION
Part of mdb1/gc-fitness#403 — backoffice side. Companion apps PR: mdb1/gc-fitness#459 (same wire contract).

## Wire contract (additive)
- Template/snapshot exercises: `setTypesBySet: string[]?` (`normal|warmup|failure|dropset`; Zod `enum(SET_TYPES).max(10)` at the server-action boundary; emitted only when some entry is non-normal — conditional spread, Admin SDK rejects `undefined`).
- Logged sets: `set_type: string?` with the sync invariant `is_warmup == (set_type == "warmup")` enforced in `sessionSetToWire`.

## What's included
- **`set-type.ts` lib twin** (mirrors Swift/Kotlin): `effectiveSetType`, Hevy display numbering (`setDisplayLabels` — normals numbered counting only normals, W/F/D letters), per-type colors (W orange / F red / D purple). Twin test vectors identical to the mobile suites (450.0 volume vector included via `live-workout-volume`).
- **Template editor**: the "Serie N" cell is a DropdownMenu picker — Normal / Calentamiento (W) / Al fallo (F) / Drop set (D); `setTypesBySet` joined the sets/reps/weights alignment logic (pad with normal, truncate together).
- **Assignment edit dialog**: full picker on per-set rows; `editAssignmentExercises` realigns and set-or-deletes the field on both edit paths. Template→snapshot copy needed no code — `templateSnapshotForAssignment` spreads exercises verbatim.
- **Live session**: rows seed their type from the prescription, session card gets the 4-type picker, finalize propagates performed types to future recurrences, `getPreviousSessionForClient` now excludes set_type-only warmups.
- **Log detail** ("Detalle de series"): W/F/D badges via `effectiveSetType`.
- Warm-up exclusion from session volume hardened to the effective predicate.

## Gates
- `npx tsc --noEmit`: clean
- `npx jest`: 791/792 — sole red is the documented pre-existing `client-activity-time` locale flake (green in CI). No new reds.

Do not merge before the companion apps PR is verified (mobile/watch flows exercise the same wire fields).