### PR TITLE
feat(gc-fitness): coach-link conflict detection + habit visibility (#374 phase 32)

### DIFF
--- a/backoffice/messages/en.json
+++ b/backoffice/messages/en.json
@@ -252,6 +252,7 @@
       "errorFallback": "Could not add client.",
       "conflictError": "This client already has a coach. The email {email} is already linked to another coach. Contact support to transfer them.",
       "selfError": "You cannot add yourself as a client.",
+      "trainerTargetError": "The email {email} belongs to a coach account and cannot be added as a client.",
       "alreadyLinked": "This client is already in your list.",
       "successBannerTitle": "Client ready",
       "errorBannerTitle": "Add client failed"

--- a/backoffice/messages/en.json
+++ b/backoffice/messages/en.json
@@ -251,6 +251,7 @@
       "successPreCreated": "Client pre-created. They will attach on first sign-in.",
       "errorFallback": "Could not add client.",
       "conflictError": "This client already has a coach. The email {email} is already linked to another coach. Contact support to transfer them.",
+      "selfError": "You cannot add yourself as a client.",
       "alreadyLinked": "This client is already in your list.",
       "successBannerTitle": "Client ready",
       "errorBannerTitle": "Add client failed"

--- a/backoffice/messages/en.json
+++ b/backoffice/messages/en.json
@@ -250,6 +250,8 @@
       "successAttached": "Client attached to your roster.",
       "successPreCreated": "Client pre-created. They will attach on first sign-in.",
       "errorFallback": "Could not add client.",
+      "conflictError": "This client already has a coach. The email {email} is already linked to another coach. Contact support to transfer them.",
+      "alreadyLinked": "This client is already in your list.",
       "successBannerTitle": "Client ready",
       "errorBannerTitle": "Add client failed"
     },

--- a/backoffice/messages/es.json
+++ b/backoffice/messages/es.json
@@ -251,6 +251,7 @@
       "successPreCreated": "Cliente pre-creado. Se vinculará al iniciar sesión por primera vez.",
       "errorFallback": "No se pudo agregar el cliente.",
       "conflictError": "Este cliente ya tiene coach. El email {email} ya está vinculado a otro coach. Para transferirlo, contactá a soporte.",
+      "selfError": "No podés agregarte a vos mismo como cliente.",
       "alreadyLinked": "Este cliente ya está en tu lista.",
       "successBannerTitle": "Cliente listo",
       "errorBannerTitle": "Falló al agregar cliente"

--- a/backoffice/messages/es.json
+++ b/backoffice/messages/es.json
@@ -252,6 +252,7 @@
       "errorFallback": "No se pudo agregar el cliente.",
       "conflictError": "Este cliente ya tiene coach. El email {email} ya está vinculado a otro coach. Para transferirlo, contactá a soporte.",
       "selfError": "No podés agregarte a vos mismo como cliente.",
+      "trainerTargetError": "El email {email} pertenece a una cuenta de coach y no puede agregarse como cliente.",
       "alreadyLinked": "Este cliente ya está en tu lista.",
       "successBannerTitle": "Cliente listo",
       "errorBannerTitle": "Falló al agregar cliente"

--- a/backoffice/messages/es.json
+++ b/backoffice/messages/es.json
@@ -250,6 +250,8 @@
       "successAttached": "Cliente vinculado a tu plantel.",
       "successPreCreated": "Cliente pre-creado. Se vinculará al iniciar sesión por primera vez.",
       "errorFallback": "No se pudo agregar el cliente.",
+      "conflictError": "Este cliente ya tiene coach. El email {email} ya está vinculado a otro coach. Para transferirlo, contactá a soporte.",
+      "alreadyLinked": "Este cliente ya está en tu lista.",
       "successBannerTitle": "Cliente listo",
       "errorBannerTitle": "Falló al agregar cliente"
     },

--- a/backoffice/src/app/gc-fitness/clients/[id]/_components/ClientSummaryCard.tsx
+++ b/backoffice/src/app/gc-fitness/clients/[id]/_components/ClientSummaryCard.tsx
@@ -45,10 +45,14 @@ export async function ClientSummaryCard({
     // Issue #437/#400: fetch by clientId only; filter `deleted === true` in
     // memory (isHabitNotDeleted) below. A `.where("deleted","==",false)`
     // equality drops client-created habits that never write the field. PR #230.
+    // WR-03: the cap counts SOFT-DELETED docs too (soft-delete is the only
+    // delete path, so they accumulate over a client's lifetime) — raised
+    // 40 → 200 so live habits don't silently drop off the summary card;
+    // truncation warning below when the raw fetch hits the cap.
     db
       .collection(FirestoreCollections.habits)
       .where("clientId", "==", clientId)
-      .limit(40)
+      .limit(200)
       .get()
       .catch(() => ({ docs: [] as Array<{ id: string; data: () => Record<string, unknown> }> })),
   ]);
