### PR TITLE
feat(gc-fitness): project scheduled workouts on the muscle-group charts (#568)

### DIFF
--- a/backoffice/messages/en.json
+++ b/backoffice/messages/en.json
@@ -286,6 +286,12 @@
         "volumeTitle": "Volume by muscle group",
         "volumeUnit": "kg",
         "setsReadout": "{sets} sets this week",
+        "setsReadoutProjected": "{sets} sets this week → {projected} projected",
+        "projection": {
+          "caption": "Dashed lines project the scheduled workouts that haven't been done yet (this week and the next 4).",
+          "today": "Today",
+          "tooltipSuffix": "{group} (projected)"
+        },
         "selectHint": "Select muscle groups above to compare them.",
         "empty": "This client hasn't logged any completed sets yet.",
         "footnote": "Each set counts as 1 for the primary muscle and ½ for each secondary muscle. Warm-up sets are excluded.",

--- a/backoffice/messages/es.json
+++ b/backoffice/messages/es.json
@@ -286,6 +286,12 @@
         "volumeTitle": "Volumen por grupo muscular",
         "volumeUnit": "kg",
         "setsReadout": "{sets} series esta semana",
+        "setsReadoutProjected": "{sets} series esta semana → {projected} proyectadas",
+        "projection": {
+          "caption": "Las líneas punteadas proyectan los entrenamientos agendados que todavía no se hicieron (esta semana y las próximas 4).",
+          "today": "Hoy",
+          "tooltipSuffix": "{group} (proyección)"
+        },
         "selectHint": "Elegí grupos musculares arriba para compararlos.",
         "empty": "Este cliente todavía no registró series completadas.",
         "footnote": "Cada serie cuenta 1 para el músculo principal y ½ para cada músculo secundario. Las series de calentamiento se excluyen.",

--- a/backoffice/src/app/gc-fitness/clients/[id]/progress/MuscleGroupProgressClient.tsx
+++ b/backoffice/src/app/gc-fitness/clients/[id]/progress/MuscleGroupProgressClient.tsx
@@ -7,9 +7,16 @@
 // Two overlaid charts share a weekly x-axis: SETS by muscle group (with a green
 // 12–20 target band) and VOLUME by muscle group. Each selected coarse group is
 // its own colored line. Weighting is baked server-side (primary 1.0 / secondary
-// 0.5 per set) — see exercise-progress-actions.buildMuscleGroupWeeks + the
+// 0.5 per set) — see muscle-group-weeks.buildMuscleGroupWeeks + the
 // muscle-group-display twin. Switching selection / range / target is pure local
 // state (zero extra Firestore reads).
+//
+// #568 PROJECTION: a dotted divider marks the current week, and from there the
+// lines continue DASHED + dimmed through the client's upcoming scheduled
+// workouts (the current week's remaining days + 4 weeks). Same idea as the iOS /
+// Android Progress-tab charts (MuscleGroupSeriesChart `projectionStartIndex`).
+// The weekly readout shows the projected week total too, so a Monday doesn't
+// read as "3 series esta semana".
 
 import { useMemo, useState } from "react";
 import {
@@ -17,12 +24,13 @@ import {
   Line,
   LineChart,
   ReferenceArea,
+  ReferenceLine,
   ResponsiveContainer,
   Tooltip,
   XAxis,
   YAxis,
 } from "recharts";
-import { Info, SlidersHorizontal } from "lucide-react";
+import { Info, SlidersHorizontal, Sparkles } from "lucide-react";
 import { useLocale, useTranslations } from "next-intl";
 
 import { cn } from "@/lib/utils";
@@ -39,7 +47,12 @@ import {
   COARSE_MUSCLE_GROUPS,
   DEFAULT_SELECTED_MUSCLE_GROUPS,
 } from "@/lib/gc-fitness/muscle-group-display";
-import type { MuscleGroupWeekPoint } from "@/lib/gc-fitness/exercise-progress-actions";
+import {
+  PROJECTED_KEY_SUFFIX as PROJ,
+  buildChartRows,
+  weekHasProjection,
+  type MuscleGroupWeekPoint,
+} from "@/lib/gc-fitness/muscle-group-weeks";
 import {
   DEFAULT_TREND_RANGE,
   type TrendRangeKey,
@@ -63,14 +76,15 @@ function formatSets(n: number): string {
 export interface MuscleGroupProgressClientProps {
   weeks: MuscleGroupWeekPoint[];
   availableGroups: string[];
-  today: string;
+  /** Monday of the current week — the projection boundary / readout anchor. */
+  currentWeekStart: string;
   rangeStarts: Record<TrendRangeKey, string>;
 }
 
 export function MuscleGroupProgressClient({
   weeks,
   availableGroups,
-  today,
+  currentWeekStart,
   rangeStarts,
 }: MuscleGroupProgressClientProps) {
   const locale = useLocale();
@@ -108,38 +122,52 @@ export function MuscleGroupProgressClient({
     [groups, selected],
   );
 
+  // #568 — only render the projection region when the client actually has
+  // upcoming scheduled work; otherwise the charts stay exactly as before.
+  const hasProjection = useMemo(() => weeks.some(weekHasProjection), [weeks]);
+
   const windowWeeks = useMemo(() => {
     const start = rangeStarts[range];
-    return weeks.filter((w) => w.weekStart >= start && w.weekStart <= today);
-  }, [weeks, range, rangeStarts, today]);
+    const inRange = weeks.filter((w) => w.weekStart >= start);
+    return hasProjection ? inRange : inRange.filter((w) => !w.projected);
+  }, [weeks, range, rangeStarts, hasProjection]);
 
-  // One row per week; a column per selected group for each metric.
+  const currentIndex = useMemo(
+    () => windowWeeks.findIndex((w) => w.weekStart === currentWeekStart),
+    [windowWeeks, currentWeekStart],
+  );
+
+  // One row per week; a solid + a dashed column per selected group. See
+  // buildChartRows for the actual/projected boundary math.
   const setsData = useMemo(
     () =>
-      windowWeeks.map((w) => {
-        const row: Record<string, number | string> = { week: w.weekStart };
-        for (const g of selectedOrdered) row[g] = w.byGroup[g]?.sets ?? 0;
-        return row;
-      }),
-    [windowWeeks, selectedOrdered],
+      buildChartRows(windowWeeks, selectedOrdered, "sets", currentIndex, hasProjection),
+    [windowWeeks, selectedOrdered, currentIndex, hasProjection],
   );
   const volumeData = useMemo(
     () =>
-      windowWeeks.map((w) => {
-        const row: Record<string, number | string> = { week: w.weekStart };
-        for (const g of selectedOrdered) row[g] = w.byGroup[g]?.volume ?? 0;
-        return row;
-      }),
-    [windowWeeks, selectedOrdered],
+      buildChartRows(windowWeeks, selectedOrdered, "volume", currentIndex, hasProjection),
+    [windowWeeks, selectedOrdered, currentIndex, hasProjection],
   );
 
-  // Latest-week weighted sets per selected group (legend readout).
-  const latestByGroup = useMemo(() => {
-    const out: Record<string, number> = {};
-    const last = windowWeeks[windowWeeks.length - 1];
-    for (const g of selectedOrdered) out[g] = last?.byGroup[g]?.sets ?? 0;
+  // Current-week weighted sets per selected group — logged so far AND the
+  // projected week total (#568: on a Monday the logged figure alone is
+  // misleading, so the readout shows what the plan adds up to).
+  const currentWeekReadout = useMemo(() => {
+    const week =
+      currentIndex >= 0
+        ? windowWeeks[currentIndex]
+        : windowWeeks[windowWeeks.length - 1];
+    const out: Record<string, { sets: number; projected: number }> = {};
+    for (const g of selectedOrdered) {
+      const sets = week?.byGroup[g]?.sets ?? 0;
+      out[g] = {
+        sets,
+        projected: week?.projectedByGroup?.[g]?.sets ?? sets,
+      };
+    }
     return out;
-  }, [windowWeeks, selectedOrdered]);
+  }, [windowWeeks, currentIndex, selectedOrdered]);
 
   const clampTarget = (nextMin: number, nextMax: number) => {
     const lo = Math.max(0, Math.min(nextMin, nextMax));
@@ -157,6 +185,48 @@ export function MuscleGroupProgressClient({
 
   const xTick = (value: string) =>
     formatCivilDateLabel(value, { month: "short", day: "numeric" }, locale);
+
+  /** Tooltip series label — projected columns are marked as such. */
+  const seriesLabel = (name: string) =>
+    name.endsWith(PROJ)
+      ? t("muscleGroups.projection.tooltipSuffix", {
+          group: muscleLabel(name.slice(0, -PROJ.length)),
+        })
+      : muscleLabel(name);
+
+  /** Dotted "current week" divider between the actual and projected regions. */
+  const projectionDivider =
+    hasProjection && currentIndex >= 0 ? (
+      <ReferenceLine
+        x={currentWeekStart}
+        stroke="var(--muted-foreground)"
+        strokeOpacity={0.5}
+        strokeDasharray="2 3"
+        strokeWidth={1.5}
+        label={{
+          value: t("muscleGroups.projection.today"),
+          position: "top",
+          fontSize: 10,
+          fill: "var(--muted-foreground)",
+        }}
+      />
+    ) : null;
+
+  /** The dashed, dimmed projected line for one group. */
+  const projectedLine = (g: string) =>
+    hasProjection ? (
+      <Line
+        key={`${g}${PROJ}`}
+        type="monotone"
+        dataKey={`${g}${PROJ}`}
+        stroke={colorFor(g)}
+        strokeOpacity={0.45}
+        strokeWidth={2}
+        strokeDasharray="5 4"
+        dot={{ r: 2, fill: colorFor(g), fillOpacity: 0.45, strokeWidth: 0 }}
+        activeDot={{ r: 4, fill: colorFor(g), fillOpacity: 0.6, strokeWidth: 0 }}
+      />
+    ) : null;
 
   const infoBlocks: Array<{ title: string; body: string }> = [
     {
@@ -350,26 +420,43 @@ export function MuscleGroupProgressClient({
         </p>
       ) : (
         <>
-          {/* Per-group latest-week readout / legend */}
+          {/* Per-group current-week readout / legend */}
           <div className="flex flex-wrap gap-x-4 gap-y-1.5">
-            {selectedOrdered.map((g) => (
-              <span
-                key={g}
-                className="inline-flex items-center gap-1.5 text-xs text-muted-foreground"
-              >
+            {selectedOrdered.map((g) => {
+              const readout = currentWeekReadout[g] ?? { sets: 0, projected: 0 };
+              const showsProjection =
+                hasProjection && readout.projected > readout.sets;
+              return (
                 <span
-                  className="size-2.5 rounded-sm"
-                  style={{ backgroundColor: colorFor(g) }}
-                />
-                <span className="text-foreground">{muscleLabel(g)}</span>
-                <span className="tabular-nums">
-                  {t("muscleGroups.setsReadout", {
-                    sets: formatSets(latestByGroup[g] ?? 0),
-                  })}
+                  key={g}
+                  className="inline-flex items-center gap-1.5 text-xs text-muted-foreground"
+                >
+                  <span
+                    className="size-2.5 rounded-sm"
+                    style={{ backgroundColor: colorFor(g) }}
+                  />
+                  <span className="text-foreground">{muscleLabel(g)}</span>
+                  <span className="tabular-nums">
+                    {showsProjection
+                      ? t("muscleGroups.setsReadoutProjected", {
+                          sets: formatSets(readout.sets),
+                          projected: formatSets(readout.projected),
+                        })
+                      : t("muscleGroups.setsReadout", {
+                          sets: formatSets(readout.sets),
+                        })}
+                  </span>
                 </span>
-              </span>
-            ))}
+              );
+            })}
           </div>
+
+          {hasProjection ? (
+            <p className="inline-flex items-center gap-1.5 text-[11px] text-muted-foreground">
+              <Sparkles className="size-3" />
+              {t("muscleGroups.projection.caption")}
+            </p>
+          ) : null}
 
           {/* SETS chart with the green target band */}
           <div className="flex flex-col gap-2">
@@ -396,6 +483,7 @@ export function MuscleGroupProgressClient({
                     strokeOpacity={0.3}
                     ifOverflow="extendDomain"
                   />
+                  {projectionDivider}
                   <XAxis
                     dataKey="week"
                     tick={{ fontSize: 11 }}
@@ -412,6 +500,7 @@ export function MuscleGroupProgressClient({
                     allowDecimals={false}
                   />
                   <Tooltip
+                    filterNull
                     contentStyle={{
                       borderRadius: 10,
                       border: "1px solid hsl(var(--border))",
@@ -419,7 +508,7 @@ export function MuscleGroupProgressClient({
                     }}
                     formatter={(value, name) => [
                       formatSets(Number(value)),
-                      muscleLabel(String(name)),
+                      seriesLabel(String(name)),
                     ]}
                     labelFormatter={(label) =>
                       formatCivilDateLabel(
@@ -440,6 +529,7 @@ export function MuscleGroupProgressClient({
                       activeDot={{ r: 5, fill: colorFor(g), strokeWidth: 0 }}
                     />
                   ))}
+                  {selectedOrdered.map(projectedLine)}
                 </LineChart>
               </ResponsiveContainer>
             </div>
@@ -461,6 +551,7 @@ export function MuscleGroupProgressClient({
                     stroke="var(--muted-foreground)"
                     strokeOpacity={0.16}
                   />
+                  {projectionDivider}
                   <XAxis
                     dataKey="week"
                     tick={{ fontSize: 11 }}
@@ -477,6 +568,7 @@ export function MuscleGroupProgressClient({
                     tickFormatter={(v: number) => String(Math.round(v))}
                   />
                   <Tooltip
+                    filterNull
                     contentStyle={{
                       borderRadius: 10,
                       border: "1px solid hsl(var(--border))",
@@ -484,7 +576,7 @@ export function MuscleGroupProgressClient({
                     }}
                     formatter={(value, name) => [
                       `${Math.round(Number(value))} ${t("muscleGroups.volumeUnit")}`,
-                      muscleLabel(String(name)),
+                      seriesLabel(String(name)),
                     ]}
                     labelFormatter={(label) =>
                       formatCivilDateLabel(
@@ -505,6 +597,7 @@ export function MuscleGroupProgressClient({
                       activeDot={{ r: 5, fill: colorFor(g), strokeWidth: 0 }}
                     />
                   ))}
+                  {selectedOrdered.map(projectedLine)}
                 </LineChart>
               </ResponsiveContainer>
             </div>

--- a/backoffice/src/app/gc-fitness/clients/[id]/progress/page.tsx
+++ b/backoffice/src/app/gc-fitness/clients/[id]/progress/page.tsx
@@ -83,8 +83,13 @@ export default async function ClientExerciseProgressPage({
 
   const t = await getTranslations("clients.exerciseProgress");
 
-  const { exercises, points, muscleGroupWeeks, availableMuscleGroups } =
-    await getClientExerciseProgress(id, timezone);
+  const {
+    exercises,
+    points,
+    muscleGroupWeeks,
+    availableMuscleGroups,
+    currentWeekStart,
+  } = await getClientExerciseProgress(id, timezone);
 
   // Anchor each range to today so the local filter windows match the other
   // client-detail trend widgets.
@@ -137,7 +142,7 @@ export default async function ClientExerciseProgressPage({
       <MuscleGroupProgressClient
         weeks={muscleGroupWeeks}
         availableGroups={availableMuscleGroups}
-        today={today}
+        currentWeekStart={currentWeekStart}
         rangeStarts={rangeStarts}
       />
     </div>

--- a/backoffice/src/lib/gc-fitness/__tests__/muscle-group-weeks.test.ts
+++ b/backoffice/src/lib/gc-fitness/__tests__/muscle-group-weeks.test.ts
@@ -1,0 +1,347 @@
+// muscle-group-weeks.test.ts — #480 weekly bucketing + #568 projection.
+//
+// The projection math is the TS twin of iOS
+// `ProgressPhotosViewModel.projectedSetVolumeKg` / `projectedContributions` and
+// Android `MuscleGroupCharts` — the vectors below mirror those twins.
+
+import {
+  PROJECTION_WEEKS,
+  buildChartRows,
+  buildMuscleGroupWeeks,
+  civilWeekStart,
+  projectedSetVolumeKg,
+  projectedSetsForAssignment,
+  shiftCivilDays,
+  weekHasProjection,
+  type ExerciseMuscleMeta,
+  type MuscleGroupWeekPoint,
+  type MuscleSetInput,
+} from "@/lib/gc-fitness/muscle-group-weeks";
+
+/** Bench press: chest primary, triceps + shoulders secondary (1.0 / 0.5 / 0.5). */
+const BENCH: ExerciseMuscleMeta = {
+  muscleGroups: ["chest", "triceps", "shoulders"],
+  primaryMuscleGroup: "chest",
+  secondaryMuscles: ["triceps", "shoulders"],
+};
+
+/** Row: back primary only. */
+const ROW: ExerciseMuscleMeta = {
+  muscleGroups: ["back"],
+  primaryMuscleGroup: "back",
+  secondaryMuscles: [],
+};
+
+const META = new Map<string, ExerciseMuscleMeta>([
+  ["bench", BENCH],
+  ["row", ROW],
+]);
+
+function set(date: string, exerciseId: string, volumeKg: number): MuscleSetInput {
+  return { date, exerciseId, volumeKg };
+}
+
+describe("civilWeekStart", () => {
+  it("anchors on Monday", () => {
+    // 2026-07-27 is a Monday; 2026-08-02 is the Sunday that closes that week.
+    expect(civilWeekStart("2026-07-27")).toBe("2026-07-27");
+    expect(civilWeekStart("2026-07-29")).toBe("2026-07-27");
+    expect(civilWeekStart("2026-08-02")).toBe("2026-07-27");
+    expect(civilWeekStart("2026-08-03")).toBe("2026-08-03");
+  });
+
+  it("returns the input unchanged on a malformed date", () => {
+    expect(civilWeekStart("nope")).toBe("nope");
+  });
+});
+
+describe("shiftCivilDays", () => {
+  it("crosses month and year boundaries", () => {
+    expect(shiftCivilDays("2026-07-27", 7)).toBe("2026-08-03");
+    expect(shiftCivilDays("2026-01-01", -1)).toBe("2025-12-31");
+  });
+});
+
+describe("projectedSetVolumeKg", () => {
+  it("uses the per-set weight × per-set reps when both are prescribed", () => {
+    const ex = { weightBySetKg: [60, 70, 80], repsBySet: [10, 8, 6] };
+    expect(projectedSetVolumeKg(ex, 0)).toBe(600);
+    expect(projectedSetVolumeKg(ex, 1)).toBe(560);
+    expect(projectedSetVolumeKg(ex, 2)).toBe(480);
+  });
+
+  it("falls back to the LAST prescribed weight past the array end", () => {
+    const ex = { weightBySetKg: [60, 70], reps: 10 };
+    expect(projectedSetVolumeKg(ex, 5)).toBe(700);
+  });
+
+  it("falls back to the exercise-level reps", () => {
+    expect(projectedSetVolumeKg({ weightBySetKg: [50], reps: 12 }, 0)).toBe(600);
+  });
+
+  it("uses weight × duration/60 for time-metric sets", () => {
+    expect(
+      projectedSetVolumeKg({ metric: "time", weightBySetKg: [20], durationSeconds: 90 }, 0),
+    ).toBe(30);
+    expect(
+      projectedSetVolumeKg({ weightBySetKg: [20], durationBySetSeconds: [30, 60] }, 1),
+    ).toBe(20);
+  });
+
+  it("is 0 when no weight is prescribed (bodyweight / open lift)", () => {
+    expect(projectedSetVolumeKg({ reps: 12 }, 0)).toBe(0);
+    expect(projectedSetVolumeKg({ weightBySetKg: [], reps: 12 }, 0)).toBe(0);
+  });
+});
+
+describe("projectedSetsForAssignment", () => {
+  it("emits one input per prescribed set, dated on scheduledFor", () => {
+    const out = projectedSetsForAssignment("2026-07-30", [
+      { exerciseId: "bench", sets: 3, weightBySetKg: [60], reps: 10 },
+      { exerciseId: "row", sets: 2, weightBySetKg: [50], reps: 12 },
+    ]);
+    expect(out).toHaveLength(5);
+    expect(out.every((s) => s.date === "2026-07-30")).toBe(true);
+    expect(out.filter((s) => s.exerciseId === "bench")).toEqual([
+      { date: "2026-07-30", exerciseId: "bench", volumeKg: 600 },
+      { date: "2026-07-30", exerciseId: "bench", volumeKg: 600 },
+      { date: "2026-07-30", exerciseId: "bench", volumeKg: 600 },
+    ]);
+  });
+
+  it("skips exercises with no id or no sets", () => {
+    expect(
+      projectedSetsForAssignment("2026-07-30", [
+        { sets: 3 },
+        { exerciseId: "bench", sets: 0 },
+        { exerciseId: "bench" },
+      ]),
+    ).toEqual([]);
+  });
+});
+
+describe("buildMuscleGroupWeeks — actuals (#480 behavior preserved)", () => {
+  it("weights primary 1.0 and secondary 0.5 and zero-fills the gap weeks", () => {
+    const { muscleGroupWeeks, availableMuscleGroups } = buildMuscleGroupWeeks(
+      [set("2026-07-14", "bench", 600), set("2026-07-27", "row", 500)],
+      [],
+      META,
+      "2026-07-27",
+    );
+
+    expect(muscleGroupWeeks.map((w) => w.weekStart).slice(0, 3)).toEqual([
+      "2026-07-13",
+      "2026-07-20",
+      "2026-07-27",
+    ]);
+    expect(muscleGroupWeeks[0].byGroup).toEqual({
+      chest: { sets: 1, volume: 600 },
+      triceps: { sets: 0.5, volume: 300 },
+      shoulders: { sets: 0.5, volume: 300 },
+    });
+    // Untrained week in the middle stays present and empty.
+    expect(muscleGroupWeeks[1].byGroup).toEqual({});
+    expect(muscleGroupWeeks[2].byGroup).toEqual({ back: { sets: 1, volume: 500 } });
+    expect(availableMuscleGroups).toEqual(["back", "chest", "triceps", "shoulders"]);
+  });
+
+  it("returns nothing when there is neither actual nor projected data", () => {
+    expect(buildMuscleGroupWeeks([], [], META, "2026-07-27")).toEqual({
+      muscleGroupWeeks: [],
+      availableMuscleGroups: [],
+    });
+  });
+
+  it("never attaches a projection to a past week", () => {
+    const { muscleGroupWeeks } = buildMuscleGroupWeeks(
+      [set("2026-07-14", "row", 100)],
+      [],
+      META,
+      "2026-07-27",
+    );
+    expect(muscleGroupWeeks[0].projectedByGroup).toBeUndefined();
+    expect(muscleGroupWeeks[0].projected).toBeUndefined();
+  });
+});
+
+describe("buildMuscleGroupWeeks — projection (#568)", () => {
+  // Monday 2026-07-27. One row logged today; two more rows scheduled Thursday,
+  // plus a full session each of the next two weeks.
+  const actual = [set("2026-07-27", "row", 500)];
+  const projected = [
+    set("2026-07-30", "row", 500),
+    set("2026-07-30", "row", 500),
+    set("2026-08-04", "bench", 600),
+    set("2026-08-11", "bench", 600),
+  ];
+
+  it("adds the current week's remaining prescription on top of the actuals", () => {
+    const { muscleGroupWeeks } = buildMuscleGroupWeeks(
+      actual,
+      projected,
+      META,
+      "2026-07-27",
+    );
+    const current = muscleGroupWeeks.find((w) => w.weekStart === "2026-07-27")!;
+
+    // Logged so far: 1 set. Projected week total: 1 logged + 2 scheduled.
+    expect(current.byGroup).toEqual({ back: { sets: 1, volume: 500 } });
+    expect(current.projectedByGroup).toEqual({ back: { sets: 3, volume: 1500 } });
+    expect(current.projected).toBeUndefined();
+  });
+
+  it("marks future weeks as projected with an empty actual bucket", () => {
+    const { muscleGroupWeeks } = buildMuscleGroupWeeks(
+      actual,
+      projected,
+      META,
+      "2026-07-27",
+    );
+    const next = muscleGroupWeeks.find((w) => w.weekStart === "2026-08-03")!;
+
+    expect(next.projected).toBe(true);
+    expect(next.byGroup).toEqual({});
+    expect(next.projectedByGroup).toEqual({
+      chest: { sets: 1, volume: 600 },
+      triceps: { sets: 0.5, volume: 300 },
+      shoulders: { sets: 0.5, volume: 300 },
+    });
+  });
+
+  it("extends the axis exactly PROJECTION_WEEKS past the current week", () => {
+    const { muscleGroupWeeks } = buildMuscleGroupWeeks(
+      actual,
+      projected,
+      META,
+      "2026-07-27",
+    );
+    const last = muscleGroupWeeks[muscleGroupWeeks.length - 1];
+    expect(last.weekStart).toBe(shiftCivilDays("2026-07-27", 7 * PROJECTION_WEEKS));
+    expect(muscleGroupWeeks.filter((w) => w.projected)).toHaveLength(
+      PROJECTION_WEEKS,
+    );
+  });
+
+  it("starts the axis at the current week when there is no logged history", () => {
+    const { muscleGroupWeeks, availableMuscleGroups } = buildMuscleGroupWeeks(
+      [],
+      projected,
+      META,
+      "2026-07-27",
+    );
+    expect(muscleGroupWeeks[0].weekStart).toBe("2026-07-27");
+    expect(muscleGroupWeeks[0].byGroup).toEqual({});
+    expect(muscleGroupWeeks[0].projectedByGroup).toEqual({
+      back: { sets: 2, volume: 1000 },
+    });
+    expect(availableMuscleGroups).toEqual(["back", "chest", "triceps", "shoulders"]);
+  });
+
+  it("ignores exercises with no resolvable muscle metadata", () => {
+    const { muscleGroupWeeks } = buildMuscleGroupWeeks(
+      [],
+      [set("2026-07-30", "ghost", 999)],
+      META,
+      "2026-07-27",
+    );
+    expect(muscleGroupWeeks).toEqual([]);
+  });
+});
+
+describe("weekHasProjection", () => {
+  it("is false without a projected bucket (a past week)", () => {
+    expect(
+      weekHasProjection({ weekStart: "2026-07-20", byGroup: { back: { sets: 3, volume: 0 } } }),
+    ).toBe(false);
+  });
+
+  it("is false for a current week whose plan adds nothing", () => {
+    expect(
+      weekHasProjection({
+        weekStart: "2026-07-27",
+        byGroup: { back: { sets: 3, volume: 0 } },
+        projectedByGroup: { back: { sets: 3, volume: 0 } },
+      }),
+    ).toBe(false);
+  });
+
+  it("is true for a current week with work still scheduled", () => {
+    expect(
+      weekHasProjection({
+        weekStart: "2026-07-27",
+        byGroup: { back: { sets: 3, volume: 0 } },
+        projectedByGroup: { back: { sets: 9, volume: 0 } },
+      }),
+    ).toBe(true);
+  });
+
+  it("is true for a future week with scheduled sets, false for an empty one", () => {
+    expect(
+      weekHasProjection({
+        weekStart: "2026-08-03",
+        byGroup: {},
+        projectedByGroup: { back: { sets: 6, volume: 0 } },
+        projected: true,
+      }),
+    ).toBe(true);
+    expect(
+      weekHasProjection({
+        weekStart: "2026-08-03",
+        byGroup: {},
+        projectedByGroup: {},
+        projected: true,
+      }),
+    ).toBe(false);
+  });
+});
+
+describe("buildChartRows", () => {
+  const WEEKS: MuscleGroupWeekPoint[] = [
+    { weekStart: "2026-07-13", byGroup: { back: { sets: 8, volume: 4000 } } },
+    { weekStart: "2026-07-20", byGroup: { back: { sets: 10, volume: 5000 } } },
+    {
+      weekStart: "2026-07-27",
+      byGroup: { back: { sets: 3, volume: 1500 } },
+      projectedByGroup: { back: { sets: 12, volume: 6000 } },
+    },
+    {
+      weekStart: "2026-08-03",
+      byGroup: {},
+      projectedByGroup: { back: { sets: 12, volume: 6000 } },
+      projected: true,
+    },
+  ];
+
+  it("splits the solid and dashed regions at the current week", () => {
+    const rows = buildChartRows(WEEKS, ["back"], "sets", 2, true);
+
+    expect(rows).toEqual([
+      { week: "2026-07-13", back: 8, back__proj: null },
+      // Seed: the dashed line starts on the last complete week's actual value.
+      { week: "2026-07-20", back: 10, back__proj: 10 },
+      { week: "2026-07-27", back: 3, back__proj: 12 },
+      // Future week — the solid line stops, only the projection continues.
+      { week: "2026-08-03", back: null, back__proj: 12 },
+    ]);
+  });
+
+  it("reads the volume metric off the same buckets", () => {
+    const rows = buildChartRows(WEEKS, ["back"], "volume", 2, true);
+    expect(rows.map((r) => r.back)).toEqual([4000, 5000, 1500, null]);
+    expect(rows.map((r) => r.back__proj)).toEqual([null, 5000, 6000, 6000]);
+  });
+
+  it("emits no projected values at all when there is nothing upcoming", () => {
+    const rows = buildChartRows(WEEKS.slice(0, 3), ["back"], "sets", 2, false);
+    expect(rows.every((r) => r.back__proj === null)).toBe(true);
+    expect(rows.map((r) => r.back)).toEqual([8, 10, 3]);
+  });
+
+  it("starts the dashed region at the current week when it's first in view", () => {
+    const rows = buildChartRows(WEEKS.slice(2), ["back"], "sets", 0, true);
+    expect(rows).toEqual([
+      { week: "2026-07-27", back: 3, back__proj: 12 },
+      { week: "2026-08-03", back: null, back__proj: 12 },
+    ]);
+  });
+});

--- a/backoffice/src/lib/gc-fitness/exercise-progress-actions.ts
+++ b/backoffice/src/lib/gc-fitness/exercise-progress-actions.ts
@@ -29,9 +29,16 @@ import { gcFitnessFirestore } from "@/lib/firebase/gc-fitness-admin";
 import { FirestoreCollections } from "@/lib/gc-fitness/collections";
 import { civilDateFormat, civilDateToday } from "@/lib/gc-fitness/civil-date";
 import {
-  COARSE_MUSCLE_GROUPS,
-  coarseWeights,
-} from "@/lib/gc-fitness/muscle-group-display";
+  PROJECTION_WEEKS,
+  buildMuscleGroupWeeks,
+  civilWeekStart,
+  projectedSetsForAssignment,
+  shiftCivilDays,
+  type ExerciseMuscleMeta,
+  type MuscleGroupWeekPoint,
+  type MuscleSetInput,
+  type SnapshotExerciseInput,
+} from "@/lib/gc-fitness/muscle-group-weeks";
 
 /** A distinct exercise that appears in the client's logged history. */
 export interface LoggedExerciseOption {
@@ -60,19 +67,7 @@ export interface ExerciseSessionPoint {
   volumeKg: number;
 }
 
-/**
- * #480 — one WEEK bucket of the muscle-group breakdown. `byGroup` is keyed by
- * COARSE muscle group (see muscle-group-display.ts); `sets` is the weighted set
- * count (primary 1.0 / secondary 0.5) and `volume` the weighted Σ kg for that
- * group in the Monday-anchored week starting `weekStart`. Only groups with data
- * appear in `byGroup`. Weeks are contiguous (zero-filled) from the earliest
- * trained week to the current week, so the overlaid lines stay continuous.
- */
-export interface MuscleGroupWeekPoint {
-  /** YYYY-MM-DD of the Monday that starts this week (client timezone). */
-  weekStart: string;
-  byGroup: Record<string, { sets: number; volume: number }>;
-}
+export type { MuscleGroupWeekPoint };
 
 export interface ClientExerciseProgress {
   clientId: string;
@@ -86,49 +81,16 @@ export interface ClientExerciseProgress {
   muscleGroupWeeks: MuscleGroupWeekPoint[];
   /** Coarse groups with any data in the window, in `COARSE_MUSCLE_GROUPS` order. */
   availableMuscleGroups: string[];
+  /**
+   * #568 — Monday of the week containing today (client timezone). The chart
+   * draws its "today" divider here and anchors the weekly readout on it.
+   */
+  currentWeekStart: string;
 }
 
 /** Firestore reserved-id guard — `.doc(id)` throws on ids matching /^__.*__$/. */
 function isReservedId(id: string): boolean {
   return /^__.*__$/.test(id);
-}
-
-/**
- * Monday that starts the week containing `civilDate` (YYYY-MM-DD). Anchored at
- * UTC noon so the weekday math never trips a DST boundary. Week starts Monday
- * (matches DashboardAggregator.weekStart across all surfaces).
- */
-function civilWeekStart(civilDate: string): string {
-  const parts = civilDate.split("-");
-  if (parts.length !== 3) return civilDate;
-  const y = Number(parts[0]);
-  const m = Number(parts[1]);
-  const d = Number(parts[2]);
-  if (!Number.isFinite(y) || !Number.isFinite(m) || !Number.isFinite(d)) {
-    return civilDate;
-  }
-  const noon = new Date(Date.UTC(y, m - 1, d, 12, 0, 0));
-  // getUTCDay(): 0=Sun … 6=Sat. Days since Monday = (day + 6) % 7.
-  const sinceMonday = (noon.getUTCDay() + 6) % 7;
-  noon.setUTCDate(noon.getUTCDate() - sinceMonday);
-  const yy = String(noon.getUTCFullYear()).padStart(4, "0");
-  const mm = String(noon.getUTCMonth() + 1).padStart(2, "0");
-  const dd = String(noon.getUTCDate()).padStart(2, "0");
-  return `${yy}-${mm}-${dd}`;
-}
-
-/** `civilDate` shifted by `delta` days (UTC-noon anchored). */
-function shiftCivilDays(civilDate: string, delta: number): string {
-  const parts = civilDate.split("-");
-  if (parts.length !== 3) return civilDate;
-  const noon = new Date(
-    Date.UTC(Number(parts[0]), Number(parts[1]) - 1, Number(parts[2]), 12, 0, 0),
-  );
-  noon.setUTCDate(noon.getUTCDate() + delta);
-  const yy = String(noon.getUTCFullYear()).padStart(4, "0");
-  const mm = String(noon.getUTCMonth() + 1).padStart(2, "0");
-  const dd = String(noon.getUTCDate()).padStart(2, "0");
-  return `${yy}-${mm}-${dd}`;
 }
 
 const MAX_LOOKBACK_DAYS = 365;
@@ -177,6 +139,9 @@ export async function getClientExerciseProgress(
 
   // Ownership gate at the query layer — only read this client's logs when the
   // logged-in trainer owns them (the page already verifies coachId too).
+  const today = civilDateToday(timezone);
+  const currentWeekStart = civilWeekStart(today);
+
   const clientSnap = await db
     .collection(FirestoreCollections.users)
     .doc(clientId)
@@ -188,6 +153,7 @@ export async function getClientExerciseProgress(
       points: [],
       muscleGroupWeeks: [],
       availableMuscleGroups: [],
+      currentWeekStart,
     };
   }
 
@@ -214,11 +180,6 @@ export async function getClientExerciseProgress(
   // #480 — every completed NON-warmup set (bodyweight included), tagged with its
   // session civil date + per-set volume, for the muscle-group aggregation. The
   // exercise→muscle-group join happens after the batched exercise read below.
-  interface MuscleSetInput {
-    date: string;
-    exerciseId: string;
-    volumeKg: number;
-  }
   const muscleSetInputs: MuscleSetInput[] = [];
   const muscleExerciseIds = new Set<string>();
 
@@ -340,6 +301,48 @@ export async function getClientExerciseProgress(
   );
   const withDataIds = new Set(withData.map(([exId]) => exId));
 
+  // #568 — PROJECTION inputs. Second bounded read: the client's still-`scheduled`
+  // assignments from today through the last projected week, flattened into
+  // prescribed sets off each assignment's frozen `templateSnapshot`. Twin of iOS
+  // `ProgressPhotosViewModel.projectedContributions` / Android
+  // `MuscleGroupCharts.projectedContributions`.
+  //
+  // The range filter is on `scheduledFor` alone (plus the clientId equality), so
+  // it rides the EXISTING (clientId, scheduledFor) composite index — status is
+  // filtered in memory (the window is at most ~5 weeks of assignments). Starting
+  // at `today` is what keeps the projection honest: sets already logged this week
+  // come from the logs above, and a still-`scheduled` assignment earlier in the
+  // week is a MISSED workout, not something to project.
+  const projectionEnd = shiftCivilDays(currentWeekStart, 7 * PROJECTION_WEEKS + 6);
+  const assignmentSnap = await db
+    .collection(FirestoreCollections.workoutAssignments)
+    .where("clientId", "==", clientId)
+    .where("scheduledFor", ">=", today)
+    .where("scheduledFor", "<=", projectionEnd)
+    .get();
+
+  const projectedSetInputs: MuscleSetInput[] = [];
+  for (const doc of assignmentSnap.docs) {
+    const data = doc.data() as Record<string, unknown>;
+    // Only not-yet-done work is projected — a `started`/`completed`/`missed`
+    // assignment is already represented by (or excluded from) the actuals.
+    if ((data.status ?? "scheduled") !== "scheduled") continue;
+    const scheduledFor =
+      typeof data.scheduledFor === "string" ? data.scheduledFor : "";
+    if (!scheduledFor) continue;
+    const snapshotExercises =
+      (data.templateSnapshot as { exercises?: SnapshotExerciseInput[] } | undefined)
+        ?.exercises ?? [];
+    if (!Array.isArray(snapshotExercises)) continue;
+    for (const input of projectedSetsForAssignment(
+      scheduledFor,
+      snapshotExercises,
+    )) {
+      projectedSetInputs.push(input);
+      muscleExerciseIds.add(input.exerciseId);
+    }
+  }
+
   // Muscle groups for BOTH the per-exercise picker filter AND the #480
   // muscle-group charts. The logs don't carry muscle metadata, so read the
   // `exercises` docs for the (small, distinct) set of logged exercises in ONE
@@ -347,11 +350,6 @@ export async function getClientExerciseProgress(
   // of docs), once per page load. We pull `muscleGroups` (picker filter),
   // `primaryMuscleGroup` + `secondaryMuscles` (the #480 attribution weighting).
   // Missing/deleted exercises resolve to nothing and simply don't contribute.
-  interface ExerciseMuscleMeta {
-    muscleGroups: string[];
-    primaryMuscleGroup: string | null;
-    secondaryMuscles: string[];
-  }
   const exerciseMetaById = new Map<string, ExerciseMuscleMeta>();
   const neededIds = Array.from(
     new Set<string>([...withDataIds, ...muscleExerciseIds]),
@@ -387,11 +385,13 @@ export async function getClientExerciseProgress(
 
   // #480 — weekly weighted sets + volume per coarse muscle group. Bucket every
   // collected set into its Monday-anchored week, spreading its weighted
-  // contribution across each coarse group its exercise trains.
+  // contribution across each coarse group its exercise trains. #568 adds the
+  // projected buckets (current week's remainder + PROJECTION_WEEKS ahead).
   const { muscleGroupWeeks, availableMuscleGroups } = buildMuscleGroupWeeks(
     muscleSetInputs,
+    projectedSetInputs,
     exerciseMetaById,
-    timezone,
+    today,
   );
 
   // Order exercises by how often they appear (most-trained first), then name.
@@ -417,94 +417,6 @@ export async function getClientExerciseProgress(
     points: leanPoints,
     muscleGroupWeeks,
     availableMuscleGroups,
+    currentWeekStart,
   };
-}
-
-/**
- * #480 — pure aggregation: fold the flat list of completed non-warmup sets into
- * contiguous WEEK buckets of weighted sets + volume per coarse muscle group.
- * Twin of MuscleGroupProgress.setsSeries / volumeSeries + the coarseWeights
- * attribution (primary 1.0 / secondary 0.5).
- *
- * TODO(#480 — deferred): the iOS charts also append a ~4-week PROJECTION to the
- * right of "today", built from upcoming `workout_assignments`'
- * `templateSnapshot.exercises[].{sets, reps, weightBySetKg, metric,
- * durationBySetSeconds}` (see ProgressPhotosViewModel.projectedContributions).
- * That was intentionally left out of this backoffice pass to keep the PR
- * focused on the actuals; add it by widening the read to the client's
- * scheduled assignments (today → +5 weeks) and appending projected weekly
- * buckets flagged so the client can dim them + draw a "today" divider.
- */
-function buildMuscleGroupWeeks(
-  inputs: { date: string; exerciseId: string; volumeKg: number }[],
-  metaById: Map<
-    string,
-    { muscleGroups: string[]; primaryMuscleGroup: string | null; secondaryMuscles: string[] }
-  >,
-  timezone: string,
-): { muscleGroupWeeks: MuscleGroupWeekPoint[]; availableMuscleGroups: string[] } {
-  // weekStart → group → { sets, volume }
-  const byWeek = new Map<string, Map<string, { sets: number; volume: number }>>();
-  const groupsWithData = new Set<string>();
-
-  for (const input of inputs) {
-    const meta = metaById.get(input.exerciseId);
-    if (!meta) continue;
-    const weights = coarseWeights({
-      muscleGroups: meta.muscleGroups,
-      primaryMuscleGroup: meta.primaryMuscleGroup,
-      secondaryMuscles: meta.secondaryMuscles,
-    });
-    const groups = Object.keys(weights);
-    if (groups.length === 0) continue;
-
-    const week = civilWeekStart(input.date);
-    let weekMap = byWeek.get(week);
-    if (!weekMap) {
-      weekMap = new Map();
-      byWeek.set(week, weekMap);
-    }
-    for (const group of groups) {
-      const weight = weights[group];
-      groupsWithData.add(group);
-      const cell = weekMap.get(group) ?? { sets: 0, volume: 0 };
-      cell.sets += weight;
-      cell.volume += input.volumeKg * weight;
-      weekMap.set(group, cell);
-    }
-  }
-
-  if (byWeek.size === 0) {
-    return { muscleGroupWeeks: [], availableMuscleGroups: [] };
-  }
-
-  // Contiguous weekly axis from the earliest trained week to the current week
-  // (zero-filled) so the overlaid lines don't skip gaps. Bounded by the 365-day
-  // read window (≤ ~53 buckets).
-  const earliest = Array.from(byWeek.keys()).sort()[0];
-  const currentWeek = civilWeekStart(civilDateToday(timezone));
-  const weeks: MuscleGroupWeekPoint[] = [];
-  let cursor = earliest;
-  // Guard the loop against a bad `currentWeek < earliest` edge (shouldn't
-  // happen) and runaway iteration.
-  for (let i = 0; i < 60 && cursor <= currentWeek; i += 1) {
-    const weekMap = byWeek.get(cursor);
-    const byGroup: Record<string, { sets: number; volume: number }> = {};
-    if (weekMap) {
-      for (const [group, cell] of weekMap) {
-        byGroup[group] = {
-          sets: Math.round(cell.sets * 10) / 10,
-          volume: Math.round(cell.volume),
-        };
-      }
-    }
-    weeks.push({ weekStart: cursor, byGroup });
-    cursor = shiftCivilDays(cursor, 7);
-  }
-
-  const availableMuscleGroups = COARSE_MUSCLE_GROUPS.filter((g) =>
-    groupsWithData.has(g),
-  );
-
-  return { muscleGroupWeeks: weeks, availableMuscleGroups };
 }

--- a/backoffice/src/lib/gc-fitness/muscle-group-weeks.ts
+++ b/backoffice/src/lib/gc-fitness/muscle-group-weeks.ts
@@ -1,0 +1,401 @@
+// muscle-group-weeks.ts
+// #480 / #568 — pure weekly bucketing for the coach's muscle-group progress
+// charts. Extracted out of exercise-progress-actions.ts (where it lived as a
+// private helper) so the projection math is unit-testable.
+//
+// SOURCE OF TRUTH (keep in sync, line-for-line):
+//   - iOS:     gc-fitness/iOS/GCFitness/Features/Profile/ProgressPhotosViewModel.swift
+//              (`projectedContributions`, `projectedSetVolumeKg`,
+//               `recomputeMuscleGroups`) + GCFitnessCore/Progress/MuscleGroupProgress.swift
+//   - Android: android/core/src/main/kotlin/com/goldencrow/fitness/core/
+//              algorithms/MuscleGroupCharts.kt
+//
+// ATTRIBUTION: a non-warmup set is attributed to every coarse group its
+// exercise trains, weighted 1.0 for the primary mover / 0.5 per secondary —
+// see muscle-group-display.coarseWeights (the shared twin).
+//
+// #568 PROJECTION: the mobile charts append ~4 weeks of dashed "what the plan
+// says you're about to do" to the right of today, built from upcoming
+// `scheduled` assignments' frozen `templateSnapshot`. The backoffice does the
+// same, and ALSO projects the *remainder of the current week* — otherwise a
+// Monday reading of "3 series esta semana" is misleadingly low (the second half
+// of #568).
+
+import { COARSE_MUSCLE_GROUPS, coarseWeights } from "@/lib/gc-fitness/muscle-group-display";
+
+/** How many FULL future weeks the projection appends (mobile parity). */
+export const PROJECTION_WEEKS = 4;
+
+/** Weighted sets + volume for one coarse group in one week. */
+export interface MuscleGroupCell {
+  sets: number;
+  volume: number;
+}
+
+/**
+ * #480 — one WEEK bucket of the muscle-group breakdown. `byGroup` is keyed by
+ * COARSE muscle group (see muscle-group-display.ts); `sets` is the weighted set
+ * count (primary 1.0 / secondary 0.5) and `volume` the weighted Σ kg for that
+ * group in the Monday-anchored week starting `weekStart`. Only groups with data
+ * appear. Weeks are contiguous (zero-filled) from the earliest trained week, so
+ * the overlaid lines stay continuous.
+ */
+export interface MuscleGroupWeekPoint {
+  /** YYYY-MM-DD of the Monday that starts this week (client timezone). */
+  weekStart: string;
+  /** What was actually LOGGED in this week. Empty for future weeks. */
+  byGroup: Record<string, MuscleGroupCell>;
+  /**
+   * #568 — actual-so-far PLUS the still-scheduled prescription for this week.
+   * Present only from the current week onward (past weeks can't be projected);
+   * equals `byGroup` when nothing is scheduled for the rest of the week.
+   */
+  projectedByGroup?: Record<string, MuscleGroupCell>;
+  /** True for weeks that start AFTER the current week (pure projection). */
+  projected?: boolean;
+}
+
+/** A single completed (or prescribed) set, tagged with its civil date. */
+export interface MuscleSetInput {
+  /** YYYY-MM-DD in the client's timezone. */
+  date: string;
+  exerciseId: string;
+  volumeKg: number;
+}
+
+/** The muscle metadata read off an `exercises` doc, for the weighting. */
+export interface ExerciseMuscleMeta {
+  muscleGroups: string[];
+  primaryMuscleGroup: string | null;
+  secondaryMuscles: string[];
+}
+
+/** The subset of a `templateSnapshot.exercises[]` entry the projection reads. */
+export interface SnapshotExerciseInput {
+  exerciseId?: unknown;
+  sets?: unknown;
+  reps?: unknown;
+  repsBySet?: unknown;
+  weightBySetKg?: unknown;
+  metric?: unknown;
+  durationSeconds?: unknown;
+  durationBySetSeconds?: unknown;
+}
+
+/**
+ * Monday that starts the week containing `civilDate` (YYYY-MM-DD). Anchored at
+ * UTC noon so the weekday math never trips a DST boundary. Week starts Monday
+ * (matches DashboardAggregator.weekStart across all surfaces).
+ */
+export function civilWeekStart(civilDate: string): string {
+  const parts = civilDate.split("-");
+  if (parts.length !== 3) return civilDate;
+  const y = Number(parts[0]);
+  const m = Number(parts[1]);
+  const d = Number(parts[2]);
+  if (!Number.isFinite(y) || !Number.isFinite(m) || !Number.isFinite(d)) {
+    return civilDate;
+  }
+  const noon = new Date(Date.UTC(y, m - 1, d, 12, 0, 0));
+  // getUTCDay(): 0=Sun … 6=Sat. Days since Monday = (day + 6) % 7.
+  const sinceMonday = (noon.getUTCDay() + 6) % 7;
+  noon.setUTCDate(noon.getUTCDate() - sinceMonday);
+  return formatUTC(noon);
+}
+
+/** `civilDate` shifted by `delta` days (UTC-noon anchored). */
+export function shiftCivilDays(civilDate: string, delta: number): string {
+  const parts = civilDate.split("-");
+  if (parts.length !== 3) return civilDate;
+  const noon = new Date(
+    Date.UTC(Number(parts[0]), Number(parts[1]) - 1, Number(parts[2]), 12, 0, 0),
+  );
+  noon.setUTCDate(noon.getUTCDate() + delta);
+  return formatUTC(noon);
+}
+
+function formatUTC(d: Date): string {
+  const yy = String(d.getUTCFullYear()).padStart(4, "0");
+  const mm = String(d.getUTCMonth() + 1).padStart(2, "0");
+  const dd = String(d.getUTCDate()).padStart(2, "0");
+  return `${yy}-${mm}-${dd}`;
+}
+
+function numberAt(raw: unknown, index: number): number | null {
+  if (!Array.isArray(raw)) return null;
+  const v = raw[index];
+  return typeof v === "number" && Number.isFinite(v) ? v : null;
+}
+
+function lastNumber(raw: unknown): number | null {
+  if (!Array.isArray(raw) || raw.length === 0) return null;
+  const v = raw[raw.length - 1];
+  return typeof v === "number" && Number.isFinite(v) ? v : null;
+}
+
+function finite(raw: unknown): number | null {
+  if (typeof raw === "number" && Number.isFinite(raw)) return raw;
+  return null;
+}
+
+/**
+ * Prescribed volume of ONE set of a snapshot exercise, in kg. Time-based sets
+ * use `weight × duration/60`; rep-based use `weight × reps`. Per-set
+ * prescriptions (`weightBySetKg` / `repsBySet` / `durationBySetSeconds`) win,
+ * then the exercise-level fallbacks, then 0 (no prescribed weight → a
+ * bodyweight / open lift contributes 0 volume but still COUNTS as a set).
+ *
+ * Twin of iOS `ProgressPhotosViewModel.projectedSetVolumeKg` and Android
+ * `MuscleGroupCharts.projectedSetVolumeKg`.
+ */
+export function projectedSetVolumeKg(
+  exercise: SnapshotExerciseInput,
+  setIndex: number,
+): number {
+  const weight =
+    numberAt(exercise.weightBySetKg, setIndex) ??
+    lastNumber(exercise.weightBySetKg) ??
+    0;
+
+  const durationBySet = exercise.durationBySetSeconds;
+  const isTime =
+    exercise.metric === "time" ||
+    finite(exercise.durationSeconds) !== null ||
+    (Array.isArray(durationBySet) && durationBySet.length > 0);
+
+  if (isTime) {
+    const seconds =
+      numberAt(durationBySet, setIndex) ?? finite(exercise.durationSeconds) ?? 0;
+    return weight * (seconds / 60);
+  }
+
+  const reps = numberAt(exercise.repsBySet, setIndex) ?? finite(exercise.reps) ?? 0;
+  return weight * reps;
+}
+
+/**
+ * Flatten one upcoming assignment's frozen `templateSnapshot.exercises[]` into
+ * per-prescribed-set inputs dated on the assignment's `scheduledFor`. Twin of
+ * iOS/Android `projectedContributions` (the caller does the status + window
+ * filtering).
+ */
+export function projectedSetsForAssignment(
+  scheduledFor: string,
+  exercises: SnapshotExerciseInput[],
+): MuscleSetInput[] {
+  const out: MuscleSetInput[] = [];
+  for (const exercise of exercises) {
+    const exerciseId =
+      typeof exercise.exerciseId === "string" ? exercise.exerciseId : "";
+    if (!exerciseId) continue;
+    const setCount = Math.max(0, Math.trunc(finite(exercise.sets) ?? 0));
+    for (let setIndex = 0; setIndex < setCount; setIndex += 1) {
+      out.push({
+        date: scheduledFor,
+        exerciseId,
+        volumeKg: projectedSetVolumeKg(exercise, setIndex),
+      });
+    }
+  }
+  return out;
+}
+
+/** Fold a flat set list into weekStart → group → weighted { sets, volume }. */
+function bucketByWeek(
+  inputs: MuscleSetInput[],
+  metaById: Map<string, ExerciseMuscleMeta>,
+  groupsWithData: Set<string>,
+): Map<string, Map<string, MuscleGroupCell>> {
+  const byWeek = new Map<string, Map<string, MuscleGroupCell>>();
+  for (const input of inputs) {
+    const meta = metaById.get(input.exerciseId);
+    if (!meta) continue;
+    const weights = coarseWeights({
+      muscleGroups: meta.muscleGroups,
+      primaryMuscleGroup: meta.primaryMuscleGroup,
+      secondaryMuscles: meta.secondaryMuscles,
+    });
+    const groups = Object.keys(weights);
+    if (groups.length === 0) continue;
+
+    const week = civilWeekStart(input.date);
+    let weekMap = byWeek.get(week);
+    if (!weekMap) {
+      weekMap = new Map();
+      byWeek.set(week, weekMap);
+    }
+    for (const group of groups) {
+      const weight = weights[group];
+      groupsWithData.add(group);
+      const cell = weekMap.get(group) ?? { sets: 0, volume: 0 };
+      cell.sets += weight;
+      cell.volume += input.volumeKg * weight;
+      weekMap.set(group, cell);
+    }
+  }
+  return byWeek;
+}
+
+/** Weighted cells → the rounded record the chart consumes. */
+function roundCells(
+  weekMap: Map<string, MuscleGroupCell> | undefined,
+): Record<string, MuscleGroupCell> {
+  const out: Record<string, MuscleGroupCell> = {};
+  if (!weekMap) return out;
+  for (const [group, cell] of weekMap) {
+    out[group] = {
+      sets: Math.round(cell.sets * 10) / 10,
+      volume: Math.round(cell.volume),
+    };
+  }
+  return out;
+}
+
+/** actual ⊎ projected, summed per group (used for the current week). */
+function mergeCells(
+  actual: Map<string, MuscleGroupCell> | undefined,
+  projected: Map<string, MuscleGroupCell> | undefined,
+): Record<string, MuscleGroupCell> {
+  const merged = new Map<string, MuscleGroupCell>();
+  for (const source of [actual, projected]) {
+    if (!source) continue;
+    for (const [group, cell] of source) {
+      const acc = merged.get(group) ?? { sets: 0, volume: 0 };
+      acc.sets += cell.sets;
+      acc.volume += cell.volume;
+      merged.set(group, acc);
+    }
+  }
+  return roundCells(merged);
+}
+
+/**
+ * #480 / #568 — fold the completed non-warmup sets (`actual`) and the upcoming
+ * prescribed sets (`projected`) into one contiguous weekly axis.
+ *
+ * - weeks BEFORE the current week carry `byGroup` only;
+ * - the CURRENT week carries `byGroup` (logged so far) AND `projectedByGroup`
+ *   (logged + still scheduled for the rest of the week);
+ * - weeks AFTER the current week carry an empty `byGroup`, a
+ *   `projectedByGroup`, and `projected: true`.
+ *
+ * The axis is bounded by the caller's read windows (≤ 53 actual buckets from
+ * the 365-day log window + PROJECTION_WEEKS ahead).
+ */
+export function buildMuscleGroupWeeks(
+  actual: MuscleSetInput[],
+  projected: MuscleSetInput[],
+  metaById: Map<string, ExerciseMuscleMeta>,
+  today: string,
+): { muscleGroupWeeks: MuscleGroupWeekPoint[]; availableMuscleGroups: string[] } {
+  const groupsWithData = new Set<string>();
+  const actualByWeek = bucketByWeek(actual, metaById, groupsWithData);
+  const projectedByWeek = bucketByWeek(projected, metaById, groupsWithData);
+
+  if (actualByWeek.size === 0 && projectedByWeek.size === 0) {
+    return { muscleGroupWeeks: [], availableMuscleGroups: [] };
+  }
+
+  const currentWeek = civilWeekStart(today);
+  // Never project further than PROJECTION_WEEKS past the current week, even if
+  // a far-future assignment slipped into the read window.
+  const lastProjectedWeek = shiftCivilDays(currentWeek, 7 * PROJECTION_WEEKS);
+
+  const knownWeeks = [...actualByWeek.keys(), ...projectedByWeek.keys()].sort();
+  const earliest =
+    knownWeeks.length > 0 && knownWeeks[0] < currentWeek
+      ? knownWeeks[0]
+      : currentWeek;
+
+  const weeks: MuscleGroupWeekPoint[] = [];
+  let cursor = earliest;
+  // Guard against runaway iteration on a malformed date.
+  for (let i = 0; i < 64 && cursor <= lastProjectedWeek; i += 1) {
+    const actualWeek = actualByWeek.get(cursor);
+    const projectedWeek = projectedByWeek.get(cursor);
+
+    if (cursor < currentWeek) {
+      // Past week — actuals only (a still-`scheduled` past assignment is a
+      // missed workout, not a projection).
+      weeks.push({ weekStart: cursor, byGroup: roundCells(actualWeek) });
+    } else if (cursor === currentWeek) {
+      weeks.push({
+        weekStart: cursor,
+        byGroup: roundCells(actualWeek),
+        projectedByGroup: mergeCells(actualWeek, projectedWeek),
+      });
+    } else {
+      weeks.push({
+        weekStart: cursor,
+        byGroup: {},
+        projectedByGroup: roundCells(projectedWeek),
+        projected: true,
+      });
+    }
+    cursor = shiftCivilDays(cursor, 7);
+  }
+
+  const availableMuscleGroups = COARSE_MUSCLE_GROUPS.filter((g) =>
+    groupsWithData.has(g),
+  );
+
+  return { muscleGroupWeeks: weeks, availableMuscleGroups };
+}
+
+// ---------------------------------------------------------------------------
+// Chart shaping (#568) — kept here, next to the bucketer, so the boundary math
+// is unit-testable without mounting recharts.
+// ---------------------------------------------------------------------------
+
+/** Suffix that marks a projected series' dataKey (`back` → `back__proj`). */
+export const PROJECTED_KEY_SUFFIX = "__proj";
+
+/**
+ * Whether a week carries a projection worth drawing: a future week with any
+ * scheduled work, or the CURRENT week whose plan still exceeds what's logged.
+ * A client with nothing upcoming keeps the pre-#568 chart (no dashed region).
+ */
+export function weekHasProjection(week: MuscleGroupWeekPoint): boolean {
+  const proj = week.projectedByGroup;
+  if (!proj) return false;
+  if (week.projected) return Object.values(proj).some((c) => c.sets > 0);
+  return Object.entries(proj).some(
+    ([group, cell]) => cell.sets > (week.byGroup[group]?.sets ?? 0),
+  );
+}
+
+/**
+ * One recharts row per week. Per selected group it emits a solid `g` column
+ * (actuals — null once the week is entirely in the future, so the solid line
+ * stops at today) and a dashed `g__proj` column.
+ *
+ * The projected column is SEEDED one week BEFORE the current week with that
+ * week's actual value, so the dashed segment grows out of the solid line
+ * instead of floating — the same `boundary - 1` trick the iOS chart uses.
+ * `null` everywhere else keeps both lines (and, with `filterNull`, the tooltip)
+ * confined to their own region.
+ */
+export function buildChartRows(
+  weeks: MuscleGroupWeekPoint[],
+  groups: string[],
+  metric: "sets" | "volume",
+  currentIndex: number,
+  hasProjection: boolean,
+): Array<Record<string, number | string | null>> {
+  return weeks.map((week, i) => {
+    const row: Record<string, number | string | null> = { week: week.weekStart };
+    for (const group of groups) {
+      row[group] = week.projected ? null : (week.byGroup[group]?.[metric] ?? 0);
+
+      const projectedKey = group + PROJECTED_KEY_SUFFIX;
+      if (!hasProjection || currentIndex < 0 || i < currentIndex - 1) {
+        row[projectedKey] = null;
+      } else if (i === currentIndex - 1) {
+        row[projectedKey] = week.byGroup[group]?.[metric] ?? 0;
+      } else {
+        row[projectedKey] = week.projectedByGroup?.[group]?.[metric] ?? 0;
+      }
+    }
+    return row;
+  });
+}


### PR DESCRIPTION
Closes mdb1/gc-fitness#568.

## Problem

`/gc-fitness/clients/[id]/progress` → **Grupos musculares** plotted **actuals only**:

1. **No projection region.** The apps draw a dotted "today" divider and continue each
   line dashed + dimmed through ~4 weeks of upcoming scheduled work
   (iOS `ProgressPhotosView.MuscleGroupSeriesChart` + `projectedContributions`,
   Android `MuscleGroupCharts.kt`). The backoffice had none of it — the code even
   carried a `TODO(#480 — deferred)` describing exactly this.
2. **The weekly readout only counted what was already logged.** On a Monday
   "3 series esta semana" is what the client did that morning, not what the week
   adds up to.

## What this does

**New pure module `lib/gc-fitness/muscle-group-weeks.ts`** — the private
`civilWeekStart` / `shiftCivilDays` / `buildMuscleGroupWeeks` helpers moved out of
`exercise-progress-actions.ts` (they were unreachable from a test), plus the TS twin of
`projectedSetVolumeKg` (per-set arrays win → exercise-level scalars → 0; time metric is
`weight × duration/60`, else `weight × reps`; **no prescribed weight ⇒ 0 volume but the
set still counts**), `projectedSetsForAssignment`, and the display-boundary helpers.

**Server** — one extra bounded read:

```
workout_assignments where clientId == X
  and scheduledFor >= today and scheduledFor <= currentWeekStart + 34d
```

Range filter on `scheduledFor` alone, so it rides the **existing
`(clientId, scheduledFor)` composite index**; `status == "scheduled"` is filtered in
memory (the window is ≤5 weeks of docs). Two deliberate window rules:

- it **starts at `today`, not the week's Monday** — sets already logged this week come
  from the logs, and a still-`scheduled` assignment *earlier* in the week is a missed
  workout, not something to project;
- **only `scheduled`** — `started`/`completed`/`missed` are already represented by (or
  excluded from) the actuals, so nothing can double count.

**Chart** — per group a solid column (actual, stops at today) and a dashed one, seeded
one week *before* the current week with that week's actual value so the dashed segment
grows out of the solid line (the iOS `boundary - 1` trick). Dotted **Hoy** divider,
`<Tooltip filterNull>` so each region keeps its own series, projected entries labelled
`{group} (proyección)`. The readout is re-anchored on the current week and reads
`3 series esta semana → 12 proyectadas`.

**Graceful degradation** — a client with nothing upcoming renders exactly the previous
chart (no dashed lines, no divider, old readout string).

No `firestore.rules` / index / functions change. iOS and Android are untouched — they
already ship this behavior.

## Gates

- `npx jest` — **874/875**; the single red is the known `client-activity-time`
  non-en-US locale flake (pre-existing, green in CI).
- New `muscle-group-weeks.test.ts` — **26 green**: week anchoring, the
  `projectedSetVolumeKg` vectors mirroring the iOS/Android twins, the 1.0/0.5
  attribution, the current-week merge, the `PROJECTION_WEEKS` axis length, the
  no-history-but-scheduled case, and the chart row boundary/seed.
- `npx tsc --noEmit` clean, `npx next build` compiles.

## Verification requested

Open a client with upcoming scheduled workouts: dotted **Hoy** on the current week,
4 dashed weeks to its right, legend reading `N series esta semana → M proyectadas`.
A client with an empty calendar should look unchanged.