### PR TITLE
feat(gc-fitness/admin): coach-less users god-mode (dashboard, subscription, grant/revoke premium, delete)

### DIFF
--- a/backoffice/src/app/gc-fitness/admin/coach-less-users/page.tsx
+++ b/backoffice/src/app/gc-fitness/admin/coach-less-users/page.tsx
@@ -1,0 +1,220 @@
+import { revalidatePath } from "next/cache";
+import Link from "next/link";
+import { redirect } from "next/navigation";
+import { ArrowLeft } from "lucide-react";
+
+import { AdminSubmitButton } from "../_components/admin-submit-button";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { PageHeader } from "@/components/gc-fitness/page-header";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { getCurrentAdmin } from "@/lib/gc-fitness/auth-helpers";
+import { sectionMetadata } from "@/lib/gc-fitness/page-metadata";
+import {
+  listCoachlessUsersWithStats,
+  setUserEntitlementTier,
+  deleteCoachlessUser,
+} from "@/lib/gc-fitness/admin-coachless-actions";
+import { resolveDisplayTier } from "@/lib/gc-fitness/coachless-user-model";
+
+export const generateMetadata = () => sectionMetadata("adminPanel");
+
+export const dynamic = "force-dynamic";
+
+const ROUTE = "/gc-fitness/admin/coach-less-users";
+
+function formatDate(iso: string | null): string {
+  // Stable YYYY-MM-DD (avoids the server-locale flake seen in date tests).
+  return iso ? iso.slice(0, 10) : "—";
+}
+
+export default async function CoachlessUsersPage({
+  searchParams,
+}: {
+  searchParams: Promise<Record<string, string | string[] | undefined>>;
+}) {
+  try {
+    await getCurrentAdmin();
+  } catch (err) {
+    const message = err instanceof Error ? err.message : "Forbidden";
+    if (message === "Forbidden") {
+      redirect("/gc-fitness/forbidden");
+    }
+    throw err;
+  }
+
+  const sp = await searchParams;
+  const op = typeof sp.op === "string" ? sp.op : null;
+  const ok = sp.ok === "1";
+  const actionMessage = op && ok ? `Action completed: ${op}.` : null;
+
+  const rows = await listCoachlessUsersWithStats();
+
+  async function setTierAction(formData: FormData) {
+    "use server";
+    const uid = String(formData.get("uid") ?? "");
+    const tier = String(formData.get("tier") ?? "");
+    await setUserEntitlementTier({ uid, tier });
+    revalidatePath(ROUTE);
+    redirect(`${ROUTE}?op=set_${tier}&ok=1`);
+  }
+
+  async function deleteUserAction(formData: FormData) {
+    "use server";
+    const uid = String(formData.get("uid") ?? "");
+    const emailConfirmation = String(formData.get("emailConfirmation") ?? "");
+    await deleteCoachlessUser({ uid, emailConfirmation });
+    revalidatePath(ROUTE);
+    redirect(`${ROUTE}?op=delete_user&ok=1`);
+  }
+
+  return (
+    <div className="gc-page flex flex-col gap-6">
+      <PageHeader
+        title="Coach-less users"
+        subtitle="Self-serve clients with no coach — subscription status, content stats, and god-mode actions (grant/revoke premium, delete)."
+      />
+
+      <Button asChild variant="outline" size="sm" className="self-start rounded-full">
+        <Link href="/gc-fitness/admin">
+          <ArrowLeft className="h-4 w-4" />
+          Back to admin
+        </Link>
+      </Button>
+
+      {actionMessage ? (
+        <div className="rounded-2xl border border-[color:var(--badge-success-border)] bg-[color:var(--badge-success-bg)] px-4 py-3 text-sm text-[color:var(--badge-success-fg)]">
+          {actionMessage}
+        </div>
+      ) : null}
+
+      <div className="text-sm text-muted-foreground">
+        {rows.length} coach-less user{rows.length === 1 ? "" : "s"}.
+      </div>
+
+      <div className="overflow-x-auto rounded-2xl border">
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead>User</TableHead>
+              <TableHead>Subscription</TableHead>
+              <TableHead className="text-right">Routines</TableHead>
+              <TableHead className="text-right">Habits</TableHead>
+              <TableHead className="text-right">Photos</TableHead>
+              <TableHead className="text-right">Logs</TableHead>
+              <TableHead>Created</TableHead>
+              <TableHead className="text-right">Actions</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {rows.length === 0 ? (
+              <TableRow>
+                <TableCell colSpan={8} className="text-sm text-muted-foreground">
+                  No coach-less users.
+                </TableCell>
+              </TableRow>
+            ) : (
+              rows.map((row) => {
+                const tier = resolveDisplayTier(row.entitlement);
+                const isPremium = tier === "premium";
+                return (
+                  <TableRow key={row.uid}>
+                    <TableCell>
+                      <div className="flex items-center gap-3">
+                        {row.photoURL ? (
+                          // eslint-disable-next-line @next/next/no-img-element
+                          <img
+                            src={row.photoURL}
+                            alt=""
+                            className="h-8 w-8 rounded-full object-cover"
+                          />
+                        ) : (
+                          <div className="h-8 w-8 rounded-full bg-muted" aria-hidden />
+                        )}
+                        <div>
+                          <div className="font-medium">{row.displayName || "—"}</div>
+                          <div className="text-xs text-muted-foreground">{row.email || "—"}</div>
+                          <div className="font-mono text-[10px] text-muted-foreground">{row.uid}</div>
+                        </div>
+                      </div>
+                    </TableCell>
+                    <TableCell>
+                      <span
+                        className={
+                          isPremium
+                            ? "inline-flex rounded-full border border-[color:var(--badge-success-border)] bg-[color:var(--badge-success-bg)] px-2 py-0.5 text-xs font-medium text-[color:var(--badge-success-fg)]"
+                            : "inline-flex rounded-full border bg-muted px-2 py-0.5 text-xs font-medium text-muted-foreground"
+                        }
+                      >
+                        {isPremium ? "Premium" : "Free"}
+                      </span>
+                      {row.entitlement ? (
+                        <div className="mt-1 space-y-0.5 text-[10px] text-muted-foreground">
+                          <div>source: {row.entitlement.source || "—"}</div>
+                          {row.entitlement.expiresAtISO ? (
+                            <div>expires: {formatDate(row.entitlement.expiresAtISO)}</div>
+                          ) : null}
+                        </div>
+                      ) : null}
+                    </TableCell>
+                    <TableCell className="text-right tabular-nums">{row.stats.routines}</TableCell>
+                    <TableCell className="text-right tabular-nums">{row.stats.habits}</TableCell>
+                    <TableCell className="text-right tabular-nums">{row.stats.progressPhotos}</TableCell>
+                    <TableCell className="text-right tabular-nums">{row.stats.workoutLogs}</TableCell>
+                    <TableCell className="text-xs text-muted-foreground">
+                      {formatDate(row.createdAtISO)}
+                    </TableCell>
+                    <TableCell className="text-right">
+                      <div className="flex flex-col items-end gap-2">
+                        <form action={setTierAction}>
+                          <input type="hidden" name="uid" value={row.uid} />
+                          <input type="hidden" name="tier" value={isPremium ? "free" : "premium"} />
+                          <AdminSubmitButton
+                            idleLabel={isPremium ? "Revoke premium" : "Grant premium"}
+                            pendingLabel="Saving…"
+                            className="h-8 rounded-full border px-3 text-xs hover:bg-muted"
+                          />
+                        </form>
+
+                        <details className="text-right">
+                          <summary className="cursor-pointer text-xs text-destructive underline underline-offset-2">
+                            Delete user
+                          </summary>
+                          <form action={deleteUserAction} className="mt-2 flex flex-col items-end gap-2">
+                            <input type="hidden" name="uid" value={row.uid} />
+                            <p className="max-w-[16rem] text-left text-[10px] text-muted-foreground">
+                              Irreversible: deletes Auth, all Firestore data, and Storage
+                              photos. Type <span className="font-mono">{row.email}</span> to confirm.
+                            </p>
+                            <Input
+                              name="emailConfirmation"
+                              placeholder="type email to confirm"
+                              className="h-8 w-64 text-xs"
+                              autoComplete="off"
+                            />
+                            <AdminSubmitButton
+                              idleLabel="Delete forever"
+                              pendingLabel="Deleting…"
+                              className="h-8 rounded-full bg-destructive px-3 text-xs text-destructive-foreground hover:bg-destructive/90"
+                            />
+                          </form>
+                        </details>
+                      </div>
+                    </TableCell>
+                  </TableRow>
+                );
+              })
+            )}
+          </TableBody>
+        </Table>
+      </div>
+    </div>
+  );
+}