@@ -80,6 +84,14 @@ export async function ClientSummaryCard({
   const pastWorkouts = workouts.filter((row) => !row.isRecurring && row.scheduledFor < todayCivil);
   const workoutsGrouped = groupWorkouts(visibleWorkouts);
 
+  if (habitsSnap.docs.length >= 200) {
+    // WR-03: raw fetch filled the cap — soft-deleted docs consume the
+    // budget, so live habits may be missing from the card.
+    console.warn(
+      "[gc-fitness/client-summary] habit fetch hit its cap — live habits may be truncated",
+      { clientId, cap: 200 },
+    );
+  }
   const habits = habitsSnap.docs
     .filter((doc) => isHabitNotDeleted(doc.data() as Record<string, unknown>))
     .map((doc) => {

--- a/backoffice/src/app/gc-fitness/clients/[id]/_components/ClientSummaryCard.tsx
+++ b/backoffice/src/app/gc-fitness/clients/[id]/_components/ClientSummaryCard.tsx
@@ -3,6 +3,7 @@ import { getTranslations } from "next-intl/server";
 import { civilDateToday } from "@/lib/gc-fitness/civil-date";
 import { gcFitnessFirestore } from "@/lib/firebase/gc-fitness-admin";
 import { FirestoreCollections } from "@/lib/gc-fitness/collections";
+import { isHabitNotDeleted } from "@/lib/gc-fitness/habit-visibility";
 import type { ClientGoalRow } from "@/lib/gc-fitness/client-goal-actions";
 import { Badge } from "@/components/ui/badge";
 import { ClientSummaryLists } from "./ClientSummaryLists";
@@ -41,10 +42,12 @@ export async function ClientSummaryCard({
       .limit(80)
       .get()
       .catch(() => ({ docs: [] as Array<{ id: string; data: () => Record<string, unknown> }> })),
+    // Issue #437/#400: fetch by clientId only; filter `deleted === true` in
+    // memory (isHabitNotDeleted) below. A `.where("deleted","==",false)`
+    // equality drops client-created habits that never write the field. PR #230.
     db
       .collection(FirestoreCollections.habits)
       .where("clientId", "==", clientId)
-      .where("deleted", "==", false)
       .limit(40)
       .get()
       .catch(() => ({ docs: [] as Array<{ id: string; data: () => Record<string, unknown> }> })),
@@ -77,7 +80,9 @@ export async function ClientSummaryCard({
   const pastWorkouts = workouts.filter((row) => !row.isRecurring && row.scheduledFor < todayCivil);
   const workoutsGrouped = groupWorkouts(visibleWorkouts);
 
-  const habits = habitsSnap.docs.map((doc) => {
+  const habits = habitsSnap.docs
+    .filter((doc) => isHabitNotDeleted(doc.data() as Record<string, unknown>))
+    .map((doc) => {
     const data = doc.data() as Record<string, unknown>;
     return {
       id: doc.id,

--- a/backoffice/src/app/gc-fitness/clients/[id]/_components/HabitTrendsWidget.tsx
+++ b/backoffice/src/app/gc-fitness/clients/[id]/_components/HabitTrendsWidget.tsx
@@ -23,6 +23,7 @@ import { FirestoreCollections } from "@/lib/gc-fitness/collections";
 import { civilDateFormat } from "@/lib/gc-fitness/civil-date";
 import { coerceLegacyHabitLogValue } from "@/lib/gc-fitness/habit-compliance";
 import { isHabitScheduledOn } from "@/lib/gc-fitness/habit-schedule";
+import { isHabitNotDeleted } from "@/lib/gc-fitness/habit-visibility";
 import { TREND_RANGES, type TrendRangeKey, addCivilDays } from "./trend-range";
 import { HabitTrendsClient, type HabitTrendRow } from "./HabitTrendsClient";
 
@@ -47,11 +48,15 @@ export async function HabitTrendsWidget({ clientId, timezone }: HabitTrendsWidge
   const unnamed = t("unnamed");
   const db = gcFitnessFirestore();
 
+  // Issue #437/#400: fetch by clientId only, filter `deleted === true` in
+  // memory (isHabitNotDeleted). A `.where("deleted","==",false)` equality only
+  // matches docs where the field EXISTS, silently dropping client-created
+  // habits that never write it. PR #230 pattern.
   const habitsSnap = await db
     .collection(FirestoreCollections.habits)
     .where("clientId", "==", clientId)
-    .where("deleted", "==", false)
     .get();
+  const habitDocs = habitsSnap.docs.filter((d) => isHabitNotDeleted(d.data()));
 
   const today = civilDateFormat(new Date(), timezone);
   // Ascending list of the trailing 365 civil dates ending today. Each
@@ -63,7 +68,7 @@ export async function HabitTrendsWidget({ clientId, timezone }: HabitTrendsWidge
   const windowStart = allDates[0] ?? today;
 
   const rows: HabitTrendRow[] = await Promise.all(
-    habitsSnap.docs.map(async (h) => {
+    habitDocs.map(async (h) => {
       const habit = h.data() as {
         name?: string | { en?: string; es?: string };
       } & Record<string, unknown>;

--- a/backoffice/src/app/gc-fitness/clients/_components/ProvisionClientForm.tsx
+++ b/backoffice/src/app/gc-fitness/clients/_components/ProvisionClientForm.tsx
@@ -49,9 +49,11 @@ export function ProvisionClientForm() {
                 setEmail("");
                 setDisplayName("");
                 setMessage(
-                  result.mode === "attached-existing-user"
-                    ? t("successAttached")
-                    : t("successPreCreated"),
+                  result.mode === "already-linked"
+                    ? t("alreadyLinked")
+                    : result.mode === "attached-existing-user"
+                      ? t("successAttached")
+                      : t("successPreCreated"),
                 );
                 router.refresh();
               } catch (err) {

--- a/backoffice/src/app/gc-fitness/clients/_components/ProvisionClientForm.tsx
+++ b/backoffice/src/app/gc-fitness/clients/_components/ProvisionClientForm.tsx
@@ -46,6 +46,20 @@ export function ProvisionClientForm() {
                   email,
                   displayName: displayName || undefined,
                 });
+                // CR-03: expected refusals arrive as a discriminated result
+                // (NOT a thrown Error) because production Next.js masks
+                // Server-Action error messages. The localized copy is
+                // rendered CLIENT-side from the mode — no server-composed
+                // string crosses the wire, which also keeps the enumeration
+                // bound (T-32-ENUM: copy names only the typed email).
+                if (!result.ok) {
+                  setError(
+                    result.mode === "conflict"
+                      ? t("conflictError", { email })
+                      : t("selfError"),
+                  );
+                  return;
+                }
                 setEmail("");
                 setDisplayName("");
                 setMessage(
@@ -56,10 +70,11 @@ export function ProvisionClientForm() {
                       : t("successPreCreated"),
                 );
                 router.refresh();
-              } catch (err) {
-                setError(
-                  err instanceof Error ? err.message : t("errorFallback"),
-                );
+              } catch {
+                // Unexpected failure only — expected refusals never throw.
+                // err.message is prod-masked by Next.js, so it carries no
+                // user-renderable copy; show the localized fallback instead.
+                setError(t("errorFallback"));
               }
             });
           }}

--- a/backoffice/src/app/gc-fitness/clients/_components/ProvisionClientForm.tsx
+++ b/backoffice/src/app/gc-fitness/clients/_components/ProvisionClientForm.tsx
@@ -56,7 +56,9 @@ export function ProvisionClientForm() {
                   setError(
                     result.mode === "conflict"
                       ? t("conflictError", { email })
-                      : t("selfError"),
+                      : result.mode === "trainer-target"
+                        ? t("trainerTargetError", { email })
+                        : t("selfError"),
                   );
                   return;
                 }

--- a/backoffice/src/lib/gc-fitness/__tests__/coach-link.test.ts
+++ b/backoffice/src/lib/gc-fitness/__tests__/coach-link.test.ts
@@ -1,0 +1,66 @@
+import { decideLinkOutcome } from "../coach-link";
+
+describe("decideLinkOutcome", () => {
+  it("links a coach-less target (null doc)", () => {
+    expect(decideLinkOutcome(null, "coachB")).toEqual({ kind: "link" });
+  });
+
+  it("treats an empty/whitespace coachId as no coach → link", () => {
+    expect(decideLinkOutcome({ coachId: "" }, "coachB")).toEqual({
+      kind: "link",
+    });
+    expect(decideLinkOutcome({ coachId: "   " }, "coachB")).toEqual({
+      kind: "link",
+    });
+    expect(decideLinkOutcome({ coachId: null }, "coachB")).toEqual({
+      kind: "link",
+    });
+  });
+
+  it("returns alreadyYours when the target is already your client", () => {
+    expect(decideLinkOutcome({ coachId: "coachB" }, "coachB")).toEqual({
+      kind: "alreadyYours",
+    });
+  });
+
+  it("links a claimable stray (autoAssignedCoach === true)", () => {
+    expect(
+      decideLinkOutcome(
+        { coachId: "coachA", autoAssignedCoach: true },
+        "coachB",
+      ),
+    ).toEqual({ kind: "link" });
+  });
+
+  it("returns conflict when the target has a different real coach", () => {
+    expect(decideLinkOutcome({ coachId: "coachA" }, "coachB")).toEqual({
+      kind: "conflict",
+      currentCoachId: "coachA",
+    });
+  });
+
+  it("prefers alreadyYours over stray when coachId matches the session", () => {
+    expect(
+      decideLinkOutcome(
+        { coachId: "coachB", autoAssignedCoach: true },
+        "coachB",
+      ),
+    ).toEqual({ kind: "alreadyYours" });
+  });
+
+  it("treats a mirror doc with a different coachId (no autoAssignedCoach) as conflict", () => {
+    expect(decideLinkOutcome({ coachId: "coachA" }, "coachB")).toEqual({
+      kind: "conflict",
+      currentCoachId: "coachA",
+    });
+  });
+
+  it("does not treat autoAssignedCoach:false as a claimable stray", () => {
+    expect(
+      decideLinkOutcome(
+        { coachId: "coachA", autoAssignedCoach: false },
+        "coachB",
+      ),
+    ).toEqual({ kind: "conflict", currentCoachId: "coachA" });
+  });
+});

--- a/backoffice/src/lib/gc-fitness/__tests__/coach-link.test.ts
+++ b/backoffice/src/lib/gc-fitness/__tests__/coach-link.test.ts
@@ -63,4 +63,34 @@ describe("decideLinkOutcome", () => {
       ),
     ).toEqual({ kind: "conflict", currentCoachId: "coachA" });
   });
+
+  // CR-02 — a trainer account is never a linkable client. A trainer doc
+  // usually has NO coachId, which rule (1) would classify as "link" and
+  // let a coach demote another trainer (doc overwrite + claims clobber).
+  it("refuses a trainer target with no coachId (the demotion vector)", () => {
+    expect(decideLinkOutcome({ role: "trainer" }, "coachB")).toEqual({
+      kind: "trainerTarget",
+    });
+  });
+
+  it("refuses a trainer target even when a coachId is present", () => {
+    expect(
+      decideLinkOutcome({ role: "trainer", coachId: "coachA" }, "coachB"),
+    ).toEqual({ kind: "trainerTarget" });
+  });
+
+  it("trainerTarget wins over alreadyYours and the stray rule", () => {
+    expect(
+      decideLinkOutcome(
+        { role: "trainer", coachId: "coachB", autoAssignedCoach: true },
+        "coachB",
+      ),
+    ).toEqual({ kind: "trainerTarget" });
+  });
+
+  it("does not refuse a client-role doc (role passthrough is trainer-only)", () => {
+    expect(decideLinkOutcome({ role: "client" }, "coachB")).toEqual({
+      kind: "link",
+    });
+  });
 });

--- a/backoffice/src/lib/gc-fitness/__tests__/habit-actions.test.ts
+++ b/backoffice/src/lib/gc-fitness/__tests__/habit-actions.test.ts
@@ -637,8 +637,47 @@ describe("listHabitsForTrainer", () => {
 });
 
 describe("listHabitsForClient", () => {
-  // T14 — filters by clientId + deleted; defense-in-depth strips cross-trainer rows
-  it("T14 — strips cross-trainer rows post-query (defense in depth)", async () => {
+  // T14 (LINK-03 / issue #437 / PR #230) — the query scopes by clientId ONLY
+  // (no `.where("deleted","==",false)` equality, which dropped client-created
+  // habits that never write the field); soft-deleted rows are filtered in
+  // memory. Ownership is the belongs-to-my-client gate (D-06):
+  //   - client belongs to the requesting trainer → old-coach / self-created
+  //     habits (trainerId !== trainer.uid) ARE included;
+  //   - client belongs to someone else → only own-authored rows return.
+  it("T14a — client belongs to me: includes old-coach/self-created rows, drops soft-deleted", async () => {
+    mockedGetTokens.mockResolvedValue(fakeTokens({ role: "trainer" }));
+    mockQueryGet.mockResolvedValue(
+      fakeQuerySnapshot([
+        { id: "hab-mine", trainerId: ALLOWED_UID, clientId: "uid-X" },
+        {
+          id: "hab-other",
+          trainerId: "other-trainer-uid",
+          clientId: "uid-X",
+        },
+        {
+          id: "hab-gone",
+          trainerId: "other-trainer-uid",
+          clientId: "uid-X",
+          deleted: true,
+        },
+      ]),
+    );
+    // Belongs-to-my-client point-read: users/uid-X.coachId === trainer.uid.
+    mockGet.mockResolvedValue(
+      fakeUserSnapshot({ exists: true, coachId: ALLOWED_UID }),
+    );
+
+    const result = await listHabitsForClient("uid-X");
+
+    // hab-other (old-coach) IS included; hab-gone (soft-deleted) is NOT.
+    expect(result.map((r) => r.id)).toEqual(["hab-mine", "hab-other"]);
+    expect(mockWhere).toHaveBeenCalledWith("clientId", "==", "uid-X");
+    // The deleted-equality is GONE — filtering happens in memory now.
+    expect(mockWhere).not.toHaveBeenCalledWith("deleted", "==", false);
+    expect(mockLimit).toHaveBeenCalledWith(200);
+  });
+
+  it("T14b — non-owned client: returns only own-authored rows", async () => {
     mockedGetTokens.mockResolvedValue(fakeTokens({ role: "trainer" }));
     mockQueryGet.mockResolvedValue(
       fakeQuerySnapshot([
@@ -650,13 +689,15 @@ describe("listHabitsForClient", () => {
         },
       ]),
     );
+    // The queried client is coached by someone else.
+    mockGet.mockResolvedValue(
+      fakeUserSnapshot({ exists: true, coachId: "someone-else" }),
+    );
 
     const result = await listHabitsForClient("uid-X");
-    expect(result).toHaveLength(1);
-    expect(result[0].id).toBe("hab-mine");
-    expect(mockWhere).toHaveBeenCalledWith("clientId", "==", "uid-X");
-    expect(mockWhere).toHaveBeenCalledWith("deleted", "==", false);
-    expect(mockLimit).toHaveBeenCalledWith(200);
+
+    expect(result.map((r) => r.id)).toEqual(["hab-mine"]);
+    expect(mockWhere).not.toHaveBeenCalledWith("deleted", "==", false);
   });
 });
 

--- a/backoffice/src/lib/gc-fitness/__tests__/habit-actions.test.ts
+++ b/backoffice/src/lib/gc-fitness/__tests__/habit-actions.test.ts
@@ -674,7 +674,10 @@ describe("listHabitsForClient", () => {
     expect(mockWhere).toHaveBeenCalledWith("clientId", "==", "uid-X");
     // The deleted-equality is GONE — filtering happens in memory now.
     expect(mockWhere).not.toHaveBeenCalledWith("deleted", "==", false);
-    expect(mockLimit).toHaveBeenCalledWith(200);
+    // WR-03: cap raised 200 → 500 — soft-deleted docs consume the fetch
+    // budget (they're filtered AFTER the query), so the cap needs headroom
+    // for a lifetime of soft-deletes before live habits truncate.
+    expect(mockLimit).toHaveBeenCalledWith(500);
   });
 
   it("T14b — non-owned client: returns only own-authored rows", async () => {

--- a/backoffice/src/lib/gc-fitness/__tests__/habit-visibility.test.ts
+++ b/backoffice/src/lib/gc-fitness/__tests__/habit-visibility.test.ts
@@ -1,0 +1,33 @@
+// __tests__/habit-visibility.test.ts
+//
+// Pure unit tests for the in-memory habit-visibility predicate that replaces
+// the `.where("deleted","==",false)` Firestore equality on the per-client
+// habit surfaces (issue #437 / PR #230 pattern). A Firestore equality filter
+// only matches docs where the field EXISTS, so client-created habits (issue
+// #400) — which never write a `deleted` field — were silently dropped. The
+// predicate keeps only a strict boolean `true` out; a missing/undefined/null/
+// false field stays visible.
+
+import { isHabitNotDeleted } from "@/lib/gc-fitness/habit-visibility";
+
+describe("isHabitNotDeleted", () => {
+  it("keeps a client-created habit with no deleted field (the #437/#400 bug)", () => {
+    expect(isHabitNotDeleted({})).toBe(true);
+  });
+
+  it("keeps a habit with deleted: false", () => {
+    expect(isHabitNotDeleted({ deleted: false })).toBe(true);
+  });
+
+  it("excludes a genuinely soft-deleted habit (deleted: true)", () => {
+    expect(isHabitNotDeleted({ deleted: true })).toBe(false);
+  });
+
+  it("keeps a habit with deleted: undefined", () => {
+    expect(isHabitNotDeleted({ deleted: undefined })).toBe(true);
+  });
+
+  it("keeps a habit with deleted: null (only strict true excludes)", () => {
+    expect(isHabitNotDeleted({ deleted: null })).toBe(true);
+  });
+});

--- a/backoffice/src/lib/gc-fitness/__tests__/user-actions.provision-link.test.ts
+++ b/backoffice/src/lib/gc-fitness/__tests__/user-actions.provision-link.test.ts
@@ -1,0 +1,369 @@
+// __tests__/user-actions.provision-link.test.ts
+//
+// Phase 32 review-fix vectors (CR-01 / CR-02 / CR-03 / WR-01 / WR-02) for
+// `provisionClient`. The pure `decideLinkOutcome` suite (coach-link.test.ts)
+// cannot see the WRITE PAYLOADS, so these tests run the action against an
+// in-memory Firestore mock (adapted from live-workout-actions.start-dedupe)
+// whose transaction buffers writes and applies them only on commit — a
+// thrown sentinel therefore aborts with zero writes, mirroring the server.
+//
+//  - CR-01: claiming a stray CLEARS `autoAssignedCoach` (FieldValue.delete
+//    survives merge), so a second coach's attempt is a conflict, not a steal.
+//  - CR-02: a `role: "trainer"` target is refused with zero writes and zero
+//    claims mutation (the demotion/lockout vector).
+//  - CR-03: refusals are RETURN VALUES ({ ok: false, mode }) — never thrown
+//    errors whose message prod-Next.js would mask.
+//  - WR-01: the idempotent claims sync also runs on the alreadyYours path,
+//    healing a prior post-commit claims failure on resubmit.
+//  - WR-02: the chat write carries no unreadCount and never rewrites an
+//    existing chat's createdAt.
+
+jest.mock("next/headers", () => ({
+  cookies: jest.fn().mockResolvedValue({}),
+}));
+jest.mock("next/cache", () => ({
+  revalidateTag: jest.fn(),
+}));
+jest.mock("next-intl/server", () => ({
+  getTranslations: jest.fn(async () => (key: string) => key),
+}));
+
+const SERVER_TIMESTAMP = "SERVER_TIMESTAMP_SENTINEL";
+const FIELD_DELETE = "FIELD_DELETE_SENTINEL";
+
+jest.mock("firebase-admin/firestore", () => ({
+  FieldValue: {
+    serverTimestamp: jest.fn(() => SERVER_TIMESTAMP),
+    delete: jest.fn(() => FIELD_DELETE),
+  },
+}));
+
+const mockState: { db: MockDb | null; sessionUid: string } = {
+  db: null,
+  sessionUid: "coach-B",
+};
+
+jest.mock("@/lib/gc-fitness/auth-helpers", () => ({
+  getCurrentTrainer: jest.fn(async () => ({
+    uid: mockState.sessionUid,
+    email: `${mockState.sessionUid}@example.com`,
+  })),
+}));
+
+type AuthUser = {
+  uid: string;
+  email: string;
+  displayName?: string;
+  photoURL?: string | null;
+  customClaims?: Record<string, unknown>;
+};
+const authUsersByEmail = new Map<string, AuthUser>();
+const mockSetCustomUserClaims = jest.fn(async () => undefined);
+
+jest.mock("@/lib/firebase/gc-fitness-admin", () => ({
+  gcFitnessFirestore: () => mockState.db,
+  gcFitnessAuth: () => ({
+    getUserByEmail: async (email: string) => {
+      const user = authUsersByEmail.get(email);
+      if (!user) {
+        throw Object.assign(new Error("no user"), {
+          code: "auth/user-not-found",
+        });
+      }
+      return user;
+    },
+    getUser: async (uid: string) => ({ uid, customClaims: {}, photoURL: null }),
+    setCustomUserClaims: mockSetCustomUserClaims,
+  }),
+}));
+
+import { provisionClient } from "../user-actions";
+import { FirestoreCollections } from "../collections";
+import { normalizeMirrorEmail } from "../email-normalization";
+
+// ── In-memory Firestore mock (merge + FieldValue.delete aware) ────────────
+
+type DocData = Record<string, unknown>;
+
+function applyPatch(base: DocData | undefined, patch: DocData): DocData {
+  const next: DocData = { ...(base ?? {}) };
+  for (const [key, value] of Object.entries(patch)) {
+    if (value === FIELD_DELETE) delete next[key];
+    else next[key] = value;
+  }
+  return next;
+}
+
+class MockDocRef {
+  constructor(
+    private store: Map<string, DocData>,
+    public readonly id: string,
+  ) {}
+  async get() {
+    const data = this.store.get(this.id);
+    return {
+      exists: data !== undefined,
+      id: this.id,
+      data: () => (data ? { ...data } : undefined),
+      get: (field: string) => data?.[field],
+    };
+  }
+  _apply(patch: DocData, merge: boolean) {
+    this.store.set(
+      this.id,
+      merge ? applyPatch(this.store.get(this.id), patch) : applyPatch(undefined, patch),
+    );
+  }
+}
+
+class MockCollection {
+  constructor(private colStore: Map<string, DocData>) {}
+  doc(id: string) {
+    return new MockDocRef(this.colStore, id);
+  }
+}
+
+class MockTxn {
+  private writes: Array<{ ref: MockDocRef; patch: DocData; merge: boolean }> =
+    [];
+  async get(ref: MockDocRef) {
+    return ref.get();
+  }
+  set(ref: MockDocRef, patch: DocData, opts?: { merge?: boolean }) {
+    this.writes.push({ ref, patch, merge: opts?.merge === true });
+    return this;
+  }
+  // Writes are buffered until the tx body resolves — a thrown sentinel
+  // therefore aborts with ZERO writes, mirroring the Admin SDK guarantee
+  // the conflict gate relies on.
+  commit() {
+    for (const w of this.writes) w.ref._apply(w.patch, w.merge);
+  }
+}
+
+class MockDb {
+  collections = new Map<string, Map<string, DocData>>();
+  collection(name: string) {
+    if (!this.collections.has(name)) this.collections.set(name, new Map());
+    return new MockCollection(this.collections.get(name)!);
+  }
+  async runTransaction<T>(fn: (tx: MockTxn) => Promise<T>): Promise<T> {
+    const tx = new MockTxn();
+    const result = await fn(tx);
+    tx.commit();
+    return result;
+  }
+  seed(col: string, id: string, data: DocData) {
+    this.collection(col);
+    this.collections.get(col)!.set(id, { ...data });
+  }
+  read(col: string, id: string): DocData | undefined {
+    return this.collections.get(col)?.get(id);
+  }
+}
+
+// ── Fixtures ──────────────────────────────────────────────────────────────
+
+const CLIENT_EMAIL = "client@example.com";
+const CLIENT_UID = "client-1";
+const MIRROR_ID = normalizeMirrorEmail(CLIENT_EMAIL);
+
+function seedAuthClient(uid = CLIENT_UID) {
+  authUsersByEmail.set(CLIENT_EMAIL, {
+    uid,
+    email: CLIENT_EMAIL,
+    displayName: "Cli Ent",
+    photoURL: null,
+    customClaims: {},
+  });
+  return uid;
+}
+
+function db(): MockDb {
+  return mockState.db!;
+}
+
+beforeEach(() => {
+  mockState.db = new MockDb();
+  mockState.sessionUid = "coach-B";
+  authUsersByEmail.clear();
+  mockSetCustomUserClaims.mockClear();
+  jest.spyOn(console, "warn").mockImplementation(() => undefined);
+});
+
+afterEach(() => {
+  (console.warn as jest.Mock).mockRestore();
+});
+
+// ── CR-01 — claiming a stray clears the stray marker ─────────────────────
+
+describe("CR-01 — stray claim clears autoAssignedCoach", () => {
+  it("existing-user branch: claimed doc loses the marker; a second coach then conflicts", async () => {
+    seedAuthClient();
+    db().seed(FirestoreCollections.users, CLIENT_UID, {
+      coachId: "coach-A",
+      autoAssignedCoach: true,
+      role: "client",
+    });
+
+    const first = await provisionClient({ email: CLIENT_EMAIL });
+    expect(first).toEqual({ ok: true, mode: "attached-existing-user" });
+
+    const doc = db().read(FirestoreCollections.users, CLIENT_UID)!;
+    expect(doc.coachId).toBe("coach-B");
+    // The steal vector: with the marker preserved, rule (3) would still
+    // classify this doc as a claimable stray for ANY other coach.
+    expect("autoAssignedCoach" in doc).toBe(false);
+
+    // Second coach's attempt is now a refused conflict, not a silent steal.
+    mockState.sessionUid = "coach-C";
+    const second = await provisionClient({ email: CLIENT_EMAIL });
+    expect(second).toEqual({ ok: false, mode: "conflict" });
+    expect(db().read(FirestoreCollections.users, CLIENT_UID)!.coachId).toBe(
+      "coach-B",
+    );
+  });
+
+  it("mirror branch: claimed mirror loses the marker too", async () => {
+    db().seed(FirestoreCollections.userMirror, MIRROR_ID, {
+      coachId: "coach-A",
+      autoAssignedCoach: true,
+    });
+
+    const result = await provisionClient({ email: CLIENT_EMAIL });
+    expect(result).toEqual({ ok: true, mode: "precreated-mirror" });
+
+    const mirror = db().read(FirestoreCollections.userMirror, MIRROR_ID)!;
+    expect(mirror.coachId).toBe("coach-B");
+    expect("autoAssignedCoach" in mirror).toBe(false);
+  });
+});
+
+// ── CR-02 — trainer target refused ────────────────────────────────────────
+
+describe("CR-02 — trainer-target refusal", () => {
+  it("refuses another trainer's email with zero writes and zero claims mutation", async () => {
+    seedAuthClient("trainer-X");
+    db().seed(FirestoreCollections.users, "trainer-X", {
+      role: "trainer",
+      displayName: "Other Trainer",
+    });
+
+    const result = await provisionClient({ email: CLIENT_EMAIL });
+    expect(result).toEqual({ ok: false, mode: "trainer-target" });
+
+    const doc = db().read(FirestoreCollections.users, "trainer-X")!;
+    expect(doc.role).toBe("trainer"); // no demotion
+    expect("coachId" in doc).toBe(false); // no ownership write
+    expect(mockSetCustomUserClaims).not.toHaveBeenCalled(); // no claims clobber
+    expect(
+      db().read(FirestoreCollections.chats, "trainer-X"),
+    ).toBeUndefined(); // no chat doc
+  });
+});
+
+// ── CR-03 — refusals are results, not thrown messages ─────────────────────
+
+describe("CR-03 — discriminated refusal results", () => {
+  it("conflict RETURNS { ok: false, mode: 'conflict' } (never throws) with zero writes", async () => {
+    seedAuthClient();
+    db().seed(FirestoreCollections.users, CLIENT_UID, {
+      coachId: "coach-A",
+      role: "client",
+    });
+
+    // Must not throw — a thrown Error's message is masked by prod Next.js.
+    const result = await provisionClient({ email: CLIENT_EMAIL });
+    expect(result).toEqual({ ok: false, mode: "conflict" });
+
+    const doc = db().read(FirestoreCollections.users, CLIENT_UID)!;
+    expect(doc.coachId).toBe("coach-A"); // untouched
+    expect(mockSetCustomUserClaims).not.toHaveBeenCalled();
+    expect(db().read(FirestoreCollections.chats, CLIENT_UID)).toBeUndefined();
+  });
+
+  it("mirror-branch conflict returns the same result shape with the mirror untouched", async () => {
+    db().seed(FirestoreCollections.userMirror, MIRROR_ID, {
+      coachId: "coach-A",
+    });
+
+    const result = await provisionClient({ email: CLIENT_EMAIL });
+    expect(result).toEqual({ ok: false, mode: "conflict" });
+    expect(
+      db().read(FirestoreCollections.userMirror, MIRROR_ID)!.coachId,
+    ).toBe("coach-A");
+  });
+
+  it("self-add returns { ok: false, mode: 'self' } instead of throwing", async () => {
+    authUsersByEmail.set(CLIENT_EMAIL, {
+      uid: "coach-B", // the session coach themself
+      email: CLIENT_EMAIL,
+      customClaims: {},
+    });
+
+    const result = await provisionClient({ email: CLIENT_EMAIL });
+    expect(result).toEqual({ ok: false, mode: "self" });
+    expect(mockSetCustomUserClaims).not.toHaveBeenCalled();
+  });
+});
+
+// ── WR-01 — claims heal on the alreadyYours retry path ────────────────────
+
+describe("WR-01 — alreadyYours re-syncs claims", () => {
+  it("runs the idempotent setCustomUserClaims even when the doc is already linked", async () => {
+    seedAuthClient();
+    db().seed(FirestoreCollections.users, CLIENT_UID, {
+      coachId: "coach-B",
+      role: "client",
+    });
+
+    const result = await provisionClient({ email: CLIENT_EMAIL });
+    expect(result).toEqual({ ok: true, mode: "already-linked" });
+
+    // The retry after a post-commit claims failure lands here — the claims
+    // write must run so the doc/claims divergence heals on resubmit.
+    expect(mockSetCustomUserClaims).toHaveBeenCalledWith(
+      CLIENT_UID,
+      expect.objectContaining({ role: "client", coachId: "coach-B" }),
+    );
+  });
+});
+
+// ── WR-02 — chat payload hygiene ──────────────────────────────────────────
+
+describe("WR-02 — chat write payload", () => {
+  it("preserves an existing chat's createdAt and unreadCount on (re-)link", async () => {
+    seedAuthClient();
+    db().seed(FirestoreCollections.users, CLIENT_UID, {
+      coachId: "coach-A",
+      autoAssignedCoach: true, // claimable stray with chat history
+      role: "client",
+    });
+    db().seed(FirestoreCollections.chats, CLIENT_UID, {
+      clientId: CLIENT_UID,
+      coachId: "coach-A",
+      createdAt: "ORIGINAL_CREATED_AT",
+      unreadCount: { "coach-A": 3, [CLIENT_UID]: 1 },
+    });
+
+    const result = await provisionClient({ email: CLIENT_EMAIL });
+    expect(result).toEqual({ ok: true, mode: "attached-existing-user" });
+
+    const chat = db().read(FirestoreCollections.chats, CLIENT_UID)!;
+    expect(chat.createdAt).toBe("ORIGINAL_CREATED_AT"); // NOT reset to now
+    expect(chat.unreadCount).toEqual({ "coach-A": 3, [CLIENT_UID]: 1 });
+    expect(chat.coachId).toBe("coach-B");
+  });
+
+  it("stamps createdAt only when the chat doc does not exist yet", async () => {
+    seedAuthClient();
+    db().seed(FirestoreCollections.users, CLIENT_UID, { role: "client" });
+
+    await provisionClient({ email: CLIENT_EMAIL });
+
+    const chat = db().read(FirestoreCollections.chats, CLIENT_UID)!;
+    expect(chat.createdAt).toBe(SERVER_TIMESTAMP);
+    // The bogus always-{} unreadCount write is gone entirely.
+    expect("unreadCount" in chat).toBe(false);
+  });
+});

--- a/backoffice/src/lib/gc-fitness/client-roster.ts
+++ b/backoffice/src/lib/gc-fitness/client-roster.ts
@@ -47,6 +47,7 @@ import { getCurrentTrainer } from "./auth-helpers";
 import { FirestoreCollections } from "./collections";
 import { coachVisibleClientName } from "./client-name";
 import { coerceLegacyHabitLogValue } from "./habit-compliance";
+import { isHabitNotDeleted } from "./habit-visibility";
 import { civilDateToday } from "./civil-date";
 import { getTrainerTimezone } from "./trainer-timezone";
 import {
@@ -533,14 +534,17 @@ export async function listClientsForRoster(): Promise<ClientRosterRow[]> {
         // every roster (260528 bug). Mirrors the exclusion in
         // listRecentLogsForTrainer.
         db.collection(FirestoreCollections.chats).doc(c.uid).get(),
+        // Issue #437/#400: fetch by clientId only; filter `deleted === true`
+        // in memory (isHabitNotDeleted) below. A `.where("deleted","==",false)`
+        // equality drops client-created habits that never write the field, so
+        // the compliance counts under-reported them. PR #230 pattern.
         db
           .collection(FirestoreCollections.habits)
           .where("clientId", "==", c.uid)
-          .where("deleted", "==", false)
           // 260529 cost backstop: a roster row never needs more than a
           // sane ceiling of habits; the compliance math below tolerates the
           // cap (no real client carries >60 active habits). Bounds the
-          // worst-case read on the (clientId, deleted, updatedAt) index.
+          // worst-case read on the (clientId, updatedAt) index.
           .limit(60)
           .get(),
         // 11-06: assignments scheduled in the last 7 civil days. scheduledFor
@@ -662,7 +666,9 @@ export async function listClientsForRoster(): Promise<ClientRosterRow[]> {
       // snapshot by habitId ONCE (replaces a per-habit query fan-out), then
       // compute per-habit ratio via the Pattern-B pure function and average.
       // The same grouped map feeds the trailing-7 habit-count loop below.
-      const habitDocs = clientHabits.docs;
+      const habitDocs = clientHabits.docs.filter((d) =>
+        isHabitNotDeleted(d.data() as Record<string, unknown>),
+      );
       const windowedLogsByHabit = new Map<string, HabitLogRow[]>();
       for (const ldoc of windowedHabitLogs.docs) {
         const data = ldoc.data() as Record<string, unknown>;

--- a/backoffice/src/lib/gc-fitness/client-roster.ts
+++ b/backoffice/src/lib/gc-fitness/client-roster.ts
@@ -543,9 +543,14 @@ export async function listClientsForRoster(): Promise<ClientRosterRow[]> {
           .where("clientId", "==", c.uid)
           // 260529 cost backstop: a roster row never needs more than a
           // sane ceiling of habits; the compliance math below tolerates the
-          // cap (no real client carries >60 active habits). Bounds the
-          // worst-case read on the (clientId, updatedAt) index.
-          .limit(60)
+          // cap (no real client carries >60 active habits).
+          // WR-03: the cap counts SOFT-DELETED docs too (filtered in memory
+          // after the fetch) and soft-delete is the only delete path, so
+          // deleted docs accumulate toward it over a client's lifetime —
+          // raised 60 → 150; a truncation warning fires below when the raw
+          // fetch hits the cap. Costs nothing unless the docs exist
+          // (limit is a ceiling, not a fetch-always).
+          .limit(150)
           .get(),
         // 11-06: assignments scheduled in the last 7 civil days. scheduledFor
         // is a "YYYY-MM-DD" string — lexicographic comparison is correct
@@ -666,6 +671,15 @@ export async function listClientsForRoster(): Promise<ClientRosterRow[]> {
       // snapshot by habitId ONCE (replaces a per-habit query fan-out), then
       // compute per-habit ratio via the Pattern-B pure function and average.
       // The same grouped map feeds the trailing-7 habit-count loop below.
+      if (clientHabits.docs.length >= 150) {
+        // WR-03: raw habit fetch filled the cap — soft-deleted docs consume
+        // the budget, so live habits (and the compliance denominators built
+        // from them) may be truncated for this client.
+        console.warn(
+          "[gc-fitness/roster] habit fetch hit its cap — live habits may be truncated",
+          { clientId: c.uid, cap: 150 },
+        );
+      }
       const habitDocs = clientHabits.docs.filter((d) =>
         isHabitNotDeleted(d.data() as Record<string, unknown>),
       );

--- a/backoffice/src/lib/gc-fitness/coach-link.ts
+++ b/backoffice/src/lib/gc-fitness/coach-link.ts
@@ -1,0 +1,64 @@
+// coach-link.ts
+//
+// PURE decision helper for the provisionClient conflict gate (Phase 32,
+// LINK-01). This module is intentionally I/O-free: no Admin SDK, no
+// Firestore, no "use server" — it takes the freshly-read target doc (a
+// /users/{uid} doc OR a /user_mirror/{email} doc) plus the requesting
+// coach's session uid and returns the link decision. Keeping it pure makes
+// the steal-vector logic jest-testable in isolation and lets BOTH
+// provisionClient branches (existing-user + mirror) share one authority.
+//
+// Outcomes (D-01 / 32-CONTEXT.md):
+//   - link         → coach-less target OR a claimable stray → safe to write.
+//   - alreadyYours → the target is already YOUR client → friendly no-op.
+//   - conflict     → the target has a DIFFERENT real coach → REFUSE (no
+//                    writes); the caller routes the coach to support. The
+//                    currentCoachId is for server-side audit ONLY and MUST
+//                    NEVER be forwarded to the requesting coach (enumeration
+//                    disclosure is bounded — threat T-32-ENUM / T-32-E2).
+//
+// Claimable stray = `autoAssignedCoach === true` (a doc field mirroring the
+// Phase 29 fallback-coach migration predicate) — a fallback-coached user is
+// claimable without conflict. We deliberately do NOT import or reference the
+// functions-repo fallback-coach uid: the predicate is the boolean field, not
+// a hardcoded uid comparison.
+
+export type LinkOutcome =
+  | { kind: "link" }
+  | { kind: "alreadyYours" }
+  | { kind: "conflict"; currentCoachId: string };
+
+export interface LinkTargetDoc {
+  coachId?: string | null;
+  autoAssignedCoach?: boolean;
+}
+
+/**
+ * Decide how a coach's "add client by email" request should resolve against
+ * the freshly-read target doc. Pure — call this INSIDE a transaction on the
+ * tx-read snapshot so the decision is authoritative against concurrent
+ * writers (T-32-TOCTOU).
+ */
+export function decideLinkOutcome(
+  existing: LinkTargetDoc | null,
+  sessionUid: string,
+): LinkOutcome {
+  // (1) Normalize: empty / whitespace-only coachId is treated as no coach.
+  const coachId = existing?.coachId?.trim() || null;
+  if (!coachId) {
+    return { kind: "link" };
+  }
+
+  // (2) Already your client — friendly no-op (wins over the stray rule).
+  if (coachId === sessionUid) {
+    return { kind: "alreadyYours" };
+  }
+
+  // (3) Claimable stray — a fallback-auto-assigned coach is claimable.
+  if (existing?.autoAssignedCoach === true) {
+    return { kind: "link" };
+  }
+
+  // (4) A different real coach owns this client — refuse.
+  return { kind: "conflict", currentCoachId: coachId };
+}

--- a/backoffice/src/lib/gc-fitness/coach-link.ts
+++ b/backoffice/src/lib/gc-fitness/coach-link.ts
@@ -28,6 +28,30 @@ export type LinkOutcome =
   | { kind: "alreadyYours" }
   | { kind: "conflict"; currentCoachId: string };
 
+/**
+ * Refusal modes surfaced to the ProvisionClientForm as a RETURN VALUE, never
+ * as a thrown Error message (CR-03): Next.js masks Server-Action error
+ * messages in production builds ("An error occurred in the Server
+ * Components render..." + digest), so localized copy carried on
+ * `err.message` degrades to a generic string exactly in prod. The form maps
+ * each mode to its own client-side translation key instead.
+ */
+export type LinkRefusalMode = "conflict" | "self";
+
+/**
+ * Sentinel thrown INSIDE the provisionClient transactions to abort them
+ * before any write (the Admin SDK aborts a tx whose body throws, and does
+ * not retry non-contention errors). provisionClient catches this sentinel
+ * and converts it into a `{ ok: false, mode }` result — the message is
+ * intentionally NOT user-facing (see LinkRefusalMode).
+ */
+export class LinkRefusedError extends Error {
+  constructor(public readonly mode: LinkRefusalMode) {
+    super(`link refused: ${mode}`);
+    this.name = "LinkRefusedError";
+  }
+}
+
 export interface LinkTargetDoc {
   coachId?: string | null;
   autoAssignedCoach?: boolean;

--- a/backoffice/src/lib/gc-fitness/coach-link.ts
+++ b/backoffice/src/lib/gc-fitness/coach-link.ts
@@ -26,7 +26,13 @@
 export type LinkOutcome =
   | { kind: "link" }
   | { kind: "alreadyYours" }
-  | { kind: "conflict"; currentCoachId: string };
+  | { kind: "conflict"; currentCoachId: string }
+  // CR-02: the target doc is a TRAINER account. A trainer email can never be
+  // linked as a client — without this refusal, a coach typing another
+  // trainer's email would overwrite their user doc (role → "client",
+  // coachId → attacker) and, post-commit, clobber their role claim,
+  // demoting them to a client and locking them out of the backoffice.
+  | { kind: "trainerTarget" };
 
 /**
  * Refusal modes surfaced to the ProvisionClientForm as a RETURN VALUE, never
@@ -36,7 +42,7 @@ export type LinkOutcome =
  * `err.message` degrades to a generic string exactly in prod. The form maps
  * each mode to its own client-side translation key instead.
  */
-export type LinkRefusalMode = "conflict" | "self";
+export type LinkRefusalMode = "conflict" | "trainer-target" | "self";
 
 /**
  * Sentinel thrown INSIDE the provisionClient transactions to abort them
@@ -55,6 +61,7 @@ export class LinkRefusedError extends Error {
 export interface LinkTargetDoc {
   coachId?: string | null;
   autoAssignedCoach?: boolean;
+  role?: string | null;
 }
 
 /**
@@ -67,6 +74,15 @@ export function decideLinkOutcome(
   existing: LinkTargetDoc | null,
   sessionUid: string,
 ): LinkOutcome {
+  // (0) CR-02: a trainer account is never a linkable client — refuse before
+  // any other rule (a trainer doc usually has NO coachId, which rule (1)
+  // would otherwise happily classify as "link" and demote the trainer).
+  // Wins over alreadyYours/stray too: no coachId combination makes
+  // overwriting a trainer doc acceptable.
+  if (existing?.role === "trainer") {
+    return { kind: "trainerTarget" };
+  }
+
   // (1) Normalize: empty / whitespace-only coachId is treated as no coach.
   const coachId = existing?.coachId?.trim() || null;
   if (!coachId) {

--- a/backoffice/src/lib/gc-fitness/habit-actions.ts
+++ b/backoffice/src/lib/gc-fitness/habit-actions.ts
@@ -1912,9 +1912,19 @@ export async function assignHabitTemplateToPending(input: unknown): Promise<{
  * Note: listHabitsForClient is currently UI-unused; it is fixed here for
  * parity with the three live surfaces (D-03 discretion: prefer fix + note).
  *
- *  - Bounded at 200 — T-06-05-07.
+ *  - Bounded at 500 — T-06-05-07. WR-03: the cap counts SOFT-DELETED docs
+ *    too (they are filtered in memory AFTER the fetch), and soft-delete is
+ *    the only delete path (`allow delete: if false`), so deleted docs
+ *    accumulate monotonically toward the cap over a client's lifetime.
+ *    Raised 200 → 500 to keep live habits from silently dropping out, and
+ *    a truncation warning fires when the raw fetch hits the cap. We
+ *    deliberately do NOT re-add `.orderBy("updatedAt")`: Firestore orderBy
+ *    EXCLUDES docs missing the field, which would re-drop field-sparse
+ *    (older/seeded) habit docs — the very regression this filter fixed.
  *  - Excludes soft-deleted (deleted === true) in memory.
  */
+const LIST_HABITS_FOR_CLIENT_CAP = 500;
+
 export async function listHabitsForClient(
   clientId: string,
 ): Promise<HabitRow[]> {
@@ -1924,8 +1934,17 @@ export async function listHabitsForClient(
   const snap = await db
     .collection(COLLECTION)
     .where("clientId", "==", clientId)
-    .limit(200)
+    .limit(LIST_HABITS_FOR_CLIENT_CAP)
     .get();
+
+  if (snap.docs.length >= LIST_HABITS_FOR_CLIENT_CAP) {
+    // WR-03: raw fetch filled the cap — live habits may have been truncated
+    // (which docs survive is doc-ID order, deleted docs included).
+    console.warn(
+      "[gc-fitness/habits] listHabitsForClient hit its fetch cap — live habits may be truncated",
+      { clientId, cap: LIST_HABITS_FOR_CLIENT_CAP },
+    );
+  }
 
   const rows = snap.docs
     .filter((d) => isHabitNotDeleted(d.data() as Record<string, unknown>))

--- a/backoffice/src/lib/gc-fitness/habit-actions.ts
+++ b/backoffice/src/lib/gc-fitness/habit-actions.ts
@@ -53,6 +53,7 @@ import {
 } from "./coach-activity-log";
 import { FirestoreCollections } from "./collections";
 import { normalizeMirrorEmail } from "./email-normalization";
+import { isHabitNotDeleted } from "./habit-visibility";
 
 const COLLECTION = FirestoreCollections.habits;
 const TEMPLATE_COLLECTION = FirestoreCollections.habitTemplates;
@@ -1888,26 +1889,31 @@ export async function assignHabitTemplateToPending(input: unknown): Promise<{
 /**
  * Lists habits assigned to a single client by the calling trainer.
  *
- * Implementation note (Plan-Task 2 choice (b)): the query scopes by
- * `clientId + deleted` and lets the rule layer (P06-03) enforce the
- * `trainerId == auth.uid` precondition on read. Rationale:
- *   - A 4-field composite index would otherwise be required
- *     (`clientId+trainerId+deleted+updatedAt DESC`); not declared in
- *     `firestore.indexes.json` from P06-01.
- *   - The rule layer is sufficient: any returned doc must already satisfy
- *     `trainerId == auth.uid OR clientId == auth.uid`. Since this Server
- *     Action is invoked by an authed trainer (getCurrentTrainer guard),
- *     a doc owned by a different trainer would surface as a
- *     PERMISSION_DENIED on Firestore-rule evaluation — except that the
- *     Admin SDK bypasses rules, so we re-enforce here at the application
- *     layer via the post-query filter.
+ * Implementation note (LINK-03 / issue #437 / PR #230): the query scopes by
+ * `clientId` ONLY, then filters + sorts in memory. Rationale:
+ *   - A `.where("deleted","==",false)` equality only matches docs where the
+ *     field EXISTS. Client-created habits (issue #400) are written WITHOUT a
+ *     `deleted` field, so that clause silently dropped every one of them.
+ *     `isHabitNotDeleted` (deleted !== true) keeps them while still excluding
+ *     genuinely soft-deleted rows.
+ *   - Dropping the equality also removes the `orderBy("updatedAt")` composite
+ *     requirement, so we sort by updatedAt desc in memory (no new index).
  *
- * Defense-in-depth: we additionally filter the result client-of-DB to
- * `row.trainerId === session.uid` so a misbehaving rule (or a future rule
- * relaxation) cannot leak cross-trainer habits.
+ * Ownership gate (T-32-03): the Admin SDK bypasses Firestore rules, so the
+ * app layer is the only gate. A row is returned when it is either authored by
+ * the requesting trainer (`trainerId === trainer.uid`) OR the queried client
+ * belongs to this trainer (`users/{clientId}.coachId === trainer.uid`,
+ * mirroring currentTrainerCanManageHabit). This is the belongs-to-my-client
+ * check — so a formerly coach-less client's self-created habits (whose
+ * `trainerId` is the client's own uid) and any old-coach habits become
+ * visible to the current coach, while a client belonging to another trainer
+ * yields only the requesting trainer's own-authored rows.
+ *
+ * Note: listHabitsForClient is currently UI-unused; it is fixed here for
+ * parity with the three live surfaces (D-03 discretion: prefer fix + note).
  *
  *  - Bounded at 200 — T-06-05-07.
- *  - Excludes soft-deleted.
+ *  - Excludes soft-deleted (deleted === true) in memory.
  */
 export async function listHabitsForClient(
   clientId: string,
@@ -1918,14 +1924,28 @@ export async function listHabitsForClient(
   const snap = await db
     .collection(COLLECTION)
     .where("clientId", "==", clientId)
-    .where("deleted", "==", false)
-    .orderBy("updatedAt", "desc")
     .limit(200)
     .get();
 
-  const rows = snap.docs.map((d) =>
-    projectHabitRow(d.id, d.data() as Record<string, unknown>),
+  const rows = snap.docs
+    .filter((d) => isHabitNotDeleted(d.data() as Record<string, unknown>))
+    .map((d) => projectHabitRow(d.id, d.data() as Record<string, unknown>))
+    // updatedAt is an ISO string; desc lexicographic sort preserves the old
+    // orderBy("updatedAt","desc") output order without a composite index.
+    .sort((a, b) => (b.updatedAt ?? "").localeCompare(a.updatedAt ?? ""));
+
+  // Belongs-to-my-client: ONE point-read (getAll fails on Vercel — use a
+  // single .doc().get()). If the queried client is coached by this trainer,
+  // every row (self-created / old-coach) is theirs to see; otherwise fall
+  // back to own-authored rows only.
+  const clientSnap = await db
+    .collection(FirestoreCollections.users)
+    .doc(clientId)
+    .get();
+  const clientBelongsToMe =
+    clientSnap.exists && clientSnap.get("coachId") === trainer.uid;
+
+  return rows.filter(
+    (r) => r.trainerId === trainer.uid || clientBelongsToMe,
   );
-  // Defense-in-depth: Admin SDK bypasses rules; re-check ownership here.
-  return rows.filter((r) => r.trainerId === trainer.uid);
 }

--- a/backoffice/src/lib/gc-fitness/habit-visibility.ts
+++ b/backoffice/src/lib/gc-fitness/habit-visibility.ts
@@ -1,0 +1,18 @@
+// habit-visibility.ts
+//
+// Pure, I/O-free predicate for the per-client habit surfaces. It replaces the
+// Firestore `.where("deleted","==",false)` equality that silently dropped
+// client-created habits.
+//
+// Issue #437 / PR #230: a Firestore equality filter only matches docs where
+// the field EXISTS. Client-created habits (issue #400) are written WITHOUT a
+// `deleted` field (the rules forbid it at create), so `deleted == false`
+// excluded every one of them. The fix is to fetch by `clientId` only and
+// filter in memory here: ONLY a strict boolean `true` is soft-deleted; a
+// missing / undefined / null / false field means the habit is visible.
+//
+// No Admin SDK import — this stays testable in isolation and reusable across
+// server components + server actions.
+export function isHabitNotDeleted(habit: { deleted?: unknown }): boolean {
+  return habit.deleted !== true;
+}

--- a/backoffice/src/lib/gc-fitness/user-actions.ts
+++ b/backoffice/src/lib/gc-fitness/user-actions.ts
@@ -52,7 +52,6 @@
 import { cookies } from "next/headers";
 import { revalidateTag } from "next/cache";
 import { FieldValue } from "firebase-admin/firestore";
-import { getTranslations } from "next-intl/server";
 import { z } from "zod";
 
 import {
@@ -61,7 +60,12 @@ import {
 } from "@/lib/firebase/gc-fitness-admin";
 
 import { getCurrentTrainer } from "./auth-helpers";
-import { decideLinkOutcome, type LinkOutcome } from "./coach-link";
+import {
+  decideLinkOutcome,
+  LinkRefusedError,
+  type LinkOutcome,
+  type LinkRefusalMode,
+} from "./coach-link";
 import { FirestoreCollections } from "./collections";
 import { normalizeMirrorEmail } from "./email-normalization";
 
@@ -383,11 +387,22 @@ export async function updateClientNickname(
  * `/users/{uid}` and sets custom claims so the iOS app can read/write under
  * the normal client rules immediately. If the email does not exist yet, it
  * creates `/user_mirror/{email}` for the first-sign-in provisioning path.
+ *
+ * REFUSALS ARE RETURN VALUES, NOT THROWN ERRORS (CR-03): production Next.js
+ * masks Server-Action error messages (generic copy + digest), so a thrown
+ * localized message renders as a generic error exactly in the auto-deployed
+ * prod build. Expected refusals (conflict / self-add) come back as
+ * `{ ok: false, mode }`; the form maps the mode to client-side translated
+ * copy. The tx-internal throw is a sentinel (LinkRefusedError) whose only
+ * job is aborting the transaction before any write.
  */
-export async function provisionClient(input: unknown): Promise<{
-  ok: true;
-  mode: "attached-existing-user" | "precreated-mirror" | "already-linked";
-}> {
+export async function provisionClient(input: unknown): Promise<
+  | {
+      ok: true;
+      mode: "attached-existing-user" | "precreated-mirror" | "already-linked";
+    }
+  | { ok: false; mode: LinkRefusalMode }
+> {
   const session = await getCurrentTrainer();
   const parsed = provisionClientSchema.parse(input);
   const db = gcFitnessFirestore();
@@ -395,9 +410,6 @@ export async function provisionClient(input: unknown): Promise<{
   const coach = await trainerProfile(session.uid, session.email);
   const coachDisplayName = coach.displayName;
   const displayName = parsed.displayName || fallbackName(parsed.email);
-  // Localized conflict copy — built once, rendered verbatim by the form's red
-  // HelperBanner. MUST NOT name the other coach (threat T-32-ENUM).
-  const tErr = await getTranslations("clients.provisionForm");
 
   let authUser: Awaited<ReturnType<typeof auth.getUserByEmail>> | null = null;
   try {
@@ -414,7 +426,9 @@ export async function provisionClient(input: unknown): Promise<{
     const mirrorRef = db
       .collection(FirestoreCollections.userMirror)
       .doc(parsed.email);
-    const mirrorOutcomeKind = await db.runTransaction<LinkOutcome["kind"]>(
+    let mirrorOutcomeKind: LinkOutcome["kind"];
+    try {
+      mirrorOutcomeKind = await db.runTransaction<LinkOutcome["kind"]>(
       async (tx) => {
         const mirrorSnap = await tx.get(mirrorRef);
         const outcome = decideLinkOutcome(
@@ -433,8 +447,10 @@ export async function provisionClient(input: unknown): Promise<{
             targetUid: null,
             existingCoachId: outcome.currentCoachId,
           });
-          // Throw INSIDE the tx → aborts before any write.
-          throw new Error(tErr("conflictError", { email: parsed.email }));
+          // Sentinel throw INSIDE the tx → aborts before any write (CR-03:
+          // caught below and converted to a { ok: false } result — the
+          // message never travels to the browser, so prod masking is moot).
+          throw new LinkRefusedError("conflict");
         }
         if (outcome.kind === "alreadyYours") {
           return "alreadyYours"; // no write — friendly no-op surfaced below
@@ -462,7 +478,13 @@ export async function provisionClient(input: unknown): Promise<{
         );
         return "link";
       },
-    );
+      );
+    } catch (err) {
+      if (err instanceof LinkRefusedError) {
+        return { ok: false, mode: err.mode };
+      }
+      throw err;
+    }
     if (mirrorOutcomeKind === "alreadyYours") {
       return { ok: true, mode: "already-linked" };
     }
@@ -471,7 +493,8 @@ export async function provisionClient(input: unknown): Promise<{
   }
 
   if (authUser.uid === session.uid) {
-    throw new Error("You cannot add yourself as a client.");
+    // CR-03: expected refusal → result, not a thrown (prod-masked) message.
+    return { ok: false, mode: "self" };
   }
 
   // EXISTING-USER branch. Read-before-write the /users doc INSIDE the tx and
@@ -480,7 +503,9 @@ export async function provisionClient(input: unknown): Promise<{
   // whose doc was never written (threat T-32-DIVERGE).
   const userRef = db.collection(FirestoreCollections.users).doc(authUser.uid);
   const chatRef = db.collection(FirestoreCollections.chats).doc(authUser.uid);
-  const userOutcomeKind = await db.runTransaction<LinkOutcome["kind"]>(
+  let userOutcomeKind: LinkOutcome["kind"];
+  try {
+    userOutcomeKind = await db.runTransaction<LinkOutcome["kind"]>(
     async (tx) => {
       const userSnap = await tx.get(userRef);
       const data = userSnap.exists ? userSnap.data() ?? {} : {};
@@ -497,8 +522,9 @@ export async function provisionClient(input: unknown): Promise<{
           targetUid: authUser.uid,
           existingCoachId: outcome.currentCoachId,
         });
-        // Throw INSIDE the tx → aborts before any write; claims still untouched.
-        throw new Error(tErr("conflictError", { email: parsed.email }));
+        // Sentinel throw INSIDE the tx → aborts before any write; claims
+        // still untouched (CR-03: converted to a result below).
+        throw new LinkRefusedError("conflict");
       }
       if (outcome.kind === "alreadyYours") {
         return "alreadyYours"; // no writes, no claims mutation
@@ -548,7 +574,13 @@ export async function provisionClient(input: unknown): Promise<{
       );
       return "link";
     },
-  );
+    );
+  } catch (err) {
+    if (err instanceof LinkRefusedError) {
+      return { ok: false, mode: err.mode };
+    }
+    throw err;
+  }
 
   if (userOutcomeKind === "alreadyYours") {
     return { ok: true, mode: "already-linked" };

--- a/backoffice/src/lib/gc-fitness/user-actions.ts
+++ b/backoffice/src/lib/gc-fitness/user-actions.ts
@@ -255,6 +255,21 @@ function logLinkConflictRefused(params: {
   console.warn("[gc-fitness/coach-link] link_conflict_refused", params);
 }
 
+/**
+ * CR-02 audit line for a refused trainer-target link attempt. Server-side
+ * console only — same T-32-E2 confinement as logLinkConflictRefused: this
+ * MUST NOT flow into the coach-activity event log, and the requesting coach
+ * only ever sees the mode-keyed banner copy (which names the typed email,
+ * never the fact that the doc belongs to a trainer's roster or claims).
+ */
+function logLinkTrainerTargetRefused(params: {
+  actorUid: string;
+  targetEmail: string;
+  targetUid: string | null;
+}): void {
+  console.warn("[gc-fitness/coach-link] link_trainer_target_refused", params);
+}
+
 async function trainerProfile(
   uid: string,
   email: string,
@@ -436,10 +451,21 @@ export async function provisionClient(input: unknown): Promise<
             ? (mirrorSnap.data() as {
                 coachId?: string | null;
                 autoAssignedCoach?: boolean;
+                role?: string | null;
               })
             : null,
           session.uid,
         );
+        if (outcome.kind === "trainerTarget") {
+          // CR-02: mirror docs shouldn't carry role, but if one ever does,
+          // refuse for the same reason as the /users branch below.
+          logLinkTrainerTargetRefused({
+            actorUid: session.uid,
+            targetEmail: parsed.email,
+            targetUid: null,
+          });
+          throw new LinkRefusedError("trainer-target");
+        }
         if (outcome.kind === "conflict") {
           logLinkConflictRefused({
             actorUid: session.uid,
@@ -511,10 +537,26 @@ export async function provisionClient(input: unknown): Promise<
       const data = userSnap.exists ? userSnap.data() ?? {} : {};
       const outcome = decideLinkOutcome(
         userSnap.exists
-          ? (data as { coachId?: string | null; autoAssignedCoach?: boolean })
+          ? (data as {
+              coachId?: string | null;
+              autoAssignedCoach?: boolean;
+              role?: string | null;
+            })
           : null,
         session.uid,
       );
+      if (outcome.kind === "trainerTarget") {
+        // CR-02: the target is another TRAINER's account — linking would
+        // overwrite their doc (role → "client", coachId → this coach) and
+        // then clobber their role claim post-commit, demoting and locking
+        // them out. Refuse before any write.
+        logLinkTrainerTargetRefused({
+          actorUid: session.uid,
+          targetEmail: parsed.email,
+          targetUid: authUser.uid,
+        });
+        throw new LinkRefusedError("trainer-target");
+      }
       if (outcome.kind === "conflict") {
         logLinkConflictRefused({
           actorUid: session.uid,

--- a/backoffice/src/lib/gc-fitness/user-actions.ts
+++ b/backoffice/src/lib/gc-fitness/user-actions.ts
@@ -569,7 +569,10 @@ export async function provisionClient(input: unknown): Promise<
         throw new LinkRefusedError("conflict");
       }
       if (outcome.kind === "alreadyYours") {
-        return "alreadyYours"; // no writes, no claims mutation
+        // No doc writes; claims ARE (re-)synced post-commit — WR-01: the
+        // idempotent setCustomUserClaims below heals a divergence left by a
+        // prior post-commit claims failure when the trainer resubmits.
+        return "alreadyYours";
       }
       tx.set(
         userRef,
@@ -624,17 +627,25 @@ export async function provisionClient(input: unknown): Promise<
     throw err;
   }
 
-  if (userOutcomeKind === "alreadyYours") {
-    return { ok: true, mode: "already-linked" };
-  }
-
   // Claims AFTER the doc-write commit (T-32-DIVERGE): the benign direction
   // (doc written, claims lag) self-heals via the Phase 30 forced token refresh.
+  //
+  // WR-01: this ALSO runs on the alreadyYours path. If a previous submit
+  // committed the tx but the claims call failed (network blip / Auth outage),
+  // the trainer's natural recovery is to resubmit — which now resolves to
+  // alreadyYours. Skipping claims there would leave the doc/claims divergence
+  // unrepairable from the UI. The call is an idempotent no-op when claims
+  // already match, so running it on every resolution of the existing-user
+  // branch is safe and heals the divergence on retry.
   await auth.setCustomUserClaims(authUser.uid, {
     ...(authUser.customClaims ?? {}),
     role: "client",
     coachId: session.uid,
   });
+
+  if (userOutcomeKind === "alreadyYours") {
+    return { ok: true, mode: "already-linked" };
+  }
 
   revalidateTag("gc-fitness-roster", "max");
   return { ok: true, mode: "attached-existing-user" };

--- a/backoffice/src/lib/gc-fitness/user-actions.ts
+++ b/backoffice/src/lib/gc-fitness/user-actions.ts
@@ -52,6 +52,7 @@
 import { cookies } from "next/headers";
 import { revalidateTag } from "next/cache";
 import { FieldValue } from "firebase-admin/firestore";
+import { getTranslations } from "next-intl/server";
 import { z } from "zod";
 
 import {
@@ -60,6 +61,7 @@ import {
 } from "@/lib/firebase/gc-fitness-admin";
 
 import { getCurrentTrainer } from "./auth-helpers";
+import { decideLinkOutcome, type LinkOutcome } from "./coach-link";
 import { FirestoreCollections } from "./collections";
 import { normalizeMirrorEmail } from "./email-normalization";
 
@@ -232,6 +234,23 @@ function fallbackName(email: string): string {
   return localPart || email;
 }
 
+/**
+ * D-02 refused-steal audit. A single support-triage server log line for a
+ * refused coach-link conflict. Deliberately NOT written to the coach-activity
+ * event log or the admin-operations log — those surface in the REQUESTING
+ * coach's My-Activity feed and would leak the other coach's identity (threat
+ * T-32-E2). The existingCoachId is safe ONLY here, in a server-side log line
+ * the requesting coach can never read.
+ */
+function logLinkConflictRefused(params: {
+  actorUid: string;
+  targetEmail: string;
+  targetUid: string | null;
+  existingCoachId: string;
+}): void {
+  console.warn("[gc-fitness/coach-link] link_conflict_refused", params);
+}
+
 async function trainerProfile(
   uid: string,
   email: string,
@@ -365,9 +384,10 @@ export async function updateClientNickname(
  * the normal client rules immediately. If the email does not exist yet, it
  * creates `/user_mirror/{email}` for the first-sign-in provisioning path.
  */
-export async function provisionClient(
-  input: unknown,
-): Promise<{ ok: true; mode: "attached-existing-user" | "precreated-mirror" }> {
+export async function provisionClient(input: unknown): Promise<{
+  ok: true;
+  mode: "attached-existing-user" | "precreated-mirror" | "already-linked";
+}> {
   const session = await getCurrentTrainer();
   const parsed = provisionClientSchema.parse(input);
   const db = gcFitnessFirestore();
@@ -375,6 +395,9 @@ export async function provisionClient(
   const coach = await trainerProfile(session.uid, session.email);
   const coachDisplayName = coach.displayName;
   const displayName = parsed.displayName || fallbackName(parsed.email);
+  // Localized conflict copy — built once, rendered verbatim by the form's red
+  // HelperBanner. MUST NOT name the other coach (threat T-32-ENUM).
+  const tErr = await getTranslations("clients.provisionForm");
 
   let authUser: Awaited<ReturnType<typeof auth.getUserByEmail>> | null = null;
   try {
@@ -385,20 +408,58 @@ export async function provisionClient(
   }
 
   if (!authUser) {
-    await db.collection(FirestoreCollections.userMirror).doc(parsed.email).set(
-      {
-        email: parsed.email,
-        displayName,
-        coachId: session.uid,
-        coachDisplayName,
-        coachPhotoURL: coach.photoURL,
-        coachBio: coach.bio,
-        pre_created: true,
-        createdAt: FieldValue.serverTimestamp(),
-        updatedAt: FieldValue.serverTimestamp(),
+    // MIRROR branch. A pre-existing `/user_mirror/{email}` owned by a DIFFERENT
+    // coach is a second silent-steal vector (Pitfall 1) — gate it read-before-
+    // write inside a transaction so a concurrent writer can't slip past.
+    const mirrorRef = db
+      .collection(FirestoreCollections.userMirror)
+      .doc(parsed.email);
+    const mirrorOutcomeKind = await db.runTransaction<LinkOutcome["kind"]>(
+      async (tx) => {
+        const mirrorSnap = await tx.get(mirrorRef);
+        const outcome = decideLinkOutcome(
+          mirrorSnap.exists
+            ? (mirrorSnap.data() as {
+                coachId?: string | null;
+                autoAssignedCoach?: boolean;
+              })
+            : null,
+          session.uid,
+        );
+        if (outcome.kind === "conflict") {
+          logLinkConflictRefused({
+            actorUid: session.uid,
+            targetEmail: parsed.email,
+            targetUid: null,
+            existingCoachId: outcome.currentCoachId,
+          });
+          // Throw INSIDE the tx → aborts before any write.
+          throw new Error(tErr("conflictError", { email: parsed.email }));
+        }
+        if (outcome.kind === "alreadyYours") {
+          return "alreadyYours"; // no write — friendly no-op surfaced below
+        }
+        tx.set(
+          mirrorRef,
+          {
+            email: parsed.email,
+            displayName,
+            coachId: session.uid,
+            coachDisplayName,
+            coachPhotoURL: coach.photoURL,
+            coachBio: coach.bio,
+            pre_created: true,
+            createdAt: FieldValue.serverTimestamp(),
+            updatedAt: FieldValue.serverTimestamp(),
+          },
+          { merge: true },
+        );
+        return "link";
       },
-      { merge: true },
     );
+    if (mirrorOutcomeKind === "alreadyYours") {
+      return { ok: true, mode: "already-linked" };
+    }
     revalidateTag("gc-fitness-roster", "max");
     return { ok: true, mode: "precreated-mirror" };
   }
@@ -407,51 +468,84 @@ export async function provisionClient(
     throw new Error("You cannot add yourself as a client.");
   }
 
+  // EXISTING-USER branch. Read-before-write the /users doc INSIDE the tx and
+  // refuse a different-coach conflict. Claims are set only AFTER the tx commits
+  // (below) so a refusal/abort can never leave claims pointing at a client
+  // whose doc was never written (threat T-32-DIVERGE).
+  const userRef = db.collection(FirestoreCollections.users).doc(authUser.uid);
+  const chatRef = db.collection(FirestoreCollections.chats).doc(authUser.uid);
+  const userOutcomeKind = await db.runTransaction<LinkOutcome["kind"]>(
+    async (tx) => {
+      const userSnap = await tx.get(userRef);
+      const data = userSnap.exists ? userSnap.data() ?? {} : {};
+      const outcome = decideLinkOutcome(
+        userSnap.exists
+          ? (data as { coachId?: string | null; autoAssignedCoach?: boolean })
+          : null,
+        session.uid,
+      );
+      if (outcome.kind === "conflict") {
+        logLinkConflictRefused({
+          actorUid: session.uid,
+          targetEmail: parsed.email,
+          targetUid: authUser.uid,
+          existingCoachId: outcome.currentCoachId,
+        });
+        // Throw INSIDE the tx → aborts before any write; claims still untouched.
+        throw new Error(tErr("conflictError", { email: parsed.email }));
+      }
+      if (outcome.kind === "alreadyYours") {
+        return "alreadyYours"; // no writes, no claims mutation
+      }
+      tx.set(
+        userRef,
+        {
+          email: parsed.email,
+          displayName:
+            parsed.displayName ||
+            (typeof data.displayName === "string" &&
+            data.displayName.length > 0
+              ? data.displayName
+              : authUser.displayName || displayName),
+          photoURL: authUser.photoURL ?? data.photoURL ?? null,
+          role: "client",
+          coachId: session.uid,
+          coachDisplayName,
+          coachPhotoURL: coach.photoURL,
+          coachBio: coach.bio,
+          preferences: data.preferences ?? {},
+          fcmTokens: data.fcmTokens ?? [],
+          deleted: false,
+          createdAt: data.createdAt ?? FieldValue.serverTimestamp(),
+          updatedAt: FieldValue.serverTimestamp(),
+        },
+        { merge: true },
+      );
+      tx.set(
+        chatRef,
+        {
+          clientId: authUser.uid,
+          coachId: session.uid,
+          unreadCount: data.unreadCount ?? {},
+          createdAt: FieldValue.serverTimestamp(),
+          updatedAt: FieldValue.serverTimestamp(),
+        },
+        { merge: true },
+      );
+      return "link";
+    },
+  );
+
+  if (userOutcomeKind === "alreadyYours") {
+    return { ok: true, mode: "already-linked" };
+  }
+
+  // Claims AFTER the doc-write commit (T-32-DIVERGE): the benign direction
+  // (doc written, claims lag) self-heals via the Phase 30 forced token refresh.
   await auth.setCustomUserClaims(authUser.uid, {
     ...(authUser.customClaims ?? {}),
     role: "client",
     coachId: session.uid,
-  });
-
-  const userRef = db.collection(FirestoreCollections.users).doc(authUser.uid);
-  const chatRef = db.collection(FirestoreCollections.chats).doc(authUser.uid);
-  await db.runTransaction(async (tx) => {
-    const userSnap = await tx.get(userRef);
-    const data = userSnap.exists ? userSnap.data() ?? {} : {};
-    tx.set(
-      userRef,
-      {
-        email: parsed.email,
-        displayName:
-          parsed.displayName ||
-          (typeof data.displayName === "string" && data.displayName.length > 0
-            ? data.displayName
-            : authUser.displayName || displayName),
-        photoURL: authUser.photoURL ?? data.photoURL ?? null,
-        role: "client",
-        coachId: session.uid,
-        coachDisplayName,
-        coachPhotoURL: coach.photoURL,
-        coachBio: coach.bio,
-        preferences: data.preferences ?? {},
-        fcmTokens: data.fcmTokens ?? [],
-        deleted: false,
-        createdAt: data.createdAt ?? FieldValue.serverTimestamp(),
-        updatedAt: FieldValue.serverTimestamp(),
-      },
-      { merge: true },
-    );
-    tx.set(
-      chatRef,
-      {
-        clientId: authUser.uid,
-        coachId: session.uid,
-        unreadCount: data.unreadCount ?? {},
-        createdAt: FieldValue.serverTimestamp(),
-        updatedAt: FieldValue.serverTimestamp(),
-      },
-      { merge: true },
-    );
   });
 
   revalidateTag("gc-fitness-roster", "max");

--- a/backoffice/src/lib/gc-fitness/user-actions.ts
+++ b/backoffice/src/lib/gc-fitness/user-actions.ts
@@ -574,6 +574,10 @@ export async function provisionClient(input: unknown): Promise<
         // prior post-commit claims failure when the trainer resubmits.
         return "alreadyYours";
       }
+      // WR-02: read the chat doc INSIDE the tx (all tx reads must precede
+      // writes) so createdAt can be create-only below — re-linking an
+      // existing user must not reset the chat's original creation timestamp.
+      const chatSnap = await tx.get(chatRef);
       tx.set(
         userRef,
         {
@@ -611,8 +615,16 @@ export async function provisionClient(input: unknown): Promise<
         {
           clientId: authUser.uid,
           coachId: session.uid,
-          unreadCount: data.unreadCount ?? {},
-          createdAt: FieldValue.serverTimestamp(),
+          // WR-02: no unreadCount here. `data` is the USER doc snapshot, so
+          // `data.unreadCount ?? {}` was always {} — counters live on
+          // /chats/{clientId} and merge:true preserves them; writing an
+          // (accidentally empty) map only worked by the grace of merge
+          // semantics and would wipe both parties' counters under any
+          // future non-merge/flat-field write. createdAt is CREATE-ONLY:
+          // claiming a stray with chat history must not reset it.
+          ...(chatSnap.exists
+            ? {}
+            : { createdAt: FieldValue.serverTimestamp() }),
           updatedAt: FieldValue.serverTimestamp(),
         },
         { merge: true },

--- a/backoffice/src/lib/gc-fitness/user-actions.ts
+++ b/backoffice/src/lib/gc-fitness/user-actions.ts
@@ -448,6 +448,12 @@ export async function provisionClient(input: unknown): Promise<{
             coachDisplayName,
             coachPhotoURL: coach.photoURL,
             coachBio: coach.bio,
+            // CR-01: a claimed doc is no longer a stray. Without this delete,
+            // `merge: true` preserves `autoAssignedCoach: true` and rule (3)
+            // of decideLinkOutcome keeps the claimed target silently
+            // stealable by any other coach. (The migration's other stray
+            // fields — coachDisplayName/PhotoURL/Bio — are overwritten above.)
+            autoAssignedCoach: FieldValue.delete(),
             pre_created: true,
             createdAt: FieldValue.serverTimestamp(),
             updatedAt: FieldValue.serverTimestamp(),
@@ -510,6 +516,14 @@ export async function provisionClient(input: unknown): Promise<{
           photoURL: authUser.photoURL ?? data.photoURL ?? null,
           role: "client",
           coachId: session.uid,
+          // CR-01: claiming a Phase-29 fallback-migrated stray MUST clear the
+          // stray marker — otherwise the doc stays `{ coachId: <me>,
+          // autoAssignedCoach: true }`, which decideLinkOutcome rule (3)
+          // still classifies as claimable, so any other coach could silently
+          // steal the client you just claimed (and the roster "NEW" badge
+          // never clears). `merge: true` preserves absent fields, so an
+          // explicit FieldValue.delete() is required.
+          autoAssignedCoach: FieldValue.delete(),
           coachDisplayName,
           coachPhotoURL: coach.photoURL,
           coachBio: coach.bio,


### PR DESCRIPTION
## Summary

Phase 32 of the gc-fitness coach-less milestone (gc-fitness#374). Backoffice-only; backwards-compatible ahead of the app releases.

### Coach-link conflict detection (LINK-01)
- `provisionClient` can no longer silently steal a client: BOTH branches (existing-user + mirror) read-before-write **inside `runTransaction`** via the pure `decideLinkOutcome` helper. Conflict → zero writes, claims untouched.
- Outcomes: link (coach-less or fallback-stray — claiming clears `autoAssignedCoach` so the client is no longer re-claimable), already-yours (friendly notice + idempotent claims heal), **conflict** (inline error routing to support — never names the other coach), **trainer-target refusal** (a trainer's email can't be linked/demoted — the #379 class).
- Conflict signaling is a discriminated result (`{ok:false, mode}`), not a thrown message — survives Next.js prod Server-Action error masking.
- Chat doc fixes: `createdAt` create-only, bogus `unreadCount` dropped.

### Habit visibility for formerly coach-less clients (LINK-03)
- The four latent surfaces (`HabitTrendsWidget`, `ClientSummaryCard`, `client-roster`, `listHabitsForClient`) no longer drop client-created habits (`deleted !== true` in memory, PR #230 pattern); `listHabitsForClient` uses belongs-to-my-client semantics (owned client → old-coach/self-created habits visible), pinned by the updated T14a/T14b tests; truncation caps raised with warnings.

## Review + gates
Code review found **3 Critical + 3 Warnings — all fixed in this PR** with 9 new payload-level integration vectors. `tsc` clean; jest **822/823** (sole red = the documented pre-existing `client-activity-time` locale flake, green in CI). Verification 9/9 must-haves (planning artifacts in gc-fitness PR #482).

## ⚠️ Merge notes
- **Merging auto-deploys prod.** Changes are backwards-compatible and safe ahead of the app releases.
- Post-merge UAT (tracked in gc-fitness `32-HUMAN-UAT.md`): conflict / already-yours / stray-claim / trainer-refusal flows on the live form, plus a `next build && next start` smoke of the conflict copy.