### PR TITLE
docs(gc-fitness): add Terms of Use (EULA) page in ES and EN

### DIFF
--- a/pocket-genes/src/components/GCFitnessDownloadPage.astro
+++ b/pocket-genes/src/components/GCFitnessDownloadPage.astro
@@ -29,6 +29,8 @@ const copy = {
     storeGridLabel: 'Opciones de descarga de GC Fitness',
     legal: 'Privacidad',
     legalHref: '/gc-fitness/privacy',
+    terms: 'Términos de uso',
+    termsHref: '/gc-fitness/terms',
   },
   en: {
     title: 'Download GC Fitness',
@@ -52,6 +54,8 @@ const copy = {
     storeGridLabel: 'GC Fitness download options',
     legal: 'Privacy',
     legalHref: '/en/gc-fitness/privacy',
+    terms: 'Terms of Use',
+    termsHref: '/en/gc-fitness/terms',
   },
 }[lang];
 ---
@@ -109,6 +113,8 @@ const copy = {
 
           <p class="gcf-legal">
             <a href={copy.legalHref}>{copy.legal}</a>
+            <span aria-hidden="true"> · </span>
+            <a href={copy.termsHref}>{copy.terms}</a>
           </p>
         </div>
 

--- a/pocket-genes/src/pages/en/gc-fitness/privacy.astro
+++ b/pocket-genes/src/pages/en/gc-fitness/privacy.astro
@@ -97,6 +97,10 @@ import BaseLayout from '../../../layouts/BaseLayout.astro';
       <p>
         Golden Crow — <a href="mailto:support@goldencrowvs.com">support@goldencrowvs.com</a>
       </p>
+
+      <p>
+        See also the GC Fitness <a href="/en/gc-fitness/terms">Terms of Use</a>.
+      </p>
     </div>
   </main>
 </BaseLayout>

--- a/pocket-genes/src/pages/en/gc-fitness/terms.astro
+++ b/pocket-genes/src/pages/en/gc-fitness/terms.astro
@@ -1,0 +1,234 @@
+---
+import BaseLayout from '../../../layouts/BaseLayout.astro';
+---
+
+<BaseLayout title="GC Fitness — Terms of Use">
+  <main class="legal-page">
+    <div class="legal-container">
+      <p class="legal-lang"><a href="/gc-fitness/terms">Versión en español</a></p>
+      <h1>Terms of Use (EULA) — GC Fitness</h1>
+      <p class="legal-updated">Effective date: July 28, 2026</p>
+
+      <p>
+        These Terms of Use ("Terms") are an agreement between you and <strong>Golden Crow</strong>
+        ("we") governing your use of the <strong>GC Fitness</strong> mobile app (package
+        <code>com.goldencrow.fitness</code>, available for iOS, Apple Watch and Android) and its
+        related services. By downloading, installing or using the app you accept these Terms. If you
+        do not agree, do not use it.
+      </p>
+      <p>
+        How we handle your personal data is described in our
+        <a href="/en/gc-fitness/privacy">Privacy Policy</a>, which forms part of these Terms.
+      </p>
+
+      <h2>1. What GC Fitness is</h2>
+      <p>
+        GC Fitness is a training and habit-tracking platform. You can use it on your own or linked
+        to a personal trainer ("coach"), who assigns you workouts, habits and guidance and can see
+        your progress. You log sets, reps, weights, habits, body metrics and progress photos, and
+        you can chat with your coach.
+      </p>
+
+      <h2>2. Your account</h2>
+      <ul>
+        <li>You need an account created with Google or Apple. You are responsible for keeping access
+          to that account and for activity carried out through it.</li>
+        <li>You must be at least 13 years old. If you are a minor in your country, you need a
+          parent's or guardian's permission.</li>
+        <li>You can delete your account at any time from within the app — see
+          <a href="/en/gc-fitness/delete-account">Account deletion</a>.</li>
+      </ul>
+
+      <h2>3. Licence</h2>
+      <p>
+        We grant you a limited, personal, non-exclusive, non-transferable and revocable licence to
+        use GC Fitness on devices you own or control, subject to the rules of the store you
+        downloaded it from. You may not resell, rent, sublicense, copy, decompile or reverse
+        engineer the app, or use it to build a competing product.
+      </p>
+
+      <h2>4. Free plan and Premium plan</h2>
+      <p>GC Fitness can be used for free with limits. <strong>Premium</strong> removes them.</p>
+      <ul>
+        <li><strong>Free:</strong> up to 3 self-created routines and 3 self-created habits, one
+          progress-photo set every 30 days, and chart history covering the last 30 days.</li>
+        <li><strong>Premium:</strong> unlimited routines and habits, progress photos with no
+          frequency limit, and full chart history.</li>
+        <li><strong>Coached clients:</strong> if a trainer is linked to your account, you get the
+          Premium features without a subscription for as long as that link lasts.</li>
+      </ul>
+
+      <h2>5. Subscriptions and purchases</h2>
+      <p>We offer the following in-app products:</p>
+      <ul>
+        <li><strong>Premium monthly</strong> (<code>gcfitness.sub.monthly</code>) — auto-renewable
+          subscription with a 1-month period.</li>
+        <li><strong>Premium yearly</strong> (<code>gcfitness.sub.yearly</code>) — auto-renewable
+          subscription with a 1-year period.</li>
+        <li><strong>Lifetime Premium</strong> (<code>gcfitness.lifetime</code>) — one-time,
+          non-renewing purchase.</li>
+      </ul>
+      <p>
+        The price of each product is shown in the app in your local currency before you confirm the
+        purchase, and may vary by region and by any promotion in effect.
+      </p>
+      <p><strong>Auto-renewable subscription terms:</strong></p>
+      <ul>
+        <li>Payment is charged to your App Store account (iOS) or Google Play account (Android) when
+          you confirm the purchase.</li>
+        <li>The subscription renews automatically for the same period unless you cancel at least
+          <strong>24 hours before</strong> the end of the current period.</li>
+        <li>Renewal is charged within the 24 hours before the current period ends, at the then-current
+          price of the plan.</li>
+        <li>You can manage or cancel your subscription at any time in your store account settings:
+          on iOS, <em>Settings → your name → Subscriptions</em>; on Android,
+          <em>Google Play → Payments and subscriptions</em>. Deleting the app does not cancel the
+          subscription.</li>
+        <li>Cancellation takes effect at the end of the period already paid for; partial periods are
+          not refunded.</li>
+      </ul>
+      <p>
+        Refunds are handled by the store that processed the payment (Apple or Google) under its own
+        policies: we do not process payments and cannot issue refunds directly. Where a promotion
+        includes a free trial, any unused portion is forfeited when you buy a subscription.
+      </p>
+
+      <h2>6. Health — important</h2>
+      <p>
+        GC Fitness is a training organisation and logging tool. <strong>It is not a medical device
+        and does not provide medical advice.</strong> Everything in the app — workouts, habits,
+        exercises, volume or calorie estimates and personal records — is informational and does not
+        replace consulting a healthcare professional.
+      </p>
+      <ul>
+        <li>Talk to a doctor before starting any exercise programme, especially if you have a
+          pre-existing condition, are pregnant, or are returning to activity after an injury.</li>
+        <li>You train at your own risk. If you feel pain, dizziness or discomfort, stop and seek
+          medical attention.</li>
+        <li>If you use the app linked to a trainer, the training programme and the instructions are
+          that trainer's responsibility, not Golden Crow's. Golden Crow provides the software; it
+          does not supervise, endorse or verify trainers' credentials or the content they
+          assign.</li>
+      </ul>
+
+      <h2>7. Your content</h2>
+      <p>
+        You keep ownership of what you upload (workouts, habits, metrics, progress photos and
+        messages). You grant us a limited licence to store, process and display it for the sole
+        purpose of operating the service — for example, showing your progress to your trainer. We do
+        not use your content for advertising and we do not sell it.
+      </p>
+
+      <h2>8. Acceptable use</h2>
+      <p>You may not use GC Fitness to:</p>
+      <ul>
+        <li>upload unlawful, offensive or harassing content, or content that infringes third-party
+          rights;</li>
+        <li>impersonate anyone or access accounts or data that are not yours;</li>
+        <li>interfere with the service, defeat its security mechanisms or automate bulk access;</li>
+        <li>circumvent the free-plan limits or the in-app purchase system.</li>
+      </ul>
+      <p>We may suspend or close accounts that breach these Terms.</p>
+
+      <h2>9. Intellectual property</h2>
+      <p>
+        The app, its design, its brand and its proprietary content belong to Golden Crow or its
+        licensors. Part of the standard exercise library's data and imagery comes from
+        <a href="https://wger.de/" rel="noopener noreferrer" target="_blank">wger.de</a> and is used
+        under the CC BY-SA 3.0 licence.
+      </p>
+
+      <h2>10. Availability and warranties</h2>
+      <p>
+        The service is provided "as is" and "as available". We make reasonable efforts to keep it
+        running, but we do not warrant that it will be uninterrupted or error-free, or that data
+        will sync without delay. To the extent permitted by law, we are not liable for indirect
+        damages, lost profits or data loss. Nothing in these Terms limits any consumer rights you
+        have under applicable law.
+      </p>
+
+      <h2>11. Apple-specific terms (App Store)</h2>
+      <p>For the iOS and watchOS versions downloaded from the App Store:</p>
+      <ul>
+        <li>These Terms are an agreement between you and Golden Crow only, <strong>not with
+          Apple</strong>. Golden Crow, not Apple, is responsible for the app and its content.</li>
+        <li>The licence is the one set out in section 3, limited to non-transferable use on
+          Apple-branded devices you own or control, as permitted by the Usage Rules of the Apple
+          Media Services Terms and Conditions.</li>
+        <li>Apple has no obligation whatsoever to furnish any maintenance or support for the
+          app.</li>
+        <li>If the app fails to conform to any applicable warranty, you may notify Apple, and Apple
+          may refund the purchase price; to the maximum extent permitted by law, Apple has no other
+          warranty obligation.</li>
+        <li>Golden Crow, not Apple, is responsible for addressing any claims relating to the app
+          (product liability, regulatory compliance, consumer protection) and any third-party claim
+          that the app infringes intellectual property rights.</li>
+        <li>You represent that you are not located in a country subject to a U.S. Government embargo
+          and are not listed on any U.S. Government list of prohibited or restricted parties.</li>
+        <li>Apple and its subsidiaries are third-party beneficiaries of these Terms and may enforce
+          them against you.</li>
+      </ul>
+
+      <h2>12. Changes to the service and to these Terms</h2>
+      <p>
+        We may change or discontinue features and update these Terms. If a change is material, we
+        will announce it in the app or by email. The current version is always published on this
+        page with its effective date. Continuing to use the app after a change means you accept it.
+      </p>
+
+      <h2>13. Termination</h2>
+      <p>
+        You can stop using the app and delete your account at any time. We may suspend or terminate
+        your access if you breach these Terms or if we stop providing the service. On termination
+        the licence in section 3 ends; purchases already made are governed by the relevant store's
+        policies.
+      </p>
+
+      <h2>14. Governing law</h2>
+      <p>
+        These Terms are governed by the laws of the Argentine Republic, without prejudice to the
+        mandatory consumer-protection rules of the country where you reside.
+      </p>
+
+      <h2>15. Contact</h2>
+      <p>
+        Golden Crow — <a href="mailto:support@goldencrowvs.com">support@goldencrowvs.com</a>
+      </p>
+    </div>
+  </main>
+</BaseLayout>
+
+<style>
+  .legal-page {
+    padding: 7rem 1.5rem 4rem;
+    min-height: 60vh;
+  }
+  .legal-container {
+    max-width: 760px;
+    margin: 0 auto;
+    line-height: 1.65;
+  }
+  .legal-container h1 {
+    font-size: 2rem;
+    margin-bottom: 0.25rem;
+  }
+  .legal-container h2 {
+    font-size: 1.2rem;
+    margin: 2rem 0 0.5rem;
+  }
+  .legal-container ul {
+    padding-left: 1.25rem;
+  }
+  .legal-container li {
+    margin-bottom: 0.4rem;
+  }
+  .legal-updated {
+    opacity: 0.7;
+    font-size: 0.9rem;
+    margin-bottom: 2rem;
+  }
+  .legal-lang {
+    font-size: 0.85rem;
+    margin-bottom: 1rem;
+  }
+</style>

--- a/pocket-genes/src/pages/gc-fitness/privacy.astro
+++ b/pocket-genes/src/pages/gc-fitness/privacy.astro
@@ -97,6 +97,10 @@ import BaseLayout from '../../layouts/BaseLayout.astro';
       <p>
         Golden Crow — <a href="mailto:support@goldencrowvs.com">support@goldencrowvs.com</a>
       </p>
+
+      <p>
+        Ver también los <a href="/gc-fitness/terms">Términos de Uso</a> de GC Fitness.
+      </p>
     </div>
   </main>
 </BaseLayout>

--- a/pocket-genes/src/pages/gc-fitness/terms.astro
+++ b/pocket-genes/src/pages/gc-fitness/terms.astro
@@ -1,0 +1,244 @@
+---
+import BaseLayout from '../../layouts/BaseLayout.astro';
+---
+
+<BaseLayout title="GC Fitness — Términos de Uso">
+  <main class="legal-page">
+    <div class="legal-container">
+      <p class="legal-lang"><a href="/en/gc-fitness/terms">English version</a></p>
+      <h1>Términos de Uso (EULA) — GC Fitness</h1>
+      <p class="legal-updated">Vigente desde: 28 de julio de 2026</p>
+
+      <p>
+        Estos Términos de Uso («Términos») son un acuerdo entre vos y <strong>Golden Crow</strong>
+        («nosotros») sobre el uso de la aplicación móvil <strong>GC Fitness</strong> (paquete
+        <code>com.goldencrow.fitness</code>, disponible para iOS, Apple Watch y Android) y de los
+        servicios asociados. Al descargar, instalar o usar la app aceptás estos Términos. Si no
+        estás de acuerdo, no la uses.
+      </p>
+      <p>
+        El tratamiento de tus datos personales se describe en nuestra
+        <a href="/gc-fitness/privacy">Política de Privacidad</a>, que forma parte de estos Términos.
+      </p>
+
+      <h2>1. Qué es GC Fitness</h2>
+      <p>
+        GC Fitness es una plataforma de entrenamiento y seguimiento de hábitos. Podés usarla por tu
+        cuenta o vinculada a un entrenador personal («coach»), que te asigna entrenamientos, hábitos
+        y pautas, y ve tu progreso. Registrás series, repeticiones, pesos, hábitos, métricas
+        corporales y fotos de progreso, y podés chatear con tu coach.
+      </p>
+
+      <h2>2. Tu cuenta</h2>
+      <ul>
+        <li>Necesitás una cuenta creada con Google o Apple. Sos responsable de mantener el acceso a
+          esa cuenta y de la actividad realizada desde ella.</li>
+        <li>Tenés que tener al menos 13 años. Si sos menor de edad en tu país, necesitás la
+          autorización de tu madre, padre o tutor.</li>
+        <li>Podés eliminar tu cuenta en cualquier momento desde la app —
+          ver <a href="/gc-fitness/delete-account">Eliminación de cuenta</a>.</li>
+      </ul>
+
+      <h2>3. Licencia de uso</h2>
+      <p>
+        Te otorgamos una licencia limitada, personal, no exclusiva, no transferible y revocable para
+        usar GC Fitness en dispositivos que poseas o controles, según las reglas de la tienda desde
+        la que la descargaste. No podés revender, alquilar, sublicenciar, copiar, descompilar ni
+        aplicar ingeniería inversa a la app, ni usarla para desarrollar un producto competidor.
+      </p>
+
+      <h2>4. Plan gratuito y plan Premium</h2>
+      <p>
+        GC Fitness se puede usar gratis con límites. El plan <strong>Premium</strong> los quita.
+      </p>
+      <ul>
+        <li><strong>Gratis:</strong> hasta 3 rutinas y 3 hábitos creados por vos, un set de fotos de
+          progreso cada 30 días, e historial de gráficos de los últimos 30 días.</li>
+        <li><strong>Premium:</strong> rutinas y hábitos ilimitados, fotos de progreso sin límite de
+          frecuencia e historial completo de gráficos.</li>
+        <li><strong>Clientes con coach:</strong> si tenés un entrenador vinculado a tu cuenta,
+          accedés a las funciones Premium sin necesidad de una suscripción, mientras dure ese
+          vínculo.</li>
+      </ul>
+
+      <h2>5. Suscripciones y compras</h2>
+      <p>Ofrecemos estos productos dentro de la app:</p>
+      <ul>
+        <li><strong>Premium mensual</strong> (<code>gcfitness.sub.monthly</code>) — suscripción de
+          renovación automática, con período de 1 mes.</li>
+        <li><strong>Premium anual</strong> (<code>gcfitness.sub.yearly</code>) — suscripción de
+          renovación automática, con período de 1 año.</li>
+        <li><strong>Premium de por vida</strong> (<code>gcfitness.lifetime</code>) — compra única,
+          sin renovación.</li>
+      </ul>
+      <p>
+        El precio de cada producto se muestra en la app antes de confirmar la compra, en tu moneda
+        local, y puede variar según la región y las promociones vigentes.
+      </p>
+      <p>
+        <strong>Condiciones de las suscripciones de renovación automática:</strong>
+      </p>
+      <ul>
+        <li>El pago se debita de tu cuenta de la App Store (iOS) o de Google Play (Android) al
+          confirmar la compra.</li>
+        <li>La suscripción se renueva automáticamente por el mismo período salvo que la canceles al
+          menos <strong>24 horas antes</strong> del fin del período en curso.</li>
+        <li>El cobro de la renovación se realiza dentro de las 24 horas previas al fin del período
+          en curso, al precio del plan vigente.</li>
+        <li>Podés gestionar o cancelar la suscripción en cualquier momento desde los ajustes de tu
+          cuenta de la tienda: en iOS, <em>Ajustes → tu nombre → Suscripciones</em>; en Android,
+          <em>Google Play → Pagos y suscripciones</em>. Desinstalar la app no cancela la
+          suscripción.</li>
+        <li>La cancelación surte efecto al final del período ya pagado; no se reembolsan períodos
+          parciales.</li>
+      </ul>
+      <p>
+        Los reembolsos los gestiona la tienda que procesó el pago (Apple o Google), de acuerdo con
+        sus políticas: nosotros no procesamos pagos ni podemos emitir reembolsos directamente. Si
+        una promoción incluye un período de prueba gratuito, la parte no utilizada se pierde al
+        contratar la suscripción.
+      </p>
+
+      <h2>6. Salud — importante</h2>
+      <p>
+        GC Fitness es una herramienta de organización y registro de entrenamiento. <strong>No es un
+        dispositivo médico y no brinda asesoramiento médico.</strong> El contenido de la app —
+        incluidos entrenamientos, hábitos, ejercicios, estimaciones de volumen o calorías y récords
+        personales — es informativo y no reemplaza la consulta con un profesional de la salud.
+      </p>
+      <ul>
+        <li>Consultá con un médico antes de comenzar cualquier programa de ejercicio, especialmente
+          si tenés una condición preexistente, estás embarazada o retomás la actividad después de
+          una lesión.</li>
+        <li>Entrenás bajo tu propia responsabilidad. Si sentís dolor, mareos o malestar, detené la
+          actividad y buscá atención médica.</li>
+        <li>Si usás la app vinculada a un entrenador, el programa de entrenamiento y las
+          indicaciones son responsabilidad de ese entrenador, no de Golden Crow. Golden Crow provee
+          el software; no supervisa, avala ni verifica las credenciales de los entrenadores ni el
+          contenido que asignan.</li>
+      </ul>
+
+      <h2>7. Tu contenido</h2>
+      <p>
+        Conservás la titularidad de lo que cargues (entrenamientos, hábitos, métricas, fotos de
+        progreso y mensajes). Nos otorgás una licencia limitada para almacenarlo, procesarlo y
+        mostrarlo con el único fin de operar el servicio — por ejemplo, mostrarle tu progreso a tu
+        entrenador. No usamos tu contenido con fines publicitarios ni lo vendemos.
+      </p>
+
+      <h2>8. Uso aceptable</h2>
+      <p>No podés usar GC Fitness para:</p>
+      <ul>
+        <li>subir contenido ilegal, ofensivo, acosador o que infrinja derechos de terceros;</li>
+        <li>suplantar a otra persona o acceder a cuentas o datos ajenos;</li>
+        <li>interferir con el servicio, vulnerar sus mecanismos de seguridad o automatizar accesos
+          masivos;</li>
+        <li>eludir los límites del plan gratuito o el sistema de compras.</li>
+      </ul>
+      <p>
+        Podemos suspender o cerrar cuentas que incumplan estos Términos.
+      </p>
+
+      <h2>9. Propiedad intelectual</h2>
+      <p>
+        La app, su diseño, su marca y su contenido propio son de Golden Crow o de sus licenciantes.
+        Los datos y las imágenes de ejercicios de la biblioteca estándar provienen en parte de
+        <a href="https://wger.de/" rel="noopener noreferrer" target="_blank">wger.de</a> y se usan
+        bajo licencia CC BY-SA 3.0.
+      </p>
+
+      <h2>10. Disponibilidad y garantías</h2>
+      <p>
+        El servicio se ofrece «tal cual» y «según disponibilidad». Hacemos un esfuerzo razonable por
+        mantenerlo funcionando, pero no garantizamos que esté libre de interrupciones o errores, ni
+        que los datos sincronicen sin demoras. En la medida permitida por la ley, no respondemos por
+        daños indirectos, lucro cesante ni pérdida de datos. Nada en estos Términos limita los
+        derechos que te correspondan como consumidor según la ley aplicable.
+      </p>
+
+      <h2>11. Condiciones específicas de Apple (App Store)</h2>
+      <p>
+        Para la versión de iOS y watchOS descargada desde la App Store:
+      </p>
+      <ul>
+        <li>Estos Términos son un acuerdo entre vos y Golden Crow únicamente, <strong>no con
+          Apple</strong>. Golden Crow —y no Apple— es responsable de la app y de su contenido.</li>
+        <li>La licencia es la establecida en la sección 3, limitada a un uso no transferible en
+          dispositivos de marca Apple que poseas o controles, según las Reglas de Uso de los
+          Términos de Servicio de los Servicios Multimedia de Apple.</li>
+        <li>Apple no tiene obligación alguna de brindar mantenimiento ni soporte para la app.</li>
+        <li>Si la app no cumpliera con una garantía aplicable, podés notificar a Apple, que podrá
+          reembolsarte el precio de compra; salvo eso, Apple no tiene otras obligaciones de
+          garantía.</li>
+        <li>Golden Crow —no Apple— es responsable de atender reclamos relacionados con la app
+          (responsabilidad por producto, cumplimiento normativo, protección al consumidor) y
+          reclamos de terceros por infracción de propiedad intelectual.</li>
+        <li>Declarás que no te encontrás en un país sujeto a embargo del gobierno de los EE. UU. ni
+          figurás en listas de partes restringidas.</li>
+        <li>Apple y sus subsidiarias son terceros beneficiarios de estos Términos y podrán exigir su
+          cumplimiento frente a vos.</li>
+      </ul>
+
+      <h2>12. Cambios en el servicio y en estos Términos</h2>
+      <p>
+        Podemos modificar o discontinuar funciones, y actualizar estos Términos. Si el cambio es
+        relevante, lo anunciaremos en la app o por email. Publicaremos siempre la versión vigente en
+        esta página con su fecha. Seguir usando la app después de un cambio implica aceptarlo.
+      </p>
+
+      <h2>13. Terminación</h2>
+      <p>
+        Podés dejar de usar la app y eliminar tu cuenta cuando quieras. Podemos suspender o terminar
+        tu acceso ante un incumplimiento de estos Términos o si dejamos de prestar el servicio. Al
+        terminar, la licencia de la sección 3 se extingue; las compras ya realizadas se rigen por
+        las políticas de la tienda correspondiente.
+      </p>
+
+      <h2>14. Ley aplicable</h2>
+      <p>
+        Estos Términos se rigen por las leyes de la República Argentina, sin perjuicio de las normas
+        imperativas de protección al consumidor del país donde residas.
+      </p>
+
+      <h2>15. Contacto</h2>
+      <p>
+        Golden Crow — <a href="mailto:support@goldencrowvs.com">support@goldencrowvs.com</a>
+      </p>
+    </div>
+  </main>
+</BaseLayout>
+
+<style>
+  .legal-page {
+    padding: 7rem 1.5rem 4rem;
+    min-height: 60vh;
+  }
+  .legal-container {
+    max-width: 760px;
+    margin: 0 auto;
+    line-height: 1.65;
+  }
+  .legal-container h1 {
+    font-size: 2rem;
+    margin-bottom: 0.25rem;
+  }
+  .legal-container h2 {
+    font-size: 1.2rem;
+    margin: 2rem 0 0.5rem;
+  }
+  .legal-container ul {
+    padding-left: 1.25rem;
+  }
+  .legal-container li {
+    margin-bottom: 0.4rem;
+  }
+  .legal-updated {
+    opacity: 0.7;
+    font-size: 0.9rem;
+    margin-bottom: 2rem;
+  }
+  .legal-lang {
+    font-size: 0.85rem;
+    margin-bottom: 1rem;
+  }
+</style>


### PR DESCRIPTION
## Why

App Store review rejected the GC Fitness submission (2026-07-28):

> The submission offers auto-renewable subscriptions but does not include a functional link to the Terms of Use (EULA) in the app's metadata.

The site had a GC Fitness privacy policy but **no terms page** to link to.

## What

- **New** `/gc-fitness/terms` (ES) and `/en/gc-fitness/terms` (EN).
- Both privacy pages now link to their terms twin.
- Download page legal line: `Privacidad · Términos de uso` / `Privacy · Terms of Use`.

Section 5 is the one the rejection was about: names `gcfitness.sub.monthly` / `gcfitness.sub.yearly` / `gcfitness.lifetime`, their durations, auto-renewal, charge to the store account, the 24-hour cancellation window, no partial refunds, and refunds being Apple/Google's to process. Section 11 carries Apple's Schedule 2 minimum terms (not an agreement with Apple, no Apple maintenance obligation, refund-only warranty remedy, Golden Crow owns product/IP claims, embargo representation, Apple as third-party beneficiary).

Section 4 mirrors the shipped gates rather than inventing them: 3 self-created routines, 3 self-created habits, one progress-photo set per 30 days, 30-day chart history (`FreeTierGate`), and coach-linked clients being Premium by identity (`EntitlementResolver`).

Section 6 is a health / not-medical-advice disclaimer, including that the training programme is the coach's responsibility, not Golden Crow's.

## Confirm before merge

**Governing law is stated as Argentina** — assumption, say the word if it should be something else.

## Test gate

`npm run build` in `pocket-genes/` — green, 70 pages, both terms routes emitted; all four cross-links asserted in the built HTML. Astro marketing site only: no backoffice, `firestore.rules`, or mobile code touched.