### PR TITLE
fix(website): "Nosotros" vuelve al ancla /#about y /about deja de servir copy vieja

### DIFF
--- a/pocket-genes/src/i18n/en.ts
+++ b/pocket-genes/src/i18n/en.ts
@@ -196,13 +196,7 @@ export const en = {
   about: {
     title: 'Golden Crow VS - About Us',
     heroTitle: 'About Golden Crow VS',
-    heroDesc: 'We are a technology company focused on creating innovative solutions for genomic data analysis and visualization.',
-    missionTitle: 'Our Mission',
-    missionDesc: 'To make genomic data accessible, understandable, and actionable for everyone.',
-    visionTitle: 'Our Vision',
-    visionDesc: 'A world where genetic insights empower individuals to make informed decisions about their health and lifestyle.',
-    technologyTitle: 'Our Technology',
-    technologyDesc: 'We leverage cutting-edge technology to transform complex genetic data into intuitive, interactive experiences.',
+    heroDesc: 'A boutique software studio building premium mobile products. Who we are, why we exist and the team behind it.',
   },
 
   // Contact page

--- a/pocket-genes/src/i18n/es.ts
+++ b/pocket-genes/src/i18n/es.ts
@@ -195,13 +195,7 @@ export const es: Translations = {
   about: {
     title: 'Golden Crow VS - Nosotros',
     heroTitle: 'Sobre Golden Crow VS',
-    heroDesc: 'Somos una empresa de tecnología enfocada en crear soluciones innovadoras para el análisis y visualización de datos genómicos.',
-    missionTitle: 'Nuestra Misión',
-    missionDesc: 'Hacer que la información genética sea accesible, comprensible y útil para más personas.',
-    visionTitle: 'Nuestra Visión',
-    visionDesc: 'Un mundo donde la información genética ayude a las personas a llegar mejor preparadas a sus conversaciones de salud.',
-    technologyTitle: 'Nuestra Tecnología',
-    technologyDesc: 'Usamos tecnología para transformar información genética compleja en experiencias claras, visuales e interactivas.',
+    heroDesc: 'Una software boutique que construye productos mobile premium. Quiénes somos, por qué existimos y el equipo que lo hace.',
   },
 
   // Contact page

--- a/pocket-genes/src/pages/about.astro
+++ b/pocket-genes/src/pages/about.astro
@@ -1,9 +1,16 @@
 ---
 import BaseLayout from '../layouts/BaseLayout.astro';
 import AboutUs from '../layouts/AboutUs.astro';
+import FoundersNote from '../components/FoundersNote.astro';
 import { useTranslations } from '../i18n/index';
 
 const t = useTranslations(Astro.currentLocale);
+
+// Esta página servía la copy de la etapa Pocket Genes ("soluciones para el
+// análisis y visualización de datos genómicos", más misión/visión/tecnología),
+// que ya no describe lo que hacemos. El contenido que sí responde "quiénes
+// somos" es la nota del fundador — la misma sección que estuvo detrás de
+// /#about — así que es lo que se sirve acá, seguida del equipo.
 ---
 
 <BaseLayout title={t.about.title}>
@@ -15,24 +22,7 @@ const t = useTranslations(Astro.currentLocale);
       </div>
     </section>
 
-    <section class="about-content">
-      <div class="container">
-        <div class="about-grid">
-          <div class="about-item">
-            <h3>{t.about.missionTitle}</h3>
-            <p>{t.about.missionDesc}</p>
-          </div>
-          <div class="about-item">
-            <h3>{t.about.visionTitle}</h3>
-            <p>{t.about.visionDesc}</p>
-          </div>
-          <div class="about-item">
-            <h3>{t.about.technologyTitle}</h3>
-            <p>{t.about.technologyDesc}</p>
-          </div>
-        </div>
-      </div>
-    </section>
+    <FoundersNote />
 
     <section class="team-section">
       <AboutUs />
@@ -69,54 +59,8 @@ const t = useTranslations(Astro.currentLocale);
     line-height: 1.6;
   }
 
-  .about-content {
-    padding: clamp(3rem, 6vw, 4rem) 0;
-  }
-
-  .about-grid {
-    display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
-    gap: clamp(1.5rem, 3vw, 2rem);
-    margin-top: clamp(1.5rem, 3vw, 2rem);
-  }
-
-  .about-item {
-    background: rgba(255, 255, 255, 0.05);
-    backdrop-filter: blur(20px);
-    border: 1px solid rgba(255, 255, 255, 0.1);
-    border-radius: 1rem;
-    padding: clamp(1.5rem, 3vw, 2rem);
-    transition: all 0.3s ease;
-  }
-
-  .about-item:hover {
-    transform: translateY(-5px);
-    box-shadow: 0 10px 30px rgba(0, 0, 0, 0.3);
-  }
-
-  .about-item h3 {
-    font-size: 1.5rem;
-    font-weight: 600;
-    margin-bottom: 1rem;
-    background: var(--primary-gradient);
-    background-clip: text;
-    -webkit-background-clip: text;
-    -webkit-text-fill-color: transparent;
-  }
-
-  .about-item p {
-    color: var(--text-secondary);
-    line-height: 1.6;
-  }
-
   .team-section {
     padding: clamp(3rem, 6vw, 4rem) 0;
     background: linear-gradient(135deg, var(--dark-surface) 0%, var(--dark-elevated) 100%);
-  }
-
-  @media (max-width: 480px) {
-    .about-grid {
-      grid-template-columns: 1fr;
-    }
   }
 </style>

--- a/pocket-genes/src/pages/en/about.astro
+++ b/pocket-genes/src/pages/en/about.astro
@@ -1,9 +1,15 @@
 ---
 import BaseLayout from '../../layouts/BaseLayout.astro';
 import AboutUs from '../../layouts/AboutUs.astro';
+import FoundersNote from '../../components/FoundersNote.astro';
 import { useTranslations } from '../../i18n/index';
 
 const t = useTranslations(Astro.currentLocale);
+
+// Mirror of /about — see the note there. This page used to serve the Pocket
+// Genes-era copy (genomic data analysis, mission/vision/technology); it now
+// serves the founder's note, the section that actually answers "who are you",
+// followed by the team.
 ---
 
 <BaseLayout title={t.about.title}>
@@ -15,24 +21,7 @@ const t = useTranslations(Astro.currentLocale);
       </div>
     </section>
 
-    <section class="about-content">
-      <div class="container">
-        <div class="about-grid">
-          <div class="about-item">
-            <h3>{t.about.missionTitle}</h3>
-            <p>{t.about.missionDesc}</p>
-          </div>
-          <div class="about-item">
-            <h3>{t.about.visionTitle}</h3>
-            <p>{t.about.visionDesc}</p>
-          </div>
-          <div class="about-item">
-            <h3>{t.about.technologyTitle}</h3>
-            <p>{t.about.technologyDesc}</p>
-          </div>
-        </div>
-      </div>
-    </section>
+    <FoundersNote />
 
     <section class="team-section">
       <AboutUs />
@@ -45,12 +34,5 @@ const t = useTranslations(Astro.currentLocale);
   .about-hero { background: linear-gradient(135deg, var(--dark-surface) 0%, var(--dark-elevated) 100%); padding: clamp(3rem, 8vw, 6rem) clamp(1rem, 4vw, 2rem); text-align: center; }
   .about-hero h1 { font-size: clamp(2.5rem, 5vw, 4rem); font-weight: 800; margin-bottom: 1.5rem; background: var(--accent-gradient); background-clip: text; -webkit-background-clip: text; -webkit-text-fill-color: transparent; }
   .about-hero p { font-size: clamp(1rem, 2.5vw, 1.25rem); color: var(--text-secondary); max-width: 600px; margin: 0 auto; line-height: 1.6; }
-  .about-content { padding: clamp(3rem, 6vw, 4rem) 0; }
-  .about-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(280px, 1fr)); gap: clamp(1.5rem, 3vw, 2rem); margin-top: clamp(1.5rem, 3vw, 2rem); }
-  .about-item { background: rgba(255, 255, 255, 0.05); backdrop-filter: blur(20px); border: 1px solid rgba(255, 255, 255, 0.1); border-radius: 1rem; padding: clamp(1.5rem, 3vw, 2rem); transition: all 0.3s ease; }
-  .about-item:hover { transform: translateY(-5px); box-shadow: 0 10px 30px rgba(0, 0, 0, 0.3); }
-  .about-item h3 { font-size: 1.5rem; font-weight: 600; margin-bottom: 1rem; background: var(--primary-gradient); background-clip: text; -webkit-background-clip: text; -webkit-text-fill-color: transparent; }
-  .about-item p { color: var(--text-secondary); line-height: 1.6; }
   .team-section { padding: clamp(3rem, 6vw, 4rem) 0; background: linear-gradient(135deg, var(--dark-surface) 0%, var(--dark-elevated) 100%); }
