### PR TITLE
feat(#480): per-muscle-group sets/volume charts on client progress

### DIFF
--- a/backoffice/messages/en.json
+++ b/backoffice/messages/en.json
@@ -278,7 +278,38 @@
       "rangeAll": "All",
       "range90": "90d",
       "range30": "30d",
-      "range7": "7d"
+      "range7": "7d",
+      "muscleGroups": {
+        "sectionTitle": "Muscle groups",
+        "sectionSubtitle": "Weekly sets and volume per muscle group. Each set counts fully for its primary muscle and half for each secondary.",
+        "setsTitle": "Sets by muscle group",
+        "volumeTitle": "Volume by muscle group",
+        "volumeUnit": "kg",
+        "setsReadout": "{sets} sets this week",
+        "selectHint": "Select muscle groups above to compare them.",
+        "empty": "This client hasn't logged any completed sets yet.",
+        "footnote": "Each set counts as 1 for the primary muscle and ½ for each secondary muscle. Warm-up sets are excluded.",
+        "config": {
+          "title": "Sets target zone",
+          "a11y": "Configure sets target zone",
+          "description": "Highlights a green band on the sets chart — the weekly sets per muscle group you're aiming for. 12–20 is a common hypertrophy range.",
+          "min": "Minimum",
+          "max": "Maximum",
+          "reset": "Reset to 12–20"
+        },
+        "info": {
+          "title": "How sets are counted",
+          "a11y": "How sets are counted",
+          "countingTitle": "Primary vs. secondary",
+          "countingBody": "Each set counts as a full set (1) for the exercise's primary muscle and half a set (½) for each secondary muscle it works.",
+          "exampleTitle": "Example",
+          "exampleBody": "One set of bench press adds 1 set for chest, ½ for triceps and ½ for shoulders.",
+          "zoneTitle": "The green zone",
+          "zoneBody": "The green band is the weekly sets target per muscle (default 12–20, a common range for muscle growth).",
+          "sourceTitle": "Why half a set?",
+          "sourceBody": "Counting secondary muscles as half a set predicted muscle growth better than any other method across a 67-study analysis."
+        }
+      }
     },
     "detail": {
       "heightLabel": "Height: {value}",
@@ -1210,6 +1241,12 @@
       "muscleGroupsPlaceholder": "Pick muscle groups…",
       "muscleGroupsAria": "Muscle groups",
       "muscleGroupsHint": "Pick the primary muscle first. Secondary muscles follow.",
+      "primaryMuscleGroupLabel": "Primary muscle",
+      "primaryMuscleGroupPlaceholder": "Pick the primary muscle…",
+      "primaryMuscleGroupHint": "The main mover. Counts as a full set in progress charts.",
+      "secondaryMuscleGroupsLabel": "Secondary muscles",
+      "secondaryMuscleGroupsPlaceholder": "Add secondary muscles…",
+      "secondaryMuscleGroupsHint": "Assisting muscles. Each counts as half a set in progress charts.",
       "equipmentLabel": "Equipment",
       "equipmentPlaceholder": "Pick equipment…",
       "equipmentAria": "Equipment",

--- a/backoffice/messages/en.json
+++ b/backoffice/messages/en.json
@@ -252,6 +252,7 @@
       "errorFallback": "Could not add client.",
       "conflictError": "This client already has a coach. The email {email} is already linked to another coach. Contact support to transfer them.",
       "selfError": "You cannot add yourself as a client.",
+      "trainerTargetError": "The email {email} belongs to a coach account and cannot be added as a client.",
       "alreadyLinked": "This client is already in your list.",
       "successBannerTitle": "Client ready",
       "errorBannerTitle": "Add client failed"

--- a/backoffice/messages/en.json
+++ b/backoffice/messages/en.json
@@ -251,6 +251,7 @@
       "successPreCreated": "Client pre-created. They will attach on first sign-in.",
       "errorFallback": "Could not add client.",
       "conflictError": "This client already has a coach. The email {email} is already linked to another coach. Contact support to transfer them.",
+      "selfError": "You cannot add yourself as a client.",
       "alreadyLinked": "This client is already in your list.",
       "successBannerTitle": "Client ready",
       "errorBannerTitle": "Add client failed"

--- a/backoffice/messages/en.json
+++ b/backoffice/messages/en.json
@@ -250,6 +250,8 @@
       "successAttached": "Client attached to your roster.",
       "successPreCreated": "Client pre-created. They will attach on first sign-in.",
       "errorFallback": "Could not add client.",
+      "conflictError": "This client already has a coach. The email {email} is already linked to another coach. Contact support to transfer them.",
+      "alreadyLinked": "This client is already in your list.",
       "successBannerTitle": "Client ready",
       "errorBannerTitle": "Add client failed"
     },

--- a/backoffice/messages/es.json
+++ b/backoffice/messages/es.json
@@ -251,6 +251,7 @@
       "successPreCreated": "Cliente pre-creado. Se vinculará al iniciar sesión por primera vez.",
       "errorFallback": "No se pudo agregar el cliente.",
       "conflictError": "Este cliente ya tiene coach. El email {email} ya está vinculado a otro coach. Para transferirlo, contactá a soporte.",
+      "selfError": "No podés agregarte a vos mismo como cliente.",
       "alreadyLinked": "Este cliente ya está en tu lista.",
       "successBannerTitle": "Cliente listo",
       "errorBannerTitle": "Falló al agregar cliente"

--- a/backoffice/messages/es.json
+++ b/backoffice/messages/es.json
@@ -278,7 +278,38 @@
       "rangeAll": "Todo",
       "range90": "90d",
       "range30": "30d",
-      "range7": "7d"
+      "range7": "7d",
+      "muscleGroups": {
+        "sectionTitle": "Grupos musculares",
+        "sectionSubtitle": "Series y volumen semanales por grupo muscular. Cada serie cuenta completa para el músculo principal y media para cada secundario.",
+        "setsTitle": "Series por grupo muscular",
+        "volumeTitle": "Volumen por grupo muscular",
+        "volumeUnit": "kg",
+        "setsReadout": "{sets} series esta semana",
+        "selectHint": "Elegí grupos musculares arriba para compararlos.",
+        "empty": "Este cliente todavía no registró series completadas.",
+        "footnote": "Cada serie cuenta 1 para el músculo principal y ½ para cada músculo secundario. Las series de calentamiento se excluyen.",
+        "config": {
+          "title": "Zona objetivo de series",
+          "a11y": "Configurar zona objetivo de series",
+          "description": "Resalta una franja verde en el gráfico de series: las series semanales por grupo muscular que buscás. 12–20 es un rango común para hipertrofia.",
+          "min": "Mínimo",
+          "max": "Máximo",
+          "reset": "Restablecer a 12–20"
+        },
+        "info": {
+          "title": "Cómo se cuentan las series",
+          "a11y": "Cómo se cuentan las series",
+          "countingTitle": "Principal vs. secundario",
+          "countingBody": "Cada serie cuenta completa (1) para el músculo principal del ejercicio y media (½) para cada músculo secundario que trabaja.",
+          "exampleTitle": "Ejemplo",
+          "exampleBody": "Una serie de press de banca suma 1 serie de pecho, ½ de tríceps y ½ de hombros.",
+          "zoneTitle": "La zona verde",
+          "zoneBody": "La franja verde es el objetivo semanal de series por músculo (por defecto 12–20, un rango habitual para crecimiento muscular).",
+          "sourceTitle": "¿Por qué media serie?",
+          "sourceBody": "Contar los músculos secundarios como media serie predijo el crecimiento muscular mejor que cualquier otro método en un análisis de 67 estudios."
+        }
+      }
     },
     "detail": {
       "heightLabel": "Altura: {value}",
@@ -1210,6 +1241,12 @@
       "muscleGroupsPlaceholder": "Elegí grupos musculares…",
       "muscleGroupsAria": "Grupos musculares",
       "muscleGroupsHint": "Elegí primero el músculo principal. Los secundarios van después.",
+      "primaryMuscleGroupLabel": "Músculo principal",
+      "primaryMuscleGroupPlaceholder": "Elegí el músculo principal…",
+      "primaryMuscleGroupHint": "El músculo protagonista. Cuenta como una serie completa en los gráficos de progreso.",
+      "secondaryMuscleGroupsLabel": "Músculos secundarios",
+      "secondaryMuscleGroupsPlaceholder": "Agregá músculos secundarios…",
+      "secondaryMuscleGroupsHint": "Músculos que asisten. Cada uno cuenta como media serie en los gráficos de progreso.",
       "equipmentLabel": "Equipamiento",
       "equipmentPlaceholder": "Elegí equipamiento…",
       "equipmentAria": "Equipamiento",

--- a/backoffice/messages/es.json
+++ b/backoffice/messages/es.json
@@ -252,6 +252,7 @@
       "errorFallback": "No se pudo agregar el cliente.",
       "conflictError": "Este cliente ya tiene coach. El email {email} ya está vinculado a otro coach. Para transferirlo, contactá a soporte.",
       "selfError": "No podés agregarte a vos mismo como cliente.",
+      "trainerTargetError": "El email {email} pertenece a una cuenta de coach y no puede agregarse como cliente.",
       "alreadyLinked": "Este cliente ya está en tu lista.",
       "successBannerTitle": "Cliente listo",
       "errorBannerTitle": "Falló al agregar cliente"

--- a/backoffice/messages/es.json
+++ b/backoffice/messages/es.json
@@ -250,6 +250,8 @@
       "successAttached": "Cliente vinculado a tu plantel.",
       "successPreCreated": "Cliente pre-creado. Se vinculará al iniciar sesión por primera vez.",
       "errorFallback": "No se pudo agregar el cliente.",
+      "conflictError": "Este cliente ya tiene coach. El email {email} ya está vinculado a otro coach. Para transferirlo, contactá a soporte.",
+      "alreadyLinked": "Este cliente ya está en tu lista.",
       "successBannerTitle": "Cliente listo",
       "errorBannerTitle": "Falló al agregar cliente"
     },

--- a/backoffice/src/app/gc-fitness/clients/[id]/_components/ClientSummaryCard.tsx
+++ b/backoffice/src/app/gc-fitness/clients/[id]/_components/ClientSummaryCard.tsx
@@ -45,10 +45,14 @@ export async function ClientSummaryCard({
     // Issue #437/#400: fetch by clientId only; filter `deleted === true` in
     // memory (isHabitNotDeleted) below. A `.where("deleted","==",false)`
     // equality drops client-created habits that never write the field. PR #230.
+    // WR-03: the cap counts SOFT-DELETED docs too (soft-delete is the only
+    // delete path, so they accumulate over a client's lifetime) — raised
+    // 40 → 200 so live habits don't silently drop off the summary card;
+    // truncation warning below when the raw fetch hits the cap.
     db
       .collection(FirestoreCollections.habits)
       .where("clientId", "==", clientId)
-      .limit(40)
+      .limit(200)
       .get()
       .catch(() => ({ docs: [] as Array<{ id: string; data: () => Record<string, unknown> }> })),
   ]);
