### PR TITLE
fix(website): "Nosotros" vuelve al ancla /#about, cayendo en el equipo

### DIFF
--- a/pocket-genes/src/layouts/BaseLayout.astro
+++ b/pocket-genes/src/layouts/BaseLayout.astro
@@ -99,7 +99,7 @@ const enPath = `/en${pathWithoutLocale === '/' ? '/' : pathWithoutLocale}`;
           <span class="hamburger-line"></span>
         </button>
         <div class="nav-links">
-          <a href={localPath('/about')} class="nav-link">{t.nav.about}</a>
+          <a href={`${localPath('/')}#about`} class="nav-link">{t.nav.about}</a>
           <a href={localPath('/work')} class="nav-link">{t.nav.work}</a>
           <a href={`${localPath('/')}#why-us`} class="nav-link">{t.nav.whyUs}</a>
           <a href={`${localPath('/')}#team`} class="nav-link">{t.nav.team}</a>
@@ -120,7 +120,7 @@ const enPath = `/en${pathWithoutLocale === '/' ? '/' : pathWithoutLocale}`;
     <footer class="main-footer">
       <div class="container">
         <nav class="footer-nav">
-          <a href={localPath('/about')}>{t.nav.about}</a>
+          <a href={`${localPath('/')}#about`}>{t.nav.about}</a>
           <span class="footer-nav-divider">&middot;</span>
           <a href={localPath('/work')}>{t.nav.work}</a>
           <span class="footer-nav-divider">&middot;</span>

--- a/pocket-genes/src/pages/en/index.astro
+++ b/pocket-genes/src/pages/en/index.astro
@@ -129,6 +129,11 @@ const projects = getProjects(t);
     </section>
 
     <!-- Section 5: Team -->
+    <!-- #about is an alias of #team: the nav's and footer's "About Us" links
+         point at /#about and must land here, on "Meet the Team". It is a bare
+         anchor because one element cannot carry two ids, and both forms are in
+         links already out in the wild. -->
+    <span id="about" class="anchor-alias" aria-hidden="true"></span>
     <section class="team-section" id="team">
       <AboutUs />
     </section>
@@ -234,6 +239,7 @@ const projects = getProjects(t);
   .step-desc { font-size: 0.88rem; color: var(--text-secondary); line-height: 1.55; margin: 0; }
 
   /* Team Section */
+  .anchor-alias { display: block; height: 0; }
   .team-section { padding: 0; }
 
   /* Booking Section */

--- a/pocket-genes/src/pages/index.astro
+++ b/pocket-genes/src/pages/index.astro
@@ -129,6 +129,11 @@ const projects = getProjects(t);
     </section>
 
     <!-- Section 5: Team -->
+    <!-- #about es un alias de #team: el "Nosotros" del nav y del footer apunta
+         a /#about y tiene que caer acá, en "Conocé al Equipo". Va como ancla
+         suelta porque un elemento no puede llevar dos ids, y las dos formas
+         están en links publicados. -->
+    <span id="about" class="anchor-alias" aria-hidden="true"></span>
     <section class="team-section" id="team">
       <AboutUs />
     </section>
@@ -474,6 +479,11 @@ const projects = getProjects(t);
   }
 
   /* Team Section */
+  .anchor-alias {
+    display: block;
+    height: 0;
+  }
+
   .team-section {
     padding: 0;
   }


### PR DESCRIPTION
Este cambio venía en el #272 pero ese PR ya estaba mergeado cuando lo pusheé, así que quedó afuera de `main`. Va solo, sin nada más.

## Qué cambia

#270 convirtió "Nosotros" en un link a la página `/about`. Era la lectura equivocada: el ancla nunca fue el problema, lo era el destino desactualizado — y eso ya se arregló en #272. El comportamiento que queremos es el de antes: tocar el item y saltar al bloque **"Conocé al Equipo"**.

- `BaseLayout`: nav y footer vuelven a `/#about` (y `/en/#about`).
- `index.astro` + `en/index.astro`: vuelve el `id="about"`, como ancla suelta justo antes de la sección del equipo. Esa es la sección a la que apunta el link; #269 lo había puesto en la nota del fundador solo porque era lo más parecido a "quiénes somos" en ese momento.

El id va en un `<span>` de altura cero porque la sección ya lleva `id="team"` — un elemento no puede tener dos ids, y las dos formas (`#about` y `#team`) están en links ya publicados.

> ⚠️ **Para mirar:** el nav queda con dos items que caen en el mismo bloque — "Nosotros" (`#about`) y "Nuestro Equipo" (`#team`). Es el estado previo a #270. Si querés, sacar uno de los dos es una línea.

`/about` sigue existiendo con el contenido bueno que le puso #272 (nota del fundador + equipo). Ya no está linkeada desde el nav, pero es una URL indexada: mejor actualizada que huérfana y vieja.

## Verificación

- `npm run build` verde sobre `main` actual — 68 páginas.
- Exactamente un `id="about"` por home (ES y EN), inmediatamente antes de la sección del equipo.
- Nav y footer renderizan `/#about` y `/en/#about`.