### PR TITLE
fix(gc-fitness): every set type counts toward sets and volume (#565)

### DIFF
--- a/backoffice/scripts/backfill-total-volume-565.cjs
+++ b/backoffice/scripts/backfill-total-volume-565.cjs
@@ -1,0 +1,187 @@
+/**
+ * backfill-total-volume-565.cjs — gc-fitness issue #565.
+ *
+ * #565 changed the volume rule: EVERY set type now contributes. Warm-up /
+ * failure / drop set all count exactly like a normal set; `set_type` became a
+ * display marker (the W/F/D letter) instead of a multiplier. Before it, a
+ * warm-up contributed 0.
+ *
+ * `workout_logs.total_volume_kg` is computed ONCE at finalize and FROZEN on the
+ * doc — the iOS `WorkoutProgressCharts` volume trend, the Android
+ * `ProgressAggregator` daily/weekly volume and the backoffice history rows all
+ * read that stored number rather than re-summing `sets[]`. So without this
+ * script a client's chart would step: everything before the #565 release keeps
+ * its warm-up-excluded total, everything after includes warm-ups. This
+ * recomputes the historical logs under the new rule so the series is continuous.
+ *
+ * FORMULA (the exact twin of iOS `WorkoutVolume.setVolumeKg`, Android
+ * `WorkoutVolume.setVolumeKg` and backoffice `computeTotalVolumeKg`):
+ *
+ *     time set (duration_seconds > 0) → weight_kg × (duration_seconds / 60)
+ *     reps set                        → weight_kg × reps
+ *     Σ over EVERY set in sets[] — no set-type filter.
+ *
+ * Only `status: "completed"` logs are touched (an in-progress log has no
+ * meaningful stored total and will be computed at finalize by the new code).
+ * Only `total_volume_kg` and `updatedAt` are written; `sets[]` is never
+ * rewritten, so the logged record itself is untouched.
+ *
+ * Idempotent — a doc already carrying the new total differs by < 0.01 kg and is
+ * skipped — and SAFE BY DEFAULT: it reports only unless you pass --apply.
+ *
+ *   node scripts/backfill-total-volume-565.cjs                  # dry run
+ *   node scripts/backfill-total-volume-565.cjs --apply          # write
+ *   node scripts/backfill-total-volume-565.cjs --client=<uid>   # one client
+ *
+ * Run from `backoffice/` (reads admin creds from .env.local, same as the other
+ * scripts). Run it ONCE, AFTER the #565 apps are released — a client still on an
+ * old build would keep writing warm-up-excluded totals for new workouts.
+ */
+const fs = require("node:fs");
+const path = require("node:path");
+const { initializeApp, cert, getApps } = require("firebase-admin/app");
+const { getFirestore, FieldValue } = require("firebase-admin/firestore");
+
+/** Below this the stored total already matches — treat as no-op (float dust). */
+const EPSILON_KG = 0.01;
+const PAGE_SIZE = 400;
+
+function loadEnv() {
+  const p = path.resolve(process.cwd(), ".env.local");
+  if (!fs.existsSync(p)) return;
+  for (const line of fs.readFileSync(p, "utf8").split(/\r?\n/)) {
+    const m = line.match(/^([A-Z0-9_]+)=(.*)$/);
+    if (m && process.env[m[1]] === undefined) process.env[m[1]] = m[2];
+  }
+}
+
+function initAdmin() {
+  const projectId = process.env.NEXT_PUBLIC_GC_FITNESS_FIREBASE_PROJECT_ID;
+  const clientEmail = process.env.GC_FITNESS_FIREBASE_ADMIN_CLIENT_EMAIL;
+  const pk = process.env.GC_FITNESS_FIREBASE_ADMIN_PRIVATE_KEY;
+  if (!projectId || !clientEmail || !pk) throw new Error("Missing admin env vars.");
+  if (getApps()[0]) return getApps()[0];
+  return initializeApp({
+    credential: cert({
+      projectId,
+      clientEmail,
+      privateKey: Buffer.from(pk, "base64").toString("utf8"),
+    }),
+  });
+}
+
+/** Tolerant numeric coercion — the wire has carried both numbers and strings. */
+function num(v) {
+  const n = typeof v === "number" ? v : Number(v);
+  return Number.isFinite(n) ? n : 0;
+}
+
+/**
+ * Σ volume over EVERY set (#565). Twin of WorkoutVolume.setVolumeKg — accepts
+ * both the snake_case wire keys and the camelCase fallbacks the readers accept.
+ */
+function totalVolumeKg(sets) {
+  let total = 0;
+  for (const s of sets) {
+    const weight = num(s.weight_kg ?? s.weight);
+    const duration = num(s.duration_seconds ?? s.durationSeconds);
+    total += duration > 0 ? weight * (duration / 60) : weight * num(s.reps);
+  }
+  return Math.round(total * 100) / 100;
+}
+
+async function main() {
+  const args = process.argv.slice(2);
+  const apply = args.includes("--apply");
+  const clientArg = args.find((a) => a.startsWith("--client="));
+  const clientId = clientArg ? clientArg.split("=")[1] : null;
+
+  loadEnv();
+  initAdmin();
+  const db = getFirestore();
+
+  console.log(
+    `\n#565 total_volume_kg backfill${clientId ? ` — client ${clientId}` : ""}` +
+      `${apply ? "  [APPLY]" : "  [DRY RUN — no writes]"}\n`,
+  );
+
+  const stats = {
+    scanned: 0,
+    skippedNotCompleted: 0,
+    skippedNoSets: 0,
+    alreadyCorrect: 0,
+    changed: 0,
+    written: 0,
+    deltaKg: 0,
+  };
+
+  let cursor = null;
+  for (;;) {
+    // `__name__` ordering + startAfter pages the whole collection with no
+    // composite index; the optional clientId equality rides the automatic
+    // single-field index.
+    let q = db.collection("workout_logs");
+    if (clientId) q = q.where("clientId", "==", clientId);
+    q = q.orderBy("__name__").limit(PAGE_SIZE);
+    if (cursor) q = q.startAfter(cursor);
+    const page = await q.get();
+    if (page.empty) break;
+    cursor = page.docs[page.docs.length - 1];
+
+    for (const doc of page.docs) {
+      stats.scanned++;
+      const data = doc.data();
+
+      if (data.status !== "completed") {
+        stats.skippedNotCompleted++;
+        continue;
+      }
+      const sets = Array.isArray(data.sets) ? data.sets : null;
+      if (!sets || sets.length === 0) {
+        stats.skippedNoSets++;
+        continue;
+      }
+
+      const next = totalVolumeKg(sets);
+      const current = num(data.total_volume_kg ?? data.totalVolumeKg);
+      if (Math.abs(next - current) < EPSILON_KG) {
+        stats.alreadyCorrect++;
+        continue;
+      }
+
+      stats.changed++;
+      stats.deltaKg += next - current;
+      console.log(
+        `  · ${doc.id}  ${current.toFixed(1)} kg → ${next.toFixed(1)} kg  ` +
+          `(+${(next - current).toFixed(1)}, ${sets.length} sets)`,
+      );
+
+      if (apply) {
+        await doc.ref.update({
+          total_volume_kg: next,
+          updatedAt: FieldValue.serverTimestamp(),
+        });
+        stats.written++;
+      }
+    }
+
+    if (page.size < PAGE_SIZE) break;
+  }
+
+  console.log("\n--- summary ---");
+  console.log(`logs scanned             ${stats.scanned}`);
+  console.log(`  skipped (not completed)${String(stats.skippedNotCompleted).padStart(6)}`);
+  console.log(`  skipped (no sets)      ${String(stats.skippedNoSets).padStart(6)}`);
+  console.log(`  already correct        ${String(stats.alreadyCorrect).padStart(6)}`);
+  console.log(`  needing a new total    ${String(stats.changed).padStart(6)}`);
+  console.log(`  written                ${String(stats.written).padStart(6)}`);
+  console.log(`total volume added       ${stats.deltaKg.toFixed(1)} kg`);
+  if (!apply && stats.changed > 0) {
+    console.log("\nDry run — re-run with --apply to write.");
+  }
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/backoffice/src/app/gc-fitness/clients/[id]/_components/WorkoutTrendsWidget.tsx
+++ b/backoffice/src/app/gc-fitness/clients/[id]/_components/WorkoutTrendsWidget.tsx
@@ -91,8 +91,8 @@ export async function WorkoutTrendsWidget({
       const done = Boolean(s.completed_at ?? s.completedAt);
       if (!done) continue;
       completedSets += 1;
-      const isWarmup = Boolean(s.is_warmup ?? s.isWarmup);
-      if (isWarmup) continue;
+      // #565 — every set type contributes to volume (warm-up / failure /
+      // drop set alike); `set_type` / `is_warmup` are display markers only.
       volumeKg += numeric(s.weight_kg ?? s.weight) * numeric(s.reps);
     }
 

--- a/backoffice/src/components/gc-fitness/share-workout-card.tsx
+++ b/backoffice/src/components/gc-fitness/share-workout-card.tsx
@@ -485,12 +485,11 @@ function buildSuccessModel(
 
   const exercises: ExerciseRow[] = order.map((key) => {
     const bucket = byExercise.get(key)!;
-    // Working sets only (warmups excluded), sorted by index.
-    const working = bucket.sets
-      .filter((s) => !s.isWarmup)
-      .sort((a, b) => a.index - b.index);
+    // #565 — every set type is listed on the card (the W/F/D marker still
+    // distinguishes them visually) and counts in the totals.
+    const working = bucket.sets.slice().sort((a, b) => a.index - b.index);
 
-    // Highest-volume working set = max(weight × reps); only weighted sets.
+    // Highest-volume set = max(weight × reps); only weighted sets.
     let topVolume = 0;
     let topIdx = -1;
     working.forEach((s, i) => {
@@ -519,11 +518,11 @@ function buildSuccessModel(
     return { name: bucket.name, chips, oneRMLabel, supersetGroup };
   });
 
-  // Volumen total = Σ(weight × reps) over working (non-warmup) sets.
+  // Volumen total = Σ(weight × reps) over EVERY set (#565).
   const totalVolume = detail.sets
-    .filter((s) => !s.isWarmup && s.metric !== "time")
+    .filter((s) => s.metric !== "time")
     .reduce((acc, s) => acc + (s.weight ?? 0) * (s.reps ?? 0), 0);
-  const seriesCount = detail.sets.filter((s) => !s.isWarmup).length;
+  const seriesCount = detail.sets.length;
   const exerciseCount = detail.exerciseCount || order.length;
 
   const stats: ShareStat[] = [

--- a/backoffice/src/lib/gc-fitness/__tests__/live-workout-volume.test.ts
+++ b/backoffice/src/lib/gc-fitness/__tests__/live-workout-volume.test.ts
@@ -31,12 +31,14 @@ describe("computeTotalVolumeKg", () => {
     expect(computeTotalVolumeKg(sets)).toBe(1500);
   });
 
-  it("excludes warmup sets", () => {
+  // #565 — REVERSES the #403 rule. Warm-ups used to contribute 0; every set
+  // type now counts identically, so `setType` is a display marker only.
+  it("#565 — includes warmup sets like any other set", () => {
     const sets = [
       set({ weightKg: 60, reps: 10, isWarmup: true }),
       set({ weightKg: 100, reps: 5 }),
     ];
-    expect(computeTotalVolumeKg(sets)).toBe(500);
+    expect(computeTotalVolumeKg(sets)).toBe(600 + 500);
   });
 
   it("uses weight × minutes for time-based sets", () => {
@@ -83,46 +85,47 @@ describe("computeDurationSeconds", () => {
 });
 
 describe("countWorkingSets", () => {
-  it("counts only non-warmup sets", () => {
+  it("#565 — counts every logged set, warmups included", () => {
     expect(
       countWorkingSets([
         set({ isWarmup: true }),
         set({}),
         set({}),
       ]),
-    ).toBe(2);
+    ).toBe(3);
   });
 });
 
-// quick-260714-m57 (#403) — twin vectors shared with iOS SetTypeTests +
-// Android WorkoutVolumeTest: set-type-aware warmup exclusion.
-describe("set-type aware volume (quick-260714-m57 #403)", () => {
-  it("warmup excluded, failure + dropset included ⇒ 450.0 exactly", () => {
+// #565 — twin vectors shared with iOS WorkoutVolumeTests + Android
+// WorkoutVolumeTest: EVERY set type contributes. These vectors read 450 / 200
+// / 2 while #403 excluded warm-ups.
+describe("set-type aware volume (#565 — all types count)", () => {
+  it("warmup + failure + dropset all included ⇒ 650.0 exactly", () => {
     const sets = [
-      set({ weightKg: 20, reps: 10, setType: "warmup", isWarmup: true }), // excluded
+      set({ weightKg: 20, reps: 10, setType: "warmup", isWarmup: true }), // 200
       set({ weightKg: 20, reps: 10 }), // 200
       set({ weightKg: 30, reps: 5, setType: "failure" }), // 150
       set({ weightKg: 10, reps: 10, setType: "dropset" }), // 100
     ];
-    expect(computeTotalVolumeKg(sets)).toBe(450);
+    expect(computeTotalVolumeKg(sets)).toBe(650);
   });
 
-  it("a set_type-only warmup (isWarmup false) is ALSO excluded", () => {
+  it("a set_type-only warmup (isWarmup false) counts too", () => {
     const sets = [
       set({ weightKg: 20, reps: 10, setType: "warmup", isWarmup: false }),
       set({ weightKg: 20, reps: 10 }),
     ];
-    expect(computeTotalVolumeKg(sets)).toBe(200);
-    expect(countWorkingSets(sets)).toBe(1);
+    expect(computeTotalVolumeKg(sets)).toBe(400);
+    expect(countWorkingSets(sets)).toBe(2);
   });
 
-  it("failure/dropset sets count as working sets", () => {
+  it("every set type counts toward the set tally", () => {
     expect(
       countWorkingSets([
         set({ setType: "failure" }),
         set({ setType: "dropset" }),
         set({ setType: "warmup", isWarmup: true }),
       ]),
-    ).toBe(2);
+    ).toBe(3);
   });
 });

--- a/backoffice/src/lib/gc-fitness/exercise-progress-actions.ts
+++ b/backoffice/src/lib/gc-fitness/exercise-progress-actions.ts
@@ -5,14 +5,16 @@
 // progression over time.
 //
 // METRICS (computed per session, see ExerciseSessionPoint):
-//   - topSetWeightKg — heaviest WORKING (non-warmup) set's weight in the
-//     session. The simplest "am I lifting heavier?" signal. PRIMARY metric.
+//   - topSetWeightKg — heaviest set's weight in the session. The simplest
+//     "am I lifting heavier?" signal. PRIMARY metric.
 //   - estimatedOneRmKg — best Epley estimate weightKg × (1 + reps/30) across
-//     the session's working sets. Matches the iOS PR e1RM math. SECONDARY.
-//   - volumeKg — Σ (weightKg × reps) over the session's working sets for THIS
+//     the session's sets. Matches the iOS PR e1RM math. SECONDARY.
+//   - volumeKg — Σ (weightKg × reps) over the session's sets for THIS
 //     exercise. Tertiary "total work" signal.
-// Bodyweight / time-based sets with no weight contribute nothing to weight
-// metrics; a session with no weighted working set for the exercise is dropped.
+// #565: EVERY set type counts (warm-up / failure / drop set alike) — `set_type`
+// is a display marker, never a filter. Bodyweight / time-based sets with no
+// weight contribute nothing to the weight metrics; a session with no weighted
+// set for the exercise is dropped.
 //
 // READ-COST: ONE Firestore read — `workout_logs where clientId == X and
 // startedAt >= today-365 orderBy startedAt desc limit 300`. Reuses the EXISTING
@@ -59,11 +61,11 @@ export interface ExerciseSessionPoint {
   exerciseId: string;
   /** civilDate YYYY-MM-DD of the session start (client timezone). */
   date: string;
-  /** Heaviest working-set weight (kg) in the session; null if unweighted. */
+  /** Heaviest set weight (kg) in the session; null if unweighted. */
   topSetWeightKg: number | null;
-  /** Best Epley estimated 1RM (kg) across working sets; null if unweighted. */
+  /** Best Epley estimated 1RM (kg) across the session's sets; null if unweighted. */
   estimatedOneRmKg: number | null;
-  /** Σ weightKg × reps over working sets for this exercise. */
+  /** Σ weightKg × reps over this exercise's sets (every type — #565). */
   volumeKg: number;
 }
 
@@ -76,7 +78,7 @@ export interface ClientExerciseProgress {
   /**
    * #480 — weekly weighted sets + volume per coarse muscle group, for the
    * muscle-group comparison charts. Empty when the client has logged no
-   * completed working sets in the window.
+   * completed sets in the window.
    */
   muscleGroupWeeks: MuscleGroupWeekPoint[];
   /** Coarse groups with any data in the window, in `COARSE_MUSCLE_GROUPS` order. */
@@ -177,9 +179,10 @@ export async function getClientExerciseProgress(
     { name: string; sessionCount: number; hasData: boolean }
   >();
 
-  // #480 — every completed NON-warmup set (bodyweight included), tagged with its
-  // session civil date + per-set volume, for the muscle-group aggregation. The
-  // exercise→muscle-group join happens after the batched exercise read below.
+  // #480 — every completed set (bodyweight and warm-ups included, #565), tagged
+  // with its session civil date + per-set volume, for the muscle-group
+  // aggregation. The exercise→muscle-group join happens after the batched
+  // exercise read below.
   const muscleSetInputs: MuscleSetInput[] = [];
   const muscleExerciseIds = new Set<string>();
 
@@ -231,9 +234,9 @@ export async function getClientExerciseProgress(
         acc.hasCompleted = true;
       }
 
-      // Warmups never count toward top-set / e1RM / volume (mirrors iOS).
-      if (Boolean(s.is_warmup ?? s.isWarmup)) continue;
-
+      // #565 — EVERY set type counts toward top-set / e1RM / volume /
+      // muscle-group attribution (warm-up / failure / drop set alike; mirrors
+      // iOS + Android). `set_type` / `is_warmup` are display markers only.
       const weight = numeric(s.weight_kg ?? s.weight);
       const reps = numeric(s.reps);
 
@@ -270,8 +273,8 @@ export async function getClientExerciseProgress(
       if (!acc.hasCompleted) continue;
       // `hasData` = this session produced a chartable value (≥1 weighted working
       // set → topWeight non-null, which also implies e1RM/volume are available).
-      // Bodyweight/warmup-only exercises (e.g. "Warm Up") never set it, so the
-      // filter below drops them from the picker — only exercises WITH data show.
+      // Bodyweight-only exercises never set it, so the filter below drops them
+      // from the picker — only exercises WITH data show.
       const sessionHasData = acc.topWeight !== null;
       const meta = exerciseMeta.get(exId);
       const name = nameById.get(exId) ?? exId;
@@ -294,8 +297,9 @@ export async function getClientExerciseProgress(
     }
   }
 
-  // Only surface exercises that actually have chartable data (drops "Warm Up"
-  // and other bodyweight/warmup-only entries the coach can't plot).
+  // Only surface exercises that actually have chartable data (drops
+  // bodyweight-only entries the coach can't plot — they carry no weight, so
+  // there's nothing to chart even though they DO count as sets).
   const withData = Array.from(exerciseMeta.entries()).filter(
     ([, m]) => m.hasData,
   );

--- a/backoffice/src/lib/gc-fitness/live-workout-volume.ts
+++ b/backoffice/src/lib/gc-fitness/live-workout-volume.ts
@@ -5,24 +5,28 @@
 // No I/O; unit-tested in __tests__/live-workout-volume.test.ts.
 //
 // Volume contract (mirrors iOS):
-//   - WARMUP sets are EXCLUDED from total volume — via the HARDENED
-//     effective predicate (quick-260714-m57 #403): a set is a warmup when
-//     EITHER the richer setType === "warmup" OR the legacy isWarmup flag
-//     says so (effectiveSetType from ./set-type). Failure / drop sets
-//     count normally.
+//   - EVERY set type contributes (issue #565). Warm-up / failure / drop sets
+//     count exactly like a normal set. This REVERSES the #403 rule where a
+//     warm-up contributed 0 — `setType` is now a display marker only (the
+//     W/F/D letter + the Hevy numbering rule), never a multiplier.
+//     `isWarmup` / `effectiveSetType` survive for that display layer and for
+//     the wire sync invariant, but NOTHING in the sets/volume math may
+//     consult them.
 //   - reps-based set:  weightKg * reps
 //   - time-based set:  weightKg * (durationSeconds / 60)   — a bodyweight
 //     plank (weightKg = 0) contributes 0, which is correct.
 //   A set counts as time-based when it carries a positive durationSeconds.
+//
+// ⚠️ `workout_logs.total_volume_kg` is FROZEN at finalize and read directly by
+// the volume-trend charts, so pre-#565 logs keep their warm-up-excluded totals
+// until `scripts/backfill-total-volume-565.cjs` runs.
 
 import type { SessionSetLog } from "./live-workout-types";
-import { effectiveSetType } from "./set-type";
 
-/** Σ working volume in kg. Warmups excluded; time sets use weight·minutes. */
+/** Σ volume in kg over EVERY logged set (#565); time sets use weight·minutes. */
 export function computeTotalVolumeKg(sets: SessionSetLog[]): number {
   let total = 0;
   for (const set of sets) {
-    if (effectiveSetType(set) === "warmup") continue;
     const duration = set.durationSeconds ?? 0;
     if (duration > 0) {
       total += set.weightKg * (duration / 60);
@@ -52,7 +56,7 @@ export function computeDurationSeconds(
   return seconds > 0 ? seconds : 0;
 }
 
-/** Count of completed (non-warmup) working sets — for the progress header. */
+/** Count of completed sets — every set type counts (#565). */
 export function countWorkingSets(sets: SessionSetLog[]): number {
-  return sets.filter((s) => effectiveSetType(s) !== "warmup").length;
+  return sets.length;
 }

--- a/backoffice/src/lib/gc-fitness/recent-logs-actions.ts
+++ b/backoffice/src/lib/gc-fitness/recent-logs-actions.ts
@@ -140,12 +140,13 @@ export interface WorkoutLogDetail {
     durationSeconds: number | null;
     completedAt: string | null;
     /**
-     * 260529-mrp — True when this set is a warmup (excluded from the share
-     * card's Volumen / Series / top-set / 1RM math, mirroring iOS, which
-     * skips warmups for those stats). Wire field `is_warmup` (iOS,
-     * snake_case); `isWarmup` camel fallback mirrors the existing
-     * weight_kg ?? weight / duration_seconds ?? durationSeconds pattern.
-     * Defaults to false when absent (pre-warmup-flag logs).
+     * 260529-mrp — True when this set is a warmup. DISPLAY ONLY as of #565:
+     * warm-ups now count toward the share card's Volumen / Series / top-set /
+     * 1RM math exactly like any other set (mirroring iOS + Android), so this
+     * flag only drives the "W" marker and the dimmed row. Wire field
+     * `is_warmup` (iOS, snake_case); `isWarmup` camel fallback mirrors the
+     * existing weight_kg ?? weight / duration_seconds ?? durationSeconds
+     * pattern. Defaults to false when absent (pre-warmup-flag logs).
      */
     isWarmup: boolean;
     /**


### PR DESCRIPTION
Backoffice half of mdb1/gc-fitness#565. The apps half is mdb1/gc-fitness#575.

Targets `main` directly. (#277 / #568 is already merged, so the earlier stacking note no longer applies — this branch is one commit on top of that work and merges cleanly.)

## The rule change

#403 made warm-ups contribute 0 to volume and drop out of every set count, while
failure and drop sets counted normally. All four types now count identically:
**`setType` is a DISPLAY marker only** — the W/F/D letter and the Hevy numbering
rule — never a multiplier or a filter. `isWarmup` / `effectiveSetType` survive for
that display layer and for the `isWarmup === (setType === "warmup")` wire sync
invariant, but nothing in the sets/volume math consults them.

## What changed here

- **`live-workout-volume`** — `computeTotalVolumeKg` drops the warm-up skip;
  `countWorkingSets` counts every logged set. The shared twin vector goes
  **450 → 650 kg**, matching the iOS and Android suites.
- **`exercise-progress-actions`** — warm-ups now feed top-set / e1RM / volume and
  the muscle-group attribution. This incidentally lines the actuals up with the
  #568 projection region, which has always counted every prescribed set regardless
  of its `setTypesBySet` entry.
- **`WorkoutTrendsWidget`** volume, **`share-workout-card`** volume + series count +
  per-exercise chips.

Deliberately **not** changed — these aren't sets/volume calcs and a warm-up is the
wrong source for them: the weight pre-fill / "ANTERIOR" column, the next-unlogged-row
navigation in the live session, the wire sync invariant, and the W/F/D badges +
dimmed rows.

## Backfill — required, not optional

`workout_logs.total_volume_kg` is computed once at finalize and **frozen on the doc**.
The iOS `WorkoutProgressCharts` trend, the Android `ProgressAggregator` daily/weekly
volume and the backoffice history rows all read that stored number rather than
re-summing `sets[]` — so without a backfill every client's volume series visibly steps
at the release boundary.

`scripts/backfill-total-volume-565.cjs` — dry-run by default, `--apply` to write,
`--client=<uid>` to scope. Recomputes from `sets[]` with the exact twin formula
(verified against the same 650 kg vector), touches only `completed` logs, writes only
`total_volume_kg` + `updatedAt`, idempotent (< 0.01 kg delta ⇒ skip).

**Run it ONCE, AFTER the #565 apps are released** — a client still on an old build
would keep writing warm-up-excluded totals.

## Gates

- `npx jest` — **874/875**; the single red is the known `client-activity-time`
  non-en-US locale flake (pre-existing, green in CI).
- `tsc --noEmit` clean, `npx next build` compiles.
- No `firestore.rules` / index / functions change.

Refs mdb1/gc-fitness#565