@@ -80,6 +84,14 @@ export async function ClientSummaryCard({
   const pastWorkouts = workouts.filter((row) => !row.isRecurring && row.scheduledFor < todayCivil);
   const workoutsGrouped = groupWorkouts(visibleWorkouts);
 
+  if (habitsSnap.docs.length >= 200) {
+    // WR-03: raw fetch filled the cap — soft-deleted docs consume the
+    // budget, so live habits may be missing from the card.
+    console.warn(
+      "[gc-fitness/client-summary] habit fetch hit its cap — live habits may be truncated",
+      { clientId, cap: 200 },
+    );
+  }
   const habits = habitsSnap.docs
     .filter((doc) => isHabitNotDeleted(doc.data() as Record<string, unknown>))
     .map((doc) => {

--- a/backoffice/src/app/gc-fitness/clients/[id]/_components/ClientSummaryCard.tsx
+++ b/backoffice/src/app/gc-fitness/clients/[id]/_components/ClientSummaryCard.tsx
@@ -3,6 +3,7 @@ import { getTranslations } from "next-intl/server";
 import { civilDateToday } from "@/lib/gc-fitness/civil-date";
 import { gcFitnessFirestore } from "@/lib/firebase/gc-fitness-admin";
 import { FirestoreCollections } from "@/lib/gc-fitness/collections";
+import { isHabitNotDeleted } from "@/lib/gc-fitness/habit-visibility";
 import type { ClientGoalRow } from "@/lib/gc-fitness/client-goal-actions";
 import { Badge } from "@/components/ui/badge";
 import { ClientSummaryLists } from "./ClientSummaryLists";
@@ -41,10 +42,12 @@ export async function ClientSummaryCard({
       .limit(80)
       .get()
       .catch(() => ({ docs: [] as Array<{ id: string; data: () => Record<string, unknown> }> })),
+    // Issue #437/#400: fetch by clientId only; filter `deleted === true` in
+    // memory (isHabitNotDeleted) below. A `.where("deleted","==",false)`
+    // equality drops client-created habits that never write the field. PR #230.
     db
       .collection(FirestoreCollections.habits)
       .where("clientId", "==", clientId)
-      .where("deleted", "==", false)
       .limit(40)
       .get()
       .catch(() => ({ docs: [] as Array<{ id: string; data: () => Record<string, unknown> }> })),
@@ -77,7 +80,9 @@ export async function ClientSummaryCard({
   const pastWorkouts = workouts.filter((row) => !row.isRecurring && row.scheduledFor < todayCivil);
   const workoutsGrouped = groupWorkouts(visibleWorkouts);
 
-  const habits = habitsSnap.docs.map((doc) => {
+  const habits = habitsSnap.docs
+    .filter((doc) => isHabitNotDeleted(doc.data() as Record<string, unknown>))
+    .map((doc) => {
     const data = doc.data() as Record<string, unknown>;
     return {
       id: doc.id,

--- a/backoffice/src/app/gc-fitness/clients/[id]/_components/HabitTrendsWidget.tsx
+++ b/backoffice/src/app/gc-fitness/clients/[id]/_components/HabitTrendsWidget.tsx
@@ -23,6 +23,7 @@ import { FirestoreCollections } from "@/lib/gc-fitness/collections";
 import { civilDateFormat } from "@/lib/gc-fitness/civil-date";
 import { coerceLegacyHabitLogValue } from "@/lib/gc-fitness/habit-compliance";
 import { isHabitScheduledOn } from "@/lib/gc-fitness/habit-schedule";
+import { isHabitNotDeleted } from "@/lib/gc-fitness/habit-visibility";
 import { TREND_RANGES, type TrendRangeKey, addCivilDays } from "./trend-range";
 import { HabitTrendsClient, type HabitTrendRow } from "./HabitTrendsClient";
 
@@ -47,11 +48,15 @@ export async function HabitTrendsWidget({ clientId, timezone }: HabitTrendsWidge
   const unnamed = t("unnamed");
   const db = gcFitnessFirestore();
 
+  // Issue #437/#400: fetch by clientId only, filter `deleted === true` in
+  // memory (isHabitNotDeleted). A `.where("deleted","==",false)` equality only
+  // matches docs where the field EXISTS, silently dropping client-created
+  // habits that never write it. PR #230 pattern.
   const habitsSnap = await db
     .collection(FirestoreCollections.habits)
     .where("clientId", "==", clientId)
-    .where("deleted", "==", false)
     .get();
+  const habitDocs = habitsSnap.docs.filter((d) => isHabitNotDeleted(d.data()));
 
   const today = civilDateFormat(new Date(), timezone);
   // Ascending list of the trailing 365 civil dates ending today. Each
@@ -63,7 +68,7 @@ export async function HabitTrendsWidget({ clientId, timezone }: HabitTrendsWidge
   const windowStart = allDates[0] ?? today;
 
   const rows: HabitTrendRow[] = await Promise.all(
-    habitsSnap.docs.map(async (h) => {
+    habitDocs.map(async (h) => {
       const habit = h.data() as {
         name?: string | { en?: string; es?: string };
       } & Record<string, unknown>;

--- a/backoffice/src/app/gc-fitness/clients/[id]/progress/MuscleGroupProgressClient.tsx
+++ b/backoffice/src/app/gc-fitness/clients/[id]/progress/MuscleGroupProgressClient.tsx
@@ -1,0 +1,520 @@
+"use client";
+
+// MuscleGroupProgressClient.tsx — #480 per-muscle-group progress section for the
+// coach's client-progress page. Twin of the iOS Progress-tab muscle-group
+// charts (ProgressPhotosView `MuscleGroupChartsSection`).
+//
+// Two overlaid charts share a weekly x-axis: SETS by muscle group (with a green
+// 12–20 target band) and VOLUME by muscle group. Each selected coarse group is
+// its own colored line. Weighting is baked server-side (primary 1.0 / secondary
+// 0.5 per set) — see exercise-progress-actions.buildMuscleGroupWeeks + the
+// muscle-group-display twin. Switching selection / range / target is pure local
+// state (zero extra Firestore reads).
+
+import { useMemo, useState } from "react";
+import {
+  CartesianGrid,
+  Line,
+  LineChart,
+  ReferenceArea,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from "recharts";
+import { Info, SlidersHorizontal } from "lucide-react";
+import { useLocale, useTranslations } from "next-intl";
+
+import { cn } from "@/lib/utils";
+import { formatCivilDateLabel } from "@/lib/gc-fitness/civil-date";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
+import {
+  COARSE_MUSCLE_GROUPS,
+  DEFAULT_SELECTED_MUSCLE_GROUPS,
+} from "@/lib/gc-fitness/muscle-group-display";
+import type { MuscleGroupWeekPoint } from "@/lib/gc-fitness/exercise-progress-actions";
+import {
+  DEFAULT_TREND_RANGE,
+  type TrendRangeKey,
+} from "../_components/trend-range";
+import { TrendRangeSelector } from "../_components/TrendRangeSelector";
+
+const DEFAULT_TARGET_MIN = 12;
+const DEFAULT_TARGET_MAX = 20;
+// Muscle-group charts read best over a multi-week trend; default to 90d.
+const DEFAULT_MUSCLE_RANGE: TrendRangeKey = "90";
+
+/** `var(--gc-muscle-<group>)` — the categorical color for a coarse group. */
+function colorFor(group: string): string {
+  return `var(--gc-muscle-${group})`;
+}
+
+function formatSets(n: number): string {
+  return Number.isInteger(n) ? String(n) : n.toFixed(1);
+}
+
+export interface MuscleGroupProgressClientProps {
+  weeks: MuscleGroupWeekPoint[];
+  availableGroups: string[];
+  today: string;
+  rangeStarts: Record<TrendRangeKey, string>;
+}
+
+export function MuscleGroupProgressClient({
+  weeks,
+  availableGroups,
+  today,
+  rangeStarts,
+}: MuscleGroupProgressClientProps) {
+  const locale = useLocale();
+  const t = useTranslations("clients.exerciseProgress");
+  const tVocab = useTranslations("exercises.vocabulary");
+  const muscleLabel = (g: string) => tVocab(`muscle.${g}`);
+
+  // Available groups in the canonical display order.
+  const groups = useMemo(
+    () => COARSE_MUSCLE_GROUPS.filter((g) => availableGroups.includes(g)),
+    [availableGroups],
+  );
+
+  const [selected, setSelected] = useState<Set<string>>(() => {
+    const defaults = DEFAULT_SELECTED_MUSCLE_GROUPS.filter((g) =>
+      availableGroups.includes(g),
+    );
+    return new Set(defaults.length > 0 ? defaults : availableGroups.slice(0, 3));
+  });
+  const [range, setRange] = useState<TrendRangeKey>(DEFAULT_MUSCLE_RANGE);
+  const [targetMin, setTargetMin] = useState(DEFAULT_TARGET_MIN);
+  const [targetMax, setTargetMax] = useState(DEFAULT_TARGET_MAX);
+
+  const toggleGroup = (g: string) =>
+    setSelected((prev) => {
+      const next = new Set(prev);
+      if (next.has(g)) next.delete(g);
+      else next.add(g);
+      return next;
+    });
+
+  // Selected groups in canonical order (stable line order + legend).
+  const selectedOrdered = useMemo(
+    () => groups.filter((g) => selected.has(g)),
+    [groups, selected],
+  );
+
+  const windowWeeks = useMemo(() => {
+    const start = rangeStarts[range];
+    return weeks.filter((w) => w.weekStart >= start && w.weekStart <= today);
+  }, [weeks, range, rangeStarts, today]);
+
+  // One row per week; a column per selected group for each metric.
+  const setsData = useMemo(
+    () =>
+      windowWeeks.map((w) => {
+        const row: Record<string, number | string> = { week: w.weekStart };
+        for (const g of selectedOrdered) row[g] = w.byGroup[g]?.sets ?? 0;
+        return row;
+      }),
+    [windowWeeks, selectedOrdered],
+  );
+  const volumeData = useMemo(
+    () =>
+      windowWeeks.map((w) => {
+        const row: Record<string, number | string> = { week: w.weekStart };
+        for (const g of selectedOrdered) row[g] = w.byGroup[g]?.volume ?? 0;
+        return row;
+      }),
+    [windowWeeks, selectedOrdered],
+  );
+
+  // Latest-week weighted sets per selected group (legend readout).
+  const latestByGroup = useMemo(() => {
+    const out: Record<string, number> = {};
+    const last = windowWeeks[windowWeeks.length - 1];
+    for (const g of selectedOrdered) out[g] = last?.byGroup[g]?.sets ?? 0;
+    return out;
+  }, [windowWeeks, selectedOrdered]);
+
+  const clampTarget = (nextMin: number, nextMax: number) => {
+    const lo = Math.max(0, Math.min(nextMin, nextMax));
+    const hi = Math.max(lo, nextMax);
+    setTargetMin(lo);
+    setTargetMax(hi);
+  };
+
+  const rangeLabels: Record<TrendRangeKey, string> = {
+    all: t("rangeAll"),
+    "90": t("range90"),
+    "30": t("range30"),
+    "7": t("range7"),
+  };
+
+  const xTick = (value: string) =>
+    formatCivilDateLabel(value, { month: "short", day: "numeric" }, locale);
+
+  const infoBlocks: Array<{ title: string; body: string }> = [
+    {
+      title: t("muscleGroups.info.countingTitle"),
+      body: t("muscleGroups.info.countingBody"),
+    },
+    {
+      title: t("muscleGroups.info.exampleTitle"),
+      body: t("muscleGroups.info.exampleBody"),
+    },
+    {
+      title: t("muscleGroups.info.zoneTitle"),
+      body: t("muscleGroups.info.zoneBody"),
+    },
+    {
+      title: t("muscleGroups.info.sourceTitle"),
+      body: t("muscleGroups.info.sourceBody"),
+    },
+  ];
+
+  if (groups.length === 0) {
+    return (
+      <section className="rounded-[1.25rem] border border-border bg-card p-5 shadow-sm">
+        <h2 className="text-sm font-semibold text-foreground">
+          {t("muscleGroups.sectionTitle")}
+        </h2>
+        <p className="mt-2 text-sm text-muted-foreground">
+          {t("muscleGroups.empty")}
+        </p>
+      </section>
+    );
+  }
+
+  return (
+    <section className="flex flex-col gap-4 rounded-[1.25rem] border border-border bg-card p-5 shadow-sm">
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div className="flex flex-col gap-1">
+          <h2 className="text-sm font-semibold text-foreground">
+            {t("muscleGroups.sectionTitle")}
+          </h2>
+          <p className="text-xs text-muted-foreground">
+            {t("muscleGroups.sectionSubtitle")}
+          </p>
+        </div>
+        <div className="flex items-center gap-2">
+          {/* Target-zone config */}
+          <Popover>
+            <PopoverTrigger asChild>
+              <Button
+                type="button"
+                variant="outline"
+                size="sm"
+                className="gap-1.5"
+                aria-label={t("muscleGroups.config.a11y")}
+              >
+                <SlidersHorizontal className="size-3.5" />
+                {t("muscleGroups.config.title")}
+              </Button>
+            </PopoverTrigger>
+            <PopoverContent align="end" className="w-72">
+              <div className="flex flex-col gap-3">
+                <div>
+                  <p className="text-sm font-medium text-foreground">
+                    {t("muscleGroups.config.title")}
+                  </p>
+                  <p className="mt-1 text-xs text-muted-foreground">
+                    {t("muscleGroups.config.description")}
+                  </p>
+                </div>
+                <div className="grid grid-cols-2 gap-3">
+                  <div className="flex flex-col gap-1.5">
+                    <Label htmlFor="target-min" className="text-xs">
+                      {t("muscleGroups.config.min")}
+                    </Label>
+                    <Input
+                      id="target-min"
+                      type="number"
+                      min={0}
+                      value={targetMin}
+                      onChange={(e) =>
+                        clampTarget(Number(e.target.value), targetMax)
+                      }
+                    />
+                  </div>
+                  <div className="flex flex-col gap-1.5">
+                    <Label htmlFor="target-max" className="text-xs">
+                      {t("muscleGroups.config.max")}
+                    </Label>
+                    <Input
+                      id="target-max"
+                      type="number"
+                      min={0}
+                      value={targetMax}
+                      onChange={(e) =>
+                        clampTarget(targetMin, Number(e.target.value))
+                      }
+                    />
+                  </div>
+                </div>
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="sm"
+                  className="w-fit"
+                  onClick={() =>
+                    clampTarget(DEFAULT_TARGET_MIN, DEFAULT_TARGET_MAX)
+                  }
+                >
+                  {t("muscleGroups.config.reset")}
+                </Button>
+              </div>
+            </PopoverContent>
+          </Popover>
+          {/* How-sets-are-counted info */}
+          <Popover>
+            <PopoverTrigger asChild>
+              <Button
+                type="button"
+                variant="outline"
+                size="icon"
+                className="size-8"
+                aria-label={t("muscleGroups.info.a11y")}
+              >
+                <Info className="size-4" />
+              </Button>
+            </PopoverTrigger>
+            <PopoverContent align="end" className="w-80">
+              <div className="flex flex-col gap-3">
+                <p className="text-sm font-semibold text-foreground">
+                  {t("muscleGroups.info.title")}
+                </p>
+                {infoBlocks.map((b) => (
+                  <div key={b.title} className="flex flex-col gap-0.5">
+                    <p className="text-xs font-medium text-foreground">
+                      {b.title}
+                    </p>
+                    <p className="text-xs text-muted-foreground">{b.body}</p>
+                  </div>
+                ))}
+              </div>
+            </PopoverContent>
+          </Popover>
+        </div>
+      </div>
+
+      {/* Coarse muscle-group multi-select chips */}
+      <div className="flex flex-wrap items-center gap-2">
+        {groups.map((g) => {
+          const isOn = selected.has(g);
+          return (
+            <button
+              key={g}
+              type="button"
+              role="checkbox"
+              aria-checked={isOn}
+              onClick={() => toggleGroup(g)}
+              className={cn(
+                "inline-flex items-center gap-1.5 rounded-full border px-3 py-1 text-xs font-medium transition-colors",
+                "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+                isOn
+                  ? "border-transparent text-foreground"
+                  : "border-border bg-transparent text-muted-foreground hover:text-foreground",
+              )}
+              style={
+                isOn
+                  ? { backgroundColor: colorFor(g), color: "#fff" }
+                  : undefined
+              }
+            >
+              <span
+                className="size-2 rounded-full"
+                style={{ backgroundColor: colorFor(g) }}
+              />
+              {muscleLabel(g)}
+            </button>
+          );
+        })}
+      </div>
+
+      <div className="flex flex-wrap items-center justify-end gap-2">
+        <TrendRangeSelector
+          value={range}
+          onChange={setRange}
+          labels={rangeLabels}
+        />
+      </div>
+
+      {selectedOrdered.length === 0 ? (
+        <p className="text-sm text-muted-foreground">
+          {t("muscleGroups.selectHint")}
+        </p>
+      ) : (
+        <>
+          {/* Per-group latest-week readout / legend */}
+          <div className="flex flex-wrap gap-x-4 gap-y-1.5">
+            {selectedOrdered.map((g) => (
+              <span
+                key={g}
+                className="inline-flex items-center gap-1.5 text-xs text-muted-foreground"
+              >
+                <span
+                  className="size-2.5 rounded-sm"
+                  style={{ backgroundColor: colorFor(g) }}
+                />
+                <span className="text-foreground">{muscleLabel(g)}</span>
+                <span className="tabular-nums">
+                  {t("muscleGroups.setsReadout", {
+                    sets: formatSets(latestByGroup[g] ?? 0),
+                  })}
+                </span>
+              </span>
+            ))}
+          </div>
+
+          {/* SETS chart with the green target band */}
+          <div className="flex flex-col gap-2">
+            <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+              {t("muscleGroups.setsTitle")}
+            </p>
+            <div className="h-64 w-full rounded-md border bg-muted/20 p-2 sm:p-3">
+              <ResponsiveContainer width="100%" height="100%">
+                <LineChart
+                  data={setsData}
+                  margin={{ top: 8, right: 8, left: 0, bottom: 0 }}
+                >
+                  <CartesianGrid
+                    strokeDasharray="3 3"
+                    stroke="var(--muted-foreground)"
+                    strokeOpacity={0.16}
+                  />
+                  <ReferenceArea
+                    y1={targetMin}
+                    y2={targetMax}
+                    fill="var(--gc-target-zone)"
+                    fillOpacity={0.12}
+                    stroke="var(--gc-target-zone)"
+                    strokeOpacity={0.3}
+                    ifOverflow="extendDomain"
+                  />
+                  <XAxis
+                    dataKey="week"
+                    tick={{ fontSize: 11 }}
+                    tickLine={false}
+                    axisLine={false}
+                    minTickGap={24}
+                    tickFormatter={xTick}
+                  />
+                  <YAxis
+                    tick={{ fontSize: 11 }}
+                    tickLine={false}
+                    axisLine={false}
+                    width={36}
+                    allowDecimals={false}
+                  />
+                  <Tooltip
+                    contentStyle={{
+                      borderRadius: 10,
+                      border: "1px solid hsl(var(--border))",
+                      background: "hsl(var(--background))",
+                    }}
+                    formatter={(value, name) => [
+                      formatSets(Number(value)),
+                      muscleLabel(String(name)),
+                    ]}
+                    labelFormatter={(label) =>
+                      formatCivilDateLabel(
+                        String(label),
+                        { year: "numeric", month: "short", day: "numeric" },
+                        locale,
+                      )
+                    }
+                  />
+                  {selectedOrdered.map((g) => (
+                    <Line
+                      key={g}
+                      type="monotone"
+                      dataKey={g}
+                      stroke={colorFor(g)}
+                      strokeWidth={2.5}
+                      dot={{ r: 2.5, fill: colorFor(g), strokeWidth: 0 }}
+                      activeDot={{ r: 5, fill: colorFor(g), strokeWidth: 0 }}
+                    />
+                  ))}
+                </LineChart>
+              </ResponsiveContainer>
+            </div>
+          </div>
+
+          {/* VOLUME chart */}
+          <div className="flex flex-col gap-2">
+            <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+              {t("muscleGroups.volumeTitle")}
+            </p>
+            <div className="h-64 w-full rounded-md border bg-muted/20 p-2 sm:p-3">
+              <ResponsiveContainer width="100%" height="100%">
+                <LineChart
+                  data={volumeData}
+                  margin={{ top: 8, right: 8, left: 0, bottom: 0 }}
+                >
+                  <CartesianGrid
+                    strokeDasharray="3 3"
+                    stroke="var(--muted-foreground)"
+                    strokeOpacity={0.16}
+                  />
+                  <XAxis
+                    dataKey="week"
+                    tick={{ fontSize: 11 }}
+                    tickLine={false}
+                    axisLine={false}
+                    minTickGap={24}
+                    tickFormatter={xTick}
+                  />
+                  <YAxis
+                    tick={{ fontSize: 11 }}
+                    tickLine={false}
+                    axisLine={false}
+                    width={44}
+                    tickFormatter={(v: number) => String(Math.round(v))}
+                  />
+                  <Tooltip
+                    contentStyle={{
+                      borderRadius: 10,
+                      border: "1px solid hsl(var(--border))",
+                      background: "hsl(var(--background))",
+                    }}
+                    formatter={(value, name) => [
+                      `${Math.round(Number(value))} ${t("muscleGroups.volumeUnit")}`,
+                      muscleLabel(String(name)),
+                    ]}
+                    labelFormatter={(label) =>
+                      formatCivilDateLabel(
+                        String(label),
+                        { year: "numeric", month: "short", day: "numeric" },
+                        locale,
+                      )
+                    }
+                  />
+                  {selectedOrdered.map((g) => (
+                    <Line
+                      key={g}
+                      type="monotone"
+                      dataKey={g}
+                      stroke={colorFor(g)}
+                      strokeWidth={2.5}
+                      dot={{ r: 2.5, fill: colorFor(g), strokeWidth: 0 }}
+                      activeDot={{ r: 5, fill: colorFor(g), strokeWidth: 0 }}
+                    />
+                  ))}
+                </LineChart>
+              </ResponsiveContainer>
+            </div>
+          </div>
+
+          <p className="text-[11px] text-muted-foreground">
+            {t("muscleGroups.footnote")}
+          </p>
+        </>
+      )}
+    </section>
+  );
+}

--- a/backoffice/src/app/gc-fitness/clients/[id]/progress/page.tsx
+++ b/backoffice/src/app/gc-fitness/clients/[id]/progress/page.tsx
@@ -25,6 +25,7 @@ import { getClientExerciseProgress } from "@/lib/gc-fitness/exercise-progress-ac
 import { PageHeader } from "@/components/gc-fitness/page-header";
 import { addCivilDays } from "../_components/trend-range";
 import { ExerciseProgressClient } from "./ExerciseProgressClient";
+import { MuscleGroupProgressClient } from "./MuscleGroupProgressClient";
 import { sectionMetadata } from "@/lib/gc-fitness/page-metadata";
 
 // Tab title: "GC Fitness - <clients>" (issue #170).
@@ -82,7 +83,8 @@ export default async function ClientExerciseProgressPage({
 
   const t = await getTranslations("clients.exerciseProgress");
 
-  const { exercises, points } = await getClientExerciseProgress(id, timezone);
+  const { exercises, points, muscleGroupWeeks, availableMuscleGroups } =
+    await getClientExerciseProgress(id, timezone);
 
   // Anchor each range to today so the local filter windows match the other
   // client-detail trend widgets.
@@ -130,6 +132,13 @@ export default async function ClientExerciseProgressPage({
             "7": t("range7"),
           },
         }}
+      />
+
+      <MuscleGroupProgressClient
+        weeks={muscleGroupWeeks}
+        availableGroups={availableMuscleGroups}
+        today={today}
+        rangeStarts={rangeStarts}
       />
     </div>
   );

--- a/backoffice/src/app/gc-fitness/clients/_components/ProvisionClientForm.tsx
+++ b/backoffice/src/app/gc-fitness/clients/_components/ProvisionClientForm.tsx
@@ -49,9 +49,11 @@ export function ProvisionClientForm() {
                 setEmail("");
                 setDisplayName("");
                 setMessage(
-                  result.mode === "attached-existing-user"
-                    ? t("successAttached")
-                    : t("successPreCreated"),
+                  result.mode === "already-linked"
+                    ? t("alreadyLinked")
+                    : result.mode === "attached-existing-user"
+                      ? t("successAttached")
+                      : t("successPreCreated"),
                 );
                 router.refresh();
               } catch (err) {

--- a/backoffice/src/app/gc-fitness/clients/_components/ProvisionClientForm.tsx
+++ b/backoffice/src/app/gc-fitness/clients/_components/ProvisionClientForm.tsx
@@ -46,6 +46,20 @@ export function ProvisionClientForm() {
                   email,
                   displayName: displayName || undefined,
                 });
+                // CR-03: expected refusals arrive as a discriminated result
+                // (NOT a thrown Error) because production Next.js masks
+                // Server-Action error messages. The localized copy is
+                // rendered CLIENT-side from the mode — no server-composed
+                // string crosses the wire, which also keeps the enumeration
+                // bound (T-32-ENUM: copy names only the typed email).
+                if (!result.ok) {
+                  setError(
+                    result.mode === "conflict"
+                      ? t("conflictError", { email })
+                      : t("selfError"),
+                  );
+                  return;
+                }
                 setEmail("");
                 setDisplayName("");
                 setMessage(
@@ -56,10 +70,11 @@ export function ProvisionClientForm() {
                       : t("successPreCreated"),
                 );
                 router.refresh();
-              } catch (err) {
-                setError(
-                  err instanceof Error ? err.message : t("errorFallback"),
-                );
+              } catch {
+                // Unexpected failure only — expected refusals never throw.
+                // err.message is prod-masked by Next.js, so it carries no
+                // user-renderable copy; show the localized fallback instead.
+                setError(t("errorFallback"));
               }
             });
           }}

--- a/backoffice/src/app/gc-fitness/clients/_components/ProvisionClientForm.tsx
+++ b/backoffice/src/app/gc-fitness/clients/_components/ProvisionClientForm.tsx
@@ -56,7 +56,9 @@ export function ProvisionClientForm() {
                   setError(
                     result.mode === "conflict"
                       ? t("conflictError", { email })
-                      : t("selfError"),
+                      : result.mode === "trainer-target"
+                        ? t("trainerTargetError", { email })
+                        : t("selfError"),
                   );
                   return;
                 }

--- a/backoffice/src/app/gc-fitness/exercises/_components/ExerciseForm.tsx
+++ b/backoffice/src/app/gc-fitness/exercises/_components/ExerciseForm.tsx
@@ -36,6 +36,13 @@ import {
 import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
 import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import {
   LocalizedTextField,
   mirrorLocalizedBlank,
   hasDistinctTranslation,
@@ -123,6 +130,11 @@ function buildDefaults(
       es: passed?.description?.es ?? "",
     }),
     muscleGroups: passed?.muscleGroups ?? [],
+    // #480 — the PRIMARY mover. Legacy docs carry `muscleGroups` but no explicit
+    // primary; seed it from the first tag so an edit surfaces a sensible primary
+    // the coach can adjust. Kept in sync with `muscleGroups` on every change.
+    primaryMuscleGroup:
+      passed?.primaryMuscleGroup ?? passed?.muscleGroups?.[0] ?? undefined,
     equipment: passed?.equipment ?? [],
     mediaURL: passed?.mediaURL ?? null,
     thumbnailURL: passed?.thumbnailURL ?? null,
@@ -214,14 +226,61 @@ export function ExerciseForm({
       hasDistinctTranslation(formDefaults.tips),
   );
 
+  // #480 — the muscle picker is split into a single PRIMARY select + a SECONDARY
+  // multi-select. Both write through to `muscleGroups` (kept as [primary,
+  // ...secondaries]) plus the dedicated `primaryMuscleGroup` field.
+  const primaryMuscle = form.watch("primaryMuscleGroup") ?? "";
+  const allMuscles = form.watch("muscleGroups") ?? [];
+  const secondaryMuscles = allMuscles.filter((g) => g !== primaryMuscle);
+  const secondaryOptions = useMemo(
+    () => MUSCLE_GROUPS.filter((g) => g !== primaryMuscle),
+    [primaryMuscle],
+  );
+
+  const handlePrimaryChange = (next: string) => {
+    const prevSecondary = (form.getValues("muscleGroups") ?? []).filter(
+      (g) => g !== primaryMuscle && g !== next,
+    );
+    form.setValue("primaryMuscleGroup", next, {
+      shouldDirty: true,
+      shouldValidate: true,
+    });
+    form.setValue("muscleGroups", [next, ...prevSecondary], {
+      shouldDirty: true,
+      shouldValidate: true,
+    });
+  };
+
+  const handleSecondaryChange = (nextSecondary: string[]) => {
+    const p = form.getValues("primaryMuscleGroup") ?? "";
+    const merged = p
+      ? [p, ...nextSecondary.filter((g) => g !== p)]
+      : nextSecondary;
+    form.setValue("muscleGroups", merged, {
+      shouldDirty: true,
+      shouldValidate: true,
+    });
+  };
+
   const onSubmit = form.handleSubmit((raw) => {
     if (isView) return;
+    // #480 — normalize the muscle selection: an empty primary collapses to
+    // `undefined` (Zod's optional enum rejects ""), and `muscleGroups` is
+    // rebuilt as [primary, ...secondaries] so the primary is always present.
+    const primary =
+      raw.primaryMuscleGroup && raw.primaryMuscleGroup.trim()
+        ? raw.primaryMuscleGroup
+        : undefined;
+    const secondaries = (raw.muscleGroups ?? []).filter((g) => g !== primary);
+    const muscleGroups = primary ? [primary, ...secondaries] : secondaries;
     // "No translation" ⇒ store the coach's text in every language.
     const values = {
       ...raw,
       name: mirrorLocalizedBlank(raw.name),
       description: mirrorLocalizedBlank(raw.description),
       tips: mirrorLocalizedBlank(raw.tips),
+      primaryMuscleGroup: primary,
+      muscleGroups,
     };
     startTransition(async () => {
       try {
@@ -460,31 +519,76 @@ export function ExerciseForm({
           }}
         />
 
-        {/* Muscle Groups + Equipment */}
+        {/* 480 — Primary muscle (single-select) + Secondary muscles
+            (multi-select, excludes the primary). Together they write
+            `muscleGroups = [primary, ...secondaries]` + `primaryMuscleGroup`,
+            which drives the coach's per-muscle-group progress charts'
+            primary(1)/secondary(½) attribution weighting. */}
         <div className="grid gap-4 sm:grid-cols-2">
           <FormField
             control={form.control}
-            name="muscleGroups"
+            name="primaryMuscleGroup"
             render={({ field }) => (
               <FormItem>
-                <FormLabel>{t("muscleGroupsLabel")}</FormLabel>
+                <FormLabel>{t("primaryMuscleGroupLabel")}</FormLabel>
                 <FormControl>
-                  <MultiSelectCombobox
-                    options={MUSCLE_GROUPS}
-                    value={field.value ?? []}
-                    onChange={field.onChange}
-                    formatLabel={formatMuscleLabel}
-                    placeholder={t("muscleGroupsPlaceholder")}
-                    ariaLabel={t("muscleGroupsAria")}
-                    max={8}
+                  <Select
+                    value={field.value || undefined}
+                    onValueChange={handlePrimaryChange}
                     disabled={isView}
-                  />
+                  >
+                    <SelectTrigger
+                      className="w-full"
+                      aria-label={t("primaryMuscleGroupLabel")}
+                    >
+                      <SelectValue
+                        placeholder={t("primaryMuscleGroupPlaceholder")}
+                      />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {MUSCLE_GROUPS.map((m) => (
+                        <SelectItem key={m} value={m}>
+                          {formatMuscleLabel(m)}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
                 </FormControl>
-                <FormDescription>{t("muscleGroupsHint")}</FormDescription>
+                <FormDescription>
+                  {t("primaryMuscleGroupHint")}
+                </FormDescription>
                 <FormMessage />
               </FormItem>
             )}
           />
+          <FormField
+            control={form.control}
+            name="muscleGroups"
+            render={() => (
+              <FormItem>
+                <FormLabel>{t("secondaryMuscleGroupsLabel")}</FormLabel>
+                <FormControl>
+                  <MultiSelectCombobox
+                    options={secondaryOptions}
+                    value={secondaryMuscles}
+                    onChange={handleSecondaryChange}
+                    formatLabel={formatMuscleLabel}
+                    placeholder={t("secondaryMuscleGroupsPlaceholder")}
+                    ariaLabel={t("secondaryMuscleGroupsLabel")}
+                    max={7}
+                    disabled={isView}
+                  />
+                </FormControl>
+                <FormDescription>
+                  {t("secondaryMuscleGroupsHint")}
+                </FormDescription>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+        </div>
+
+        <div className="grid gap-4 sm:grid-cols-2">
           <FormField
             control={form.control}
             name="equipment"

--- a/backoffice/src/app/globals.css
+++ b/backoffice/src/app/globals.css
@@ -239,6 +239,18 @@
     --input: #1a1e26;
     --ring: rgba(211, 168, 78, 0.6);
     --chart-1: #d3a84e;
+    /* #480 — 7 distinct categorical colors for the muscle-group charts (one
+       overlaid line per coarse group). Tuned for legibility on the dark canvas
+       (#0e1016). Mirrors the iOS `muscleGroupColor(_:)` intent. */
+    --gc-muscle-back: #5b9dff;
+    --gc-muscle-chest: #ff6b6b;
+    --gc-muscle-biceps: #c08bff;
+    --gc-muscle-triceps: #ffa94d;
+    --gc-muscle-shoulders: #34c9c9;
+    --gc-muscle-legs: #51cf66;
+    --gc-muscle-core: #ffd43b;
+    /* Green "target zone" band on the sets chart (12–20 sets/week default). */
+    --gc-target-zone: #51cf66;
     --sidebar: #14171e;
     --sidebar-foreground: #aab2c0;
     --sidebar-primary: #d3a84e;
@@ -281,6 +293,18 @@
     --input: #f4f5f7;
     --ring: rgba(195, 152, 46, 0.5);
     --chart-1: #c3982e;
+    /* #480 — muscle-group categorical palette, darkened for legibility on the
+       light canvas (white cards). Yellow/teal are deepened so they don't wash
+       out on white. */
+    --gc-muscle-back: #2e7be0;
+    --gc-muscle-chest: #e03b3b;
+    --gc-muscle-biceps: #8b4fe0;
+    --gc-muscle-triceps: #d9741a;
+    --gc-muscle-shoulders: #0f8f8f;
+    --gc-muscle-legs: #2f9e44;
+    --gc-muscle-core: #a67c00;
+    /* Green "target zone" band on the sets chart (12–20 sets/week default). */
+    --gc-target-zone: #2f9e44;
     --sidebar: #ffffff;
     /* Inactive nav / labels: darkened a touch for legibility. */
     --sidebar-foreground: #4d5667;

--- a/backoffice/src/components/gc-fitness/exercise-quick-create.tsx
+++ b/backoffice/src/components/gc-fitness/exercise-quick-create.tsx
@@ -164,6 +164,9 @@ export function QuickCreateExercise({
         name: localizedName,
         description: localizedDescription,
         muscleGroups: [muscleGroup],
+        // #480 — the single picked muscle is this exercise's PRIMARY mover, so
+        // it weights as a full set in the coach's muscle-group progress charts.
+        primaryMuscleGroup: muscleGroup,
         equipment: [equipment],
         thumbnailURL: gifUrl.trim() || null,
         source: "trainer",

--- a/backoffice/src/lib/gc-fitness/__tests__/coach-link.test.ts
+++ b/backoffice/src/lib/gc-fitness/__tests__/coach-link.test.ts
@@ -1,0 +1,66 @@
+import { decideLinkOutcome } from "../coach-link";
+
+describe("decideLinkOutcome", () => {
+  it("links a coach-less target (null doc)", () => {
+    expect(decideLinkOutcome(null, "coachB")).toEqual({ kind: "link" });
+  });
+
+  it("treats an empty/whitespace coachId as no coach → link", () => {
+    expect(decideLinkOutcome({ coachId: "" }, "coachB")).toEqual({
+      kind: "link",
+    });
+    expect(decideLinkOutcome({ coachId: "   " }, "coachB")).toEqual({
+      kind: "link",
+    });
+    expect(decideLinkOutcome({ coachId: null }, "coachB")).toEqual({
+      kind: "link",
+    });
+  });
+
+  it("returns alreadyYours when the target is already your client", () => {
+    expect(decideLinkOutcome({ coachId: "coachB" }, "coachB")).toEqual({
+      kind: "alreadyYours",
+    });
+  });
+
+  it("links a claimable stray (autoAssignedCoach === true)", () => {
+    expect(
+      decideLinkOutcome(
+        { coachId: "coachA", autoAssignedCoach: true },
+        "coachB",
+      ),
+    ).toEqual({ kind: "link" });
+  });
+
+  it("returns conflict when the target has a different real coach", () => {
+    expect(decideLinkOutcome({ coachId: "coachA" }, "coachB")).toEqual({
+      kind: "conflict",
+      currentCoachId: "coachA",
+    });
+  });
+
+  it("prefers alreadyYours over stray when coachId matches the session", () => {
+    expect(
+      decideLinkOutcome(
+        { coachId: "coachB", autoAssignedCoach: true },
+        "coachB",
+      ),
+    ).toEqual({ kind: "alreadyYours" });
+  });
+
+  it("treats a mirror doc with a different coachId (no autoAssignedCoach) as conflict", () => {
+    expect(decideLinkOutcome({ coachId: "coachA" }, "coachB")).toEqual({
+      kind: "conflict",
+      currentCoachId: "coachA",
+    });
+  });
+
+  it("does not treat autoAssignedCoach:false as a claimable stray", () => {
+    expect(
+      decideLinkOutcome(
+        { coachId: "coachA", autoAssignedCoach: false },
+        "coachB",
+      ),
+    ).toEqual({ kind: "conflict", currentCoachId: "coachA" });
+  });
+});

--- a/backoffice/src/lib/gc-fitness/__tests__/coach-link.test.ts
+++ b/backoffice/src/lib/gc-fitness/__tests__/coach-link.test.ts
@@ -63,4 +63,34 @@ describe("decideLinkOutcome", () => {
       ),
     ).toEqual({ kind: "conflict", currentCoachId: "coachA" });
   });
+
+  // CR-02 — a trainer account is never a linkable client. A trainer doc
+  // usually has NO coachId, which rule (1) would classify as "link" and
+  // let a coach demote another trainer (doc overwrite + claims clobber).
+  it("refuses a trainer target with no coachId (the demotion vector)", () => {
+    expect(decideLinkOutcome({ role: "trainer" }, "coachB")).toEqual({
+      kind: "trainerTarget",
+    });
+  });
+
+  it("refuses a trainer target even when a coachId is present", () => {
+    expect(
+      decideLinkOutcome({ role: "trainer", coachId: "coachA" }, "coachB"),
+    ).toEqual({ kind: "trainerTarget" });
+  });
+
+  it("trainerTarget wins over alreadyYours and the stray rule", () => {
+    expect(
+      decideLinkOutcome(
+        { role: "trainer", coachId: "coachB", autoAssignedCoach: true },
+        "coachB",
+      ),
+    ).toEqual({ kind: "trainerTarget" });
+  });
+
+  it("does not refuse a client-role doc (role passthrough is trainer-only)", () => {
+    expect(decideLinkOutcome({ role: "client" }, "coachB")).toEqual({
+      kind: "link",
+    });
+  });
 });

--- a/backoffice/src/lib/gc-fitness/__tests__/exercise-form-validation.test.tsx
+++ b/backoffice/src/lib/gc-fitness/__tests__/exercise-form-validation.test.tsx
@@ -145,9 +145,13 @@ describe("ExerciseForm — UI-SPEC verbatim validation copy", () => {
     expect(
       screen.getByRole("button", { name: /add translation/i }),
     ).toBeInTheDocument();
-    // Muscle groups + Equipment render as Combobox triggers — assert by aria-label.
+    // #480 — Primary muscle (single-select) + Secondary muscles (multi-select)
+    // + Equipment render as combobox triggers — assert by accessible name.
     expect(
-      screen.getByRole("combobox", { name: /muscle groups/i }),
+      screen.getByRole("combobox", { name: /primary muscle/i }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("combobox", { name: /secondary muscles/i }),
     ).toBeInTheDocument();
     expect(
       screen.getByRole("combobox", { name: /equipment/i }),
@@ -192,10 +196,9 @@ describe("ExerciseForm — UI-SPEC verbatim validation copy", () => {
       screen.getByLabelText(/^description$/i),
       "Lie on a flat bench and press the bar.",
     );
-    // Open muscle Combobox and select "chest".
-    await user.click(screen.getByRole("combobox", { name: /muscle groups/i }));
+    // #480 — pick "chest" as the PRIMARY muscle (single-select Radix Select).
+    await user.click(screen.getByRole("combobox", { name: /primary muscle/i }));
     await user.click(await screen.findByRole("option", { name: /chest/i }));
-    await user.keyboard("{Escape}");
     await user.click(screen.getByRole("combobox", { name: /equipment/i }));
     await user.click(await screen.findByRole("option", { name: /barbell/i }));
     await user.keyboard("{Escape}");
@@ -206,11 +209,20 @@ describe("ExerciseForm — UI-SPEC verbatim validation copy", () => {
       expect(mockCreateExercise).toHaveBeenCalledTimes(1);
     });
     const calls = mockCreateExercise.mock.calls as unknown as Array<
-      [{ name: { en: string }; muscleGroups: string[]; equipment: string[] }]
+      [
+        {
+          name: { en: string };
+          muscleGroups: string[];
+          primaryMuscleGroup?: string;
+          equipment: string[];
+        },
+      ]
     >;
     const payload = calls[0][0];
     expect(payload.name.en).toBe("Barbell Bench Press");
     expect(payload.muscleGroups).toContain("chest");
+    // #480 — the picked muscle is written as the explicit PRIMARY mover.
+    expect(payload.primaryMuscleGroup).toBe("chest");
     expect(payload.equipment).toContain("barbell");
   });
 
@@ -226,9 +238,8 @@ describe("ExerciseForm — UI-SPEC verbatim validation copy", () => {
       screen.getByLabelText(/^description$/i),
       "Move with control.",
     );
-    await user.click(screen.getByRole("combobox", { name: /muscle groups/i }));
+    await user.click(screen.getByRole("combobox", { name: /primary muscle/i }));
     await user.click(await screen.findByRole("option", { name: /core/i }));
-    await user.keyboard("{Escape}");
 
     await user.click(screen.getByRole("button", { name: /^save$/i }));
 

--- a/backoffice/src/lib/gc-fitness/__tests__/habit-actions.test.ts
+++ b/backoffice/src/lib/gc-fitness/__tests__/habit-actions.test.ts
@@ -637,8 +637,47 @@ describe("listHabitsForTrainer", () => {
 });
 
 describe("listHabitsForClient", () => {
-  // T14 — filters by clientId + deleted; defense-in-depth strips cross-trainer rows
-  it("T14 — strips cross-trainer rows post-query (defense in depth)", async () => {
+  // T14 (LINK-03 / issue #437 / PR #230) — the query scopes by clientId ONLY
+  // (no `.where("deleted","==",false)` equality, which dropped client-created
+  // habits that never write the field); soft-deleted rows are filtered in
+  // memory. Ownership is the belongs-to-my-client gate (D-06):
+  //   - client belongs to the requesting trainer → old-coach / self-created
+  //     habits (trainerId !== trainer.uid) ARE included;
+  //   - client belongs to someone else → only own-authored rows return.
+  it("T14a — client belongs to me: includes old-coach/self-created rows, drops soft-deleted", async () => {
+    mockedGetTokens.mockResolvedValue(fakeTokens({ role: "trainer" }));
+    mockQueryGet.mockResolvedValue(
+      fakeQuerySnapshot([
+        { id: "hab-mine", trainerId: ALLOWED_UID, clientId: "uid-X" },
+        {
+          id: "hab-other",
+          trainerId: "other-trainer-uid",
+          clientId: "uid-X",
+        },
+        {
+          id: "hab-gone",
+          trainerId: "other-trainer-uid",
+          clientId: "uid-X",
+          deleted: true,
+        },
+      ]),
+    );
+    // Belongs-to-my-client point-read: users/uid-X.coachId === trainer.uid.
+    mockGet.mockResolvedValue(
+      fakeUserSnapshot({ exists: true, coachId: ALLOWED_UID }),
+    );
+
+    const result = await listHabitsForClient("uid-X");
+
+    // hab-other (old-coach) IS included; hab-gone (soft-deleted) is NOT.
+    expect(result.map((r) => r.id)).toEqual(["hab-mine", "hab-other"]);
+    expect(mockWhere).toHaveBeenCalledWith("clientId", "==", "uid-X");
+    // The deleted-equality is GONE — filtering happens in memory now.
+    expect(mockWhere).not.toHaveBeenCalledWith("deleted", "==", false);
+    expect(mockLimit).toHaveBeenCalledWith(200);
+  });
+
+  it("T14b — non-owned client: returns only own-authored rows", async () => {
     mockedGetTokens.mockResolvedValue(fakeTokens({ role: "trainer" }));
     mockQueryGet.mockResolvedValue(
       fakeQuerySnapshot([
@@ -650,13 +689,15 @@ describe("listHabitsForClient", () => {
         },
       ]),
     );
+    // The queried client is coached by someone else.
+    mockGet.mockResolvedValue(
+      fakeUserSnapshot({ exists: true, coachId: "someone-else" }),
+    );
 
     const result = await listHabitsForClient("uid-X");
-    expect(result).toHaveLength(1);
-    expect(result[0].id).toBe("hab-mine");
-    expect(mockWhere).toHaveBeenCalledWith("clientId", "==", "uid-X");
-    expect(mockWhere).toHaveBeenCalledWith("deleted", "==", false);
-    expect(mockLimit).toHaveBeenCalledWith(200);
+
+    expect(result.map((r) => r.id)).toEqual(["hab-mine"]);
+    expect(mockWhere).not.toHaveBeenCalledWith("deleted", "==", false);
   });
 });
 

--- a/backoffice/src/lib/gc-fitness/__tests__/habit-actions.test.ts
+++ b/backoffice/src/lib/gc-fitness/__tests__/habit-actions.test.ts
@@ -674,7 +674,10 @@ describe("listHabitsForClient", () => {
     expect(mockWhere).toHaveBeenCalledWith("clientId", "==", "uid-X");
     // The deleted-equality is GONE — filtering happens in memory now.
     expect(mockWhere).not.toHaveBeenCalledWith("deleted", "==", false);
-    expect(mockLimit).toHaveBeenCalledWith(200);
+    // WR-03: cap raised 200 → 500 — soft-deleted docs consume the fetch
+    // budget (they're filtered AFTER the query), so the cap needs headroom
+    // for a lifetime of soft-deletes before live habits truncate.
+    expect(mockLimit).toHaveBeenCalledWith(500);
   });
 
   it("T14b — non-owned client: returns only own-authored rows", async () => {

--- a/backoffice/src/lib/gc-fitness/__tests__/habit-visibility.test.ts
+++ b/backoffice/src/lib/gc-fitness/__tests__/habit-visibility.test.ts
@@ -1,0 +1,33 @@
+// __tests__/habit-visibility.test.ts
+//
+// Pure unit tests for the in-memory habit-visibility predicate that replaces
+// the `.where("deleted","==",false)` Firestore equality on the per-client
+// habit surfaces (issue #437 / PR #230 pattern). A Firestore equality filter
+// only matches docs where the field EXISTS, so client-created habits (issue
+// #400) — which never write a `deleted` field — were silently dropped. The
+// predicate keeps only a strict boolean `true` out; a missing/undefined/null/
+// false field stays visible.
+
+import { isHabitNotDeleted } from "@/lib/gc-fitness/habit-visibility";
+
+describe("isHabitNotDeleted", () => {
+  it("keeps a client-created habit with no deleted field (the #437/#400 bug)", () => {
+    expect(isHabitNotDeleted({})).toBe(true);
+  });
+
+  it("keeps a habit with deleted: false", () => {
+    expect(isHabitNotDeleted({ deleted: false })).toBe(true);
+  });
+
+  it("excludes a genuinely soft-deleted habit (deleted: true)", () => {
+    expect(isHabitNotDeleted({ deleted: true })).toBe(false);
+  });
+
+  it("keeps a habit with deleted: undefined", () => {
+    expect(isHabitNotDeleted({ deleted: undefined })).toBe(true);
+  });
+
+  it("keeps a habit with deleted: null (only strict true excludes)", () => {
+    expect(isHabitNotDeleted({ deleted: null })).toBe(true);
+  });
+});

--- a/backoffice/src/lib/gc-fitness/__tests__/muscle-group-display.test.ts
+++ b/backoffice/src/lib/gc-fitness/__tests__/muscle-group-display.test.ts
@@ -1,0 +1,86 @@
+// __tests__/muscle-group-display.test.ts
+// #480 — parity tests for the coarse muscle-group mapping + primary/secondary
+// attribution weighting. Mirrors the iOS (MuscleGroupProgress.swift +
+// ProgressPhotosViewModel.coarseWeights) and Android (MuscleGroupDisplay.kt)
+// twins — same inputs must yield the same outputs on all three surfaces.
+
+import {
+  COARSE_MUSCLE_GROUPS,
+  DEFAULT_SELECTED_MUSCLE_GROUPS,
+  coarseGroup,
+  coarseGroupFromAnatomy,
+  coarseWeights,
+} from "../muscle-group-display";
+
+describe("muscle-group-display", () => {
+  it("exposes the canonical coarse group order + defaults", () => {
+    expect(COARSE_MUSCLE_GROUPS).toEqual([
+      "back",
+      "chest",
+      "biceps",
+      "triceps",
+      "shoulders",
+      "legs",
+      "core",
+    ]);
+    expect(DEFAULT_SELECTED_MUSCLE_GROUPS).toEqual(["back", "chest", "legs"]);
+  });
+
+  it("rolls fine tags up to coarse buckets", () => {
+    expect(coarseGroup("quadriceps")).toBe("legs");
+    expect(coarseGroup("hamstrings")).toBe("legs");
+    expect(coarseGroup("glutes")).toBe("legs");
+    expect(coarseGroup("calves")).toBe("legs");
+    expect(coarseGroup("abs")).toBe("core");
+    expect(coarseGroup("chest")).toBe("chest");
+    // Not surfaced in the coarse view.
+    expect(coarseGroup("forearms")).toBeNull();
+    expect(coarseGroup("cardio")).toBeNull();
+    expect(coarseGroup("full_body")).toBeNull();
+  });
+
+  it("anatomy heuristic order is load-bearing (femoris → legs, not biceps)", () => {
+    expect(coarseGroupFromAnatomy("Biceps femoris")).toBe("legs");
+    expect(coarseGroupFromAnatomy("Triceps brachii")).toBe("triceps");
+    expect(coarseGroupFromAnatomy("Biceps brachii")).toBe("biceps");
+    expect(coarseGroupFromAnatomy("Anterior deltoid")).toBe("shoulders");
+    expect(coarseGroupFromAnatomy("Pectoralis major")).toBe("chest");
+    expect(coarseGroupFromAnatomy("Latissimus dorsi")).toBe("back");
+    expect(coarseGroupFromAnatomy("Rectus abdominis")).toBe("core");
+    expect(coarseGroupFromAnatomy("Brachioradialis")).toBeNull();
+  });
+
+  it("bench press: chest primary (1.0), triceps/shoulders secondary (0.5)", () => {
+    const w = coarseWeights({
+      muscleGroups: ["chest", "triceps", "shoulders"],
+      primaryMuscleGroup: "chest",
+    });
+    expect(w).toEqual({ chest: 1.0, triceps: 0.5, shoulders: 0.5 });
+  });
+
+  it("falls back to the anatomy heuristic when no explicit primary", () => {
+    const w = coarseWeights({
+      muscleGroups: ["chest", "triceps", "shoulders"],
+      secondaryMuscles: ["Triceps brachii", "Anterior deltoid"],
+    });
+    expect(w).toEqual({ chest: 1.0, triceps: 0.5, shoulders: 0.5 });
+  });
+
+  it("every group stays primary when no secondary signal exists", () => {
+    const w = coarseWeights({ muscleGroups: ["chest", "triceps"] });
+    expect(w).toEqual({ chest: 1.0, triceps: 1.0 });
+  });
+
+  it("collapses fine leg tags into a single weighted legs group", () => {
+    const w = coarseWeights({
+      muscleGroups: ["quadriceps", "glutes", "hamstrings"],
+      primaryMuscleGroup: "quadriceps",
+    });
+    // All three roll up to `legs`; the primary maps to legs so legs is primary.
+    expect(w).toEqual({ legs: 1.0 });
+  });
+
+  it("returns an empty map for exercises with no surfaced coarse group", () => {
+    expect(coarseWeights({ muscleGroups: ["cardio", "full_body"] })).toEqual({});
+  });
+});

--- a/backoffice/src/lib/gc-fitness/__tests__/user-actions.provision-link.test.ts
+++ b/backoffice/src/lib/gc-fitness/__tests__/user-actions.provision-link.test.ts
@@ -1,0 +1,369 @@
+// __tests__/user-actions.provision-link.test.ts
+//
+// Phase 32 review-fix vectors (CR-01 / CR-02 / CR-03 / WR-01 / WR-02) for
+// `provisionClient`. The pure `decideLinkOutcome` suite (coach-link.test.ts)
+// cannot see the WRITE PAYLOADS, so these tests run the action against an
+// in-memory Firestore mock (adapted from live-workout-actions.start-dedupe)
+// whose transaction buffers writes and applies them only on commit — a
+// thrown sentinel therefore aborts with zero writes, mirroring the server.
+//
+//  - CR-01: claiming a stray CLEARS `autoAssignedCoach` (FieldValue.delete
+//    survives merge), so a second coach's attempt is a conflict, not a steal.
+//  - CR-02: a `role: "trainer"` target is refused with zero writes and zero
+//    claims mutation (the demotion/lockout vector).
+//  - CR-03: refusals are RETURN VALUES ({ ok: false, mode }) — never thrown
+//    errors whose message prod-Next.js would mask.
+//  - WR-01: the idempotent claims sync also runs on the alreadyYours path,
+//    healing a prior post-commit claims failure on resubmit.
+//  - WR-02: the chat write carries no unreadCount and never rewrites an
+//    existing chat's createdAt.
+
+jest.mock("next/headers", () => ({
+  cookies: jest.fn().mockResolvedValue({}),
+}));
+jest.mock("next/cache", () => ({
+  revalidateTag: jest.fn(),
+}));
+jest.mock("next-intl/server", () => ({
+  getTranslations: jest.fn(async () => (key: string) => key),
+}));
+
+const SERVER_TIMESTAMP = "SERVER_TIMESTAMP_SENTINEL";
+const FIELD_DELETE = "FIELD_DELETE_SENTINEL";
+
+jest.mock("firebase-admin/firestore", () => ({
+  FieldValue: {
+    serverTimestamp: jest.fn(() => SERVER_TIMESTAMP),
+    delete: jest.fn(() => FIELD_DELETE),
+  },
+}));
+
+const mockState: { db: MockDb | null; sessionUid: string } = {
+  db: null,
+  sessionUid: "coach-B",
+};
+
+jest.mock("@/lib/gc-fitness/auth-helpers", () => ({
+  getCurrentTrainer: jest.fn(async () => ({
+    uid: mockState.sessionUid,
+    email: `${mockState.sessionUid}@example.com`,
+  })),
+}));
+
+type AuthUser = {
+  uid: string;
+  email: string;
+  displayName?: string;
+  photoURL?: string | null;
+  customClaims?: Record<string, unknown>;
+};
+const authUsersByEmail = new Map<string, AuthUser>();
+const mockSetCustomUserClaims = jest.fn(async () => undefined);
+
+jest.mock("@/lib/firebase/gc-fitness-admin", () => ({
+  gcFitnessFirestore: () => mockState.db,
+  gcFitnessAuth: () => ({
+    getUserByEmail: async (email: string) => {
+      const user = authUsersByEmail.get(email);
+      if (!user) {
+        throw Object.assign(new Error("no user"), {
+          code: "auth/user-not-found",
+        });
+      }
+      return user;
+    },
+    getUser: async (uid: string) => ({ uid, customClaims: {}, photoURL: null }),
+    setCustomUserClaims: mockSetCustomUserClaims,
+  }),
+}));
+
+import { provisionClient } from "../user-actions";
+import { FirestoreCollections } from "../collections";
+import { normalizeMirrorEmail } from "../email-normalization";
+
+// ── In-memory Firestore mock (merge + FieldValue.delete aware) ────────────
+
+type DocData = Record<string, unknown>;
+
+function applyPatch(base: DocData | undefined, patch: DocData): DocData {
+  const next: DocData = { ...(base ?? {}) };
+  for (const [key, value] of Object.entries(patch)) {
+    if (value === FIELD_DELETE) delete next[key];
+    else next[key] = value;
+  }
+  return next;
+}
+
+class MockDocRef {
+  constructor(
+    private store: Map<string, DocData>,
+    public readonly id: string,
+  ) {}
+  async get() {
+    const data = this.store.get(this.id);
+    return {
+      exists: data !== undefined,
+      id: this.id,
+      data: () => (data ? { ...data } : undefined),
+      get: (field: string) => data?.[field],
+    };
+  }
+  _apply(patch: DocData, merge: boolean) {
+    this.store.set(
+      this.id,
+      merge ? applyPatch(this.store.get(this.id), patch) : applyPatch(undefined, patch),
+    );
+  }
+}
+
+class MockCollection {
+  constructor(private colStore: Map<string, DocData>) {}
+  doc(id: string) {
+    return new MockDocRef(this.colStore, id);
+  }
+}
+
+class MockTxn {
+  private writes: Array<{ ref: MockDocRef; patch: DocData; merge: boolean }> =
+    [];
+  async get(ref: MockDocRef) {
+    return ref.get();
+  }
+  set(ref: MockDocRef, patch: DocData, opts?: { merge?: boolean }) {
+    this.writes.push({ ref, patch, merge: opts?.merge === true });
+    return this;
+  }
+  // Writes are buffered until the tx body resolves — a thrown sentinel
+  // therefore aborts with ZERO writes, mirroring the Admin SDK guarantee
+  // the conflict gate relies on.
+  commit() {
+    for (const w of this.writes) w.ref._apply(w.patch, w.merge);
+  }
+}
+
+class MockDb {
+  collections = new Map<string, Map<string, DocData>>();
+  collection(name: string) {
+    if (!this.collections.has(name)) this.collections.set(name, new Map());
+    return new MockCollection(this.collections.get(name)!);
+  }
+  async runTransaction<T>(fn: (tx: MockTxn) => Promise<T>): Promise<T> {
+    const tx = new MockTxn();
+    const result = await fn(tx);
+    tx.commit();
+    return result;
+  }
+  seed(col: string, id: string, data: DocData) {
+    this.collection(col);
+    this.collections.get(col)!.set(id, { ...data });
+  }
+  read(col: string, id: string): DocData | undefined {
+    return this.collections.get(col)?.get(id);
+  }
+}
+
+// ── Fixtures ──────────────────────────────────────────────────────────────
+
+const CLIENT_EMAIL = "client@example.com";
+const CLIENT_UID = "client-1";
+const MIRROR_ID = normalizeMirrorEmail(CLIENT_EMAIL);
+
+function seedAuthClient(uid = CLIENT_UID) {
+  authUsersByEmail.set(CLIENT_EMAIL, {
+    uid,
+    email: CLIENT_EMAIL,
+    displayName: "Cli Ent",
+    photoURL: null,
+    customClaims: {},
+  });
+  return uid;
+}
+
+function db(): MockDb {
+  return mockState.db!;
+}
+
+beforeEach(() => {
+  mockState.db = new MockDb();
+  mockState.sessionUid = "coach-B";
+  authUsersByEmail.clear();
+  mockSetCustomUserClaims.mockClear();
+  jest.spyOn(console, "warn").mockImplementation(() => undefined);
+});
+
+afterEach(() => {
+  (console.warn as jest.Mock).mockRestore();
+});
+
+// ── CR-01 — claiming a stray clears the stray marker ─────────────────────
+
+describe("CR-01 — stray claim clears autoAssignedCoach", () => {
+  it("existing-user branch: claimed doc loses the marker; a second coach then conflicts", async () => {
+    seedAuthClient();
+    db().seed(FirestoreCollections.users, CLIENT_UID, {
+      coachId: "coach-A",
+      autoAssignedCoach: true,
+      role: "client",
+    });
+
+    const first = await provisionClient({ email: CLIENT_EMAIL });
+    expect(first).toEqual({ ok: true, mode: "attached-existing-user" });
+
+    const doc = db().read(FirestoreCollections.users, CLIENT_UID)!;
+    expect(doc.coachId).toBe("coach-B");
+    // The steal vector: with the marker preserved, rule (3) would still
+    // classify this doc as a claimable stray for ANY other coach.
+    expect("autoAssignedCoach" in doc).toBe(false);
+
+    // Second coach's attempt is now a refused conflict, not a silent steal.
+    mockState.sessionUid = "coach-C";
+    const second = await provisionClient({ email: CLIENT_EMAIL });
+    expect(second).toEqual({ ok: false, mode: "conflict" });
+    expect(db().read(FirestoreCollections.users, CLIENT_UID)!.coachId).toBe(
+      "coach-B",
+    );
+  });
+
+  it("mirror branch: claimed mirror loses the marker too", async () => {
+    db().seed(FirestoreCollections.userMirror, MIRROR_ID, {
+      coachId: "coach-A",
+      autoAssignedCoach: true,
+    });
+
+    const result = await provisionClient({ email: CLIENT_EMAIL });
+    expect(result).toEqual({ ok: true, mode: "precreated-mirror" });
+
+    const mirror = db().read(FirestoreCollections.userMirror, MIRROR_ID)!;
+    expect(mirror.coachId).toBe("coach-B");
+    expect("autoAssignedCoach" in mirror).toBe(false);
+  });
+});
+
+// ── CR-02 — trainer target refused ────────────────────────────────────────
+
+describe("CR-02 — trainer-target refusal", () => {
+  it("refuses another trainer's email with zero writes and zero claims mutation", async () => {
+    seedAuthClient("trainer-X");
+    db().seed(FirestoreCollections.users, "trainer-X", {
+      role: "trainer",
+      displayName: "Other Trainer",
+    });
+
+    const result = await provisionClient({ email: CLIENT_EMAIL });
+    expect(result).toEqual({ ok: false, mode: "trainer-target" });
+
+    const doc = db().read(FirestoreCollections.users, "trainer-X")!;
+    expect(doc.role).toBe("trainer"); // no demotion
+    expect("coachId" in doc).toBe(false); // no ownership write
+    expect(mockSetCustomUserClaims).not.toHaveBeenCalled(); // no claims clobber
+    expect(
+      db().read(FirestoreCollections.chats, "trainer-X"),
+    ).toBeUndefined(); // no chat doc
+  });
+});
+
+// ── CR-03 — refusals are results, not thrown messages ─────────────────────
+
+describe("CR-03 — discriminated refusal results", () => {
+  it("conflict RETURNS { ok: false, mode: 'conflict' } (never throws) with zero writes", async () => {
+    seedAuthClient();
+    db().seed(FirestoreCollections.users, CLIENT_UID, {
+      coachId: "coach-A",
+      role: "client",
+    });
+
+    // Must not throw — a thrown Error's message is masked by prod Next.js.
+    const result = await provisionClient({ email: CLIENT_EMAIL });
+    expect(result).toEqual({ ok: false, mode: "conflict" });
+
+    const doc = db().read(FirestoreCollections.users, CLIENT_UID)!;
+    expect(doc.coachId).toBe("coach-A"); // untouched
+    expect(mockSetCustomUserClaims).not.toHaveBeenCalled();
+    expect(db().read(FirestoreCollections.chats, CLIENT_UID)).toBeUndefined();
+  });
+
+  it("mirror-branch conflict returns the same result shape with the mirror untouched", async () => {
+    db().seed(FirestoreCollections.userMirror, MIRROR_ID, {
+      coachId: "coach-A",
+    });
+
+    const result = await provisionClient({ email: CLIENT_EMAIL });
+    expect(result).toEqual({ ok: false, mode: "conflict" });
+    expect(
+      db().read(FirestoreCollections.userMirror, MIRROR_ID)!.coachId,
+    ).toBe("coach-A");
+  });
+
+  it("self-add returns { ok: false, mode: 'self' } instead of throwing", async () => {
+    authUsersByEmail.set(CLIENT_EMAIL, {
+      uid: "coach-B", // the session coach themself
+      email: CLIENT_EMAIL,
+      customClaims: {},
+    });
+
+    const result = await provisionClient({ email: CLIENT_EMAIL });
+    expect(result).toEqual({ ok: false, mode: "self" });
+    expect(mockSetCustomUserClaims).not.toHaveBeenCalled();
+  });
+});
+
+// ── WR-01 — claims heal on the alreadyYours retry path ────────────────────
+
+describe("WR-01 — alreadyYours re-syncs claims", () => {
+  it("runs the idempotent setCustomUserClaims even when the doc is already linked", async () => {
+    seedAuthClient();
+    db().seed(FirestoreCollections.users, CLIENT_UID, {
+      coachId: "coach-B",
+      role: "client",
+    });
+
+    const result = await provisionClient({ email: CLIENT_EMAIL });
+    expect(result).toEqual({ ok: true, mode: "already-linked" });
+
+    // The retry after a post-commit claims failure lands here — the claims
+    // write must run so the doc/claims divergence heals on resubmit.
+    expect(mockSetCustomUserClaims).toHaveBeenCalledWith(
+      CLIENT_UID,
+      expect.objectContaining({ role: "client", coachId: "coach-B" }),
+    );
+  });
+});
+
+// ── WR-02 — chat payload hygiene ──────────────────────────────────────────
+
+describe("WR-02 — chat write payload", () => {
+  it("preserves an existing chat's createdAt and unreadCount on (re-)link", async () => {
+    seedAuthClient();
+    db().seed(FirestoreCollections.users, CLIENT_UID, {
+      coachId: "coach-A",
+      autoAssignedCoach: true, // claimable stray with chat history
+      role: "client",
+    });
+    db().seed(FirestoreCollections.chats, CLIENT_UID, {
+      clientId: CLIENT_UID,
+      coachId: "coach-A",
+      createdAt: "ORIGINAL_CREATED_AT",
+      unreadCount: { "coach-A": 3, [CLIENT_UID]: 1 },
+    });
+
+    const result = await provisionClient({ email: CLIENT_EMAIL });
+    expect(result).toEqual({ ok: true, mode: "attached-existing-user" });
+
+    const chat = db().read(FirestoreCollections.chats, CLIENT_UID)!;
+    expect(chat.createdAt).toBe("ORIGINAL_CREATED_AT"); // NOT reset to now
+    expect(chat.unreadCount).toEqual({ "coach-A": 3, [CLIENT_UID]: 1 });
+    expect(chat.coachId).toBe("coach-B");
+  });
+
+  it("stamps createdAt only when the chat doc does not exist yet", async () => {
+    seedAuthClient();
+    db().seed(FirestoreCollections.users, CLIENT_UID, { role: "client" });
+
+    await provisionClient({ email: CLIENT_EMAIL });
+
+    const chat = db().read(FirestoreCollections.chats, CLIENT_UID)!;
+    expect(chat.createdAt).toBe(SERVER_TIMESTAMP);
+    // The bogus always-{} unreadCount write is gone entirely.
+    expect("unreadCount" in chat).toBe(false);
+  });
+});

--- a/backoffice/src/lib/gc-fitness/client-roster.ts
+++ b/backoffice/src/lib/gc-fitness/client-roster.ts
@@ -47,6 +47,7 @@ import { getCurrentTrainer } from "./auth-helpers";
 import { FirestoreCollections } from "./collections";
 import { coachVisibleClientName } from "./client-name";
 import { coerceLegacyHabitLogValue } from "./habit-compliance";
+import { isHabitNotDeleted } from "./habit-visibility";
 import { civilDateToday } from "./civil-date";
 import { getTrainerTimezone } from "./trainer-timezone";
 import {
@@ -533,14 +534,17 @@ export async function listClientsForRoster(): Promise<ClientRosterRow[]> {
         // every roster (260528 bug). Mirrors the exclusion in
         // listRecentLogsForTrainer.
         db.collection(FirestoreCollections.chats).doc(c.uid).get(),
+        // Issue #437/#400: fetch by clientId only; filter `deleted === true`
+        // in memory (isHabitNotDeleted) below. A `.where("deleted","==",false)`
+        // equality drops client-created habits that never write the field, so
+        // the compliance counts under-reported them. PR #230 pattern.
         db
           .collection(FirestoreCollections.habits)
           .where("clientId", "==", c.uid)
-          .where("deleted", "==", false)
           // 260529 cost backstop: a roster row never needs more than a
           // sane ceiling of habits; the compliance math below tolerates the
           // cap (no real client carries >60 active habits). Bounds the
-          // worst-case read on the (clientId, deleted, updatedAt) index.
+          // worst-case read on the (clientId, updatedAt) index.
           .limit(60)
           .get(),
         // 11-06: assignments scheduled in the last 7 civil days. scheduledFor
@@ -662,7 +666,9 @@ export async function listClientsForRoster(): Promise<ClientRosterRow[]> {
       // snapshot by habitId ONCE (replaces a per-habit query fan-out), then
       // compute per-habit ratio via the Pattern-B pure function and average.
       // The same grouped map feeds the trailing-7 habit-count loop below.
-      const habitDocs = clientHabits.docs;
+      const habitDocs = clientHabits.docs.filter((d) =>
+        isHabitNotDeleted(d.data() as Record<string, unknown>),
+      );
       const windowedLogsByHabit = new Map<string, HabitLogRow[]>();
       for (const ldoc of windowedHabitLogs.docs) {
         const data = ldoc.data() as Record<string, unknown>;

--- a/backoffice/src/lib/gc-fitness/client-roster.ts
+++ b/backoffice/src/lib/gc-fitness/client-roster.ts
@@ -543,9 +543,14 @@ export async function listClientsForRoster(): Promise<ClientRosterRow[]> {
           .where("clientId", "==", c.uid)
           // 260529 cost backstop: a roster row never needs more than a
           // sane ceiling of habits; the compliance math below tolerates the
-          // cap (no real client carries >60 active habits). Bounds the
-          // worst-case read on the (clientId, updatedAt) index.
-          .limit(60)
+          // cap (no real client carries >60 active habits).
+          // WR-03: the cap counts SOFT-DELETED docs too (filtered in memory
+          // after the fetch) and soft-delete is the only delete path, so
+          // deleted docs accumulate toward it over a client's lifetime —
+          // raised 60 → 150; a truncation warning fires below when the raw
+          // fetch hits the cap. Costs nothing unless the docs exist
+          // (limit is a ceiling, not a fetch-always).
+          .limit(150)
           .get(),
         // 11-06: assignments scheduled in the last 7 civil days. scheduledFor
         // is a "YYYY-MM-DD" string — lexicographic comparison is correct
@@ -666,6 +671,15 @@ export async function listClientsForRoster(): Promise<ClientRosterRow[]> {
       // snapshot by habitId ONCE (replaces a per-habit query fan-out), then
       // compute per-habit ratio via the Pattern-B pure function and average.
       // The same grouped map feeds the trailing-7 habit-count loop below.
+      if (clientHabits.docs.length >= 150) {
+        // WR-03: raw habit fetch filled the cap — soft-deleted docs consume
+        // the budget, so live habits (and the compliance denominators built
+        // from them) may be truncated for this client.
+        console.warn(
+          "[gc-fitness/roster] habit fetch hit its cap — live habits may be truncated",
+          { clientId: c.uid, cap: 150 },
+        );
+      }
       const habitDocs = clientHabits.docs.filter((d) =>
         isHabitNotDeleted(d.data() as Record<string, unknown>),
       );

--- a/backoffice/src/lib/gc-fitness/coach-link.ts
+++ b/backoffice/src/lib/gc-fitness/coach-link.ts
@@ -1,0 +1,64 @@
+// coach-link.ts
+//
+// PURE decision helper for the provisionClient conflict gate (Phase 32,
+// LINK-01). This module is intentionally I/O-free: no Admin SDK, no
+// Firestore, no "use server" — it takes the freshly-read target doc (a
+// /users/{uid} doc OR a /user_mirror/{email} doc) plus the requesting
+// coach's session uid and returns the link decision. Keeping it pure makes
+// the steal-vector logic jest-testable in isolation and lets BOTH
+// provisionClient branches (existing-user + mirror) share one authority.
+//
+// Outcomes (D-01 / 32-CONTEXT.md):
+//   - link         → coach-less target OR a claimable stray → safe to write.
+//   - alreadyYours → the target is already YOUR client → friendly no-op.
+//   - conflict     → the target has a DIFFERENT real coach → REFUSE (no
+//                    writes); the caller routes the coach to support. The
+//                    currentCoachId is for server-side audit ONLY and MUST
+//                    NEVER be forwarded to the requesting coach (enumeration
+//                    disclosure is bounded — threat T-32-ENUM / T-32-E2).
+//
+// Claimable stray = `autoAssignedCoach === true` (a doc field mirroring the
+// Phase 29 fallback-coach migration predicate) — a fallback-coached user is
+// claimable without conflict. We deliberately do NOT import or reference the
+// functions-repo fallback-coach uid: the predicate is the boolean field, not
+// a hardcoded uid comparison.
+
+export type LinkOutcome =
+  | { kind: "link" }
+  | { kind: "alreadyYours" }
+  | { kind: "conflict"; currentCoachId: string };
+
+export interface LinkTargetDoc {
+  coachId?: string | null;
+  autoAssignedCoach?: boolean;
+}
+
+/**
+ * Decide how a coach's "add client by email" request should resolve against
+ * the freshly-read target doc. Pure — call this INSIDE a transaction on the
+ * tx-read snapshot so the decision is authoritative against concurrent
+ * writers (T-32-TOCTOU).
+ */
+export function decideLinkOutcome(
+  existing: LinkTargetDoc | null,
+  sessionUid: string,
+): LinkOutcome {
+  // (1) Normalize: empty / whitespace-only coachId is treated as no coach.
+  const coachId = existing?.coachId?.trim() || null;
+  if (!coachId) {
+    return { kind: "link" };
+  }
+
+  // (2) Already your client — friendly no-op (wins over the stray rule).
+  if (coachId === sessionUid) {
+    return { kind: "alreadyYours" };
+  }
+
+  // (3) Claimable stray — a fallback-auto-assigned coach is claimable.
+  if (existing?.autoAssignedCoach === true) {
+    return { kind: "link" };
+  }
+
+  // (4) A different real coach owns this client — refuse.
+  return { kind: "conflict", currentCoachId: coachId };
+}

--- a/backoffice/src/lib/gc-fitness/coach-link.ts
+++ b/backoffice/src/lib/gc-fitness/coach-link.ts
@@ -28,6 +28,30 @@ export type LinkOutcome =
   | { kind: "alreadyYours" }
   | { kind: "conflict"; currentCoachId: string };
 
+/**
+ * Refusal modes surfaced to the ProvisionClientForm as a RETURN VALUE, never
+ * as a thrown Error message (CR-03): Next.js masks Server-Action error
+ * messages in production builds ("An error occurred in the Server
+ * Components render..." + digest), so localized copy carried on
+ * `err.message` degrades to a generic string exactly in prod. The form maps
+ * each mode to its own client-side translation key instead.
+ */
+export type LinkRefusalMode = "conflict" | "self";
+
+/**
+ * Sentinel thrown INSIDE the provisionClient transactions to abort them
+ * before any write (the Admin SDK aborts a tx whose body throws, and does
+ * not retry non-contention errors). provisionClient catches this sentinel
+ * and converts it into a `{ ok: false, mode }` result — the message is
+ * intentionally NOT user-facing (see LinkRefusalMode).
+ */
+export class LinkRefusedError extends Error {
+  constructor(public readonly mode: LinkRefusalMode) {
+    super(`link refused: ${mode}`);
+    this.name = "LinkRefusedError";
+  }
+}
+
 export interface LinkTargetDoc {
   coachId?: string | null;
   autoAssignedCoach?: boolean;

--- a/backoffice/src/lib/gc-fitness/coach-link.ts
+++ b/backoffice/src/lib/gc-fitness/coach-link.ts
@@ -26,7 +26,13 @@
 export type LinkOutcome =
   | { kind: "link" }
   | { kind: "alreadyYours" }
-  | { kind: "conflict"; currentCoachId: string };
+  | { kind: "conflict"; currentCoachId: string }
+  // CR-02: the target doc is a TRAINER account. A trainer email can never be
+  // linked as a client — without this refusal, a coach typing another
+  // trainer's email would overwrite their user doc (role → "client",
+  // coachId → attacker) and, post-commit, clobber their role claim,
+  // demoting them to a client and locking them out of the backoffice.
+  | { kind: "trainerTarget" };
 
 /**
  * Refusal modes surfaced to the ProvisionClientForm as a RETURN VALUE, never
@@ -36,7 +42,7 @@ export type LinkOutcome =
  * `err.message` degrades to a generic string exactly in prod. The form maps
  * each mode to its own client-side translation key instead.
  */
-export type LinkRefusalMode = "conflict" | "self";
+export type LinkRefusalMode = "conflict" | "trainer-target" | "self";
 
 /**
  * Sentinel thrown INSIDE the provisionClient transactions to abort them
@@ -55,6 +61,7 @@ export class LinkRefusedError extends Error {
 export interface LinkTargetDoc {
   coachId?: string | null;
   autoAssignedCoach?: boolean;
+  role?: string | null;
 }
 
 /**
@@ -67,6 +74,15 @@ export function decideLinkOutcome(
   existing: LinkTargetDoc | null,
   sessionUid: string,
 ): LinkOutcome {
+  // (0) CR-02: a trainer account is never a linkable client — refuse before
+  // any other rule (a trainer doc usually has NO coachId, which rule (1)
+  // would otherwise happily classify as "link" and demote the trainer).
+  // Wins over alreadyYours/stray too: no coachId combination makes
+  // overwriting a trainer doc acceptable.
+  if (existing?.role === "trainer") {
+    return { kind: "trainerTarget" };
+  }
+
   // (1) Normalize: empty / whitespace-only coachId is treated as no coach.
   const coachId = existing?.coachId?.trim() || null;
   if (!coachId) {

--- a/backoffice/src/lib/gc-fitness/exercise-progress-actions.ts
+++ b/backoffice/src/lib/gc-fitness/exercise-progress-actions.ts
@@ -27,7 +27,11 @@ import {
 } from "@/lib/gc-fitness/auth-helpers";
 import { gcFitnessFirestore } from "@/lib/firebase/gc-fitness-admin";
 import { FirestoreCollections } from "@/lib/gc-fitness/collections";
-import { civilDateFormat } from "@/lib/gc-fitness/civil-date";
+import { civilDateFormat, civilDateToday } from "@/lib/gc-fitness/civil-date";
+import {
+  COARSE_MUSCLE_GROUPS,
+  coarseWeights,
+} from "@/lib/gc-fitness/muscle-group-display";
 
 /** A distinct exercise that appears in the client's logged history. */
 export interface LoggedExerciseOption {
@@ -56,10 +60,75 @@ export interface ExerciseSessionPoint {
   volumeKg: number;
 }
 
+/**
+ * #480 — one WEEK bucket of the muscle-group breakdown. `byGroup` is keyed by
+ * COARSE muscle group (see muscle-group-display.ts); `sets` is the weighted set
+ * count (primary 1.0 / secondary 0.5) and `volume` the weighted Σ kg for that
+ * group in the Monday-anchored week starting `weekStart`. Only groups with data
+ * appear in `byGroup`. Weeks are contiguous (zero-filled) from the earliest
+ * trained week to the current week, so the overlaid lines stay continuous.
+ */
+export interface MuscleGroupWeekPoint {
+  /** YYYY-MM-DD of the Monday that starts this week (client timezone). */
+  weekStart: string;
+  byGroup: Record<string, { sets: number; volume: number }>;
+}
+
 export interface ClientExerciseProgress {
   clientId: string;
   exercises: LoggedExerciseOption[];
   points: ExerciseSessionPoint[];
+  /**
+   * #480 — weekly weighted sets + volume per coarse muscle group, for the
+   * muscle-group comparison charts. Empty when the client has logged no
+   * completed working sets in the window.
+   */
+  muscleGroupWeeks: MuscleGroupWeekPoint[];
+  /** Coarse groups with any data in the window, in `COARSE_MUSCLE_GROUPS` order. */
+  availableMuscleGroups: string[];
+}
+
+/** Firestore reserved-id guard — `.doc(id)` throws on ids matching /^__.*__$/. */
+function isReservedId(id: string): boolean {
+  return /^__.*__$/.test(id);
+}
+
+/**
+ * Monday that starts the week containing `civilDate` (YYYY-MM-DD). Anchored at
+ * UTC noon so the weekday math never trips a DST boundary. Week starts Monday
+ * (matches DashboardAggregator.weekStart across all surfaces).
+ */
+function civilWeekStart(civilDate: string): string {
+  const parts = civilDate.split("-");
+  if (parts.length !== 3) return civilDate;
+  const y = Number(parts[0]);
+  const m = Number(parts[1]);
+  const d = Number(parts[2]);
+  if (!Number.isFinite(y) || !Number.isFinite(m) || !Number.isFinite(d)) {
+    return civilDate;
+  }
+  const noon = new Date(Date.UTC(y, m - 1, d, 12, 0, 0));
+  // getUTCDay(): 0=Sun … 6=Sat. Days since Monday = (day + 6) % 7.
+  const sinceMonday = (noon.getUTCDay() + 6) % 7;
+  noon.setUTCDate(noon.getUTCDate() - sinceMonday);
+  const yy = String(noon.getUTCFullYear()).padStart(4, "0");
+  const mm = String(noon.getUTCMonth() + 1).padStart(2, "0");
+  const dd = String(noon.getUTCDate()).padStart(2, "0");
+  return `${yy}-${mm}-${dd}`;
+}
+
+/** `civilDate` shifted by `delta` days (UTC-noon anchored). */
+function shiftCivilDays(civilDate: string, delta: number): string {
+  const parts = civilDate.split("-");
+  if (parts.length !== 3) return civilDate;
+  const noon = new Date(
+    Date.UTC(Number(parts[0]), Number(parts[1]) - 1, Number(parts[2]), 12, 0, 0),
+  );
+  noon.setUTCDate(noon.getUTCDate() + delta);
+  const yy = String(noon.getUTCFullYear()).padStart(4, "0");
+  const mm = String(noon.getUTCMonth() + 1).padStart(2, "0");
+  const dd = String(noon.getUTCDate()).padStart(2, "0");
+  return `${yy}-${mm}-${dd}`;
 }
 
 const MAX_LOOKBACK_DAYS = 365;
@@ -113,7 +182,13 @@ export async function getClientExerciseProgress(
     .doc(clientId)
     .get();
   if (!clientSnap.exists || clientSnap.get("coachId") !== trainer.uid) {
-    return { clientId, exercises: [], points: [] };
+    return {
+      clientId,
+      exercises: [],
+      points: [],
+      muscleGroupWeeks: [],
+      availableMuscleGroups: [],
+    };
   }
 
   const windowStartDate = new Date(
@@ -135,6 +210,17 @@ export async function getClientExerciseProgress(
     string,
     { name: string; sessionCount: number; hasData: boolean }
   >();
+
+  // #480 — every completed NON-warmup set (bodyweight included), tagged with its
+  // session civil date + per-set volume, for the muscle-group aggregation. The
+  // exercise→muscle-group join happens after the batched exercise read below.
+  interface MuscleSetInput {
+    date: string;
+    exerciseId: string;
+    volumeKg: number;
+  }
+  const muscleSetInputs: MuscleSetInput[] = [];
+  const muscleExerciseIds = new Set<string>();
 
   for (const doc of snap.docs) {
     const data = doc.data() as Record<string, unknown>;
@@ -189,6 +275,23 @@ export async function getClientExerciseProgress(
 
       const weight = numeric(s.weight_kg ?? s.weight);
       const reps = numeric(s.reps);
+
+      // #480 — per-set volume for the muscle-group charts. Twin of
+      // WorkoutVolume.setVolumeKg: a TIME set (duration present) → weight ×
+      // (duration/60); otherwise → weight × reps. Bodyweight sets contribute 0
+      // volume but still COUNT as a set (weighted set-count is a separate tally).
+      const durRaw = s.duration_seconds ?? s.durationSeconds;
+      const hasDuration =
+        typeof durRaw === "number" ||
+        (typeof durRaw === "string" &&
+          durRaw.trim() !== "" &&
+          Number.isFinite(Number(durRaw)));
+      const setVolume = hasDuration
+        ? weight * (numeric(durRaw) / 60)
+        : weight * reps;
+      muscleSetInputs.push({ date, exerciseId: exId, volumeKg: setVolume });
+      muscleExerciseIds.add(exId);
+
       if (weight > 0) {
         acc.topWeight =
           acc.topWeight === null ? weight : Math.max(acc.topWeight, weight);
@@ -237,28 +340,59 @@ export async function getClientExerciseProgress(
   );
   const withDataIds = new Set(withData.map(([exId]) => exId));
 
-  // Muscle groups for the muscle-group filter. The logs don't carry them, so
-  // read the `exercises` docs for the (small, distinct) set of logged-with-data
-  // exercises in ONE batched getAll — bounded by the client's training variety
-  // (typically tens of docs), once per page load. Missing/deleted exercises
-  // resolve to no groups and simply won't match any group filter.
-  const muscleById = new Map<string, string[]>();
-  if (withData.length > 0) {
-    const refs = withData.map(([exId]) =>
+  // Muscle groups for BOTH the per-exercise picker filter AND the #480
+  // muscle-group charts. The logs don't carry muscle metadata, so read the
+  // `exercises` docs for the (small, distinct) set of logged exercises in ONE
+  // batched getAll — bounded by the client's training variety (typically tens
+  // of docs), once per page load. We pull `muscleGroups` (picker filter),
+  // `primaryMuscleGroup` + `secondaryMuscles` (the #480 attribution weighting).
+  // Missing/deleted exercises resolve to nothing and simply don't contribute.
+  interface ExerciseMuscleMeta {
+    muscleGroups: string[];
+    primaryMuscleGroup: string | null;
+    secondaryMuscles: string[];
+  }
+  const exerciseMetaById = new Map<string, ExerciseMuscleMeta>();
+  const neededIds = Array.from(
+    new Set<string>([...withDataIds, ...muscleExerciseIds]),
+  ).filter((id) => id.length > 0 && !isReservedId(id));
+  if (neededIds.length > 0) {
+    const refs = neededIds.map((exId) =>
       db.collection(FirestoreCollections.exercises).doc(exId),
     );
     const exerciseDocs = await db.getAll(...refs);
     for (const exDoc of exerciseDocs) {
       if (!exDoc.exists) continue;
-      const mg = exDoc.get("muscleGroups");
-      if (Array.isArray(mg)) {
-        muscleById.set(
-          exDoc.id,
-          mg.filter((v): v is string => typeof v === "string"),
-        );
-      }
+      const mgRaw = exDoc.get("muscleGroups");
+      const secRaw = exDoc.get("secondaryMuscles");
+      const primaryRaw = exDoc.get("primaryMuscleGroup");
+      exerciseMetaById.set(exDoc.id, {
+        muscleGroups: Array.isArray(mgRaw)
+          ? mgRaw.filter((v): v is string => typeof v === "string")
+          : [],
+        primaryMuscleGroup:
+          typeof primaryRaw === "string" && primaryRaw.trim()
+            ? primaryRaw
+            : null,
+        secondaryMuscles: Array.isArray(secRaw)
+          ? secRaw.filter((v): v is string => typeof v === "string")
+          : [],
+      });
     }
   }
+  const muscleById = new Map<string, string[]>();
+  for (const [exId, meta] of exerciseMetaById) {
+    if (meta.muscleGroups.length > 0) muscleById.set(exId, meta.muscleGroups);
+  }
+
+  // #480 — weekly weighted sets + volume per coarse muscle group. Bucket every
+  // collected set into its Monday-anchored week, spreading its weighted
+  // contribution across each coarse group its exercise trains.
+  const { muscleGroupWeeks, availableMuscleGroups } = buildMuscleGroupWeeks(
+    muscleSetInputs,
+    exerciseMetaById,
+    timezone,
+  );
 
   // Order exercises by how often they appear (most-trained first), then name.
   const exercises: LoggedExerciseOption[] = withData
@@ -277,5 +411,100 @@ export async function getClientExerciseProgress(
   // stays lean (those exercises can never be selected anyway).
   const leanPoints = points.filter((p) => withDataIds.has(p.exerciseId));
 
-  return { clientId, exercises, points: leanPoints };
+  return {
+    clientId,
+    exercises,
+    points: leanPoints,
+    muscleGroupWeeks,
+    availableMuscleGroups,
+  };
+}
+
+/**
+ * #480 — pure aggregation: fold the flat list of completed non-warmup sets into
+ * contiguous WEEK buckets of weighted sets + volume per coarse muscle group.
+ * Twin of MuscleGroupProgress.setsSeries / volumeSeries + the coarseWeights
+ * attribution (primary 1.0 / secondary 0.5).
+ *
+ * TODO(#480 — deferred): the iOS charts also append a ~4-week PROJECTION to the
+ * right of "today", built from upcoming `workout_assignments`'
+ * `templateSnapshot.exercises[].{sets, reps, weightBySetKg, metric,
+ * durationBySetSeconds}` (see ProgressPhotosViewModel.projectedContributions).
+ * That was intentionally left out of this backoffice pass to keep the PR
+ * focused on the actuals; add it by widening the read to the client's
+ * scheduled assignments (today → +5 weeks) and appending projected weekly
+ * buckets flagged so the client can dim them + draw a "today" divider.
+ */
+function buildMuscleGroupWeeks(
+  inputs: { date: string; exerciseId: string; volumeKg: number }[],
+  metaById: Map<
+    string,
+    { muscleGroups: string[]; primaryMuscleGroup: string | null; secondaryMuscles: string[] }
+  >,
+  timezone: string,
+): { muscleGroupWeeks: MuscleGroupWeekPoint[]; availableMuscleGroups: string[] } {
+  // weekStart → group → { sets, volume }
+  const byWeek = new Map<string, Map<string, { sets: number; volume: number }>>();
+  const groupsWithData = new Set<string>();
+
+  for (const input of inputs) {
+    const meta = metaById.get(input.exerciseId);
+    if (!meta) continue;
+    const weights = coarseWeights({
+      muscleGroups: meta.muscleGroups,
+      primaryMuscleGroup: meta.primaryMuscleGroup,
+      secondaryMuscles: meta.secondaryMuscles,
+    });
+    const groups = Object.keys(weights);
+    if (groups.length === 0) continue;
+
+    const week = civilWeekStart(input.date);
+    let weekMap = byWeek.get(week);
+    if (!weekMap) {
+      weekMap = new Map();
+      byWeek.set(week, weekMap);
+    }
+    for (const group of groups) {
+      const weight = weights[group];
+      groupsWithData.add(group);
+      const cell = weekMap.get(group) ?? { sets: 0, volume: 0 };
+      cell.sets += weight;
+      cell.volume += input.volumeKg * weight;
+      weekMap.set(group, cell);
+    }
+  }
+
+  if (byWeek.size === 0) {
+    return { muscleGroupWeeks: [], availableMuscleGroups: [] };
+  }
+
+  // Contiguous weekly axis from the earliest trained week to the current week
+  // (zero-filled) so the overlaid lines don't skip gaps. Bounded by the 365-day
+  // read window (≤ ~53 buckets).
+  const earliest = Array.from(byWeek.keys()).sort()[0];
+  const currentWeek = civilWeekStart(civilDateToday(timezone));
+  const weeks: MuscleGroupWeekPoint[] = [];
+  let cursor = earliest;
+  // Guard the loop against a bad `currentWeek < earliest` edge (shouldn't
+  // happen) and runaway iteration.
+  for (let i = 0; i < 60 && cursor <= currentWeek; i += 1) {
+    const weekMap = byWeek.get(cursor);
+    const byGroup: Record<string, { sets: number; volume: number }> = {};
+    if (weekMap) {
+      for (const [group, cell] of weekMap) {
+        byGroup[group] = {
+          sets: Math.round(cell.sets * 10) / 10,
+          volume: Math.round(cell.volume),
+        };
+      }
+    }
+    weeks.push({ weekStart: cursor, byGroup });
+    cursor = shiftCivilDays(cursor, 7);
+  }
+
+  const availableMuscleGroups = COARSE_MUSCLE_GROUPS.filter((g) =>
+    groupsWithData.has(g),
+  );
+
+  return { muscleGroupWeeks: weeks, availableMuscleGroups };
 }

--- a/backoffice/src/lib/gc-fitness/exercise-schema.ts
+++ b/backoffice/src/lib/gc-fitness/exercise-schema.ts
@@ -198,6 +198,14 @@ export const exerciseSchema = z.object({
     .array(muscleGroupSchema)
     .min(1, "Pick at least one muscle group.")
     .max(8),
+  // #480 — the PRIMARY mover (a canonical muscle-group tag). Drives the
+  // per-muscle-group progress charts' primary(1.0)/secondary(0.5) attribution
+  // weighting (twin of iOS `Exercise.primaryMuscleGroup`). Optional so every
+  // legacy / wger-seeded doc — which has `muscleGroups` but no explicit primary
+  // — still parses; those fall back to the anatomy heuristic over
+  // `secondaryMuscles`. The form writes `muscleGroups = [primary, ...secondary]`
+  // so the primary is always also present in `muscleGroups`.
+  primaryMuscleGroup: muscleGroupSchema.optional(),
   equipment: equipmentListSchema,
   mediaURL: gsUrlSchema,
   thumbnailURL: thumbnailUrlSchema,

--- a/backoffice/src/lib/gc-fitness/habit-actions.ts
+++ b/backoffice/src/lib/gc-fitness/habit-actions.ts
@@ -1912,9 +1912,19 @@ export async function assignHabitTemplateToPending(input: unknown): Promise<{
  * Note: listHabitsForClient is currently UI-unused; it is fixed here for
  * parity with the three live surfaces (D-03 discretion: prefer fix + note).
  *
- *  - Bounded at 200 — T-06-05-07.
+ *  - Bounded at 500 — T-06-05-07. WR-03: the cap counts SOFT-DELETED docs
+ *    too (they are filtered in memory AFTER the fetch), and soft-delete is
+ *    the only delete path (`allow delete: if false`), so deleted docs
+ *    accumulate monotonically toward the cap over a client's lifetime.
+ *    Raised 200 → 500 to keep live habits from silently dropping out, and
+ *    a truncation warning fires when the raw fetch hits the cap. We
+ *    deliberately do NOT re-add `.orderBy("updatedAt")`: Firestore orderBy
+ *    EXCLUDES docs missing the field, which would re-drop field-sparse
+ *    (older/seeded) habit docs — the very regression this filter fixed.
  *  - Excludes soft-deleted (deleted === true) in memory.
  */
+const LIST_HABITS_FOR_CLIENT_CAP = 500;
+
 export async function listHabitsForClient(
   clientId: string,
 ): Promise<HabitRow[]> {
@@ -1924,8 +1934,17 @@ export async function listHabitsForClient(
   const snap = await db
     .collection(COLLECTION)
     .where("clientId", "==", clientId)
-    .limit(200)
+    .limit(LIST_HABITS_FOR_CLIENT_CAP)
     .get();
+
+  if (snap.docs.length >= LIST_HABITS_FOR_CLIENT_CAP) {
+    // WR-03: raw fetch filled the cap — live habits may have been truncated
+    // (which docs survive is doc-ID order, deleted docs included).
+    console.warn(
+      "[gc-fitness/habits] listHabitsForClient hit its fetch cap — live habits may be truncated",
+      { clientId, cap: LIST_HABITS_FOR_CLIENT_CAP },
+    );
+  }
 
   const rows = snap.docs
     .filter((d) => isHabitNotDeleted(d.data() as Record<string, unknown>))

--- a/backoffice/src/lib/gc-fitness/habit-actions.ts
+++ b/backoffice/src/lib/gc-fitness/habit-actions.ts
@@ -53,6 +53,7 @@ import {
 } from "./coach-activity-log";
 import { FirestoreCollections } from "./collections";
 import { normalizeMirrorEmail } from "./email-normalization";
+import { isHabitNotDeleted } from "./habit-visibility";
 
 const COLLECTION = FirestoreCollections.habits;
 const TEMPLATE_COLLECTION = FirestoreCollections.habitTemplates;
@@ -1888,26 +1889,31 @@ export async function assignHabitTemplateToPending(input: unknown): Promise<{
 /**
  * Lists habits assigned to a single client by the calling trainer.
  *
- * Implementation note (Plan-Task 2 choice (b)): the query scopes by
- * `clientId + deleted` and lets the rule layer (P06-03) enforce the
- * `trainerId == auth.uid` precondition on read. Rationale:
- *   - A 4-field composite index would otherwise be required
- *     (`clientId+trainerId+deleted+updatedAt DESC`); not declared in
- *     `firestore.indexes.json` from P06-01.
- *   - The rule layer is sufficient: any returned doc must already satisfy
- *     `trainerId == auth.uid OR clientId == auth.uid`. Since this Server
- *     Action is invoked by an authed trainer (getCurrentTrainer guard),
- *     a doc owned by a different trainer would surface as a
- *     PERMISSION_DENIED on Firestore-rule evaluation — except that the
- *     Admin SDK bypasses rules, so we re-enforce here at the application
- *     layer via the post-query filter.
+ * Implementation note (LINK-03 / issue #437 / PR #230): the query scopes by
+ * `clientId` ONLY, then filters + sorts in memory. Rationale:
+ *   - A `.where("deleted","==",false)` equality only matches docs where the
+ *     field EXISTS. Client-created habits (issue #400) are written WITHOUT a
+ *     `deleted` field, so that clause silently dropped every one of them.
+ *     `isHabitNotDeleted` (deleted !== true) keeps them while still excluding
+ *     genuinely soft-deleted rows.
+ *   - Dropping the equality also removes the `orderBy("updatedAt")` composite
+ *     requirement, so we sort by updatedAt desc in memory (no new index).
  *
- * Defense-in-depth: we additionally filter the result client-of-DB to
- * `row.trainerId === session.uid` so a misbehaving rule (or a future rule
- * relaxation) cannot leak cross-trainer habits.
+ * Ownership gate (T-32-03): the Admin SDK bypasses Firestore rules, so the
+ * app layer is the only gate. A row is returned when it is either authored by
+ * the requesting trainer (`trainerId === trainer.uid`) OR the queried client
+ * belongs to this trainer (`users/{clientId}.coachId === trainer.uid`,
+ * mirroring currentTrainerCanManageHabit). This is the belongs-to-my-client
+ * check — so a formerly coach-less client's self-created habits (whose
+ * `trainerId` is the client's own uid) and any old-coach habits become
+ * visible to the current coach, while a client belonging to another trainer
+ * yields only the requesting trainer's own-authored rows.
+ *
+ * Note: listHabitsForClient is currently UI-unused; it is fixed here for
+ * parity with the three live surfaces (D-03 discretion: prefer fix + note).
  *
  *  - Bounded at 200 — T-06-05-07.
- *  - Excludes soft-deleted.
+ *  - Excludes soft-deleted (deleted === true) in memory.
  */
 export async function listHabitsForClient(
   clientId: string,
@@ -1918,14 +1924,28 @@ export async function listHabitsForClient(
   const snap = await db
     .collection(COLLECTION)
     .where("clientId", "==", clientId)
-    .where("deleted", "==", false)
-    .orderBy("updatedAt", "desc")
     .limit(200)
     .get();
 
-  const rows = snap.docs.map((d) =>
-    projectHabitRow(d.id, d.data() as Record<string, unknown>),
+  const rows = snap.docs
+    .filter((d) => isHabitNotDeleted(d.data() as Record<string, unknown>))
+    .map((d) => projectHabitRow(d.id, d.data() as Record<string, unknown>))
+    // updatedAt is an ISO string; desc lexicographic sort preserves the old
+    // orderBy("updatedAt","desc") output order without a composite index.
+    .sort((a, b) => (b.updatedAt ?? "").localeCompare(a.updatedAt ?? ""));
+
+  // Belongs-to-my-client: ONE point-read (getAll fails on Vercel — use a
+  // single .doc().get()). If the queried client is coached by this trainer,
+  // every row (self-created / old-coach) is theirs to see; otherwise fall
+  // back to own-authored rows only.
+  const clientSnap = await db
+    .collection(FirestoreCollections.users)
+    .doc(clientId)
+    .get();
+  const clientBelongsToMe =
+    clientSnap.exists && clientSnap.get("coachId") === trainer.uid;
+
+  return rows.filter(
+    (r) => r.trainerId === trainer.uid || clientBelongsToMe,
   );
-  // Defense-in-depth: Admin SDK bypasses rules; re-check ownership here.
-  return rows.filter((r) => r.trainerId === trainer.uid);
 }

--- a/backoffice/src/lib/gc-fitness/habit-visibility.ts
+++ b/backoffice/src/lib/gc-fitness/habit-visibility.ts
@@ -1,0 +1,18 @@
+// habit-visibility.ts
+//
+// Pure, I/O-free predicate for the per-client habit surfaces. It replaces the
+// Firestore `.where("deleted","==",false)` equality that silently dropped
+// client-created habits.
+//
+// Issue #437 / PR #230: a Firestore equality filter only matches docs where
+// the field EXISTS. Client-created habits (issue #400) are written WITHOUT a
+// `deleted` field (the rules forbid it at create), so `deleted == false`
+// excluded every one of them. The fix is to fetch by `clientId` only and
+// filter in memory here: ONLY a strict boolean `true` is soft-deleted; a
+// missing / undefined / null / false field means the habit is visible.
+//
+// No Admin SDK import — this stays testable in isolation and reusable across
+// server components + server actions.
+export function isHabitNotDeleted(habit: { deleted?: unknown }): boolean {
+  return habit.deleted !== true;
+}

--- a/backoffice/src/lib/gc-fitness/muscle-group-display.ts
+++ b/backoffice/src/lib/gc-fitness/muscle-group-display.ts
@@ -1,0 +1,173 @@
+// muscle-group-display.ts
+// #480 — TypeScript twin of the coarse muscle-group mapping + attribution
+// weighting used by the Progress-tab muscle-group charts.
+//
+// SOURCE OF TRUTH (keep in sync, line-for-line):
+//   - iOS:     gc-fitness/iOS/Packages/GCFitnessCore/Sources/GCFitnessCore/
+//              Progress/MuscleGroupProgress.swift  (enum MuscleGroupDisplay)
+//              + ProgressPhotosViewModel.coarseWeights(for:)
+//   - Android: android/core/src/main/kotlin/com/goldencrow/fitness/core/
+//              algorithms/MuscleGroupDisplay.kt
+//
+// The exercise library tags with the fine 17-item `MUSCLE_GROUPS` vocabulary;
+// the charts roll those up into a handful of big COARSE groups so the selector
+// stays short and the overlaid lines stay legible.
+//
+// ATTRIBUTION MODEL (product decision — identical on all three surfaces):
+// A logged (non-warmup) set is attributed to every COARSE group its exercise
+// trains, weighted 1.0 for the PRIMARY mover and 0.5 for each SECONDARY mover
+// (fractional counting — best predicts hypertrophy across a 67-study analysis).
+// Because each group is drawn as its own overlaid series there is no
+// double-counting problem.
+
+/** Display order in the selector (matches the product spec). */
+export const COARSE_MUSCLE_GROUPS: readonly string[] = [
+  "back",
+  "chest",
+  "biceps",
+  "triceps",
+  "shoulders",
+  "legs",
+  "core",
+] as const;
+
+/** Groups checked by default on first open (espalda, pecho, piernas). */
+export const DEFAULT_SELECTED_MUSCLE_GROUPS: readonly string[] = [
+  "back",
+  "chest",
+  "legs",
+] as const;
+
+/**
+ * Roll a fine canonical muscle tag up to its coarse bucket, or null when it
+ * isn't surfaced in the coarse view (arms / forearms / full_body / cardio /
+ * flexibility — niche or ambiguous for a major-group breakdown).
+ */
+export function coarseGroup(fine: string): string | null {
+  switch (fine.toLowerCase()) {
+    case "back":
+      return "back";
+    case "chest":
+      return "chest";
+    case "biceps":
+      return "biceps";
+    case "triceps":
+      return "triceps";
+    case "shoulders":
+      return "shoulders";
+    case "legs":
+    case "quadriceps":
+    case "hamstrings":
+    case "glutes":
+    case "calves":
+      return "legs";
+    case "core":
+    case "abs":
+      return "core";
+    default:
+      return null;
+  }
+}
+
+/**
+ * Roll a free-text ANATOMY muscle name (from `Exercise.secondaryMuscles`, e.g.
+ * "Triceps brachii", "Anterior deltoid", "Biceps femoris") up to a coarse
+ * bucket via lenient substring matching. Used to identify which of an
+ * exercise's coarse groups are SECONDARY movers (weighted 0.5) when the doc
+ * carries no explicit `primaryMuscleGroup`.
+ *
+ * Order is load-bearing: leg-flexor names ("biceps femoris") must be caught as
+ * legs before the generic "biceps" test, and deltoid names before "lat"/"back".
+ */
+export function coarseGroupFromAnatomy(raw: string): string | null {
+  const s = raw.toLowerCase();
+  if (
+    s.includes("hamstring") ||
+    s.includes("femoris") ||
+    s.includes("quadricep") ||
+    s.includes("quad") ||
+    s.includes("glute") ||
+    s.includes("calf") ||
+    s.includes("calves") ||
+    s.includes("soleus") ||
+    s.includes("gastrocnemius") ||
+    s.includes("adductor") ||
+    s.includes("abductor")
+  ) {
+    return "legs";
+  }
+  if (s.includes("tricep")) return "triceps";
+  if (s.includes("bicep")) return "biceps";
+  if (s.includes("delt") || s.includes("shoulder")) return "shoulders";
+  if (s.includes("pec") || s.includes("chest")) return "chest";
+  if (
+    s.includes("lat") ||
+    s.includes("trap") ||
+    s.includes("rhom") ||
+    s.includes("teres") ||
+    s.includes("erector") ||
+    s.includes("back")
+  ) {
+    return "back";
+  }
+  if (
+    s.includes("abdom") ||
+    s.includes("oblique") ||
+    s.includes("core") ||
+    s.includes("serratus")
+  ) {
+    return "core";
+  }
+  return null;
+}
+
+export interface CoarseWeightsInput {
+  /** The exercise's fine `muscleGroups` tags (e.g. ["chest", "triceps"]). */
+  muscleGroups: string[];
+  /** Explicit primary mover (a fine tag), when the doc carries one. */
+  primaryMuscleGroup?: string | null;
+  /** Free-text anatomy names (FEXD enrichment), the legacy fallback signal. */
+  secondaryMuscles?: string[];
+}
+
+/**
+ * Coarse group → attribution weight (1.0 primary, 0.5 secondary) for an
+ * exercise. Twin of `ProgressPhotosViewModel.coarseWeights(for:)`.
+ *
+ * Prefers the explicit `primaryMuscleGroup` (the coarse group it maps to is
+ * primary; every OTHER coarse group in `muscleGroups` is secondary). Falls back
+ * to the anatomy-name heuristic over `secondaryMuscles` when no explicit
+ * primary is set (legacy / seeded docs). When neither signal is present every
+ * coarse group stays primary (1.0).
+ *
+ * Returns an empty map when the exercise maps to no surfaced coarse group.
+ */
+export function coarseWeights(input: CoarseWeightsInput): Record<string, number> {
+  const allCoarse = new Set<string>();
+  for (const fine of input.muscleGroups) {
+    const c = coarseGroup(fine);
+    if (c) allCoarse.add(c);
+  }
+  if (allCoarse.size === 0) return {};
+
+  let secondaryCoarse: Set<string>;
+  const primaryToken = input.primaryMuscleGroup;
+  const primaryCoarse = primaryToken ? coarseGroup(primaryToken) : null;
+  if (primaryCoarse) {
+    secondaryCoarse = new Set(
+      Array.from(allCoarse).filter((g) => g !== primaryCoarse),
+    );
+  } else {
+    secondaryCoarse = new Set<string>();
+    for (const name of input.secondaryMuscles ?? []) {
+      const c = coarseGroupFromAnatomy(name);
+      if (c) secondaryCoarse.add(c);
+    }
+  }
+
+  const weights: Record<string, number> = {};
+  for (const group of allCoarse) {
+    weights[group] = secondaryCoarse.has(group) ? 0.5 : 1.0;
+  }
+  return weights;
+}

--- a/backoffice/src/lib/gc-fitness/user-actions.ts
+++ b/backoffice/src/lib/gc-fitness/user-actions.ts
@@ -52,7 +52,6 @@
 import { cookies } from "next/headers";
 import { revalidateTag } from "next/cache";
 import { FieldValue } from "firebase-admin/firestore";
-import { getTranslations } from "next-intl/server";
 import { z } from "zod";
 
 import {
@@ -61,7 +60,12 @@ import {
 } from "@/lib/firebase/gc-fitness-admin";
 
 import { getCurrentTrainer } from "./auth-helpers";
-import { decideLinkOutcome, type LinkOutcome } from "./coach-link";
+import {
+  decideLinkOutcome,
+  LinkRefusedError,
+  type LinkOutcome,
+  type LinkRefusalMode,
+} from "./coach-link";
 import { FirestoreCollections } from "./collections";
 import { normalizeMirrorEmail } from "./email-normalization";
 
@@ -383,11 +387,22 @@ export async function updateClientNickname(
  * `/users/{uid}` and sets custom claims so the iOS app can read/write under
  * the normal client rules immediately. If the email does not exist yet, it
  * creates `/user_mirror/{email}` for the first-sign-in provisioning path.
+ *
+ * REFUSALS ARE RETURN VALUES, NOT THROWN ERRORS (CR-03): production Next.js
+ * masks Server-Action error messages (generic copy + digest), so a thrown
+ * localized message renders as a generic error exactly in the auto-deployed
+ * prod build. Expected refusals (conflict / self-add) come back as
+ * `{ ok: false, mode }`; the form maps the mode to client-side translated
+ * copy. The tx-internal throw is a sentinel (LinkRefusedError) whose only
+ * job is aborting the transaction before any write.
  */
-export async function provisionClient(input: unknown): Promise<{
-  ok: true;
-  mode: "attached-existing-user" | "precreated-mirror" | "already-linked";
-}> {
+export async function provisionClient(input: unknown): Promise<
+  | {
+      ok: true;
+      mode: "attached-existing-user" | "precreated-mirror" | "already-linked";
+    }
+  | { ok: false; mode: LinkRefusalMode }
+> {
   const session = await getCurrentTrainer();
   const parsed = provisionClientSchema.parse(input);
   const db = gcFitnessFirestore();
@@ -395,9 +410,6 @@ export async function provisionClient(input: unknown): Promise<{
   const coach = await trainerProfile(session.uid, session.email);
   const coachDisplayName = coach.displayName;
   const displayName = parsed.displayName || fallbackName(parsed.email);
-  // Localized conflict copy — built once, rendered verbatim by the form's red
-  // HelperBanner. MUST NOT name the other coach (threat T-32-ENUM).
-  const tErr = await getTranslations("clients.provisionForm");
 
   let authUser: Awaited<ReturnType<typeof auth.getUserByEmail>> | null = null;
   try {
@@ -414,7 +426,9 @@ export async function provisionClient(input: unknown): Promise<{
     const mirrorRef = db
       .collection(FirestoreCollections.userMirror)
       .doc(parsed.email);
-    const mirrorOutcomeKind = await db.runTransaction<LinkOutcome["kind"]>(
+    let mirrorOutcomeKind: LinkOutcome["kind"];
+    try {
+      mirrorOutcomeKind = await db.runTransaction<LinkOutcome["kind"]>(
       async (tx) => {
         const mirrorSnap = await tx.get(mirrorRef);
         const outcome = decideLinkOutcome(
@@ -433,8 +447,10 @@ export async function provisionClient(input: unknown): Promise<{
             targetUid: null,
             existingCoachId: outcome.currentCoachId,
           });
-          // Throw INSIDE the tx → aborts before any write.
-          throw new Error(tErr("conflictError", { email: parsed.email }));
+          // Sentinel throw INSIDE the tx → aborts before any write (CR-03:
+          // caught below and converted to a { ok: false } result — the
+          // message never travels to the browser, so prod masking is moot).
+          throw new LinkRefusedError("conflict");
         }
         if (outcome.kind === "alreadyYours") {
           return "alreadyYours"; // no write — friendly no-op surfaced below
@@ -462,7 +478,13 @@ export async function provisionClient(input: unknown): Promise<{
         );
         return "link";
       },
-    );
+      );
+    } catch (err) {
+      if (err instanceof LinkRefusedError) {
+        return { ok: false, mode: err.mode };
+      }
+      throw err;
+    }
     if (mirrorOutcomeKind === "alreadyYours") {
       return { ok: true, mode: "already-linked" };
     }
@@ -471,7 +493,8 @@ export async function provisionClient(input: unknown): Promise<{
   }
 
   if (authUser.uid === session.uid) {
-    throw new Error("You cannot add yourself as a client.");
+    // CR-03: expected refusal → result, not a thrown (prod-masked) message.
+    return { ok: false, mode: "self" };
   }
 
   // EXISTING-USER branch. Read-before-write the /users doc INSIDE the tx and
@@ -480,7 +503,9 @@ export async function provisionClient(input: unknown): Promise<{
   // whose doc was never written (threat T-32-DIVERGE).
   const userRef = db.collection(FirestoreCollections.users).doc(authUser.uid);
   const chatRef = db.collection(FirestoreCollections.chats).doc(authUser.uid);
-  const userOutcomeKind = await db.runTransaction<LinkOutcome["kind"]>(
+  let userOutcomeKind: LinkOutcome["kind"];
+  try {
+    userOutcomeKind = await db.runTransaction<LinkOutcome["kind"]>(
     async (tx) => {
       const userSnap = await tx.get(userRef);
       const data = userSnap.exists ? userSnap.data() ?? {} : {};
@@ -497,8 +522,9 @@ export async function provisionClient(input: unknown): Promise<{
           targetUid: authUser.uid,
           existingCoachId: outcome.currentCoachId,
         });
-        // Throw INSIDE the tx → aborts before any write; claims still untouched.
-        throw new Error(tErr("conflictError", { email: parsed.email }));
+        // Sentinel throw INSIDE the tx → aborts before any write; claims
+        // still untouched (CR-03: converted to a result below).
+        throw new LinkRefusedError("conflict");
       }
       if (outcome.kind === "alreadyYours") {
         return "alreadyYours"; // no writes, no claims mutation
@@ -548,7 +574,13 @@ export async function provisionClient(input: unknown): Promise<{
       );
       return "link";
     },
-  );
+    );
+  } catch (err) {
+    if (err instanceof LinkRefusedError) {
+      return { ok: false, mode: err.mode };
+    }
+    throw err;
+  }
 
   if (userOutcomeKind === "alreadyYours") {
     return { ok: true, mode: "already-linked" };

--- a/backoffice/src/lib/gc-fitness/user-actions.ts
+++ b/backoffice/src/lib/gc-fitness/user-actions.ts
@@ -255,6 +255,21 @@ function logLinkConflictRefused(params: {
   console.warn("[gc-fitness/coach-link] link_conflict_refused", params);
 }
 
+/**
+ * CR-02 audit line for a refused trainer-target link attempt. Server-side
+ * console only — same T-32-E2 confinement as logLinkConflictRefused: this
+ * MUST NOT flow into the coach-activity event log, and the requesting coach
+ * only ever sees the mode-keyed banner copy (which names the typed email,
+ * never the fact that the doc belongs to a trainer's roster or claims).
+ */
+function logLinkTrainerTargetRefused(params: {
+  actorUid: string;
+  targetEmail: string;
+  targetUid: string | null;
+}): void {
+  console.warn("[gc-fitness/coach-link] link_trainer_target_refused", params);
+}
+
 async function trainerProfile(
   uid: string,
   email: string,
@@ -436,10 +451,21 @@ export async function provisionClient(input: unknown): Promise<
             ? (mirrorSnap.data() as {
                 coachId?: string | null;
                 autoAssignedCoach?: boolean;
+                role?: string | null;
               })
             : null,
           session.uid,
         );
+        if (outcome.kind === "trainerTarget") {
+          // CR-02: mirror docs shouldn't carry role, but if one ever does,
+          // refuse for the same reason as the /users branch below.
+          logLinkTrainerTargetRefused({
+            actorUid: session.uid,
+            targetEmail: parsed.email,
+            targetUid: null,
+          });
+          throw new LinkRefusedError("trainer-target");
+        }
         if (outcome.kind === "conflict") {
           logLinkConflictRefused({
             actorUid: session.uid,
@@ -511,10 +537,26 @@ export async function provisionClient(input: unknown): Promise<
       const data = userSnap.exists ? userSnap.data() ?? {} : {};
       const outcome = decideLinkOutcome(
         userSnap.exists
-          ? (data as { coachId?: string | null; autoAssignedCoach?: boolean })
+          ? (data as {
+              coachId?: string | null;
+              autoAssignedCoach?: boolean;
+              role?: string | null;
+            })
           : null,
         session.uid,
       );
+      if (outcome.kind === "trainerTarget") {
+        // CR-02: the target is another TRAINER's account — linking would
+        // overwrite their doc (role → "client", coachId → this coach) and
+        // then clobber their role claim post-commit, demoting and locking
+        // them out. Refuse before any write.
+        logLinkTrainerTargetRefused({
+          actorUid: session.uid,
+          targetEmail: parsed.email,
+          targetUid: authUser.uid,
+        });
+        throw new LinkRefusedError("trainer-target");
+      }
       if (outcome.kind === "conflict") {
         logLinkConflictRefused({
           actorUid: session.uid,

--- a/backoffice/src/lib/gc-fitness/user-actions.ts
+++ b/backoffice/src/lib/gc-fitness/user-actions.ts
@@ -569,7 +569,10 @@ export async function provisionClient(input: unknown): Promise<
         throw new LinkRefusedError("conflict");
       }
       if (outcome.kind === "alreadyYours") {
-        return "alreadyYours"; // no writes, no claims mutation
+        // No doc writes; claims ARE (re-)synced post-commit — WR-01: the
+        // idempotent setCustomUserClaims below heals a divergence left by a
+        // prior post-commit claims failure when the trainer resubmits.
+        return "alreadyYours";
       }
       tx.set(
         userRef,
@@ -624,17 +627,25 @@ export async function provisionClient(input: unknown): Promise<
     throw err;
   }
 
-  if (userOutcomeKind === "alreadyYours") {
-    return { ok: true, mode: "already-linked" };
-  }
-
   // Claims AFTER the doc-write commit (T-32-DIVERGE): the benign direction
   // (doc written, claims lag) self-heals via the Phase 30 forced token refresh.
+  //
+  // WR-01: this ALSO runs on the alreadyYours path. If a previous submit
+  // committed the tx but the claims call failed (network blip / Auth outage),
+  // the trainer's natural recovery is to resubmit — which now resolves to
+  // alreadyYours. Skipping claims there would leave the doc/claims divergence
+  // unrepairable from the UI. The call is an idempotent no-op when claims
+  // already match, so running it on every resolution of the existing-user
+  // branch is safe and heals the divergence on retry.
   await auth.setCustomUserClaims(authUser.uid, {
     ...(authUser.customClaims ?? {}),
     role: "client",
     coachId: session.uid,
   });
+
+  if (userOutcomeKind === "alreadyYours") {
+    return { ok: true, mode: "already-linked" };
+  }
 
   revalidateTag("gc-fitness-roster", "max");
   return { ok: true, mode: "attached-existing-user" };

--- a/backoffice/src/lib/gc-fitness/user-actions.ts
+++ b/backoffice/src/lib/gc-fitness/user-actions.ts
@@ -52,6 +52,7 @@
 import { cookies } from "next/headers";
 import { revalidateTag } from "next/cache";
 import { FieldValue } from "firebase-admin/firestore";
+import { getTranslations } from "next-intl/server";
 import { z } from "zod";
 
 import {
@@ -60,6 +61,7 @@ import {
 } from "@/lib/firebase/gc-fitness-admin";
 
 import { getCurrentTrainer } from "./auth-helpers";
+import { decideLinkOutcome, type LinkOutcome } from "./coach-link";
 import { FirestoreCollections } from "./collections";
 import { normalizeMirrorEmail } from "./email-normalization";
 
@@ -232,6 +234,23 @@ function fallbackName(email: string): string {
   return localPart || email;
 }
 
+/**
+ * D-02 refused-steal audit. A single support-triage server log line for a
+ * refused coach-link conflict. Deliberately NOT written to the coach-activity
+ * event log or the admin-operations log — those surface in the REQUESTING
+ * coach's My-Activity feed and would leak the other coach's identity (threat
+ * T-32-E2). The existingCoachId is safe ONLY here, in a server-side log line
+ * the requesting coach can never read.
+ */
+function logLinkConflictRefused(params: {
+  actorUid: string;
+  targetEmail: string;
+  targetUid: string | null;
+  existingCoachId: string;
+}): void {
+  console.warn("[gc-fitness/coach-link] link_conflict_refused", params);
+}
+
 async function trainerProfile(
   uid: string,
   email: string,
@@ -365,9 +384,10 @@ export async function updateClientNickname(
  * the normal client rules immediately. If the email does not exist yet, it
  * creates `/user_mirror/{email}` for the first-sign-in provisioning path.
  */
-export async function provisionClient(
-  input: unknown,
-): Promise<{ ok: true; mode: "attached-existing-user" | "precreated-mirror" }> {
+export async function provisionClient(input: unknown): Promise<{
+  ok: true;
+  mode: "attached-existing-user" | "precreated-mirror" | "already-linked";
+}> {
   const session = await getCurrentTrainer();
   const parsed = provisionClientSchema.parse(input);
   const db = gcFitnessFirestore();
@@ -375,6 +395,9 @@ export async function provisionClient(
   const coach = await trainerProfile(session.uid, session.email);
   const coachDisplayName = coach.displayName;
   const displayName = parsed.displayName || fallbackName(parsed.email);
+  // Localized conflict copy — built once, rendered verbatim by the form's red
+  // HelperBanner. MUST NOT name the other coach (threat T-32-ENUM).
+  const tErr = await getTranslations("clients.provisionForm");
 
   let authUser: Awaited<ReturnType<typeof auth.getUserByEmail>> | null = null;
   try {
@@ -385,20 +408,58 @@ export async function provisionClient(
   }
 
   if (!authUser) {
-    await db.collection(FirestoreCollections.userMirror).doc(parsed.email).set(
-      {
-        email: parsed.email,
-        displayName,
-        coachId: session.uid,
-        coachDisplayName,
-        coachPhotoURL: coach.photoURL,
-        coachBio: coach.bio,
-        pre_created: true,
-        createdAt: FieldValue.serverTimestamp(),
-        updatedAt: FieldValue.serverTimestamp(),
+    // MIRROR branch. A pre-existing `/user_mirror/{email}` owned by a DIFFERENT
+    // coach is a second silent-steal vector (Pitfall 1) — gate it read-before-
+    // write inside a transaction so a concurrent writer can't slip past.
+    const mirrorRef = db
+      .collection(FirestoreCollections.userMirror)
+      .doc(parsed.email);
+    const mirrorOutcomeKind = await db.runTransaction<LinkOutcome["kind"]>(
+      async (tx) => {
+        const mirrorSnap = await tx.get(mirrorRef);
+        const outcome = decideLinkOutcome(
+          mirrorSnap.exists
+            ? (mirrorSnap.data() as {
+                coachId?: string | null;
+                autoAssignedCoach?: boolean;
+              })
+            : null,
+          session.uid,
+        );
+        if (outcome.kind === "conflict") {
+          logLinkConflictRefused({
+            actorUid: session.uid,
+            targetEmail: parsed.email,
+            targetUid: null,
+            existingCoachId: outcome.currentCoachId,
+          });
+          // Throw INSIDE the tx → aborts before any write.
+          throw new Error(tErr("conflictError", { email: parsed.email }));
+        }
+        if (outcome.kind === "alreadyYours") {
+          return "alreadyYours"; // no write — friendly no-op surfaced below
+        }
+        tx.set(
+          mirrorRef,
+          {
+            email: parsed.email,
+            displayName,
+            coachId: session.uid,
+            coachDisplayName,
+            coachPhotoURL: coach.photoURL,
+            coachBio: coach.bio,
+            pre_created: true,
+            createdAt: FieldValue.serverTimestamp(),
+            updatedAt: FieldValue.serverTimestamp(),
+          },
+          { merge: true },
+        );
+        return "link";
       },
-      { merge: true },
     );
+    if (mirrorOutcomeKind === "alreadyYours") {
+      return { ok: true, mode: "already-linked" };
+    }
     revalidateTag("gc-fitness-roster", "max");
     return { ok: true, mode: "precreated-mirror" };
   }
@@ -407,51 +468,84 @@ export async function provisionClient(
     throw new Error("You cannot add yourself as a client.");
   }
 
+  // EXISTING-USER branch. Read-before-write the /users doc INSIDE the tx and
+  // refuse a different-coach conflict. Claims are set only AFTER the tx commits
+  // (below) so a refusal/abort can never leave claims pointing at a client
+  // whose doc was never written (threat T-32-DIVERGE).
+  const userRef = db.collection(FirestoreCollections.users).doc(authUser.uid);
+  const chatRef = db.collection(FirestoreCollections.chats).doc(authUser.uid);
+  const userOutcomeKind = await db.runTransaction<LinkOutcome["kind"]>(
+    async (tx) => {
+      const userSnap = await tx.get(userRef);
+      const data = userSnap.exists ? userSnap.data() ?? {} : {};
+      const outcome = decideLinkOutcome(
+        userSnap.exists
+          ? (data as { coachId?: string | null; autoAssignedCoach?: boolean })
+          : null,
+        session.uid,
+      );
+      if (outcome.kind === "conflict") {
+        logLinkConflictRefused({
+          actorUid: session.uid,
+          targetEmail: parsed.email,
+          targetUid: authUser.uid,
+          existingCoachId: outcome.currentCoachId,
+        });
+        // Throw INSIDE the tx → aborts before any write; claims still untouched.
+        throw new Error(tErr("conflictError", { email: parsed.email }));
+      }
+      if (outcome.kind === "alreadyYours") {
+        return "alreadyYours"; // no writes, no claims mutation
+      }
+      tx.set(
+        userRef,
+        {
+          email: parsed.email,
+          displayName:
+            parsed.displayName ||
+            (typeof data.displayName === "string" &&
+            data.displayName.length > 0
+              ? data.displayName
+              : authUser.displayName || displayName),
+          photoURL: authUser.photoURL ?? data.photoURL ?? null,
+          role: "client",
+          coachId: session.uid,
+          coachDisplayName,
+          coachPhotoURL: coach.photoURL,
+          coachBio: coach.bio,
+          preferences: data.preferences ?? {},
+          fcmTokens: data.fcmTokens ?? [],
+          deleted: false,
+          createdAt: data.createdAt ?? FieldValue.serverTimestamp(),
+          updatedAt: FieldValue.serverTimestamp(),
+        },
+        { merge: true },
+      );
+      tx.set(
+        chatRef,
+        {
+          clientId: authUser.uid,
+          coachId: session.uid,
+          unreadCount: data.unreadCount ?? {},
+          createdAt: FieldValue.serverTimestamp(),
+          updatedAt: FieldValue.serverTimestamp(),
+        },
+        { merge: true },
+      );
+      return "link";
+    },
+  );
+
+  if (userOutcomeKind === "alreadyYours") {
+    return { ok: true, mode: "already-linked" };
+  }
+
+  // Claims AFTER the doc-write commit (T-32-DIVERGE): the benign direction
+  // (doc written, claims lag) self-heals via the Phase 30 forced token refresh.
   await auth.setCustomUserClaims(authUser.uid, {
     ...(authUser.customClaims ?? {}),
     role: "client",
     coachId: session.uid,
-  });
-
-  const userRef = db.collection(FirestoreCollections.users).doc(authUser.uid);
-  const chatRef = db.collection(FirestoreCollections.chats).doc(authUser.uid);
-  await db.runTransaction(async (tx) => {
-    const userSnap = await tx.get(userRef);
-    const data = userSnap.exists ? userSnap.data() ?? {} : {};
-    tx.set(
-      userRef,
-      {
-        email: parsed.email,
-        displayName:
-          parsed.displayName ||
-          (typeof data.displayName === "string" && data.displayName.length > 0
-            ? data.displayName
-            : authUser.displayName || displayName),
-        photoURL: authUser.photoURL ?? data.photoURL ?? null,
-        role: "client",
-        coachId: session.uid,
-        coachDisplayName,
-        coachPhotoURL: coach.photoURL,
-        coachBio: coach.bio,
-        preferences: data.preferences ?? {},
-        fcmTokens: data.fcmTokens ?? [],
-        deleted: false,
-        createdAt: data.createdAt ?? FieldValue.serverTimestamp(),
-        updatedAt: FieldValue.serverTimestamp(),
-      },
-      { merge: true },
-    );
-    tx.set(
-      chatRef,
-      {
-        clientId: authUser.uid,
-        coachId: session.uid,
-        unreadCount: data.unreadCount ?? {},
-        createdAt: FieldValue.serverTimestamp(),
-        updatedAt: FieldValue.serverTimestamp(),
-      },
-      { merge: true },
-    );
   });
 
   revalidateTag("gc-fitness-roster", "max");

--- a/backoffice/src/lib/gc-fitness/user-actions.ts
+++ b/backoffice/src/lib/gc-fitness/user-actions.ts
@@ -574,6 +574,10 @@ export async function provisionClient(input: unknown): Promise<
         // prior post-commit claims failure when the trainer resubmits.
         return "alreadyYours";
       }
+      // WR-02: read the chat doc INSIDE the tx (all tx reads must precede
+      // writes) so createdAt can be create-only below — re-linking an
+      // existing user must not reset the chat's original creation timestamp.
+      const chatSnap = await tx.get(chatRef);
       tx.set(
         userRef,
         {
@@ -611,8 +615,16 @@ export async function provisionClient(input: unknown): Promise<
         {
           clientId: authUser.uid,
           coachId: session.uid,
-          unreadCount: data.unreadCount ?? {},
-          createdAt: FieldValue.serverTimestamp(),
+          // WR-02: no unreadCount here. `data` is the USER doc snapshot, so
+          // `data.unreadCount ?? {}` was always {} — counters live on
+          // /chats/{clientId} and merge:true preserves them; writing an
+          // (accidentally empty) map only worked by the grace of merge
+          // semantics and would wipe both parties' counters under any
+          // future non-merge/flat-field write. createdAt is CREATE-ONLY:
+          // claiming a stray with chat history must not reset it.
+          ...(chatSnap.exists
+            ? {}
+            : { createdAt: FieldValue.serverTimestamp() }),
           updatedAt: FieldValue.serverTimestamp(),
         },
         { merge: true },

--- a/backoffice/src/lib/gc-fitness/user-actions.ts
+++ b/backoffice/src/lib/gc-fitness/user-actions.ts
@@ -448,6 +448,12 @@ export async function provisionClient(input: unknown): Promise<{
             coachDisplayName,
             coachPhotoURL: coach.photoURL,
             coachBio: coach.bio,
+            // CR-01: a claimed doc is no longer a stray. Without this delete,
+            // `merge: true` preserves `autoAssignedCoach: true` and rule (3)
+            // of decideLinkOutcome keeps the claimed target silently
+            // stealable by any other coach. (The migration's other stray
+            // fields — coachDisplayName/PhotoURL/Bio — are overwritten above.)
+            autoAssignedCoach: FieldValue.delete(),
             pre_created: true,
             createdAt: FieldValue.serverTimestamp(),
             updatedAt: FieldValue.serverTimestamp(),
@@ -510,6 +516,14 @@ export async function provisionClient(input: unknown): Promise<{
           photoURL: authUser.photoURL ?? data.photoURL ?? null,
           role: "client",
           coachId: session.uid,
+          // CR-01: claiming a Phase-29 fallback-migrated stray MUST clear the
+          // stray marker — otherwise the doc stays `{ coachId: <me>,
+          // autoAssignedCoach: true }`, which decideLinkOutcome rule (3)
+          // still classifies as claimable, so any other coach could silently
+          // steal the client you just claimed (and the roster "NEW" badge
+          // never clears). `merge: true` preserves absent fields, so an
+          // explicit FieldValue.delete() is required.
+          autoAssignedCoach: FieldValue.delete(),
           coachDisplayName,
           coachPhotoURL: coach.photoURL,
           coachBio: coach.bio,


### PR DESCRIPTION
Companion to mdb1/gc-fitness#511 (iOS + Android). Backoffice port of issue #480.

Adds a per-muscle-group **sets** and **volume** breakdown to the trainer's **client progress page**, plus the exercise-form changes to author primary/secondary muscles.

## Feature
- **`MuscleGroupProgressClient`** card on `clients/[id]/progress`: coarse-group toggle chips (default back/chest/legs), a **Series** chart with a configurable green **12–20 target band**, a **Volumen** chart, a per-group readout, and info + target-zone popovers. Recharts + `.gc-fitness-theme` tokens.
- **Sets counting (primary 1 · secondary ½):** faithful TS twin (`muscle-group-display.ts`) of the iOS/Android `coarseWeights` (line-for-line), with parity tests. New weekly aggregation (`buildMuscleGroupWeeks`) buckets weighted sets + volume per coarse group (warmups excluded, time branch handled) — reuses the existing `workout_logs` read, no new query/index.
- **Exercise form:** single **primary** muscle + multiple **secondary** muscles; new `primaryMuscleGroup` on the Zod schema (+ quick-create).
- i18n EN + ES. No `firestore.rules` change (exercises create rule is `hasAll`, update has no key whitelist).

## Deferred
- The future-week **projection** from upcoming assignments (TODO documented in `exercise-progress-actions.ts`) — kept this PR focused on actuals.

## Gates
- `tsc --noEmit` clean.
- `npx jest`: affected suites (muscle-group-display, exercise-schema, exercise-form-validation) green; full run is 830 pass / 1 fail = the documented `client-activity-time` locale flake only (green in CI).

> ⚠️ main auto-deploys — reviewed on an isolated feature branch.