-  @media (max-width: 480px) { .about-grid { grid-template-columns: 1fr; } }
 </style>


### PR DESCRIPTION
Dos cambios sobre el mismo enredo del "Nosotros".

## 1. "Nosotros" vuelve a ser un ancla (`/#about`), y cae en el equipo

#270 convirtió "Nosotros" en un link a la página `/about`. Era la lectura equivocada: el ancla nunca fue el problema, lo era el destino desactualizado. El comportamiento que queremos es el de antes — tocar el item y saltar al bloque **"Conocé al Equipo"**.

- `BaseLayout`: nav y footer vuelven a `/#about` (y `/en/#about`).
- `index.astro` + `en/index.astro`: vuelve el `id="about"`, ahora como ancla suelta justo antes de la sección del equipo. Esa es la sección a la que apunta el link; #269 lo había puesto en la nota del fundador solo porque era lo más parecido a "quiénes somos" en ese momento.

El id va en un `<span>` de altura cero porque la sección ya lleva `id="team"` — un elemento no puede tener dos ids, y las dos formas (`#about` y `#team`) están en links ya publicados.

> ⚠️ **Para mirar:** el nav queda con dos items que caen en el mismo bloque — "Nosotros" (`#about`) y "Nuestro Equipo" (`#team`). Es el estado previo a #270. Si querés, sacar uno de los dos es una línea.

