### PR TITLE
fix(gc-fitness): weekly-sets muscle chart no longer halves whole primary sets (#529)

### DIFF
--- a/backoffice/src/lib/gc-fitness/__tests__/muscle-group-display.test.ts
+++ b/backoffice/src/lib/gc-fitness/__tests__/muscle-group-display.test.ts
@@ -83,4 +83,23 @@ describe("muscle-group-display", () => {
   it("returns an empty map for exercises with no surfaced coarse group", () => {
     expect(coarseWeights({ muscleGroups: ["cardio", "full_body"] })).toEqual({});
   });
+
+  it("#529 anatomy echoing the primary muscle does not demote a sole group", () => {
+    // Seeded leg doc: no explicit primary, secondaryMuscles echo the exercise's
+    // OWN primary anatomy → both map to `legs`, the only coarse group. It must
+    // stay 1.0 (this demotion turned ~18 leg sets into 11.5 in issue #529).
+    const w = coarseWeights({
+      muscleGroups: ["legs"],
+      secondaryMuscles: ["Quadriceps femoris", "Gluteus maximus"],
+    });
+    expect(w).toEqual({ legs: 1.0 });
+  });
+
+  it("#529 guard is scoped — a true secondary is still 0.5 when a primary remains", () => {
+    const w = coarseWeights({
+      muscleGroups: ["chest", "triceps"],
+      secondaryMuscles: ["Triceps brachii"],
+    });
+    expect(w).toEqual({ chest: 1.0, triceps: 0.5 });
+  });
 });

--- a/backoffice/src/lib/gc-fitness/muscle-group-display.ts
+++ b/backoffice/src/lib/gc-fitness/muscle-group-display.ts
@@ -158,11 +158,21 @@ export function coarseWeights(input: CoarseWeightsInput): Record<string, number>
       Array.from(allCoarse).filter((g) => g !== primaryCoarse),
     );
   } else {
-    secondaryCoarse = new Set<string>();
+    // #529 — the anatomy heuristic must never demote EVERY coarse group to 0.5.
+    // Seeded docs routinely echo the exercise's OWN primary muscle in
+    // `secondaryMuscles` (e.g. a leg lift listing "Quadriceps femoris" /
+    // "Gluteus maximus"), which would collapse a whole 1.0 leg set to 0.5 and make
+    // ~18 leg sets read as ~11.5. When it would swallow all of `allCoarse` there's
+    // no primary mover left to carry 1.0, so keep every group primary.
+    const anatomySecondary = new Set<string>();
     for (const name of input.secondaryMuscles ?? []) {
       const c = coarseGroupFromAnatomy(name);
-      if (c) secondaryCoarse.add(c);
+      if (c) anatomySecondary.add(c);
     }
+    const swallowsAll = Array.from(allCoarse).every((g) =>
+      anatomySecondary.has(g),
+    );
+    secondaryCoarse = swallowsAll ? new Set<string>() : anatomySecondary;
   }
 
   const weights: Record<string, number> = {};


### PR DESCRIPTION
Backoffice twin of mdb1/gc-fitness#531 — fixes #529.

## Problem
The client Progress muscle-group **sets** readout showed a fractional weekly total (e.g. 11.5) for a week that actually had ~18 leg sets.

## Root cause
`coarseWeights` weights each set 1.0 (primary) / 0.5 (secondary). With no mappable `primaryMuscleGroup`, it derives the secondary set from `secondaryMuscles` anatomy names. Seeded leg docs echo the primary muscle's own anatomy there (`"Quadriceps femoris"`, `"Gluteus maximus"`), so `legs` — the only coarse group — was demoted to 0.5 and whole sets became half-sets.

## Fix
If the anatomy heuristic would mark **every** coarse group as secondary, keep them all primary (there's no primary left to carry 1.0). A true secondary is still 0.5 while any primary remains. Byte-for-byte twin of the iOS/Android fix.

## Tests
`src/lib/gc-fitness/__tests__/muscle-group-display.test.ts` — two new cases; `npx jest muscle-group-display` → **10/10 green**.