--- a/backoffice/src/app/gc-fitness/admin/page.tsx
+++ b/backoffice/src/app/gc-fitness/admin/page.tsx
@@ -118,6 +118,22 @@ export default async function AdminPage({
 
       <Card>
         <CardHeader>
+          <CardTitle className="text-xl">Coach-less users (god mode)</CardTitle>
+          <CardDescription>
+            Self-serve clients with no coach: subscription status, per-user
+            content stats (routines, habits, photos, logs), grant/revoke premium,
+            and full cascade delete.
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <Button asChild>
+            <Link href="/gc-fitness/admin/coach-less-users">Open coach-less users</Link>
+          </Button>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
           <CardTitle className="text-xl">App version (force update)</CardTitle>
           <CardDescription>
             Set the minimum supported app build per platform. Clients on an

--- a/backoffice/src/app/gc-fitness/admin/users/page.tsx
+++ b/backoffice/src/app/gc-fitness/admin/users/page.tsx
@@ -19,6 +19,7 @@ import {
   type UserSearchResultRow,
 } from "@/lib/gc-fitness/admin-actions";
 import { getCurrentAdmin } from "@/lib/gc-fitness/auth-helpers";
+import { resolveDisplayTier } from "@/lib/gc-fitness/coachless-user-model";
 import { sectionMetadata } from "@/lib/gc-fitness/page-metadata";
 
 // Tab title: "GC Fitness - <adminPanel>" (issue #170).
@@ -150,6 +151,17 @@ export default async function AdminUserSearchPage({
                           <div className="text-xs text-muted-foreground">
                             {row.email}
                           </div>
+                          <div className="mt-0.5">
+                            {resolveDisplayTier(row.entitlement) === "premium" ? (
+                              <span className="inline-flex rounded-full border border-[color:var(--badge-success-border)] bg-[color:var(--badge-success-bg)] px-2 py-0.5 text-[10px] font-medium text-[color:var(--badge-success-fg)]">
+                                Premium
+                              </span>
+                            ) : (
+                              <span className="inline-flex rounded-full border bg-muted px-2 py-0.5 text-[10px] font-medium text-muted-foreground">
+                                Free
+                              </span>
+                            )}
+                          </div>
                         </div>
                       </div>
                     </TableCell>
@@ -186,6 +198,15 @@ export default async function AdminUserSearchPage({
                             <div>
                               <span className="text-muted-foreground">Roles:</span>{" "}
                               {row.roles.join(", ") || "—"}
+                            </div>
+                            <div>
+                              <span className="text-muted-foreground">Subscription:</span>{" "}
+                              {resolveDisplayTier(row.entitlement) === "premium"
+                                ? "Premium"
+                                : "Free"}
+                              {row.entitlement?.source
+                                ? ` (${row.entitlement.source})`
+                                : ""}
                             </div>
                           </div>
                         </details>

--- a/backoffice/src/lib/gc-fitness/__tests__/admin-user-search.test.ts
+++ b/backoffice/src/lib/gc-fitness/__tests__/admin-user-search.test.ts
@@ -147,6 +147,7 @@ describe("searchUsersByEmailForAdmin", () => {
       "photoURL",
       "deleted",
       "coachId",
+      "entitlement",
     );
     // Both the prefix match AND the mid-string match come back; the non-match doesn't.
     expect(rows.map((r) => r.uid).sort()).toEqual(["uid-prefix", "uid-substr"]);
@@ -173,6 +174,7 @@ describe("searchUsersByEmailForAdmin", () => {
         photoURL: "https://example.com/c.jpg",
         deleted: false,
         coachId: "coach-9",
+        entitlement: { tier: "premium", source: "revenuecat", productId: "gcfitness.lifetime" },
       }),
       mockDoc("uid-admin", {
         email: "admin2@example.com",
@@ -203,6 +205,11 @@ describe("searchUsersByEmailForAdmin", () => {
     expect(clientRow.roles).toEqual(["client"]);
     expect(clientRow.photoURL).toBe("https://example.com/c.jpg");
     expect(clientRow.coachId).toBe("coach-9");
+    // Subscription status is parsed from the entitlement map (this change).
+    expect(clientRow.entitlement?.tier).toBe("premium");
+    expect(clientRow.entitlement?.source).toBe("revenuecat");
+    // A user with no entitlement field resolves to null.
+    expect(adminRow.entitlement).toBeNull();
 
     // Sorted by email asc (admin2@ before client@).
     expect(rows.map((r) => r.email)).toEqual([

--- a/backoffice/src/lib/gc-fitness/__tests__/coachless-user-model.test.ts
+++ b/backoffice/src/lib/gc-fitness/__tests__/coachless-user-model.test.ts
@@ -1,0 +1,109 @@
+// __tests__/coachless-user-model.test.ts
+//
+// Unit coverage for the pure (firebase-free) helpers behind the admin
+// coach-less users god-mode surface. No firebase imports → no mocks needed.
+
+import {
+  normalizeTier,
+  resolveDisplayTier,
+  firestoreValueToISO,
+  toEntitlementInfo,
+  isCoachlessClientRow,
+  type EntitlementInfo,
+} from "../coachless-user-model";
+
+describe("normalizeTier", () => {
+  it("maps only the literal 'premium' to premium; everything else to free", () => {
+    expect(normalizeTier("premium")).toBe("premium");
+    expect(normalizeTier("free")).toBe("free");
+    expect(normalizeTier("")).toBe("free");
+    expect(normalizeTier(undefined)).toBe("free");
+    expect(normalizeTier(null)).toBe("free");
+    expect(normalizeTier("PREMIUM")).toBe("free"); // case-sensitive by design
+    expect(normalizeTier(1)).toBe("free");
+  });
+});
+
+describe("resolveDisplayTier", () => {
+  it("is premium only when the entitlement tier is premium", () => {
+    expect(resolveDisplayTier(null)).toBe("free");
+    expect(
+      resolveDisplayTier({ tier: "free", source: null, productId: null, expiresAtISO: null, updatedAtISO: null }),
+    ).toBe("free");
+    expect(
+      resolveDisplayTier({ tier: "premium", source: "revenuecat", productId: "gcfitness.lifetime", expiresAtISO: null, updatedAtISO: null }),
+    ).toBe("premium");
+  });
+});
+
+describe("firestoreValueToISO", () => {
+  it("converts a Timestamp-like {toDate}, passes ISO strings, else null", () => {
+    const d = new Date("2026-07-26T12:00:00.000Z");
+    expect(firestoreValueToISO({ toDate: () => d })).toBe("2026-07-26T12:00:00.000Z");
+    expect(firestoreValueToISO("2026-01-02T03:04:05.000Z")).toBe("2026-01-02T03:04:05.000Z");
+    expect(firestoreValueToISO(null)).toBeNull();
+    expect(firestoreValueToISO(undefined)).toBeNull();
+    expect(firestoreValueToISO(123)).toBeNull();
+  });
+
+  it("returns null when toDate throws (never blows up the scan)", () => {
+    expect(
+      firestoreValueToISO({
+        toDate: () => {
+          throw new Error("bad ts");
+        },
+      }),
+    ).toBeNull();
+  });
+});
+
+describe("toEntitlementInfo", () => {
+  it("returns null for absent / non-object entitlement", () => {
+    expect(toEntitlementInfo(undefined)).toBeNull();
+    expect(toEntitlementInfo(null)).toBeNull();
+    expect(toEntitlementInfo("premium")).toBeNull();
+  });
+
+  it("parses a full RevenueCat-shaped map with a Timestamp expiresAt", () => {
+    const d = new Date("2027-01-01T00:00:00.000Z");
+    const info = toEntitlementInfo({
+      tier: "premium",
+      source: "revenuecat",
+      productId: "gcfitness.sub.yearly",
+      expiresAt: { toDate: () => d },
+      updatedAt: { toDate: () => new Date("2026-07-26T00:00:00.000Z") },
+    });
+    expect(info).toEqual<EntitlementInfo>({
+      tier: "premium",
+      source: "revenuecat",
+      productId: "gcfitness.sub.yearly",
+      expiresAtISO: "2027-01-01T00:00:00.000Z",
+      updatedAtISO: "2026-07-26T00:00:00.000Z",
+    });
+  });
+
+  it("defaults a present-but-tierless map to free with null fields", () => {
+    expect(toEntitlementInfo({})).toEqual<EntitlementInfo>({
+      tier: "free",
+      source: null,
+      productId: null,
+      expiresAtISO: null,
+      updatedAtISO: null,
+    });
+  });
+});
+
+describe("isCoachlessClientRow", () => {
+  it("is true only for an active client with no coach", () => {
+    expect(isCoachlessClientRow({ role: "client", coachId: null, deleted: false })).toBe(true);
+    expect(isCoachlessClientRow({ role: "client", coachId: "", deleted: false })).toBe(true);
+    expect(isCoachlessClientRow({ role: "client", coachId: "   ", deleted: false })).toBe(true);
+  });
+
+  it("is false for coached clients, non-clients, or deleted users", () => {
+    expect(isCoachlessClientRow({ role: "client", coachId: "coach123", deleted: false })).toBe(false);
+    expect(isCoachlessClientRow({ role: "trainer", coachId: null, deleted: false })).toBe(false);
+    expect(isCoachlessClientRow({ role: null, coachId: null, deleted: false })).toBe(false);
+    expect(isCoachlessClientRow({ role: "client", coachId: null, deleted: true })).toBe(false);
+  });
+});

--- a/backoffice/src/lib/gc-fitness/admin-actions.ts
+++ b/backoffice/src/lib/gc-fitness/admin-actions.ts
@@ -8,6 +8,10 @@ import { emailMatchesQuery, normalizeSearchQuery } from "@/lib/gc-fitness/admin-
 import { getCurrentAdmin } from "@/lib/gc-fitness/auth-helpers";
 import { FirestoreCollections } from "@/lib/gc-fitness/collections";
 import { recurrenceLabel } from "@/lib/gc-fitness/coach-activity-log";
+import {
+  toEntitlementInfo,
+  type EntitlementInfo,
+} from "@/lib/gc-fitness/coachless-user-model";
 
 export interface CoachAdminRow {
   uid: string;
@@ -189,6 +193,8 @@ export interface UserSearchResultRow {
   photoURL: string | null;
   deleted: boolean;
   coachId: string | null;
+  /** Subscription status from `/users/{uid}.entitlement` (null when absent). */
+  entitlement: EntitlementInfo | null;
 }
 
 export async function searchUsersByEmailForAdmin(
@@ -211,7 +217,7 @@ export async function searchUsersByEmailForAdmin(
   const cappedLimit = Math.min(Math.max(limit, 1), 50);
   const snap = await db
     .collection(FirestoreCollections.users)
-    .select("email", "displayName", "role", "photoURL", "deleted", "coachId")
+    .select("email", "displayName", "role", "photoURL", "deleted", "coachId", "entitlement")
     .get();
 
   const matches = snap.docs
@@ -251,6 +257,7 @@ export async function searchUsersByEmailForAdmin(
         photoURL: typeof data.photoURL === "string" ? data.photoURL : null,
         deleted: data.deleted === true,
         coachId: typeof data.coachId === "string" ? data.coachId : null,
+        entitlement: toEntitlementInfo(data.entitlement),
       } satisfies UserSearchResultRow;
     }),
   );

--- a/backoffice/src/lib/gc-fitness/admin-coachless-actions.ts
+++ b/backoffice/src/lib/gc-fitness/admin-coachless-actions.ts
@@ -1,0 +1,229 @@
+"use server";
+
+// admin-coachless-actions.ts
+//
+// God-mode admin actions for the "coach-less users" surface (#374 follow-up):
+//   • listCoachlessUsersWithStats — dashboard scan (role=client, no coach) with
+//     per-user content counts + subscription status.
+//   • setUserEntitlementTier       — manual grant/revoke of premium (admin override).
+//   • deleteCoachlessUser          — full cascade delete (Storage binaries +
+//     Firestore + Auth), reusing the tested `deleteClientCascade`.
+//
+// Every action is admin-gated (getCurrentAdmin throws "Forbidden" otherwise) and
+// mutations are logged to `admin_operations`. Pure shaping/parse logic lives in
+// the firebase-free `coachless-user-model.ts` (unit-tested).
+
+import { FieldValue } from "firebase-admin/firestore";
+import { z } from "zod";
+
+import { deleteClientCascade } from "@/lib/gc-fitness/admin-actions";
+import { getCurrentAdmin } from "@/lib/gc-fitness/auth-helpers";
+import { FirestoreCollections } from "@/lib/gc-fitness/collections";
+import {
+  firestoreValueToISO,
+  toEntitlementInfo,
+  isCoachlessClientRow,
+  type CoachlessUserStats,
+  type EntitlementInfo,
+} from "@/lib/gc-fitness/coachless-user-model";
+import {
+  gcFitnessFirestore,
+  gcFitnessStorage,
+} from "@/lib/firebase/gc-fitness-admin";
+
+export interface CoachlessUserRow {
+  uid: string;
+  email: string;
+  displayName: string;
+  photoURL: string | null;
+  createdAtISO: string | null;
+  entitlement: EntitlementInfo | null;
+  stats: CoachlessUserStats;
+}
+
+/**
+ * Scan `/users` for coach-less clients and attach per-user content counts +
+ * subscription status. Admin-only. Aggregation `.count()` queries keep the
+ * per-user cost cheap; the coach-less segment is small, so a full projected
+ * scan + parallel per-user counts is fine (mirrors `searchUsersByEmailForAdmin`).
+ */
+export async function listCoachlessUsersWithStats(): Promise<CoachlessUserRow[]> {
+  await getCurrentAdmin();
+  const db = gcFitnessFirestore();
+
+  const snap = await db
+    .collection(FirestoreCollections.users)
+    .select("email", "displayName", "role", "photoURL", "deleted", "coachId", "entitlement", "createdAt")
+    .get();
+
+  const candidates = snap.docs.filter((doc) => {
+    const d = doc.data() as Record<string, unknown>;
+    return isCoachlessClientRow({
+      role: typeof d.role === "string" ? d.role : null,
+      coachId: typeof d.coachId === "string" ? d.coachId : null,
+      deleted: d.deleted === true,
+    });
+  });
+
+  const rows = await Promise.all(
+    candidates.map(async (doc) => {
+      const d = doc.data() as Record<string, unknown>;
+      const uid = doc.id;
+
+      // A coach-less user never has coach-assigned content, so a single
+      // clientId/trainerId equality per collection is enough (no composite
+      // index needed). Habits carry `clientOwned` only on client-created docs,
+      // set in-memory (backoffice never writes it), so fetch + filter.
+      const [routinesAgg, habitsSnap, photosAgg, logsAgg] = await Promise.all([
+        db
+          .collection(FirestoreCollections.workoutTemplates)
+          .where("trainerId", "==", uid)
+          .count()
+          .get(),
+        db
+          .collection(FirestoreCollections.habits)
+          .where("clientId", "==", uid)
+          .select("clientOwned")
+          .get(),
+        db
+          .collection(FirestoreCollections.progressPhotos)
+          .where("clientId", "==", uid)
+          .count()
+          .get(),
+        db
+          .collection(FirestoreCollections.workoutLogs)
+          .where("clientId", "==", uid)
+          .count()
+          .get(),
+      ]);
+
+      const stats: CoachlessUserStats = {
+        routines: routinesAgg.data().count,
+        habits: habitsSnap.docs.filter((h) => h.get("clientOwned") === true).length,
+        progressPhotos: photosAgg.data().count,
+        workoutLogs: logsAgg.data().count,
+      };
+
+      return {
+        uid,
+        email: typeof d.email === "string" ? d.email : "",
+        displayName: typeof d.displayName === "string" ? d.displayName : "",
+        photoURL: typeof d.photoURL === "string" ? d.photoURL : null,
+        createdAtISO: firestoreValueToISO(d.createdAt),
+        entitlement: toEntitlementInfo(d.entitlement),
+        stats,
+      } satisfies CoachlessUserRow;
+    }),
+  );
+
+  rows.sort((a, b) => a.email.localeCompare(b.email));
+  return rows;
+}
+
+const setEntitlementSchema = z.object({
+  uid: z.string().trim().min(6).max(128),
+  tier: z.enum(["premium", "free"]),
+});
+
+/**
+ * Manually set a user's entitlement tier (god-mode override). Overwrites the
+ * whole `entitlement` map so a stale productId/expiresAt can't leak; marks
+ * `source: "admin"` so it's distinguishable from a RevenueCat-written one. NOTE:
+ * a later real RevenueCat webhook event will overwrite this (server truth wins),
+ * and a coached user is premium regardless of this field.
+ */
+export async function setUserEntitlementTier(
+  input: unknown,
+): Promise<{ ok: true; uid: string; tier: "premium" | "free" }> {
+  const admin = await getCurrentAdmin();
+  const { uid, tier } = setEntitlementSchema.parse(input);
+  const db = gcFitnessFirestore();
+
+  await db
+    .collection(FirestoreCollections.users)
+    .doc(uid)
+    .set(
+      {
+        entitlement: {
+          tier,
+          source: "admin",
+          productId: null,
+          expiresAt: null,
+          updatedAt: FieldValue.serverTimestamp(),
+        },
+      },
+      { merge: true },
+    );
+
+  await db.collection(FirestoreCollections.adminOperations).add({
+    actorUid: admin.uid,
+    kind: "set_entitlement",
+    mode: "execute",
+    targetUid: uid,
+    status: "success",
+    summary: { tier, source: "admin" },
+    createdAt: FieldValue.serverTimestamp(),
+  });
+
+  return { ok: true, uid, tier };
+}
+
+const deleteCoachlessSchema = z.object({
+  uid: z.string().trim().min(6).max(128),
+  emailConfirmation: z.string().trim().min(1),
+});
+
+/**
+ * Full cascade delete of a coach-less client: Storage progress-photo binaries
+ * (best-effort) + all Firestore data + Auth user (via the tested
+ * `deleteClientCascade`). Guards: refuses non-coach-less / non-client accounts,
+ * and requires the typed email to match the target's email.
+ */
+export async function deleteCoachlessUser(
+  input: unknown,
+): Promise<{ ok: true; deletedDocsApprox: number }> {
+  await getCurrentAdmin();
+  const { uid, emailConfirmation } = deleteCoachlessSchema.parse(input);
+  const db = gcFitnessFirestore();
+
+  const userDoc = await db.collection(FirestoreCollections.users).doc(uid).get();
+  if (!userDoc.exists) {
+    throw new Error("User not found.");
+  }
+  const data = userDoc.data() as Record<string, unknown>;
+
+  // Safety: this god-mode tool only deletes COACH-LESS CLIENT accounts. Deleting
+  // a coach (cascade of all their clients) must go through the coach delete tool.
+  const role = typeof data.role === "string" ? data.role : null;
+  const coachId = typeof data.coachId === "string" ? data.coachId : null;
+  if (!isCoachlessClientRow({ role, coachId, deleted: data.deleted === true })) {
+    throw new Error(
+      "Refusing to delete: target is not an active coach-less client.",
+    );
+  }
+
+  // Typed-email confirmation (case-insensitive) — a strong destructive guard.
+  const email = typeof data.email === "string" ? data.email : "";
+  if (email.trim().toLowerCase() !== emailConfirmation.trim().toLowerCase()) {
+    throw new Error("Email confirmation does not match the target user.");
+  }
+
+  // Best-effort Storage cleanup — the Firestore cascade only removes the
+  // progress_photos METADATA docs, not the binaries under progress_photos/{uid}/.
+  try {
+    await gcFitnessStorage()
+      .bucket()
+      .deleteFiles({ prefix: `${FirestoreCollections.progressPhotos}/${uid}/` });
+  } catch {
+    // Never block the account delete on a storage cleanup failure.
+  }
+
+  // Reuse the tested Firestore + Auth cascade (writes its own admin_operations log).
+  const result = await deleteClientCascade({
+    clientUid: uid,
+    confirmation: "DELETE CLIENT",
+    mode: "execute",
+  });
+
+  return { ok: true, deletedDocsApprox: result.deletedDocsApprox };
+}

--- a/backoffice/src/lib/gc-fitness/coachless-user-model.ts
+++ b/backoffice/src/lib/gc-fitness/coachless-user-model.ts
@@ -1,0 +1,103 @@
+// coachless-user-model.ts
+//
+// Pure, side-effect-free helpers for the admin "coach-less users" god-mode
+// surface (no firebase imports) — the unit-testable seam for the Admin-SDK
+// scans in `admin-coachless-actions.ts` and the subscription read in
+// `admin-actions.ts`. Mirrors the split used by `admin-user-search.ts`.
+//
+// "Coach-less" = a client with NO coach. For such a user the entitlement tier
+// is the sole premium source (the iOS/Android `EntitlementResolver` short-
+// circuits coached ⇒ premium, so with no coach only `entitlement.tier` matters).
+
+/** The two resolved tiers (twin of GCFitnessCore `EntitlementTier`). */
+export type EntitlementTier = "free" | "premium";
+
+/** A plain, transport-safe view of `/users/{uid}.entitlement`. */
+export interface EntitlementInfo {
+  tier: EntitlementTier;
+  /** e.g. "revenuecat" (webhook) or "admin" (manual override). */
+  source: string | null;
+  productId: string | null;
+  expiresAtISO: string | null;
+  updatedAtISO: string | null;
+}
+
+/** Per-user content counts shown in the coach-less dashboard. */
+export interface CoachlessUserStats {
+  /** Self-authored workout templates (routines the user created). */
+  routines: number;
+  /** Client-owned habits. */
+  habits: number;
+  /** Progress-photo check-ins. */
+  progressPhotos: number;
+  /** Logged workout sessions. */
+  workoutLogs: number;
+}
+
+export const EMPTY_STATS: CoachlessUserStats = {
+  routines: 0,
+  habits: 0,
+  progressPhotos: 0,
+  workoutLogs: 0,
+};
+
+/** Normalize any raw tier value to a strict tier (anything but "premium" → free). */
+export function normalizeTier(raw: unknown): EntitlementTier {
+  return raw === "premium" ? "premium" : "free";
+}
+
+/**
+ * The tier to DISPLAY for a coach-less user. With no coach, the entitlement
+ * decides: premium iff `entitlement.tier === "premium"`, else free (incl. when
+ * there is no entitlement at all).
+ */
+export function resolveDisplayTier(entitlement: EntitlementInfo | null): EntitlementTier {
+  return entitlement?.tier === "premium" ? "premium" : "free";
+}
+
+/**
+ * Coerce a Firestore field that may be a Timestamp (`{ toDate() }`), an ISO
+ * string, or absent into an ISO string (or null). Duck-typed on `toDate` so
+ * this file never imports `firebase-admin` and stays purely unit-testable.
+ */
+export function firestoreValueToISO(value: unknown): string | null {
+  if (value && typeof (value as { toDate?: unknown }).toDate === "function") {
+    try {
+      return (value as { toDate: () => Date }).toDate().toISOString();
+    } catch {
+      return null;
+    }
+  }
+  return typeof value === "string" ? value : null;
+}
+
+/**
+ * Parse a raw `/users/{uid}.entitlement` map into `EntitlementInfo`, or null
+ * when absent. A present-but-tier-less map resolves to free (least-privileged).
+ */
+export function toEntitlementInfo(raw: unknown): EntitlementInfo | null {
+  if (!raw || typeof raw !== "object") return null;
+  const r = raw as Record<string, unknown>;
+  return {
+    tier: normalizeTier(r.tier),
+    source: typeof r.source === "string" ? r.source : null,
+    productId: typeof r.productId === "string" ? r.productId : null,
+    expiresAtISO: firestoreValueToISO(r.expiresAt),
+    updatedAtISO: firestoreValueToISO(r.updatedAt),
+  };
+}
+
+/**
+ * True when a `/users/{uid}` doc represents a coach-less client: role client,
+ * no coach linked (nil / empty / whitespace coachId), and not soft-deleted.
+ * The single predicate used by the dashboard scan AND its unit tests.
+ */
+export function isCoachlessClientRow(args: {
+  role: string | null;
+  coachId: string | null;
+  deleted: boolean;
+}): boolean {
+  const isClient = args.role === "client";
+  const noCoach = !args.coachId || args.coachId.trim().length === 0;
+  return isClient && noCoach && !args.deleted;
+}


### PR DESCRIPTION
## What
God-mode admin tooling for the new coach-less (self-serve) user segment.

### New: `/gc-fitness/admin/coach-less-users` dashboard
Lists every client with **no coach**, with per-user:
- **Subscription status** (tier / source / expiry, from `/users/{uid}.entitlement`)
- **#routines** (self-authored workout templates), **#habits** (client-owned), **#progress photos**, **#workout logs**
- Created date

### Actions (all admin-gated + audit-logged to `admin_operations`)
- **Grant / revoke premium** — `setUserEntitlementTier` writes `entitlement.tier` with `source:"admin"` (manual override; a real RevenueCat webhook still wins later).
- **Delete user (cascade)** — `deleteCoachlessUser`: Storage photo binaries + all Firestore data + Auth (reuses the tested `deleteClientCascade`). Guards: **coach-less clients only** + **typed-email confirmation**.

### Also
- Surface subscription status (Premium/Free badge + source) in the admin **User Search**.

## Design
- Pure, firebase-free helpers in `coachless-user-model.ts` (tier resolution, entitlement parsing, coach-less predicate) — **9 new unit tests**.
- Server actions in `admin-coachless-actions.ts`; every action calls `getCurrentAdmin()`.

## Tests
- `npx tsc --noEmit` clean.
- `npx jest` green except the pre-existing `client-activity-time` locale flake (green in CI).

## Notes
- This delete also removes Storage binaries — an improvement over the existing coach cascade, which only removes `progress_photos` metadata docs.