### PR TITLE
feat(gc-fitness): search the exercise picker + per-session set breakdown (#574)

### DIFF
--- a/backoffice/messages/en.json
+++ b/backoffice/messages/en.json
@@ -261,6 +261,18 @@
       "title": "Per-exercise progress",
       "subtitle": "Pick an exercise to see this client's progression over time.",
       "exercisePickerLabel": "Exercise",
+      "exerciseSearchPlaceholder": "Search exercise…",
+      "exerciseSearchEmpty": "No exercise matches that search.",
+      "setHistory": {
+        "title": "Logged sets",
+        "subtitle": "{count, plural, one {# session recorded} other {# sessions recorded}}, newest first. Not affected by the range selector above.",
+        "lineWeighted": "{reps} reps × {weight} kg",
+        "lineReps": "{reps} reps",
+        "lineTime": "{seconds} s",
+        "loadMore": "See more ({remaining})",
+        "prLabel": "Personal record",
+        "truncated": "Showing the {count} most recent sessions for this exercise."
+      },
       "muscleGroupLabel": "Muscle group",
       "muscleGroupAll": "All",
       "metricTopSet": "Top set",

--- a/backoffice/messages/es.json
+++ b/backoffice/messages/es.json
@@ -261,6 +261,18 @@
       "title": "Progreso por ejercicio",
       "subtitle": "Elegí un ejercicio para ver la progresión de este cliente a lo largo del tiempo.",
       "exercisePickerLabel": "Ejercicio",
+      "exerciseSearchPlaceholder": "Buscar ejercicio…",
+      "exerciseSearchEmpty": "Ningún ejercicio coincide con la búsqueda.",
+      "setHistory": {
+        "title": "Series registradas",
+        "subtitle": "{count, plural, one {# sesión registrada} other {# sesiones registradas}}, de la más reciente a la más antigua. No se ve afectada por el selector de rango de arriba.",
+        "lineWeighted": "{reps} reps × {weight} kg",
+        "lineReps": "{reps} reps",
+        "lineTime": "{seconds} s",
+        "loadMore": "Ver más ({remaining})",
+        "prLabel": "Récord personal",
+        "truncated": "Mostrando las {count} sesiones más recientes de este ejercicio."
+      },
       "muscleGroupLabel": "Grupo muscular",
       "muscleGroupAll": "Todos",
       "metricTopSet": "Serie máxima",

--- a/backoffice/src/app/gc-fitness/clients/[id]/progress/ExerciseProgressClient.tsx
+++ b/backoffice/src/app/gc-fitness/clients/[id]/progress/ExerciseProgressClient.tsx
@@ -6,10 +6,18 @@
 // switching exercise / metric / range costs ZERO extra Firestore reads — all
 // filtering happens locally.
 //
-// Controls: an exercise picker (only exercises the client actually logged), a
-// metric segmented control (top-set weight / estimated 1RM / volume), and the
-// shared All/90d/30d/7d range selector. Chart styling mirrors
+// Controls: a SEARCHABLE exercise picker (#574 — Popover + Command, the same
+// primitive the template form's exercise picker uses; only exercises the client
+// actually logged), a metric segmented control (top-set weight / estimated 1RM /
+// volume), and the shared All/90d/30d/7d range selector. Chart styling mirrors
 // BodyWeightTrendChartClient (gold AreaChart, recharts, token colors).
+//
+// #574 also adds the "Series registradas" breakdown under the chart: the
+// selected exercise's sessions newest-first, each listing its logged sets
+// ("1 · 8 reps × 70 kg"), revealed 3 at a time via "Ver más". The rows ride the
+// SAME server payload as the chart, so paging costs zero Firestore reads. The
+// list is deliberately NOT filtered by the chart's range selector — it is the
+// exercise's history, and pagination is what keeps it manageable.
 
 import { useEffect, useMemo, useState } from "react";
 import {
@@ -21,10 +29,25 @@ import {
   XAxis,
   YAxis,
 } from "recharts";
+import { Check, ChevronsUpDown, Trophy } from "lucide-react";
 import { useLocale, useTranslations } from "next-intl";
 
 import { cn } from "@/lib/utils";
 import { formatCivilDateLabel } from "@/lib/gc-fitness/civil-date";
+import { Button } from "@/components/ui/button";
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from "@/components/ui/command";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
 import {
   Select,
   SelectContent,
@@ -32,8 +55,15 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
+import { normalizeSearchText } from "@/lib/gc-fitness/exercise-search";
+import { SET_TYPE_TEXT_CLASS } from "@/lib/gc-fitness/set-type";
+import {
+  SET_HISTORY_PAGE_SIZE,
+  sessionSetLines,
+} from "@/lib/gc-fitness/exercise-set-history";
 import type {
   ExerciseSessionPoint,
+  ExerciseSetSession,
   LoggedExerciseOption,
 } from "@/lib/gc-fitness/exercise-progress-actions";
 import {
@@ -47,6 +77,10 @@ type MetricKey = "topSet" | "e1rm" | "volume";
 export interface ExerciseProgressClientProps {
   exercises: LoggedExerciseOption[];
   points: ExerciseSessionPoint[];
+  /** #574 — per-exercise session set breakdowns, newest session first. */
+  setSessions: ExerciseSetSession[];
+  /** #574 — exerciseIds whose breakdown was capped server-side. */
+  truncatedSetHistoryExerciseIds: string[];
   today: string;
   rangeStarts: Record<TrendRangeKey, string>;
   labels: {
@@ -78,9 +112,16 @@ function formatMuscleGroup(group: string): string {
   return group.replace(/_/g, " ").replace(/^[a-z]/, (c) => c.toUpperCase());
 }
 
+/** #574 — set-row weight: whole kg when it is one, else one decimal. */
+function formatSetWeight(kg: number): string {
+  return Number.isInteger(kg) ? String(kg) : kg.toFixed(1);
+}
+
 export function ExerciseProgressClient({
   exercises,
   points,
+  setSessions,
+  truncatedSetHistoryExerciseIds,
   today,
   rangeStarts,
   labels,
@@ -93,6 +134,9 @@ export function ExerciseProgressClient({
   );
   const [metric, setMetric] = useState<MetricKey>("topSet");
   const [range, setRange] = useState<TrendRangeKey>(DEFAULT_TREND_RANGE);
+  const [pickerOpen, setPickerOpen] = useState(false);
+  // #574 — how many of the selected exercise's sessions the list reveals.
+  const [visibleSessions, setVisibleSessions] = useState(SET_HISTORY_PAGE_SIZE);
 
   // Distinct muscle groups present across the client's logged exercises.
   const muscleGroups = useMemo(() => {
@@ -119,6 +163,25 @@ export function ExerciseProgressClient({
       setExerciseId(visibleExercises[0].exerciseId);
     }
   }, [visibleExercises, exerciseId]);
+
+  const selectedExercise = useMemo(
+    () => exercises.find((ex) => ex.exerciseId === exerciseId) ?? null,
+    [exercises, exerciseId],
+  );
+
+  // #574 — every session of the selected exercise, newest first (the server
+  // already emits them in that order). NOT range-filtered: this is the
+  // exercise's history, and "Ver más" is what keeps it manageable.
+  const exerciseSessions = useMemo(
+    () => setSessions.filter((s) => s.exerciseId === exerciseId),
+    [setSessions, exerciseId],
+  );
+  const isTruncated = truncatedSetHistoryExerciseIds.includes(exerciseId);
+
+  // A new exercise starts the list back at the first page.
+  useEffect(() => {
+    setVisibleSessions(SET_HISTORY_PAGE_SIZE);
+  }, [exerciseId]);
 
   const metricOptions: Array<{ key: MetricKey; label: string }> = [
     { key: "topSet", label: labels.metricTopSet },
@@ -212,21 +275,80 @@ export function ExerciseProgressClient({
             >
               {labels.exercisePickerLabel}
             </label>
-            <Select value={exerciseId} onValueChange={setExerciseId}>
-              <SelectTrigger
-                id="exercise-progress-picker"
-                className="w-full sm:max-w-sm"
+            {/* #574 — searchable picker. A client with dozens of logged
+                exercises made the plain <Select> unusable; Command's fuzzy
+                filter runs over the diacritic-normalized name so "sentadilla"
+                and "Sentadílla" both match. */}
+            <Popover open={pickerOpen} onOpenChange={setPickerOpen}>
+              <PopoverTrigger asChild>
+                <Button
+                  id="exercise-progress-picker"
+                  type="button"
+                  variant="outline"
+                  role="combobox"
+                  aria-expanded={pickerOpen}
+                  className="w-full justify-between font-normal sm:max-w-sm"
+                >
+                  <span className="truncate">
+                    {selectedExercise?.name ?? labels.exercisePickerLabel}
+                  </span>
+                  <ChevronsUpDown className="ml-2 size-4 shrink-0 opacity-50" />
+                </Button>
+              </PopoverTrigger>
+              <PopoverContent
+                align="start"
+                className="w-[--radix-popover-trigger-width] p-0"
               >
-                <SelectValue />
-              </SelectTrigger>
-              <SelectContent>
-                {visibleExercises.map((ex) => (
-                  <SelectItem key={ex.exerciseId} value={ex.exerciseId}>
-                    {ex.name}
-                  </SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
+                <Command
+                  // `value` below is ALREADY normalized, so the filter is a
+                  // plain substring test on normalized text — predictable
+                  // ("press" matches "Press de banca") instead of cmdk's
+                  // default fuzzy scoring.
+                  filter={(value, search) => {
+                    const q = normalizeSearchText(search);
+                    return !q || value.includes(q) ? 1 : 0;
+                  }}
+                >
+                  <CommandInput placeholder={t("exerciseSearchPlaceholder")} />
+                  <CommandList>
+                    <CommandEmpty>{t("exerciseSearchEmpty")}</CommandEmpty>
+                    <CommandGroup>
+                      {visibleExercises.map((ex) => (
+                        <CommandItem
+                          key={ex.exerciseId}
+                          // What Command filters on. Normalized (lowercase +
+                          // no diacritics) so "sentadilla" matches
+                          // "Sentadílla", and suffixed with the id so two
+                          // same-named library twins (the known double-seed)
+                          // stay DISTINCT items — cmdk keys its registry on
+                          // `value`, so a collision would merge the rows.
+                          value={normalizeSearchText(
+                            `${ex.name} ${ex.exerciseId}`,
+                          )}
+                          onSelect={() => {
+                            setExerciseId(ex.exerciseId);
+                            setPickerOpen(false);
+                          }}
+                        >
+                          <Check
+                            className={cn(
+                              "mr-2 size-4",
+                              ex.exerciseId === exerciseId
+                                ? "opacity-100"
+                                : "opacity-0",
+                            )}
+                          />
+                          <span className="flex-1 truncate">{ex.name}</span>
+                          <span className="ml-2 shrink-0 text-xs tabular-nums text-muted-foreground">
+                            {ex.sessionCount}
+                          </span>
+                        </CommandItem>
+                      ))}
+                    </CommandGroup>
+                  </CommandList>
+                </Command>
+              </PopoverContent>
+            </Popover>
           </div>
         </div>
 
@@ -365,6 +487,94 @@ export function ExerciseProgressClient({
           </div>
         </>
       )}
+
+      {/* #574 — per-session set breakdown for the selected exercise. */}
+      {exerciseSessions.length > 0 ? (
+        <div className="flex flex-col gap-3 border-t pt-4">
+          <div className="flex flex-col gap-0.5">
+            <h3 className="text-sm font-semibold text-foreground">
+              {t("setHistory.title")}
+            </h3>
+            <p className="text-xs text-muted-foreground">
+              {t("setHistory.subtitle", { count: exerciseSessions.length })}
+            </p>
+          </div>
+
+          <ul className="flex flex-col gap-2">
+            {exerciseSessions.slice(0, visibleSessions).map((session) => (
+              <li
+                key={`${session.logId}-${session.exerciseId}`}
+                className="rounded-lg border bg-muted/20 p-3"
+              >
+                <p className="text-xs font-medium text-foreground">
+                  {formatCivilDateLabel(
+                    session.date,
+                    { year: "numeric", month: "long", day: "numeric" },
+                    locale,
+                  )}
+                </p>
+                <ul className="mt-1.5 flex flex-col gap-1">
+                  {sessionSetLines(session.sets).map((line, i) => (
+                    <li
+                      key={`${session.logId}-${i}`}
+                      className="flex items-center gap-2 text-xs text-muted-foreground"
+                    >
+                      <span
+                        className={cn(
+                          "w-5 shrink-0 text-center font-semibold tabular-nums",
+                          line.setType === "normal"
+                            ? "text-muted-foreground"
+                            : SET_TYPE_TEXT_CLASS[line.setType],
+                        )}
+                      >
+                        {line.label}
+                      </span>
+                      <span className="tabular-nums text-foreground">
+                        {line.kind === "time"
+                          ? t("setHistory.lineTime", {
+                              seconds: line.durationSeconds ?? 0,
+                            })
+                          : line.kind === "weighted"
+                            ? t("setHistory.lineWeighted", {
+                                reps: line.reps,
+                                weight: formatSetWeight(line.weightKg),
+                              })
+                            : t("setHistory.lineReps", { reps: line.reps })}
+                      </span>
+                      {line.isPR ? (
+                        <Trophy
+                          className="size-3 text-amber-500"
+                          aria-label={t("setHistory.prLabel")}
+                        />
+                      ) : null}
+                    </li>
+                  ))}
+                </ul>
+              </li>
+            ))}
+          </ul>
+
+          {visibleSessions < exerciseSessions.length ? (
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              className="w-fit"
+              onClick={() =>
+                setVisibleSessions((n) => n + SET_HISTORY_PAGE_SIZE)
+              }
+            >
+              {t("setHistory.loadMore", {
+                remaining: exerciseSessions.length - visibleSessions,
+              })}
+            </Button>
+          ) : isTruncated ? (
+            <p className="text-[11px] text-muted-foreground">
+              {t("setHistory.truncated", { count: exerciseSessions.length })}
+            </p>
+          ) : null}
+        </div>
+      ) : null}
     </section>
   );
 }

--- a/backoffice/src/app/gc-fitness/clients/[id]/progress/page.tsx
+++ b/backoffice/src/app/gc-fitness/clients/[id]/progress/page.tsx
@@ -89,6 +89,8 @@ export default async function ClientExerciseProgressPage({
     muscleGroupWeeks,
     availableMuscleGroups,
     currentWeekStart,
+    exerciseSetSessions,
+    truncatedSetHistoryExerciseIds,
   } = await getClientExerciseProgress(id, timezone);
 
   // Anchor each range to today so the local filter windows match the other
@@ -115,6 +117,8 @@ export default async function ClientExerciseProgressPage({
       <ExerciseProgressClient
         exercises={exercises}
         points={points}
+        setSessions={exerciseSetSessions}
+        truncatedSetHistoryExerciseIds={truncatedSetHistoryExerciseIds}
         today={today}
         rangeStarts={rangeStarts}
         labels={{

--- a/backoffice/src/lib/gc-fitness/__tests__/exercise-set-history.test.ts
+++ b/backoffice/src/lib/gc-fitness/__tests__/exercise-set-history.test.ts
@@ -1,0 +1,90 @@
+// exercise-set-history.test.ts — #574 per-session set breakdown shaping.
+
+import {
+  SET_HISTORY_PAGE_SIZE,
+  sessionSetLines,
+} from "@/lib/gc-fitness/exercise-set-history";
+import type { ExerciseSetRow } from "@/lib/gc-fitness/exercise-progress-actions";
+
+function row(overrides: Partial<ExerciseSetRow> = {}): ExerciseSetRow {
+  return { setIndex: 0, weightKg: 70, reps: 8, ...overrides };
+}
+
+describe("sessionSetLines", () => {
+  it("orders by setIndex regardless of the input order", () => {
+    const lines = sessionSetLines([
+      row({ setIndex: 2, reps: 6 }),
+      row({ setIndex: 0, reps: 10 }),
+      row({ setIndex: 1, reps: 8 }),
+    ]);
+    expect(lines.map((l) => l.reps)).toEqual([10, 8, 6]);
+    expect(lines.map((l) => l.label)).toEqual(["1", "2", "3"]);
+  });
+
+  it("applies the Hevy numbering rule — W/F/D don't consume a number", () => {
+    const lines = sessionSetLines([
+      row({ setIndex: 0, setType: "warmup" }),
+      row({ setIndex: 1 }),
+      row({ setIndex: 2 }),
+      row({ setIndex: 3, setType: "dropset" }),
+      row({ setIndex: 4 }),
+    ]);
+    expect(lines.map((l) => l.label)).toEqual(["W", "1", "2", "D", "3"]);
+    expect(lines.map((l) => l.setType)).toEqual([
+      "warmup",
+      "normal",
+      "normal",
+      "dropset",
+      "normal",
+    ]);
+  });
+
+  it("labels a failure set F", () => {
+    const lines = sessionSetLines([
+      row({ setIndex: 0 }),
+      row({ setIndex: 1, setType: "failure" }),
+    ]);
+    expect(lines.map((l) => l.label)).toEqual(["1", "F"]);
+  });
+
+  it("classifies weighted / bodyweight / time sets", () => {
+    const lines = sessionSetLines([
+      row({ setIndex: 0, weightKg: 70, reps: 8 }),
+      row({ setIndex: 1, weightKg: 0, reps: 12 }),
+      row({ setIndex: 2, weightKg: 20, reps: 0, durationSeconds: 90 }),
+    ]);
+    expect(lines.map((l) => l.kind)).toEqual(["weighted", "reps", "time"]);
+    expect(lines[2].durationSeconds).toBe(90);
+  });
+
+  it("treats a zero/absent duration as a reps set, not a 0 s time set", () => {
+    expect(sessionSetLines([row({ durationSeconds: 0 })])[0].kind).toBe(
+      "weighted",
+    );
+    expect(sessionSetLines([row({ weightKg: 0 })])[0].durationSeconds).toBeNull();
+  });
+
+  it("carries the PR flag through, defaulting to false", () => {
+    const lines = sessionSetLines([
+      row({ setIndex: 0 }),
+      row({ setIndex: 1, isPR: true }),
+    ]);
+    expect(lines.map((l) => l.isPR)).toEqual([false, true]);
+  });
+
+  it("returns [] for a session with no sets", () => {
+    expect(sessionSetLines([])).toEqual([]);
+  });
+
+  it("does not mutate the caller's array", () => {
+    const sets = [row({ setIndex: 1 }), row({ setIndex: 0 })];
+    sessionSetLines(sets);
+    expect(sets.map((s) => s.setIndex)).toEqual([1, 0]);
+  });
+});
+
+describe("SET_HISTORY_PAGE_SIZE", () => {
+  it("reveals 3 sessions per press, per issue #574", () => {
+    expect(SET_HISTORY_PAGE_SIZE).toBe(3);
+  });
+});

--- a/backoffice/src/lib/gc-fitness/exercise-progress-actions.ts
+++ b/backoffice/src/lib/gc-fitness/exercise-progress-actions.ts
@@ -30,6 +30,7 @@ import {
 import { gcFitnessFirestore } from "@/lib/firebase/gc-fitness-admin";
 import { FirestoreCollections } from "@/lib/gc-fitness/collections";
 import { civilDateFormat, civilDateToday } from "@/lib/gc-fitness/civil-date";
+import { effectiveSetType, type SetType } from "@/lib/gc-fitness/set-type";
 import {
   PROJECTION_WEEKS,
   buildMuscleGroupWeeks,
@@ -54,6 +55,40 @@ export interface LoggedExerciseOption {
    * (e.g. deleted) or carries no groups.
    */
   muscleGroups: string[];
+}
+
+/**
+ * #574 — ONE logged set of the selected exercise, for the coach's per-session
+ * set breakdown ("set 1: 8 reps × 70 kg"). Optional fields are OMITTED when
+ * they carry the default so the payload stays small — a plain reps set
+ * serializes as `{setIndex, weightKg, reps}`.
+ */
+export interface ExerciseSetRow {
+  /** 0-based wire `set_index`. The DISPLAY label is derived from the set types
+   *  via `setDisplayLabels` (Hevy rule: W/F/D letters, normal sets numbered). */
+  setIndex: number;
+  weightKg: number;
+  reps: number;
+  /** Present only for time-metric sets. */
+  durationSeconds?: number;
+  /** Omitted when "normal". */
+  setType?: SetType;
+  /** Omitted when false — this set matched a row in the log's `prs[]`. */
+  isPR?: boolean;
+}
+
+/**
+ * #574 — one SESSION's logged sets for a single exercise, newest-first in
+ * `exerciseSetSessions`. Bounded by `MAX_SET_DETAIL_SESSIONS` per exercise
+ * (see the constant) so a heavily-repeated lift can't blow up the payload.
+ */
+export interface ExerciseSetSession {
+  exerciseId: string;
+  /** civilDate YYYY-MM-DD of the session start (client timezone). */
+  date: string;
+  /** `workout_logs` doc id — lets the coach jump to the full session. */
+  logId: string;
+  sets: ExerciseSetRow[];
 }
 
 /** One session's aggregated metrics for a single exercise. */
@@ -84,6 +119,17 @@ export interface ClientExerciseProgress {
   /** Coarse groups with any data in the window, in `COARSE_MUSCLE_GROUPS` order. */
   availableMuscleGroups: string[];
   /**
+   * #574 — per-exercise session→sets breakdown, newest session first, for the
+   * "Series registradas" list under the chart. Shipped with the SAME single
+   * read as everything else, so paging through it costs zero Firestore reads.
+   */
+  exerciseSetSessions: ExerciseSetSession[];
+  /**
+   * #574 — exerciseIds whose breakdown hit `MAX_SET_DETAIL_SESSIONS`, so the
+   * UI can say the list is truncated instead of silently ending.
+   */
+  truncatedSetHistoryExerciseIds: string[];
+  /**
    * #568 — Monday of the week containing today (client timezone). The chart
    * draws its "today" divider here and anchors the weekly readout on it.
    */
@@ -97,6 +143,16 @@ function isReservedId(id: string): boolean {
 
 const MAX_LOOKBACK_DAYS = 365;
 const LOG_FETCH_LIMIT = 300;
+
+/**
+ * #574 — how many SESSIONS per exercise carry a full set breakdown. The whole
+ * breakdown rides the existing single read (no extra Firestore cost, and
+ * switching exercise stays instant), so the only thing to bound is the RSC
+ * payload: worst case ≈ exercises × 30 × sets-per-session. 30 sessions is
+ * ~7 months of a once-a-week lift — well past what "ver más" is for — and the
+ * UI tells the coach when a list was truncated (`truncatedSetHistoryExerciseIds`).
+ */
+const MAX_SET_DETAIL_SESSIONS = 30;
 
 function toDate(v: unknown): Date | null {
   if (v && typeof (v as { toDate?: () => Date }).toDate === "function") {
@@ -156,6 +212,8 @@ export async function getClientExerciseProgress(
       muscleGroupWeeks: [],
       availableMuscleGroups: [],
       currentWeekStart,
+      exerciseSetSessions: [],
+      truncatedSetHistoryExerciseIds: [],
     };
   }
 
@@ -185,6 +243,12 @@ export async function getClientExerciseProgress(
   // exercise read below.
   const muscleSetInputs: MuscleSetInput[] = [];
   const muscleExerciseIds = new Set<string>();
+
+  // #574 — exerciseId → its sessions' set breakdowns. `snap.docs` is already
+  // newest-first, so pushing in iteration order keeps each list newest-first
+  // and lets the `MAX_SET_DETAIL_SESSIONS` cap drop the OLDEST sessions.
+  const setSessionsByExercise = new Map<string, ExerciseSetSession[]>();
+  const truncatedSetHistory = new Set<string>();
 
   for (const doc of snap.docs) {
     const data = doc.data() as Record<string, unknown>;
@@ -219,6 +283,16 @@ export async function getClientExerciseProgress(
       hasCompleted: boolean;
     }
     const byExercise = new Map<string, Acc>();
+
+    // #574 — this session's set rows per exercise, in wire order. Collected
+    // alongside the metric accumulation so the breakdown costs no extra read.
+    const setRowsByExercise = new Map<string, ExerciseSetRow[]>();
+    // setLogId → true for the sets that earned a PR in this session.
+    const prSetLogIds = new Set(
+      (Array.isArray(data.prs) ? (data.prs as Array<Record<string, unknown>>) : [])
+        .map((pr) => (typeof pr.setLogId === "string" ? pr.setLogId : ""))
+        .filter((id) => id.length > 0),
+    );
 
     for (const s of rawSets) {
       const exId = typeof s.exerciseId === "string" ? s.exerciseId : "";
@@ -255,6 +329,27 @@ export async function getClientExerciseProgress(
         : weight * reps;
       muscleSetInputs.push({ date, exerciseId: exId, volumeKg: setVolume });
       muscleExerciseIds.add(exId);
+
+      // #574 — the coach-facing set row. Optional fields are omitted at their
+      // default so a plain reps set stays `{setIndex, weightKg, reps}`.
+      const row: ExerciseSetRow = {
+        setIndex: Math.max(0, Math.trunc(numeric(s.set_index ?? s.setIndex))),
+        weightKg: weight,
+        reps,
+      };
+      if (hasDuration) row.durationSeconds = numeric(durRaw);
+      const setType = effectiveSetType({
+        set_type: typeof s.set_type === "string" ? s.set_type : null,
+        setType: typeof s.setType === "string" ? s.setType : null,
+        is_warmup: s.is_warmup === true || s.isWarmup === true,
+      });
+      if (setType !== "normal") row.setType = setType;
+      const setLogId = typeof s.id === "string" ? s.id : "";
+      if (setLogId && prSetLogIds.has(setLogId)) row.isPR = true;
+
+      const rows = setRowsByExercise.get(exId);
+      if (rows) rows.push(row);
+      else setRowsByExercise.set(exId, [row]);
 
       if (weight > 0) {
         acc.topWeight =
@@ -294,6 +389,19 @@ export async function getClientExerciseProgress(
           acc.bestE1rm === null ? null : Math.round(acc.bestE1rm * 10) / 10,
         volumeKg: Math.round(acc.volume),
       });
+
+      // #574 — file this session's set breakdown, newest-first, capped.
+      const rows = setRowsByExercise.get(exId);
+      if (rows && rows.length > 0) {
+        const sessions = setSessionsByExercise.get(exId) ?? [];
+        if (sessions.length >= MAX_SET_DETAIL_SESSIONS) {
+          truncatedSetHistory.add(exId);
+        } else {
+          rows.sort((a, b) => a.setIndex - b.setIndex);
+          sessions.push({ exerciseId: exId, date, logId: doc.id, sets: rows });
+          setSessionsByExercise.set(exId, sessions);
+        }
+      }
     }
   }
 
@@ -415,6 +523,14 @@ export async function getClientExerciseProgress(
   // stays lean (those exercises can never be selected anyway).
   const leanPoints = points.filter((p) => withDataIds.has(p.exerciseId));
 
+  // #574 — same lean-payload rule for the set breakdown: only exercises the
+  // picker can actually select ship their sessions.
+  const exerciseSetSessions: ExerciseSetSession[] = [];
+  for (const [exId, sessions] of setSessionsByExercise) {
+    if (!withDataIds.has(exId)) continue;
+    exerciseSetSessions.push(...sessions);
+  }
+
   return {
     clientId,
     exercises,
@@ -422,5 +538,9 @@ export async function getClientExerciseProgress(
     muscleGroupWeeks,
     availableMuscleGroups,
     currentWeekStart,
+    exerciseSetSessions,
+    truncatedSetHistoryExerciseIds: Array.from(truncatedSetHistory).filter((id) =>
+      withDataIds.has(id),
+    ),
   };
 }

--- a/backoffice/src/lib/gc-fitness/exercise-set-history.ts
+++ b/backoffice/src/lib/gc-fitness/exercise-set-history.ts
@@ -1,0 +1,72 @@
+// exercise-set-history.ts
+//
+// #574 — pure shaping for the coach's per-exercise "Series registradas" list on
+// /gc-fitness/clients/[id]/progress. Turns one session's `ExerciseSetRow[]`
+// into display lines: the Hevy set label (W/F/D letters, normal sets numbered
+// counting ONLY normal sets) plus the numbers the coach reads.
+//
+// Formatting of the numbers themselves stays in the component (the "reps" word
+// is localized); everything ORDER- and LABEL-related lives here so it's
+// unit-tested and can't drift from the `setDisplayLabels` twin.
+
+import { effectiveSetType, setDisplayLabels, type SetType } from "./set-type";
+import type { ExerciseSetRow } from "./exercise-progress-actions";
+
+/** How the value column should be rendered for one set. */
+export type SetLineKind =
+  /** Time-metric set — `durationSeconds` is authoritative. */
+  | "time"
+  /** Weighted set — `weightKg > 0`. */
+  | "weighted"
+  /** Bodyweight / unweighted reps set. */
+  | "reps";
+
+export interface SetLine {
+  /** Hevy display label: "1", "2", … for normal sets; "W" / "F" / "D". */
+  label: string;
+  kind: SetLineKind;
+  weightKg: number;
+  reps: number;
+  durationSeconds: number | null;
+  setType: SetType;
+  isPR: boolean;
+}
+
+/** How many sessions the list reveals per "Ver más" press (issue #574). */
+export const SET_HISTORY_PAGE_SIZE = 3;
+
+/**
+ * One session's sets → display lines, in `setIndex` order.
+ *
+ * The label comes from `setDisplayLabels`, the shared twin of iOS
+ * `SetTypeDisplay.labels` / Android `SetTypeUi`: a warm-up / failure / drop set
+ * renders its letter and does NOT consume a number, so a
+ * `[warmup, normal, normal, dropset, normal]` session reads W, 1, 2, D, 3.
+ */
+export function sessionSetLines(sets: readonly ExerciseSetRow[]): SetLine[] {
+  const ordered = sets.slice().sort((a, b) => a.setIndex - b.setIndex);
+  const types = ordered.map((row) =>
+    // A row's `setType` is omitted at "normal" on the wire; `effectiveSetType`
+    // also covers a legacy row that only carried the warm-up flag.
+    effectiveSetType({ setType: row.setType ?? null }),
+  );
+  const labels = setDisplayLabels(types);
+
+  return ordered.map((row, i) => {
+    const durationSeconds =
+      typeof row.durationSeconds === "number" && row.durationSeconds > 0
+        ? row.durationSeconds
+        : null;
+    const kind: SetLineKind =
+      durationSeconds !== null ? "time" : row.weightKg > 0 ? "weighted" : "reps";
+    return {
+      label: labels[i],
+      kind,
+      weightKg: row.weightKg,
+      reps: row.reps,
+      durationSeconds,
+      setType: types[i],
+      isPR: row.isPR === true,
+    };
+  });
+}


### PR DESCRIPTION
Closes mdb1/gc-fitness#574. **Re-opens the work from #279, which never reached `main`.**

#279 was based on `fix/565-all-set-types-count` and got merged into that branch *after*
#278 had already merged it to `main` — so its commit (`a31b49a`) is sitting on the
stale branch and none of the #574 work shipped. This PR targets `main` directly; the
diff is exactly the 7 files of #574 (merges cleanly, verified locally).

## What was missing

On `/gc-fitness/clients/[id]/progress` the coach had no way to find an exercise in a
long list, and no way to see what was actually logged — only the aggregated chart.

## Search

The plain `<Select>` becomes a **Popover + Command combobox**, the same primitive the
template form's exercise picker uses. The filter runs on diacritic-normalized text, so
`sentadilla` finds "Sentadílla" and `press` finds "Press de banca". Each row shows its
session count.

One subtlety worth flagging: each item's `value` is suffixed with its `exerciseId`.
cmdk keys its internal registry on `value`, so two same-named library twins (the known
standard-library double-seed) would otherwise merge into one row.

## Set breakdown

A **"Series registradas"** list under the chart shows the selected exercise's sessions
newest-first, each with its logged sets — `1 · 8 reps × 70 kg` — revealed **3 at a
time** via "Ver más", exactly as the issue asks.

Set labels come from the shared `setDisplayLabels` twin, so a warm-up / failure / drop
set renders **W / F / D** in its type color and doesn't consume a set number. PR sets
get a trophy.

## Why it's server-shaped, and the one cap

The rows ride the **same single Firestore read** as the chart, so paging costs zero
extra reads and switching exercise stays instant. That's deliberate: a per-exercise
server action could not filter by `exerciseId` anyway (it lives inside the `sets`
array), so it would re-read all 300 logs on every selection.

To bound the RSC payload that buys, `MAX_SET_DETAIL_SESSIONS = 30` sessions per
exercise carry a breakdown, and optional row fields are omitted at their default so a
plain reps set serializes as `{setIndex, weightKg, reps}`. **The cap is not silent** —
`truncatedSetHistoryExerciseIds` drives a footnote saying the list shows the 30 most
recent sessions.

The list is deliberately **not** filtered by the chart's range selector — it's the
exercise's history, and pagination is what keeps it manageable. The subtitle says so;
tell me if you'd rather it track the range.

## Tests

New pure `exercise-set-history.ts` (set ordering, Hevy labels, weighted/bodyweight/time
classification, PR flag) with 9 unit tests, including the `[W, 1, 2, D, 3]` numbering
vector and a no-mutation check.

- `npx jest` — **883/884**; the single red is the known `client-activity-time`
  non-en-US locale flake (pre-existing, green in CI).
- `tsc --noEmit` clean, `npx next build` compiles.
- No `firestore.rules` / index / functions change; no new Firestore reads.

## Verification requested

Open a client with a long exercise history: typing in the picker should filter it, and
picking an exercise should list its sessions 3 at a time with working "Ver más".