### PR TITLE
fix(gc-fitness): search the progress exercise picker in ES and EN (#581)

### DIFF
--- a/backoffice/src/app/gc-fitness/clients/[id]/progress/ExerciseProgressClient.tsx
+++ b/backoffice/src/app/gc-fitness/clients/[id]/progress/ExerciseProgressClient.tsx
@@ -278,7 +278,9 @@ export function ExerciseProgressClient({
             {/* #574 — searchable picker. A client with dozens of logged
                 exercises made the plain <Select> unusable; Command's fuzzy
                 filter runs over the diacritic-normalized name so "sentadilla"
-                and "Sentadílla" both match. */}
+                and "Sentadílla" both match. #581 — the search text also carries
+                the exercise's OTHER language, so a Spanish-labelled row is
+                findable by its English name and vice versa. */}
             <Popover open={pickerOpen} onOpenChange={setPickerOpen}>
               <PopoverTrigger asChild>
                 <Button
@@ -318,12 +320,17 @@ export function ExerciseProgressClient({
                           key={ex.exerciseId}
                           // What Command filters on. Normalized (lowercase +
                           // no diacritics) so "sentadilla" matches
-                          // "Sentadílla", and suffixed with the id so two
-                          // same-named library twins (the known double-seed)
-                          // stay DISTINCT items — cmdk keys its registry on
-                          // `value`, so a collision would merge the rows.
+                          // "Sentadílla"; #581 folds in `searchAliases` (the
+                          // language NOT displayed, plus any older name) so
+                          // "bench press" finds "Press de banca"; and suffixed
+                          // with the id so two same-named library twins (the
+                          // known double-seed) stay DISTINCT items — cmdk keys
+                          // its registry on `value`, so a collision would merge
+                          // the rows.
                           value={normalizeSearchText(
-                            `${ex.name} ${ex.exerciseId}`,
+                            [ex.name, ...ex.searchAliases, ex.exerciseId].join(
+                              " ",
+                            ),
                           )}
                           onSelect={() => {
                             setExerciseId(ex.exerciseId);

--- a/backoffice/src/lib/gc-fitness/__tests__/exercise-name-variants.test.ts
+++ b/backoffice/src/lib/gc-fitness/__tests__/exercise-name-variants.test.ts
@@ -1,0 +1,124 @@
+// exercise-name-variants.test.ts
+//
+// Issue #581: the client Progress tab's exercise picker only matched the ONE
+// language the row displayed (the payload flattens `{en, es}` ES-first), so a
+// coach typing "bench press" found nothing on a "Press de banca" row. These
+// cover the pure half of the fix — pulling every language out of a wire name
+// and turning the collected set into the search-only alias list.
+
+import {
+  collectExerciseNameVariants,
+  exerciseNameVariants,
+  searchAliasesFor,
+} from "../exercise-name-variants";
+
+describe("exerciseNameVariants", () => {
+  it("returns both languages of a bilingual name, EN first", () => {
+    expect(
+      exerciseNameVariants({ en: "Bench Press", es: "Press de banca" }),
+    ).toEqual(["Bench Press", "Press de banca"]);
+  });
+
+  it("keeps the single language when only one is filled", () => {
+    expect(exerciseNameVariants({ en: "Bench Press", es: "" })).toEqual([
+      "Bench Press",
+    ]);
+    expect(exerciseNameVariants({ es: "Sentadilla" })).toEqual(["Sentadilla"]);
+  });
+
+  it("accepts a legacy plain-string name", () => {
+    expect(exerciseNameVariants("  Squat  ")).toEqual(["Squat"]);
+  });
+
+  it("yields nothing for absent / blank / non-name values", () => {
+    expect(exerciseNameVariants(null)).toEqual([]);
+    expect(exerciseNameVariants(undefined)).toEqual([]);
+    expect(exerciseNameVariants("   ")).toEqual([]);
+    expect(exerciseNameVariants(42)).toEqual([]);
+    expect(exerciseNameVariants({ en: 7, es: null })).toEqual([]);
+  });
+});
+
+describe("collectExerciseNameVariants", () => {
+  it("accumulates across several logs, keyed by normalized text", () => {
+    const variants = new Map<string, string>();
+    collectExerciseNameVariants(variants, {
+      en: "Bench Press",
+      es: "Press de banca",
+    });
+    collectExerciseNameVariants(variants, {
+      en: "Bench Press",
+      es: "Press de banca",
+    });
+    expect([...variants.values()]).toEqual(["Bench Press", "Press de banca"]);
+  });
+
+  it("treats case/diacritic spelling differences as the same name", () => {
+    const variants = new Map<string, string>();
+    collectExerciseNameVariants(variants, { es: "Sentadílla" });
+    collectExerciseNameVariants(variants, { es: "sentadilla" });
+    // First spelling seen wins — one entry, not two.
+    expect([...variants.values()]).toEqual(["Sentadílla"]);
+  });
+
+  it("keeps an older name so a renamed exercise stays findable", () => {
+    const variants = new Map<string, string>();
+    collectExerciseNameVariants(variants, { en: "Barbell Row", es: "Remo" });
+    collectExerciseNameVariants(variants, {
+      en: "Bent Over Row",
+      es: "Remo inclinado",
+    });
+    expect([...variants.values()]).toEqual([
+      "Barbell Row",
+      "Remo",
+      "Bent Over Row",
+      "Remo inclinado",
+    ]);
+  });
+});
+
+describe("searchAliasesFor", () => {
+  it("drops the displayed name and keeps the other language", () => {
+    const variants = new Map<string, string>();
+    collectExerciseNameVariants(variants, {
+      en: "Bench Press",
+      es: "Press de banca",
+    });
+    expect(searchAliasesFor("Press de banca", variants)).toEqual([
+      "Bench Press",
+    ]);
+    expect(searchAliasesFor("Bench Press", variants)).toEqual([
+      "Press de banca",
+    ]);
+  });
+
+  it("matches the display name on normalized text, not raw text", () => {
+    const variants = new Map<string, string>();
+    collectExerciseNameVariants(variants, {
+      en: "Squat",
+      es: "Sentadílla",
+    });
+    // Display came through a different accent/case path — still the same name,
+    // so it must not be echoed back as an alias.
+    expect(searchAliasesFor("sentadilla", variants)).toEqual(["Squat"]);
+  });
+
+  it("is empty when the exercise is known by exactly one name", () => {
+    const variants = new Map<string, string>();
+    collectExerciseNameVariants(variants, { en: "Plank", es: "Plank" });
+    expect(searchAliasesFor("Plank", variants)).toEqual([]);
+  });
+
+  it("returns everything when no variant matches the display name", () => {
+    const variants = new Map<string, string>();
+    collectExerciseNameVariants(variants, {
+      en: "Bench Press",
+      es: "Press de banca",
+    });
+    // Display fell back to the exerciseId (no snapshot name resolved).
+    expect(searchAliasesFor("std-bench-press", variants)).toEqual([
+      "Bench Press",
+      "Press de banca",
+    ]);
+  });
+});

--- a/backoffice/src/lib/gc-fitness/exercise-name-variants.ts
+++ b/backoffice/src/lib/gc-fitness/exercise-name-variants.ts
@@ -1,0 +1,82 @@
+// exercise-name-variants.ts — #581.
+//
+// The progress payload ships ONE display name per logged exercise (ES-first),
+// so the other language never reaches the browser and the picker's search can
+// only ever match the language the coach happens to be shown. This module is
+// the pure half of the fix: it pulls EVERY language out of a bilingual
+// `{ en, es }` name (from a log's `templateSnapshot` or from the `exercises`
+// doc) and turns the collected set into the search-only alias list that rides
+// alongside the display name.
+//
+// Both mobile twins already search `name.en` AND `name.es` (iOS
+// `GCFitnessCore/ExerciseSearch.swift`, `ExerciseListViewModel`), as does the
+// backoffice's own library search (`exercise-search.ts` `scoreExercise`) — they
+// all hold the whole exercise doc. Only the progress payload flattens, which is
+// why this helper exists here and has no mobile counterpart.
+
+import { normalizeSearchText } from "./exercise-search";
+
+/**
+ * Every non-empty language variant of a wire `name` value, in EN→ES order.
+ *
+ * Accepts the two shapes the wire actually carries:
+ *   - `{ en?, es? }` — the modern bilingual name (both languages returned)
+ *   - `"Squat"`      — a legacy plain-string name (single variant)
+ *
+ * Anything else (null, number, empty strings) yields `[]`. Values are trimmed;
+ * no normalization is applied — these stay display-shaped, and the search layer
+ * normalizes at match time.
+ */
+export function exerciseNameVariants(value: unknown): string[] {
+  if (typeof value === "string") {
+    const trimmed = value.trim();
+    return trimmed ? [trimmed] : [];
+  }
+  if (!value || typeof value !== "object") return [];
+  const loc = value as { en?: unknown; es?: unknown };
+  const out: string[] = [];
+  for (const raw of [loc.en, loc.es]) {
+    if (typeof raw !== "string") continue;
+    const trimmed = raw.trim();
+    if (trimmed) out.push(trimmed);
+  }
+  return out;
+}
+
+/**
+ * Accumulate the variants of `value` into `target`, deduped by NORMALIZED text
+ * so "Press de Banca" and "Press de banca" (the same name spelled differently
+ * across two logs) don't both survive. First spelling seen wins.
+ *
+ * Callers fold every log's snapshot name for an exercise through this, so an
+ * exercise renamed mid-history stays findable by BOTH its old and new names.
+ */
+export function collectExerciseNameVariants(
+  target: Map<string, string>,
+  value: unknown,
+): void {
+  for (const variant of exerciseNameVariants(value)) {
+    const key = normalizeSearchText(variant);
+    if (!key || target.has(key)) continue;
+    target.set(key, variant);
+  }
+}
+
+/**
+ * The search-only alias list for a picker row: every collected variant EXCEPT
+ * the one already displayed, so nothing is duplicated on the wire. Comparison
+ * is on normalized text, so a display name that differs from its variant only
+ * by case/diacritics is still recognized as the same name.
+ */
+export function searchAliasesFor(
+  displayName: string,
+  variants: Map<string, string>,
+): string[] {
+  const displayKey = normalizeSearchText(displayName);
+  const out: string[] = [];
+  for (const [key, variant] of variants) {
+    if (key === displayKey) continue;
+    out.push(variant);
+  }
+  return out;
+}

--- a/backoffice/src/lib/gc-fitness/exercise-progress-actions.ts
+++ b/backoffice/src/lib/gc-fitness/exercise-progress-actions.ts
@@ -32,6 +32,10 @@ import { FirestoreCollections } from "@/lib/gc-fitness/collections";
 import { civilDateFormat, civilDateToday } from "@/lib/gc-fitness/civil-date";
 import { effectiveSetType, type SetType } from "@/lib/gc-fitness/set-type";
 import {
+  collectExerciseNameVariants,
+  searchAliasesFor,
+} from "@/lib/gc-fitness/exercise-name-variants";
+import {
   PROJECTION_WEEKS,
   buildMuscleGroupWeeks,
   civilWeekStart,
@@ -47,6 +51,15 @@ import {
 export interface LoggedExerciseOption {
   exerciseId: string;
   name: string;
+  /**
+   * #581 — the OTHER language(s) this exercise is known by, for the picker's
+   * search only (never displayed). `name` above is a single ES-first pick, so
+   * without this the coach could not find "Press de banca" by typing "bench
+   * press". Collected from every scanned log's snapshot name plus the
+   * `exercises` doc already read for `muscleGroups` — no extra Firestore read.
+   * Empty when the exercise is known by exactly one name.
+   */
+  searchAliases: string[];
   /** How many sessions logged this exercise (helps order the picker). */
   sessionCount: number;
   /**
@@ -237,6 +250,20 @@ export async function getClientExerciseProgress(
     { name: string; sessionCount: number; hasData: boolean }
   >();
 
+  // #581 — exerciseId → normalized-key → display-cased name, every language
+  // variant seen for that exercise across the scanned logs. The display name is
+  // one ES-first pick; these are what make the picker searchable in the OTHER
+  // language (and by an older name, if the exercise was renamed mid-history).
+  const nameVariantsById = new Map<string, Map<string, string>>();
+  const rememberNameVariants = (exId: string, rawName: unknown): void => {
+    let variants = nameVariantsById.get(exId);
+    if (!variants) {
+      variants = new Map<string, string>();
+      nameVariantsById.set(exId, variants);
+    }
+    collectExerciseNameVariants(variants, rawName);
+  };
+
   // #480 — every completed set (bodyweight and warm-ups included, #565), tagged
   // with its session civil date + per-set volume, for the muscle-group
   // aggregation. The exercise→muscle-group join happens after the batched
@@ -270,7 +297,11 @@ export async function getClientExerciseProgress(
     const nameById = new Map<string, string>();
     for (const ex of templateExercises) {
       const exId = typeof ex.exerciseId === "string" ? ex.exerciseId : "";
-      if (exId) nameById.set(exId, localizedName(ex.name, exId));
+      if (!exId) continue;
+      nameById.set(exId, localizedName(ex.name, exId));
+      // #581 — the snapshot name is `{en, es}`; keep BOTH for search even
+      // though only one is displayed.
+      rememberNameVariants(exId, ex.name);
     }
 
     const date = civilDateFormat(startedAt, timezone);
@@ -473,6 +504,10 @@ export async function getClientExerciseProgress(
     const exerciseDocs = await db.getAll(...refs);
     for (const exDoc of exerciseDocs) {
       if (!exDoc.exists) continue;
+      // #581 — fold the canonical doc's bilingual name into the search
+      // variants. Free (this read already happens for muscleGroups) and it
+      // covers logs whose snapshot carried only one language.
+      rememberNameVariants(exDoc.id, exDoc.get("name"));
       const mgRaw = exDoc.get("muscleGroups");
       const secRaw = exDoc.get("secondaryMuscles");
       const primaryRaw = exDoc.get("primaryMuscleGroup");
@@ -511,6 +546,12 @@ export async function getClientExerciseProgress(
     .map(([exerciseId, m]) => ({
       exerciseId,
       name: m.name,
+      // #581 — search-only: everything this exercise is called EXCEPT the name
+      // already displayed, so the picker matches in Spanish and English alike.
+      searchAliases: searchAliasesFor(
+        m.name,
+        nameVariantsById.get(exerciseId) ?? new Map<string, string>(),
+      ),
       sessionCount: m.sessionCount,
       muscleGroups: muscleById.get(exerciseId) ?? [],
     }))


### PR DESCRIPTION
Fixes mdb1/gc-fitness#581 — *"esto tiene que soportar busqueda en spanish/english"*.

## What was broken

`/gc-fitness/clients/[id]/progress` → the searchable exercise picker (shipped in #574) only matched the language it **displayed**. Typing an English name found nothing on a Spanish-labelled row.

The cause is at the server boundary, not in the filter: `LoggedExerciseOption.name` is a single ES-first string produced by `localizedName()`, so the other language was discarded before the payload reached the browser. No client-side filter change could have recovered it.

## Fix

**Server** (`exercise-progress-actions.ts`) — collect every name *variant* per exercise during the log scan that already runs (each log's `templateSnapshot` name is `{ en, es }` — both languages are right there), and fold in `name` from the `exercises` docs already batch-read for `muscleGroups`. Ship them as a new **`searchAliases: string[]`** = the variants **minus** the displayed name, so nothing is duplicated on the wire.

**Zero new Firestore reads** — both sources are reads the page already makes.

**Client** (`ExerciseProgressClient.tsx`) — the cmdk item value becomes `name + aliases + exerciseId`. The id suffix stays: cmdk keys its item registry on `value`, so two same-named library twins (the known standard-library double-seed) would merge into one row without it (#574).

Collecting across *all* logs rather than just the newest is deliberate — an exercise renamed mid-history stays findable by its old name too.

## Parity — backoffice only

Both mobile twins already search both languages, because they hold the whole `Exercise` doc instead of a flattened payload:

- iOS `GCFitnessCore/ExerciseSearch.swift` → `score(query:exercise:)` compares `name.en` **and** `name.es` at every band, and `exerciseSearchHaystack` starts with both.
- iOS `ExerciseListViewModel.filteredExercises` → `nameEn.contains(q) || nameEs.contains(q)`.
- The backoffice's own **library** search (`lib/gc-fitness/exercise-search.ts` `scoreExercise`) is already bilingual.

The progress picker was the only surface that flattened. Nothing to mirror on iOS/Android.

## Out of scope

- **Ranking.** This picker's filter is a deliberate plain substring test over normalized text (#574), not the `scoreExercise` band ranking the library uses. Making it rank-aware is a bigger UX change than the issue asks for — say the word if you want it.
- The muscle-group `<Select>` labels (`formatMuscleGroup` title-case, no per-group i18n map exists yet).
- No `firestore.rules` / index / functions change.

## Gates

- `npx jest` — **914/915**, the 1 red being the known `client-activity-time` non-en-US locale flake (pre-existing, green in CI). New `exercise-name-variants` suite: 11/11.
- `npx tsc --noEmit` — clean.
- `npx next build` — compiles.

## Verify

Open a client with a logged history, click the exercise picker and type an **English** name (e.g. `bench press`) — the Spanish-labelled row should now appear; typing the Spanish name still works.