### PR TITLE
fix(website): make /#about resolve, and lead the carousel with GC Fitness

### DIFF
--- a/pocket-genes/src/components/FoundersNote.astro
+++ b/pocket-genes/src/components/FoundersNote.astro
@@ -2,9 +2,15 @@
 import { useTranslations } from '../i18n/index';
 
 const t = useTranslations(Astro.currentLocale);
+
+// id="about" below is the target of the nav's and footer's "Nosotros" /
+// "About Us" link (`/#about`). Nothing on the page carried that id before, so
+// the link silently landed back at the top of the hero. This is the section
+// that actually answers "who are you" — the founder's note on why Golden Crow
+// exists. "Conocé al Equipo" keeps its own separate anchor (#team).
 ---
 
-<section class="founders-note-section">
+<section class="founders-note-section" id="about">
   <div class="container">
     <div class="founders-note-card">
       <div class="founders-photo-wrap">

--- a/pocket-genes/src/data/projects.ts
+++ b/pocket-genes/src/data/projects.ts
@@ -30,11 +30,15 @@ interface ProjectDef {
   category: CategoryId;
 }
 
+// Order matters twice over: it is the order of the homepage "Success Stories"
+// carousel AND the order inside each category on /work. GC Fitness leads —
+// it is our own product, and the carousel only shows three cards at a time, so
+// anything in fourth place is invisible until the user drags.
 const projectDefs: readonly ProjectDef[] = [
+  { key: 'project4', category: 'fitness' },
   { key: 'project1', category: 'fitness' },
   { key: 'project2', category: 'health' },
   { key: 'project3', category: 'fitness' },
-  { key: 'project4', category: 'fitness' },
 ] as const;
 
 // Extra link slots a project may fill. The URL lives in the i18n bundle next to


### PR DESCRIPTION
Follow-up to #268. Two separate problems, both visible from `goldencrowvs.com/#about`.

## 1. `/#about` was a dead anchor

The nav's **Nosotros** / **About Us** link and the footer's both point at `/#about`, but **no element on the homepage carried that id** — the only ids are `projects`, `why-us`, `team`, `booking` and `tsparticles`. Clicking it just left you at the top of the hero, which is why the homepage looked like it was missing content.

The anchor now sits on the **founder's note** (*"Por eso creamos Golden Crow: una software boutique…"*) — the section that actually answers "who are you". **Conocé al Equipo** keeps its own `#team` anchor, so the two nav items stay distinct destinations.

## 2. GC Fitness was on the homepage, just invisible

`index.astro` renders `getProjects()`, so #268 already shipped GC Fitness into the "Nuestros Casos de Éxito" carousel — I confirmed all five destinations in the production HTML. But it was **fourth in a carousel that shows three cards at a time**, so it never appeared without dragging.

`projectDefs` now leads with it. It's our own product, and first place is the only slot the carousel gives away for free.

The reorder also applies to `/work`, where the Fitness category now reads **GC Fitness → StrongerU → Anytime Fitness**. Same reasoning; say the word if you'd rather keep the client work first there.

## Verification

- `npm run build` green — 66 pages.
- Exactly one `id="about"` per locale (checked the built HTML; an earlier draft leaked the explanation as an HTML comment, so it's a frontmatter comment now and ships nothing).
- `/#about` lands on the founder's note, ES and EN.
- GC Fitness renders first in the carousel with its store badges and Descargar / Instagram / Wiki pills.
- No `backoffice/`, iOS or `firestore.rules` files touched.