### PR TITLE
fix(website): point "Nosotros" at the /about page instead of a homepage anchor

### DIFF
--- a/pocket-genes/src/components/FoundersNote.astro
+++ b/pocket-genes/src/components/FoundersNote.astro
@@ -2,15 +2,9 @@
 import { useTranslations } from '../i18n/index';
 
 const t = useTranslations(Astro.currentLocale);
-
-// id="about" below is the target of the nav's and footer's "Nosotros" /
-// "About Us" link (`/#about`). Nothing on the page carried that id before, so
-// the link silently landed back at the top of the hero. This is the section
-// that actually answers "who are you" — the founder's note on why Golden Crow
-// exists. "Conocé al Equipo" keeps its own separate anchor (#team).
 ---
 
-<section class="founders-note-section" id="about">
+<section class="founders-note-section">
   <div class="container">
     <div class="founders-note-card">
       <div class="founders-photo-wrap">

--- a/pocket-genes/src/layouts/BaseLayout.astro
+++ b/pocket-genes/src/layouts/BaseLayout.astro
@@ -99,7 +99,7 @@ const enPath = `/en${pathWithoutLocale === '/' ? '/' : pathWithoutLocale}`;
           <span class="hamburger-line"></span>
         </button>
         <div class="nav-links">
-          <a href={`${localPath('/')}#about`} class="nav-link">{t.nav.about}</a>
+          <a href={localPath('/about')} class="nav-link">{t.nav.about}</a>
           <a href={localPath('/work')} class="nav-link">{t.nav.work}</a>
           <a href={`${localPath('/')}#why-us`} class="nav-link">{t.nav.whyUs}</a>
           <a href={`${localPath('/')}#team`} class="nav-link">{t.nav.team}</a>
@@ -120,7 +120,7 @@ const enPath = `/en${pathWithoutLocale === '/' ? '/' : pathWithoutLocale}`;
     <footer class="main-footer">
       <div class="container">
         <nav class="footer-nav">
-          <a href={`${localPath('/')}#about`}>{t.nav.about}</a>
+          <a href={localPath('/about')}>{t.nav.about}</a>
           <span class="footer-nav-divider">&middot;</span>
           <a href={localPath('/work')}>{t.nav.work}</a>
           <span class="footer-nav-divider">&middot;</span>


### PR DESCRIPTION
**Trabajos** goes to `/work` — a page. **Nosotros** went to `/#about` — an anchor — so clicking it jumped you down the homepage to the founder's note instead of navigating anywhere. Two different behaviours behind two adjacent nav items.

The nav and the footer now link to **`/about`** (and `/en/about`): the page that already existed in the repo and was reachable from nowhere. Same shape as `/work` — a real destination, no scroll jump. Clicking "Nosotros" from the homepage now lands on `/about` at `scrollY 0`.

This also drops the `id="about"` I added to the founder's note in #269. That was the best fix available *while the link was still an anchor*; now that nothing points at a homepage `#about`, the id is dead weight — and leaving it would keep the jump alive for any stale `/#about` link still floating around.

The GC Fitness carousel ordering from #269 is untouched.

## ⚠️ The /about page copy is stale — worth a look

Now that this page is actually reachable, its content is the first thing anyone reading "Nosotros" will see, and **it still describes Golden Crow as a genomics company**:

> "Somos una empresa de tecnología enfocada en crear soluciones innovadoras para el análisis y visualización de datos genómicos."
>
> **Nuestra Misión** — "Hacer que la información genética sea accesible…"
> **Nuestra Visión** — "Un mundo donde la información genética ayude…"
> **Nuestra Tecnología** — "…transformar información genética compleja…"

Same in English (`about.heroDesc`, `missionDesc`, `visionDesc`, `technologyDesc` in `src/i18n/{es,en}.ts`). That's Pocket Genes positioning, not the native-mobile-agency positioning the homepage uses.

I left it alone because it's company positioning copy — your call, not mine. Say the word and I'll rewrite the four strings in both locales to match the homepage voice. Two smaller things on the same page: the hero heading uses `--accent-gradient` (pink `#c27ba0`), off-brand against the gold everywhere else, and the page has no meta description even though `BaseLayout` now supports one.

## Verification

- `npm run build` green — 66 pages.
- No `#about` and no `id="about"` anywhere in `dist/`.
- Clicked "Nosotros" from the homepage in a real browser: lands on `/about`, `scrollY 0`, ES and EN.
- No `backoffice/`, iOS or `firestore.rules` files touched.