### PR TITLE
fix(gc-fitness): show set types on the assign + assignment detail dialogs (#582)

### DIFF
--- a/backoffice/src/components/gc-fitness/schedule/assign-template-modal.tsx
+++ b/backoffice/src/components/gc-fitness/schedule/assign-template-modal.tsx
@@ -46,6 +46,25 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { Calendar } from "@/components/ui/calendar";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import {
+  SET_TYPES,
+  SET_TYPE_LABELS_ES,
+  SET_TYPE_LETTERS,
+  SET_TYPE_TEXT_CLASS,
+  plannedSetType,
+  setDisplayLabels,
+  type SetType,
+} from "@/lib/gc-fitness/set-type";
+import {
+  alignSetTypes,
+  setTypesDiffer,
+} from "@/lib/gc-fitness/assignment-set-types";
 
 import {
   assignTemplate,
@@ -69,6 +88,24 @@ import {
 // (selected) day keeps its solid `selected` styling on top of this.
 const RECURRENCE_PREVIEW_CLASS =
   "rounded-md bg-primary/15 font-semibold text-primary";
+
+/**
+ * One editable prescribed set inside the assign modal.
+ *
+ * #582 — the per-set TYPE lives on the row, NOT in a sibling `setTypes[]` array
+ * (the shape the assignment EDIT dialog uses). The modal mutates `setRows`
+ * inline at five call sites (per-field edit, remove, append, copy-to-all,
+ * metric flip); a parallel array would have to be re-synced at every one of
+ * them, and a missed sync is exactly the misalignment this issue is about —
+ * the warm-up marker sliding onto the wrong set. Embedding it makes
+ * add/remove correct by construction.
+ */
+interface AssignSetRow {
+  reps: string;
+  kg: string;
+  duration?: string;
+  type: SetType;
+}
 
 interface AssignTemplateModalProps {
   open: boolean;
@@ -171,7 +208,7 @@ export function AssignTemplateModal({
         rest_seconds: string;
         transition_rest_seconds: string;
         notes: string;
-        setRows: Array<{ reps: string; kg: string; duration?: string }>;
+        setRows: AssignSetRow[];
         // 260610-j67 (issue #159) — "Sin peso" intent. Seeded from the source
         // template exercise's hasExplicitNoWeightPrescription; ON → the
         // override writes weightBySetKg: [] + hides the kg column.
@@ -236,7 +273,7 @@ export function AssignTemplateModal({
             rest_seconds: string;
             transition_rest_seconds: string;
             notes: string;
-            setRows: Array<{ reps: string; kg: string; duration?: string }>;
+            setRows: AssignSetRow[];
             noWeight: boolean;
             metric?: "reps" | "time";
           }>>((acc, exercise) => {
@@ -283,6 +320,11 @@ export function AssignTemplateModal({
               kg: Number.isFinite(weightBySetKg[i])
                 ? String(weightBySetKg[i])
                 : "",
+              // #582 — seed from the template's prescription. Short / missing /
+              // unknown entries coerce to "normal" (forgiving decode), and the
+              // row count above may exceed the array, so this always yields a
+              // type for every row.
+              type: plannedSetType(i, exercise.setTypesBySet),
               ...(exerciseEffectiveMetric === "time"
                 ? {
                     duration: String(
@@ -387,6 +429,13 @@ export function AssignTemplateModal({
         const finalDurationBySetSeconds = durationBySetSeconds
           .slice(0, finalSets)
           .map((n) => (Number.isFinite(n) ? n : 60));
+        // #582 — per-set types, always exactly `finalSets` long (rows beyond
+        // the draft pad to "normal"), so a set the coach REMOVED can't leave a
+        // trailing entry that slides the markers on the surviving rows.
+        const finalSetTypes = alignSetTypes(
+          draft.setRows.map((row) => row.type),
+          finalSets,
+        );
 
         const nextRest = Number(draft.rest_seconds);
         const nextTransitionRest = Number(draft.transition_rest_seconds);
@@ -411,6 +460,12 @@ export function AssignTemplateModal({
         const changedWeights =
           finalWeights.length !== baseWeightBySetKg.length ||
           finalWeights.some((v, i) => v !== baseWeightBySetKg[i]);
+        // #582 — compare against the template's array COERCED to the final set
+        // count, so "the coach deleted a set" registers as a change even when
+        // no picker was opened: the inherited array is then the wrong length
+        // and every marker after the deleted row is off by one.
+        const baseSetTypes = alignSetTypes(exercise.setTypesBySet, finalSets);
+        const changedSetTypes = setTypesDiffer(finalSetTypes, baseSetTypes);
         const changedRest =
           Number.isFinite(nextRest) && nextRest !== exercise.rest_seconds;
         const changedTransitionRest =
@@ -434,7 +489,8 @@ export function AssignTemplateModal({
           !changedTransitionRest &&
           !changedNotes &&
           !changedDurations &&
-          !changedMetric
+          !changedMetric &&
+          !changedSetTypes
         ) {
           return null;
         }
@@ -464,6 +520,10 @@ export function AssignTemplateModal({
               }
             : {}),
           ...(changedNotes ? { notes: nextNotes } : {}),
+          // #582 — the server realigns to the final set count and DROPS the
+          // key when everything came out normal, so an inherited array can't
+          // outlive an all-normal prescription.
+          ...(changedSetTypes ? { setTypesBySet: finalSetTypes } : {}),
           // Emit the chosen metric when the trainer flipped reps↔time so the
           // assignment snapshot carries the new metric (consumers branch on it).
           ...(changedMetric ? { metric: effectiveMetric } : {}),
@@ -531,6 +591,10 @@ export function AssignTemplateModal({
       if (!cur || !first || cur.setRows.length <= 1) return prev;
       const next = cur.setRows.map((row, index) => {
         if (index === 0) return row;
+        // #582 — `...row` keeps each row's own `type`. Copying the first
+        // set's TYPE is deliberately NOT part of "copiar a todas": set 1 is
+        // very often the warm-up, and turning every set into a warm-up is
+        // never what the coach means by copying the prescription.
         return {
           ...row,
           reps: first.reps,
@@ -542,6 +606,18 @@ export function AssignTemplateModal({
         ...prev,
         [exerciseIndex]: { ...cur, setRows: next },
       };
+    });
+  }
+
+  /** #582 — swap ONE row's per-set type (Hevy picker in the `#` column). */
+  function setRowType(exerciseIndex: number, setIdx: number, type: SetType) {
+    setOverrideDrafts((prev) => {
+      const cur = prev[exerciseIndex];
+      if (!cur) return prev;
+      const next = cur.setRows.map((row, i) =>
+        i === setIdx ? { ...row, type } : row,
+      );
+      return { ...prev, [exerciseIndex]: { ...cur, setRows: next } };
     });
   }
 
@@ -1269,7 +1345,57 @@ export function AssignTemplateModal({
                             : "grid grid-cols-[24px_minmax(52px,1fr)_minmax(52px,1fr)_40px] items-center gap-2 sm:grid-cols-[28px_minmax(80px,1fr)_minmax(80px,1fr)_max-content]"
                         }
                       >
-                        <span className="text-xs text-muted-foreground">{setIdx + 1}</span>
+                        {/* #582 — the `#` cell is the per-set type picker, same
+                            control the assignment EDIT dialog and the template
+                            form use. Hevy label: a colored letter for
+                            warm-up/fallo/drop, otherwise a number counting ONLY
+                            normal sets. */}
+                        <DropdownMenu>
+                          <DropdownMenuTrigger asChild>
+                            <button
+                              type="button"
+                              tabIndex={-1}
+                              aria-label={`Tipo de la serie ${setIdx + 1}: ${SET_TYPE_LABELS_ES[row.type]}`}
+                              title="Cambiar tipo de serie"
+                              className={cn(
+                                "inline-flex h-7 w-7 items-center justify-center rounded-md text-xs hover:bg-muted",
+                                row.type === "normal"
+                                  ? "text-muted-foreground"
+                                  : cn("font-bold", SET_TYPE_TEXT_CLASS[row.type]),
+                              )}
+                            >
+                              {
+                                setDisplayLabels(
+                                  draft.setRows.map((r) => r.type),
+                                )[setIdx]
+                              }
+                            </button>
+                          </DropdownMenuTrigger>
+                          <DropdownMenuContent align="start">
+                            {SET_TYPES.map((type) => (
+                              <DropdownMenuItem
+                                key={type}
+                                onSelect={() =>
+                                  setRowType(exercise.index, setIdx, type)
+                                }
+                                className={cn(
+                                  "gap-2",
+                                  type === row.type && "bg-muted",
+                                )}
+                              >
+                                <span
+                                  className={cn(
+                                    "w-4 text-center font-semibold",
+                                    SET_TYPE_TEXT_CLASS[type],
+                                  )}
+                                >
+                                  {SET_TYPE_LETTERS[type] ?? "#"}
+                                </span>
+                                {SET_TYPE_LABELS_ES[type]}
+                              </DropdownMenuItem>
+                            ))}
+                          </DropdownMenuContent>
+                        </DropdownMenu>
                         {/* 26-03 — Primary input branches on effectiveMetric.
                             Time exercises bind to row.duration (5..1800
                             placeholder 60); reps stays as today. */}
@@ -1395,13 +1521,14 @@ export function AssignTemplateModal({
                           // surfaces a usable number instead of an empty
                           // string.
                           const last = cur.setRows[cur.setRows.length - 1];
-                          const newRow: {
-                            reps: string;
-                            kg: string;
-                            duration?: string;
-                          } = {
+                          const newRow: AssignSetRow = {
                             reps: last?.reps ?? "0",
                             kg: last?.kg ?? "",
+                            // #582 — an appended set is NORMAL, never the
+                            // previous row's type: inheriting it would turn
+                            // "+ agregar serie" after a warm-up into a second
+                            // warm-up. Values carry over, the type does not.
+                            type: "normal",
                           };
                           if (effectiveMetric === "time") {
                             newRow.duration = last?.duration ?? "60";

--- a/backoffice/src/components/gc-fitness/schedule/workout-detail-dialog.tsx
+++ b/backoffice/src/components/gc-fitness/schedule/workout-detail-dialog.tsx
@@ -52,6 +52,12 @@ import {
   ShareWorkoutCard,
 } from "@/components/gc-fitness/share-workout-card";
 import { getSupersetGroupRest } from "@/lib/gc-fitness/superset-groups";
+import {
+  SET_TYPE_LABELS_ES,
+  SET_TYPE_TEXT_CLASS,
+  plannedSetType,
+  setDisplayLabels,
+} from "@/lib/gc-fitness/set-type";
 import { WorkoutLogDetailView } from "@/components/gc-fitness/workout-log-detail-view";
 import { WorkoutAssignmentDeleteDialog } from "@/components/gc-fitness/workout-assignment-delete-dialog";
 import { WorkoutAssignmentEditDialog } from "./workout-assignment-edit-dialog";
@@ -535,8 +541,19 @@ function ExerciseSetTable({
   // bodyweight), drop the Peso column entirely so the detail reads reps-only
   // with NO "kg" label. Legacy (nil) + weighted exercises keep the column.
   const noWeight = ex.metric === "time" || ex.hasExplicitNoWeightPrescription;
+  // #582 — planned per-set types + Hevy display labels, the twin of iOS
+  // `WorkoutAssignmentDetailView.setRows` (SetType.planned → SetTypeDisplay
+  // .labels). Non-normal sets render their colored letter INSTEAD of a number,
+  // and normal sets number counting only normals — so W/F/D are visible on the
+  // read-only detail exactly as they are in the client's app.
+  const setTypes = Array.from({ length: ex.sets }, (_, i) =>
+    plannedSetType(i, ex.setTypesBySet),
+  );
+  const setLabels = setDisplayLabels(setTypes);
   const rows = Array.from({ length: ex.sets }, (_, i) => ({
     setNumber: i + 1,
+    setType: setTypes[i],
+    label: setLabels[i],
     reps: ex.repsBySet[i] ?? ex.reps,
     kg: ex.weightBySetKg[i] ?? null,
     durationSeconds:
@@ -560,7 +577,20 @@ function ExerciseSetTable({
           key={row.setNumber}
           className={`grid ${gridCols} gap-2 border-t py-1 text-xs`}
         >
-          <span className="text-muted-foreground">{row.setNumber}</span>
+          <span
+            className={
+              row.setType === "normal"
+                ? "text-muted-foreground"
+                : `font-bold ${SET_TYPE_TEXT_CLASS[row.setType]}`
+            }
+            title={
+              row.setType === "normal"
+                ? undefined
+                : SET_TYPE_LABELS_ES[row.setType]
+            }
+          >
+            {row.label}
+          </span>
           <span className="tabular-nums">
             {ex.metric === "time"
               ? row.durationSeconds !== null

--- a/backoffice/src/lib/gc-fitness/__tests__/assignment-set-types.test.ts
+++ b/backoffice/src/lib/gc-fitness/__tests__/assignment-set-types.test.ts
@@ -1,0 +1,130 @@
+// assignment-set-types.test.ts
+//
+// Issue #582: the assign-template modal showed no set-type marker AND wrote
+// `sets` / `repsBySet` without ever realigning the template's inherited
+// `setTypesBySet` — so removing a set slid the warm-up marker onto a different
+// row. These lock the realignment rule shared by the assign-time override path
+// and the assignment edit path.
+
+import {
+  alignSetTypes,
+  normalizeSetTypesToCount,
+  setTypesDiffer,
+} from "../assignment-set-types";
+
+describe("alignSetTypes", () => {
+  it("pads a short array with normal", () => {
+    expect(alignSetTypes(["warmup"], 3)).toEqual([
+      "warmup",
+      "normal",
+      "normal",
+    ]);
+  });
+
+  it("truncates a long array to the set count", () => {
+    expect(
+      alignSetTypes(["warmup", "normal", "normal", "dropset"], 2),
+    ).toEqual(["warmup", "normal"]);
+  });
+
+  it("coerces unknown entries POSITIONALLY, never by filtering", () => {
+    // The bad entry becomes "normal" AT ITS OWN INDEX — dropping it would
+    // slide "dropset" from set 3 to set 2.
+    expect(alignSetTypes(["warmup", "bogus", "dropset"], 3)).toEqual([
+      "warmup",
+      "normal",
+      "dropset",
+    ]);
+  });
+
+  it("treats an absent array as all-normal", () => {
+    expect(alignSetTypes(undefined, 3)).toEqual([
+      "normal",
+      "normal",
+      "normal",
+    ]);
+    expect(alignSetTypes(null, 2)).toEqual(["normal", "normal"]);
+  });
+
+  it("falls back to the source length when no count is given", () => {
+    expect(alignSetTypes(["warmup", "failure"], 0)).toEqual([
+      "warmup",
+      "failure",
+    ]);
+    expect(alignSetTypes([], 0)).toEqual(["normal"]);
+  });
+
+  it("clamps to the 20-set ceiling", () => {
+    expect(alignSetTypes(["warmup"], 999)).toHaveLength(20);
+  });
+});
+
+describe("normalizeSetTypesToCount", () => {
+  it("returns the aligned array when anything is non-normal", () => {
+    expect(normalizeSetTypesToCount(["warmup", "normal"], 3)).toEqual([
+      "warmup",
+      "normal",
+      "normal",
+    ]);
+  });
+
+  it("returns null when everything came out normal — the DELETE signal", () => {
+    expect(normalizeSetTypesToCount(["normal", "normal"], 2)).toBeNull();
+    // The stale-array case: the only non-normal entry is past the new set
+    // count, so nothing non-normal survives and the key must be dropped.
+    expect(normalizeSetTypesToCount(["normal", "normal", "dropset"], 2)).toBeNull();
+  });
+
+  it("returns null for a non-array (nothing prescribed)", () => {
+    expect(normalizeSetTypesToCount(undefined, 3)).toBeNull();
+    expect(normalizeSetTypesToCount("warmup", 3)).toBeNull();
+  });
+});
+
+describe("setTypesDiffer", () => {
+  it("is false for identical arrays", () => {
+    expect(setTypesDiffer(["warmup", "normal"], ["warmup", "normal"])).toBe(
+      false,
+    );
+  });
+
+  it("is true on a differing entry or a differing length", () => {
+    expect(setTypesDiffer(["warmup", "normal"], ["normal", "normal"])).toBe(
+      true,
+    );
+    expect(setTypesDiffer(["normal"], ["normal", "normal"])).toBe(true);
+  });
+});
+
+describe("the #582 delete-a-set scenario", () => {
+  // Template: 4 sets, set 1 is the warm-up. The coach removes set 1 while
+  // assigning, leaving 3 sets — all of them normal working sets.
+  const templateTypes = ["warmup", "normal", "normal", "normal"];
+
+  it("registers as a change even though the coach never opened the picker", () => {
+    // The surviving rows carried their own types with them (row-embedded).
+    const finalTypes = alignSetTypes(["normal", "normal", "normal"], 3);
+    const baseTypes = alignSetTypes(templateTypes, 3);
+    expect(baseTypes).toEqual(["warmup", "normal", "normal"]);
+    expect(setTypesDiffer(finalTypes, baseTypes)).toBe(true);
+  });
+
+  it("writes nothing non-normal, so the server drops the inherited array", () => {
+    expect(normalizeSetTypesToCount(["normal", "normal", "normal"], 3)).toBeNull();
+  });
+
+  it("leaves an untouched assignment alone (no spurious override)", () => {
+    const finalTypes = alignSetTypes(templateTypes, 4);
+    const baseTypes = alignSetTypes(templateTypes, 4);
+    expect(setTypesDiffer(finalTypes, baseTypes)).toBe(false);
+  });
+
+  it("keeps the warm-up when the coach removes a LATER set instead", () => {
+    const finalTypes = alignSetTypes(["warmup", "normal", "normal"], 3);
+    expect(normalizeSetTypesToCount(finalTypes, 3)).toEqual([
+      "warmup",
+      "normal",
+      "normal",
+    ]);
+  });
+});

--- a/backoffice/src/lib/gc-fitness/assignment-set-types.ts
+++ b/backoffice/src/lib/gc-fitness/assignment-set-types.ts
@@ -1,0 +1,76 @@
+// assignment-set-types.ts — #582.
+//
+// The per-set-type (#403) rules that both ends of the ASSIGNMENT path need:
+// the assign modal / edit dialog on the client, and the Server Actions that
+// write `templateSnapshot.exercises[].setTypesBySet`.
+//
+// Why this exists: a template's `setTypesBySet` rides into the assignment
+// snapshot verbatim (`templateSnapshotForAssignment` copies each exercise with
+// `...exercise`), but the coach can ADD or REMOVE sets while assigning. A
+// 4-entry array against 3 sets slides the warm-up marker onto the wrong row —
+// so the array has to be realigned to the FINAL set count on every write, and
+// dropped entirely when nothing non-normal survives.
+//
+// Plain module (NOT "use server") so client components and Server Actions can
+// both import it — unit-tested in __tests__/assignment-set-types.test.ts.
+
+import { plannedSetType, type SetType } from "./set-type";
+
+/** Upper bound on a realigned array — matches the edit dialog's clamp. */
+const MAX_ALIGNED_SETS = 20;
+
+/**
+ * Coerce a raw `setTypesBySet` (any wire shape) to exactly `count` entries.
+ *
+ * POSITIONAL, never filtering: an unknown / missing entry becomes "normal" at
+ * its own index. Dropping bad entries instead would shift every later set's
+ * type up a row — the exact corruption this module exists to prevent.
+ *
+ * `count` falls back to the source length (then 1) when it is 0/absent, and is
+ * clamped to `MAX_ALIGNED_SETS`.
+ */
+export function alignSetTypes(raw: unknown, count: number): SetType[] {
+  const source = Array.isArray(raw) ? (raw as readonly string[]) : [];
+  const length = Math.max(
+    1,
+    Math.min(MAX_ALIGNED_SETS, count || source.length || 1),
+  );
+  return Array.from({ length }, (_, i) => plannedSetType(i, source));
+}
+
+/**
+ * Wire form of a realigned array: the array itself, or **null when every entry
+ * is normal**.
+ *
+ * Null is the signal to DELETE the key, not to skip the write — the wire
+ * contract omits all-normal arrays, and an inherited non-normal array must not
+ * outlive an all-normal prescription.
+ *
+ * Returns null for a non-array input (nothing was prescribed), so callers can
+ * pass a possibly-absent field straight through.
+ */
+export function normalizeSetTypesToCount(
+  raw: unknown,
+  setCount: number,
+): SetType[] | null {
+  if (!Array.isArray(raw)) return null;
+  const aligned = alignSetTypes(raw, setCount);
+  return aligned.some((t) => t !== "normal") ? aligned : null;
+}
+
+/**
+ * True when two aligned type arrays differ — the assign modal's "did the coach
+ * change the types?" test.
+ *
+ * Compare arrays that were BOTH aligned to the same final set count: that is
+ * what makes a pure set-count change (delete a set, keep every type) register
+ * as a difference, which it must — the inherited array is then the wrong
+ * length and every marker after the removed row is off by one.
+ */
+export function setTypesDiffer(
+  a: readonly SetType[],
+  b: readonly SetType[],
+): boolean {
+  if (a.length !== b.length) return true;
+  return a.some((type, i) => type !== b[i]);
+}

--- a/backoffice/src/lib/gc-fitness/workout-assignment-actions.ts
+++ b/backoffice/src/lib/gc-fitness/workout-assignment-actions.ts
@@ -53,6 +53,9 @@ import {
 } from "./weight-diff";
 // quick-260714-m57 (#403) — per-set type helpers (TS twin of iOS SetType).
 import { plannedSetType, type SetType } from "./set-type";
+// #582 — the shared "realign to the final set count, drop when all-normal"
+// rule, used by BOTH the edit path and the assign-time override path.
+import { normalizeSetTypesToCount as normalizeEditedSetTypes } from "./assignment-set-types";
 import {
   recordCoachActivityEvent,
   markCoachActivityDeleted,
@@ -240,6 +243,7 @@ function applyExerciseOverrides(
         metric?: "reps" | "time";
         durationBySetSeconds?: number[];
         durationSeconds?: number;
+        setTypesBySet?: SetType[];
       }>
     | undefined,
 ) {
@@ -250,7 +254,7 @@ function applyExerciseOverrides(
   for (const override of overrides) {
     const current = exercises[override.index];
     if (!current) continue;
-    exercises[override.index] = {
+    const next: Record<string, unknown> = {
       ...current,
       ...(override.sets !== undefined ? { sets: override.sets } : {}),
       ...(override.reps !== undefined ? { reps: override.reps } : {}),
@@ -278,32 +282,27 @@ function applyExerciseOverrides(
         ? { durationSeconds: override.durationSeconds }
         : {}),
     };
+    // #582 — per-set types at assignment time. The template's array otherwise
+    // rides `...current` VERBATIM, which goes stale the moment the coach adds
+    // or removes a set (a 4-entry array against 3 sets slides the warm-up
+    // marker onto the wrong row). Realign against the FINAL set count, and
+    // DELETE the key when nothing non-normal survives — the same rule
+    // `editAssignmentExercises` applies, so a stale inherited array can never
+    // outlive an all-normal prescription.
+    if (override.setTypesBySet !== undefined) {
+      const setCount =
+        override.sets ??
+        (typeof next.sets === "number" ? (next.sets as number) : 0);
+      const aligned = normalizeEditedSetTypes(override.setTypesBySet, setCount);
+      if (aligned) next.setTypesBySet = aligned;
+      else delete next.setTypesBySet;
+    }
+    exercises[override.index] = next;
   }
   return {
     ...templateSnapshot,
     exercises,
   };
-}
-
-/**
- * quick-260714-m57 (#403) — normalize per-set types coming from the edit
- * dialog (or realigned from the existing snapshot when the edit doesn't
- * carry them). Coerces unknown entries POSITIONALLY to "normal" (never
- * filters — dropping an entry would shift later sets' types), aligns to
- * `setCount`, and returns null when every entry is normal: the wire
- * contract omits all-normal arrays, and callers DELETE the key so a stale
- * non-normal array can't survive an all-normal edit.
- */
-function normalizeEditedSetTypes(
-  raw: unknown,
-  setCount: number,
-): SetType[] | null {
-  if (!Array.isArray(raw)) return null;
-  const length = Math.max(1, Math.min(20, setCount || raw.length || 1));
-  const aligned = Array.from({ length }, (_, i) =>
-    plannedSetType(i, raw as readonly string[]),
-  );
-  return aligned.some((t) => t !== "normal") ? aligned : null;
 }
 
 function normalizeEditedWeights(opts: {

--- a/backoffice/src/lib/gc-fitness/workout-assignment-schema.ts
+++ b/backoffice/src/lib/gc-fitness/workout-assignment-schema.ts
@@ -19,6 +19,8 @@
 
 import { z } from "zod";
 
+import { SET_TYPES } from "@/lib/gc-fitness/set-type";
+
 /** Rule-layer civil-date regex from 04-02 (`matches('^\\d{4}-\\d{2}-\\d{2}$')`). */
 export const CIVIL_DATE_REGEX = /^\d{4}-\d{2}-\d{2}$/;
 
@@ -70,6 +72,11 @@ const assignmentExerciseOverrideSchema = z.object({
   notes: z.string().max(500).optional(),
   weightBySetKg: z.array(z.number().min(0).max(500)).max(10).optional(),
   repsBySet: z.array(z.number().int().min(1).max(50)).max(10).optional(),
+  // #582 — per-set types at ASSIGNMENT time. The template's array rides the
+  // snapshot verbatim, so this is only sent when the coach re-typed a set OR
+  // changed the set count (which makes the inherited array misaligned).
+  // The action normalizes + drops it when the result is all-normal.
+  setTypesBySet: z.array(z.enum(SET_TYPES)).max(10).optional(),
   // 26-01 — Per-client override mirrors of the template-side metric +
   // duration fields. Optional and permissive: a trainer assigning a
   // plank to a single client may tweak ONLY the per-set duration array

--- a/backoffice/src/lib/gc-fitness/workout-template-actions.ts
+++ b/backoffice/src/lib/gc-fitness/workout-template-actions.ts
@@ -115,6 +115,14 @@ export interface WorkoutTemplateExerciseDetail {
   repsBySet?: number[];
   weightBySetKg?: number[];
   /**
+   * quick-260714-m57 (#403) — per-set type prescription (raw wire strings).
+   * Surfaced for the assign-template modal (#582), which shows the W/F/D
+   * marker AND has to realign the array when the coach adds/removes a set.
+   * Raw + positional: unknown entries coerce to "normal" on READ, never
+   * filtered — dropping one would shift later sets onto the wrong type.
+   */
+  setTypesBySet?: string[];
+  /**
    * 260610-j67 (issue #159) — no-weight ("Sin peso") sentinel, twin of iOS
    * `ExerciseRef.hasExplicitNoWeightPrescription`. True when the source
    * `weightBySetKg` was an EXPLICIT empty array (reps-only prescription).
@@ -552,6 +560,15 @@ export async function getWorkoutTemplateForAssignment(templateId: string): Promi
           : [],
         weightBySetKg: Array.isArray(exercise.weightBySetKg)
           ? (exercise.weightBySetKg as number[]).filter((n) => Number.isFinite(n))
+          : [],
+        // #403/#582 — positional pass-through. NOT filtered (unlike the
+        // numeric arrays above): a dropped entry would slide every later
+        // set's type up one row. Non-strings become "" and coerce to
+        // "normal" at read time via plannedSetType.
+        setTypesBySet: Array.isArray(exercise.setTypesBySet)
+          ? (exercise.setTypesBySet as unknown[]).map((t) =>
+              typeof t === "string" ? t : "",
+            )
           : [],
         // 260610-j67 — capture the no-weight sentinel before the array
         // collapse above erases it. Explicit empty array = reps-only.


### PR DESCRIPTION
Fixes mdb1/gc-fitness#582 — *"en asignacion no muestra los tipos de serie (warm-up / fallo / etc)"* + the follow-up comment *"tampoco al ver el detalle"*.

#403 shipped the Hevy W/F/D marker on the template form, the assignment **edit** dialog, the live session and the log detail. Two surfaces were missed, and both rendered a bare 1-based index:

1. **"Asignar una plantilla de entrenamiento"** (`assign-template-modal.tsx`)
2. **The read-only assignment detail** (`workout-detail-dialog.tsx` → `ExerciseSetTable`)

## The assign modal was not just a display gap

`applyExerciseOverrides` spreads `...current`, so a template's `setTypesBySet` rode into the assignment snapshot verbatim — while the modal freely let the coach **add and remove sets**, writing `sets` / `repsBySet` / `weightBySetKg` and never touching the type array.

Delete set 1 of a `[warmup, normal, normal, normal]` template and the 4-entry array stays against 3 sets: the warm-up marker lands on what used to be set 2. **The assign path could silently corrupt the alignment**, so fixing the display alone would only have made the corruption visible.

## What changed

**Assign modal** — the `#` cell is now the same `DropdownMenu` type picker the edit dialog uses (Hevy label, colored W/F/D, four Spanish-labelled items).

The per-set type lives **on the row** (`setRows[i].type`), not in a parallel `setTypes[]` array like the edit dialog has. The modal mutates `setRows` inline at five call sites (per-field edit, remove, append, copy-to-all, metric flip) — a sibling array would need re-syncing at every one, and a missed sync is precisely the misalignment this issue is about. Row-embedded is correct by construction.

Two deliberate non-inheritances: **"Copiar a todas"** copies reps/kg/duration but **not** the type (set 1 is very often the warm-up — copying it onto every set is never what that button means), and **"+ Agregar serie"** appends a **normal** set rather than inheriting the previous row's type.

**Payload** — `setTypesBySet` is emitted whenever the aligned array differs from the template's, comparing both **aligned to the final set count**. That makes a pure set-count change register even when the coach never opened the picker, which is what ships the realignment.

**Server** — new pure `lib/gc-fitness/assignment-set-types.ts` (`alignSetTypes` / `normalizeSetTypesToCount` / `setTypesDiffer`, 15 tests). `normalizeEditedSetTypes` moved out of the actions file into it, so the assign path and the **existing edit path** now share one tested rule: realign positionally to the final set count (never filter — dropping a bad entry slides every later type up a row), and **delete the key** when nothing non-normal survives, so an inherited array can't outlive an all-normal prescription.

**Detail dialog** — Hevy labels in the read-only table, the twin of iOS `WorkoutAssignmentDetailView.setRows` (`SetType.planned` → `SetTypeDisplay.labels`).

## Parity — backoffice only

iOS already renders the planned markers on the assignment detail (link above); Android carries `setTypesBySet` on its `ExerciseSnapshot` / `WorkoutAssignment` core schema. The assign modal is a coach-only surface with no mobile twin. Nothing to mirror.

## Flagged, not fixed

**The share card** (`share-workout-card.tsx`, the "Descargar imagen" button on this same dialog) renders per-set chips with **no W/F/D marker either**, on both the prescribed and the logged card — its `#565` comment claims the marker distinguishes them, but nothing draws it. Different layout (chips, not numbered rows) and not a surface the issue names, so I left it. Say the word and it's a small follow-up.

## Gates

- `npx jest` — **918/919**, the 1 red being the known `client-activity-time` non-en-US locale flake (pre-existing, green in CI). New suite: 15/15.
- `npx tsc --noEmit` — clean.
- `npx next build` — exit 0.
- No `firestore.rules` / index / functions change (`setTypesBySet` already rides `templateSnapshot`), no new Firestore reads.

## Verify

Assign a template whose first set is a warm-up: the modal should show an orange **W** on set 1, the picker should change it, and the assignment detail should show the same marker. Then remove set 1 in the modal before assigning — the detail should show three plain normal sets, not a warm-up on the wrong row.