## 2. `/about` deja de servir la copy de la etapa Pocket Genes

La página seguía diciendo *"Somos una empresa de tecnología enfocada en crear soluciones innovadoras para el análisis y visualización de datos genómicos"*, más una grilla Misión / Visión / Tecnología toda escrita sobre datos genéticos.

Ahora sirve la **nota del fundador** (*"Por eso creamos Golden Crow: una software boutique…"*) seguida del equipo. Ya no está linkeada desde el nav, pero es una URL que existe y estaba indexada: mejor actualizada que desactualizada y huérfana.

- `pages/about.astro` y `pages/en/about.astro`: se va la grilla, entra `<FoundersNote />`.
- `i18n/es.ts` + `i18n/en.ts`: `about.heroDesc` al posicionamiento actual y borradas las seis claves `about.{mission,vision,technology}{Title,Desc}` — no las consumía nadie más.

La nota del fundador sigue también en el home: es parte del hilo que lleva al CTA de booking, así que el componente se renderiza en los dos lados.

## Verificación

- `npm run build` verde — 66 páginas.
- Exactamente un `id="about"` por home (ES y EN), inmediatamente antes de la sección del equipo.
- Nav y footer renderizan `/#about` y `/en/#about`.
- `/about` y `/en/about`: cero matches de "genómic"/"genomic", una nota del fundador y el equipo completo.