### PR TITLE
feat(gc-fitness): remember the muscle-group chart selection (#578)

### DIFF
--- a/backoffice/src/app/gc-fitness/clients/[id]/progress/MuscleGroupProgressClient.tsx
+++ b/backoffice/src/app/gc-fitness/clients/[id]/progress/MuscleGroupProgressClient.tsx
@@ -17,8 +17,17 @@
 // Android Progress-tab charts (MuscleGroupSeriesChart `projectionStartIndex`).
 // The weekly readout shows the projected week total too, so a Monday doesn't
 // read as "3 series esta semana".
+//
+// #578 PERSISTENCE: the chip selection + target-zone bounds survive a reload and
+// a hop to another client, via localStorage — see muscle-group-preferences.ts,
+// which documents the two restore semantics copied from the iOS twin. The state
+// below still SEEDS from the defaults so the server render is deterministic;
+// the stored bundle is applied in a mount effect (reading localStorage in a
+// useState initializer would be a hydration mismatch), and each mutation
+// handler persists as it goes — never a state-sync effect, which would race the
+// restore and write the defaults over the coach's choice.
 
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import {
   CartesianGrid,
   Line,
@@ -48,6 +57,14 @@ import {
   DEFAULT_SELECTED_MUSCLE_GROUPS,
 } from "@/lib/gc-fitness/muscle-group-display";
 import {
+  DEFAULT_TARGET_MAX,
+  DEFAULT_TARGET_MIN,
+  clampTargetZone,
+  readMusclePreferences,
+  writeSelectedMuscleGroups,
+  writeTargetZone,
+} from "@/lib/gc-fitness/muscle-group-preferences";
+import {
   PROJECTED_KEY_SUFFIX as PROJ,
   buildChartRows,
   weekHasProjection,
@@ -59,8 +76,8 @@ import {
 } from "../_components/trend-range";
 import { TrendRangeSelector } from "../_components/TrendRangeSelector";
 
-const DEFAULT_TARGET_MIN = 12;
-const DEFAULT_TARGET_MAX = 20;
+// DEFAULT_TARGET_MIN / MAX moved to muscle-group-preferences.ts (#578) — the
+// restore path needs them to fill in a half-written pair.
 // Muscle-group charts read best over a multi-week trend; default to 90d.
 const DEFAULT_MUSCLE_RANGE: TrendRangeKey = "90";
 
@@ -108,13 +125,34 @@ export function MuscleGroupProgressClient({
   const [targetMin, setTargetMin] = useState(DEFAULT_TARGET_MIN);
   const [targetMax, setTargetMax] = useState(DEFAULT_TARGET_MAX);
 
-  const toggleGroup = (g: string) =>
-    setSelected((prev) => {
-      const next = new Set(prev);
-      if (next.has(g)) next.delete(g);
-      else next.add(g);
-      return next;
-    });
+  // #578 — apply the persisted bundle once the component is on the client. A
+  // stored selection wins outright over the seeded defaults (including an empty
+  // one: that's "the coach unticked everything", not "no value") and is NOT
+  // intersected with `availableGroups`, so a group this client doesn't train is
+  // merely not drawn rather than dropped from the preference.
+  useEffect(() => {
+    const stored = readMusclePreferences();
+    if (stored.selected !== null) setSelected(new Set(stored.selected));
+    if (stored.targetMin !== null || stored.targetMax !== null) {
+      const { min, max } = clampTargetZone(
+        stored.targetMin ?? DEFAULT_TARGET_MIN,
+        stored.targetMax ?? DEFAULT_TARGET_MAX,
+      );
+      setTargetMin(min);
+      setTargetMax(max);
+    }
+  }, []);
+
+  // `next` is computed outside the updater so the exact value that lands in
+  // state is the one persisted (a side effect inside a React updater would run
+  // twice under StrictMode).
+  const toggleGroup = (g: string) => {
+    const next = new Set(selected);
+    if (next.has(g)) next.delete(g);
+    else next.add(g);
+    setSelected(next);
+    writeSelectedMuscleGroups(next);
+  };
 
   // Selected groups in canonical order (stable line order + legend).
   const selectedOrdered = useMemo(
@@ -170,10 +208,10 @@ export function MuscleGroupProgressClient({
   }, [windowWeeks, currentIndex, selectedOrdered]);
 
   const clampTarget = (nextMin: number, nextMax: number) => {
-    const lo = Math.max(0, Math.min(nextMin, nextMax));
-    const hi = Math.max(lo, nextMax);
-    setTargetMin(lo);
-    setTargetMax(hi);
+    const { min, max } = clampTargetZone(nextMin, nextMax);
+    setTargetMin(min);
+    setTargetMax(max);
+    writeTargetZone(min, max);
   };
 
   const rangeLabels: Record<TrendRangeKey, string> = {

--- a/backoffice/src/lib/gc-fitness/__tests__/muscle-group-preferences.test.ts
+++ b/backoffice/src/lib/gc-fitness/__tests__/muscle-group-preferences.test.ts
@@ -1,0 +1,180 @@
+/** @jest-environment jsdom */
+// muscle-group-preferences.test.ts — #578
+//
+// jsdom (the repo default is `node`) because the round-trip block exercises the
+// real `window.localStorage`; the pure parsers below would run in either.
+//
+// Locks the restore semantics the chart depends on. The two that matter most
+// (and that a future refactor would plausibly "simplify" away):
+//   - a stored EMPTY array is a deliberate "untick everything", NOT a missing
+//     value, so it must NOT fall back to the defaults;
+//   - the stored selection is never intersected with the client's available
+//     groups here — that intersection is the CHART's job, so walking the roster
+//     can't erase a group from the preference.
+
+import {
+  DEFAULT_TARGET_MAX,
+  DEFAULT_TARGET_MIN,
+  MUSCLE_PREFERENCE_KEYS,
+  clampTargetZone,
+  parseSelectedMuscleGroups,
+  parseTargetBound,
+  readMusclePreferences,
+  writeSelectedMuscleGroups,
+  writeTargetZone,
+} from "../muscle-group-preferences";
+
+describe("parseSelectedMuscleGroups", () => {
+  it("returns null when nothing is stored (caller seeds its defaults)", () => {
+    expect(parseSelectedMuscleGroups(null)).toBeNull();
+  });
+
+  it("returns null for unparseable JSON", () => {
+    expect(parseSelectedMuscleGroups("{not json")).toBeNull();
+  });
+
+  it("returns null when the stored value is not an array", () => {
+    expect(parseSelectedMuscleGroups('{"back":true}')).toBeNull();
+    expect(parseSelectedMuscleGroups('"back"')).toBeNull();
+    expect(parseSelectedMuscleGroups("null")).toBeNull();
+  });
+
+  it("restores a full selection in canonical display order, not write order", () => {
+    // Written in the order the coach happened to click them.
+    const raw = JSON.stringify(["legs", "back", "core", "chest"]);
+    expect(parseSelectedMuscleGroups(raw)).toEqual([
+      "back",
+      "chest",
+      "legs",
+      "core",
+    ]);
+  });
+
+  it("restores an EMPTY selection as empty — not as the defaults", () => {
+    expect(parseSelectedMuscleGroups("[]")).toEqual([]);
+  });
+
+  it("drops unknown / non-string entries", () => {
+    const raw = JSON.stringify(["back", "quadriceps", 7, null, "chest"]);
+    expect(parseSelectedMuscleGroups(raw)).toEqual(["back", "chest"]);
+  });
+
+  it("dedupes repeated entries", () => {
+    expect(parseSelectedMuscleGroups('["back","back","back"]')).toEqual(["back"]);
+  });
+});
+
+describe("parseTargetBound", () => {
+  it("accepts a whole count, including 0", () => {
+    expect(parseTargetBound("12")).toBe(12);
+    expect(parseTargetBound("0")).toBe(0);
+  });
+
+  it("rejects absent, empty, non-numeric, negative, fractional and absurd values", () => {
+    expect(parseTargetBound(null)).toBeNull();
+    expect(parseTargetBound("")).toBeNull();
+    expect(parseTargetBound("   ")).toBeNull();
+    expect(parseTargetBound("abc")).toBeNull();
+    expect(parseTargetBound("-3")).toBeNull();
+    expect(parseTargetBound("12.5")).toBeNull();
+    expect(parseTargetBound("100000")).toBeNull();
+  });
+});
+
+describe("clampTargetZone", () => {
+  it("passes an already-valid band through", () => {
+    expect(clampTargetZone(12, 20)).toEqual({ min: 12, max: 20 });
+  });
+
+  it("un-inverts a band whose min exceeds its max", () => {
+    expect(clampTargetZone(30, 20)).toEqual({ min: 20, max: 20 });
+  });
+
+  it("floors a negative edge at 0", () => {
+    expect(clampTargetZone(-5, 20)).toEqual({ min: 0, max: 20 });
+  });
+
+  it("falls back to the defaults for a non-finite edge instead of going NaN", () => {
+    expect(clampTargetZone(Number.NaN, 20)).toEqual({ min: 12, max: 20 });
+    expect(clampTargetZone(8, Number.NaN)).toEqual({ min: 8, max: 20 });
+    expect(clampTargetZone(Number.NaN, Number.NaN)).toEqual({
+      min: DEFAULT_TARGET_MIN,
+      max: DEFAULT_TARGET_MAX,
+    });
+  });
+});
+
+describe("localStorage round-trip", () => {
+  beforeEach(() => window.localStorage.clear());
+
+  it("reads back nothing when the store is empty", () => {
+    expect(readMusclePreferences()).toEqual({
+      selected: null,
+      targetMin: null,
+      targetMax: null,
+    });
+  });
+
+  it("round-trips a selection + target zone", () => {
+    writeSelectedMuscleGroups(new Set(["shoulders", "back"]));
+    writeTargetZone(10, 18);
+    expect(readMusclePreferences()).toEqual({
+      selected: ["back", "shoulders"],
+      targetMin: 10,
+      targetMax: 18,
+    });
+  });
+
+  it("persists an empty selection as [] so it restores as empty", () => {
+    writeSelectedMuscleGroups(new Set());
+    expect(window.localStorage.getItem(MUSCLE_PREFERENCE_KEYS.selected)).toBe("[]");
+    expect(readMusclePreferences().selected).toEqual([]);
+  });
+
+  it("stores the selection in canonical order regardless of insertion order", () => {
+    writeSelectedMuscleGroups(["core", "chest", "back"]);
+    expect(window.localStorage.getItem(MUSCLE_PREFERENCE_KEYS.selected)).toBe(
+      JSON.stringify(["back", "chest", "core"]),
+    );
+  });
+
+  it("ignores unknown groups on write", () => {
+    writeSelectedMuscleGroups(["back", "not-a-group"]);
+    expect(readMusclePreferences().selected).toEqual(["back"]);
+  });
+
+  it("degrades to no-preference when the stored value is corrupt", () => {
+    window.localStorage.setItem(MUSCLE_PREFERENCE_KEYS.selected, "¯\\_(ツ)_/¯");
+    window.localStorage.setItem(MUSCLE_PREFERENCE_KEYS.targetMin, "twelve");
+    expect(readMusclePreferences()).toEqual({
+      selected: null,
+      targetMin: null,
+      targetMax: null,
+    });
+  });
+
+  it("survives a localStorage that throws (Safari private mode / blocked site data)", () => {
+    const getItem = jest
+      .spyOn(Storage.prototype, "getItem")
+      .mockImplementation(() => {
+        throw new Error("SecurityError");
+      });
+    const setItem = jest
+      .spyOn(Storage.prototype, "setItem")
+      .mockImplementation(() => {
+        throw new Error("QuotaExceededError");
+      });
+    try {
+      expect(readMusclePreferences()).toEqual({
+        selected: null,
+        targetMin: null,
+        targetMax: null,
+      });
+      expect(() => writeSelectedMuscleGroups(["back"])).not.toThrow();
+      expect(() => writeTargetZone(12, 20)).not.toThrow();
+    } finally {
+      getItem.mockRestore();
+      setItem.mockRestore();
+    }
+  });
+});

--- a/backoffice/src/lib/gc-fitness/muscle-group-preferences.ts
+++ b/backoffice/src/lib/gc-fitness/muscle-group-preferences.ts
@@ -1,0 +1,162 @@
+// muscle-group-preferences.ts
+// #578 — persistence for the coach's "Grupos musculares" chart controls on
+// `/gc-fitness/clients/[id]/progress`.
+//
+// The chips + target-zone bounds used to be plain `useState`, so ticking all
+// seven groups survived neither a reload nor a hop to the next client (a route
+// change remounts the component and re-runs the seed initializer).
+//
+// TWIN — both mobile surfaces already persist exactly this bundle; the
+// backoffice was the only one that didn't:
+//   - iOS:     ProgressPhotosViewModel.MuscleDefaultsKey / loadMusclePreferences()
+//              (UserDefaults `progress.muscleGroups.{selected,targetSetsMin,
+//               targetSetsMax}.v1`)
+//   - Android: ProgressViewModel / MuscleGroupChartsStandalone — musclePrefs.loadSelected()
+//
+// Storage is device-local on all three surfaces (UserDefaults / SharedPreferences
+// / localStorage). Nothing here reads or writes Firestore.
+//
+// TWO SEMANTICS COPIED FROM iOS ON PURPOSE:
+//
+//  1. A restored selection is NOT intersected with the client's available
+//     groups. Client B may not train legs, but the chart only ever draws
+//     `availableGroups ∩ selected` anyway — so an unavailable group is simply
+//     not drawn while STAYING in the preference. Intersecting on read would
+//     silently erase groups as the coach walks the roster.
+//  2. A restored selection suppresses default seeding entirely (iOS
+//     `didSeedMuscleSelection`). An empty stored array means "the coach
+//     unticked everything", not "no value" — it is restored as empty.
+
+import { COARSE_MUSCLE_GROUPS } from "./muscle-group-display";
+
+/** localStorage keys — `gc-fitness:` prefixed like `gc-fitness:template-draft:new`. */
+export const MUSCLE_PREFERENCE_KEYS = {
+  selected: "gc-fitness:progress.muscleGroups.selected.v1",
+  targetMin: "gc-fitness:progress.muscleGroups.targetSetsMin.v1",
+  targetMax: "gc-fitness:progress.muscleGroups.targetSetsMax.v1",
+} as const;
+
+/**
+ * Default green target band on the sets chart — 12–20 weighted sets per muscle
+ * group per week. Twin of the iOS `defaultTargetSetsMin/Max`.
+ */
+export const DEFAULT_TARGET_MIN = 12;
+export const DEFAULT_TARGET_MAX = 20;
+
+/** Upper sanity bound for a persisted target-zone edge (the input is free-form). */
+const MAX_TARGET_BOUND = 1000;
+
+export interface MusclePreferences {
+  /** `null` when nothing was stored — the caller keeps its default seeding. */
+  selected: string[] | null;
+  /** `null` when absent/corrupt — the caller keeps its default. */
+  targetMin: number | null;
+  targetMax: number | null;
+}
+
+/**
+ * Parse a stored selection.
+ *
+ * Returns `null` ONLY when the value is absent, unparseable, or not an array —
+ * i.e. "no preference, seed the defaults". A well-formed array yields the
+ * entries that are real coarse groups, deduped and in canonical display order
+ * (so the order values happened to be written in can never disturb the line /
+ * legend order), possibly empty.
+ *
+ * An array of nothing but unknown ids therefore degrades to an empty selection
+ * rather than to the defaults — indistinguishable from a deliberate "untick
+ * everything", and one click away from recovery either way.
+ */
+export function parseSelectedMuscleGroups(raw: string | null): string[] | null {
+  if (raw === null) return null;
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return null;
+  }
+  if (!Array.isArray(parsed)) return null;
+  const stored = new Set(parsed.filter((v): v is string => typeof v === "string"));
+  return COARSE_MUSCLE_GROUPS.filter((g) => stored.has(g));
+}
+
+/** Parse a stored target-zone edge; `null` for anything not a sane whole count. */
+export function parseTargetBound(raw: string | null): number | null {
+  if (raw === null || raw.trim() === "") return null;
+  const n = Number(raw);
+  if (!Number.isInteger(n) || n < 0 || n > MAX_TARGET_BOUND) return null;
+  return n;
+}
+
+/**
+ * Clamp the green target band so `0 ≤ min ≤ max`. Twin of iOS
+ * `ProgressPhotosViewModel.updateTargetSets(min:max:)`. Used for BOTH the live
+ * edit and the restore path, so corrupt storage can't produce an inverted band.
+ *
+ * A non-finite edge (an emptied `<input type="number">` yields `Number("") === 0`,
+ * but a pasted "abc" yields NaN) falls back to that edge's default instead of
+ * poisoning the band — NaN would otherwise flow through every Math.min/max and
+ * blank the ReferenceArea.
+ */
+export function clampTargetZone(
+  min: number,
+  max: number,
+): { min: number; max: number } {
+  const safeMin = Number.isFinite(min) ? min : DEFAULT_TARGET_MIN;
+  const safeMax = Number.isFinite(max) ? max : DEFAULT_TARGET_MAX;
+  const lo = Math.max(0, Math.min(safeMin, safeMax));
+  return { min: lo, max: Math.max(lo, safeMax) };
+}
+
+// ---------------------------------------------------------------------------
+// window-touching wrappers — the ONLY non-pure functions in this file.
+// Every one is SSR-guarded and try/catch'd: localStorage throws in Safari
+// private mode / when site data is blocked, and a chart preference must never
+// take the progress page down with it.
+// ---------------------------------------------------------------------------
+
+const NO_PREFERENCES: MusclePreferences = {
+  selected: null,
+  targetMin: null,
+  targetMax: null,
+};
+
+/** Restore the persisted bundle. Call from a mount effect, never during SSR. */
+export function readMusclePreferences(): MusclePreferences {
+  if (typeof window === "undefined") return NO_PREFERENCES;
+  try {
+    const { localStorage: ls } = window;
+    return {
+      selected: parseSelectedMuscleGroups(ls.getItem(MUSCLE_PREFERENCE_KEYS.selected)),
+      targetMin: parseTargetBound(ls.getItem(MUSCLE_PREFERENCE_KEYS.targetMin)),
+      targetMax: parseTargetBound(ls.getItem(MUSCLE_PREFERENCE_KEYS.targetMax)),
+    };
+  } catch {
+    return NO_PREFERENCES;
+  }
+}
+
+/** Persist the chip selection (canonical order; an empty set is stored as `[]`). */
+export function writeSelectedMuscleGroups(groups: Iterable<string>): void {
+  if (typeof window === "undefined") return;
+  const set = new Set(groups);
+  try {
+    window.localStorage.setItem(
+      MUSCLE_PREFERENCE_KEYS.selected,
+      JSON.stringify(COARSE_MUSCLE_GROUPS.filter((g) => set.has(g))),
+    );
+  } catch {
+    // Storage unavailable — the selection still applies for this session.
+  }
+}
+
+/** Persist the target-zone bounds (already clamped by the caller). */
+export function writeTargetZone(min: number, max: number): void {
+  if (typeof window === "undefined") return;
+  try {
+    window.localStorage.setItem(MUSCLE_PREFERENCE_KEYS.targetMin, String(min));
+    window.localStorage.setItem(MUSCLE_PREFERENCE_KEYS.targetMax, String(max));
+  } catch {
+    // Storage unavailable — see above.
+  }
+}


### PR DESCRIPTION
Closes mdb1/gc-fitness#578.

## Problem

On `/gc-fitness/clients/[id]/progress` → **Grupos musculares**, the coarse-group chips and the target-zone bounds were plain `useState` seeded from the espalda / pecho / piernas defaults. A coach who ticks all seven groups loses that on a page reload **and** on every navigation to another client (a route change remounts the component, re-running the seed initializer).

## Parity finding — this is the only surface that forgot

Both mobile twins already persist this exact bundle (selection **and** target zone):

- **iOS** — `ProgressPhotosViewModel.loadMusclePreferences()` / `toggleMuscleGroup` / `updateTargetSets`, `UserDefaults` keys `progress.muscleGroups.{selected,targetSetsMin,targetSetsMax}.v1`
- **Android** — `ProgressViewModel` / `MuscleGroupChartsStandalone` → `musclePrefs.loadSelected()`

So this ports the whole bundle rather than just the chips — persisting the selection while the target band kept resetting would leave the backoffice half in parity. Storage is device-local on all three surfaces (UserDefaults / SharedPreferences / localStorage).

## What shipped

New pure module `lib/gc-fitness/muscle-group-preferences.ts`:

- `parseSelectedMuscleGroups(raw)` → `string[] | null`. `null` **only** when the key is absent / unparseable / not an array; otherwise the entries that are real `COARSE_MUSCLE_GROUPS`, deduped and in canonical display order, so the order values happened to be written in can never disturb the line/legend order.
- `parseTargetBound(raw)` — finite whole `0 ≤ n ≤ 1000`, else `null`.
- `clampTargetZone(min, max)` — twin of iOS `updateTargetSets`, now shared by the live edit **and** the restore path so corrupt storage can't produce an inverted band.
- `readMusclePreferences` / `writeSelectedMuscleGroups` / `writeTargetZone` — the only `window`-touching functions, each SSR-guarded + `try/catch`'d (Safari private mode / blocked site data must not take the progress page down).

Two restore semantics copied from iOS **on purpose**, both locked by tests:

1. **A restored selection is NOT intersected with `availableGroups`.** Client B may not train legs; the chart already draws only `groups.filter(selected.has)`, so an unavailable group is simply not drawn while *staying* in the preference. Intersecting on read would silently erase groups as the coach walks the roster.
2. **A stored empty array is a deliberate "untick everything"**, not a missing value — restored as empty (the existing `muscleGroups.selectHint` copy covers that state), never falling back to the defaults.

Wiring in `MuscleGroupProgressClient.tsx`:

- `useState` initializers keep the current defaults — reading `localStorage` in an initializer would be a **hydration mismatch**, since this renders on the server.
- One mount `useEffect` applies the stored bundle.
- Persistence happens in the mutation handlers (`toggleGroup`, `clampTarget`), **not** in a state-sync effect — a sync effect would race the restore and write the pre-hydration defaults over the coach's choice. `toggleGroup` computes `next` outside the updater so the value stored is exactly the value set (a side effect inside a React updater runs twice under StrictMode).

Drive-by: `clampTargetZone` now falls back to the defaults for a non-finite edge. A pasted `"abc"` in the min/max input previously flowed `NaN` through every `Math.min`/`Math.max` and blanked the `ReferenceArea`.

## Deliberately out of scope

- **iOS / Android** — they already ship this; parity is being restored, not added.
- **The trend-range selector** (7/30/90/all) — not part of the mobile preference bundle, and it reads as a per-visit question rather than a standing preference. Still session-local. Easy to add if you'd rather it stuck too.
- **Server-side (per-coach Firestore) persistence** — the mobile twins are device-local, so localStorage is the browser equivalent. **No new Firestore reads or writes**, no rules / index / functions change.

## Test gate

| Gate | Result |
|---|---|
| `npx jest` | 903/904 — the 1 red is the known pre-existing `client-activity-time` non-en-US locale flake (green in CI), unrelated |
| new `muscle-group-preferences.test.ts` | 20/20 green |
| `npx tsc --noEmit` | clean |
| `npx next build` | compiles |

## Please verify

Open a client's Progress page, tick all seven groups and change the target band → reload → still all ticked with your band. Then navigate to a different client → same. Untick everything → reload → it stays empty (the "elegí un grupo" hint), not re-seeded to the three defaults.