### PR TITLE
feat(gc-fitness/admin): coach-less user profile drill-down (god-mode)

### DIFF
--- a/backoffice/src/app/gc-fitness/admin/coach-less-users/[uid]/page.tsx
+++ b/backoffice/src/app/gc-fitness/admin/coach-less-users/[uid]/page.tsx
@@ -1,0 +1,604 @@
+// /gc-fitness/admin/coach-less-users/[uid]/page.tsx
+//
+// Admin god-mode profile for ONE coach-less (self-serve) user — the drill-down
+// the list page was missing. Coached clients already have
+// `/admin/coaches/{coachId}/clients/{clientId}`; a coach-less user has no coach
+// to nest under, so this route stands in for it and reuses the very same
+// loaders and widgets.
+//
+// It can do that because a coach-less user is their own trainer-of-record
+// (`adminCanViewClientUnderCoach` — mirrors the #392 selfAssigned
+// `trainerId === clientId` wire shape). Passing `uid` as BOTH the coach uid and
+// the client uid therefore lights up the shared recent-activity feed, the
+// workout-log detail route and the photo comparator with no new plumbing.
+//
+// Authorization: admin-gated at the page AND inside every action; the profile
+// action additionally refuses any target that isn't an active coach-less
+// client, so this URL can't be used to read a coached client's data.
+
+import { revalidatePath } from "next/cache";
+import Link from "next/link";
+import { notFound, redirect } from "next/navigation";
+import { ArrowLeft } from "lucide-react";
+
+import { AdminSubmitButton } from "../../_components/admin-submit-button";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { PageHeader } from "@/components/gc-fitness/page-header";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { getCurrentAdmin } from "@/lib/gc-fitness/auth-helpers";
+import { sectionMetadata } from "@/lib/gc-fitness/page-metadata";
+import {
+  listClientAssignmentsForAdmin,
+  listClientHabitsForAdmin,
+} from "@/lib/gc-fitness/admin-actions";
+import {
+  deleteCoachlessUser,
+  getCoachlessUserProfile,
+  setUserEntitlementTier,
+  type CoachlessUserProfile,
+} from "@/lib/gc-fitness/admin-coachless-actions";
+import {
+  daysSince,
+  resolveDisplayTier,
+  type ActivityWindow,
+} from "@/lib/gc-fitness/coachless-user-model";
+import { listProgressPhotosForClientAsAdmin } from "@/lib/gc-fitness/progress-photo-actions";
+import { listRecentLogsForClientAsAdmin } from "@/lib/gc-fitness/recent-logs-actions";
+
+import { BodyWeightTrendChart } from "@/app/gc-fitness/clients/[id]/_components/BodyWeightTrendChart";
+import { ClientRecentLogsFeed } from "@/app/gc-fitness/clients/[id]/_components/ClientRecentLogsFeed";
+import { ProgressPhotosGridClient } from "@/app/gc-fitness/clients/[id]/_components/ProgressPhotosGridClient";
+
+export const generateMetadata = () => sectionMetadata("adminPanel");
+
+export const dynamic = "force-dynamic";
+
+const LIST_ROUTE = "/gc-fitness/admin/coach-less-users";
+
+/** Stable YYYY-MM-DD (avoids the server-locale flake seen in date tests). */
+function formatDate(iso: string | null): string {
+  return iso ? iso.slice(0, 10) : "—";
+}
+
+/** "2026-07-26 (hace 2 d)" — absolute date first, recency in parentheses. */
+function formatDateWithAge(iso: string | null, nowMs: number): string {
+  if (!iso) return "—";
+  const days = daysSince(iso, nowMs);
+  if (days === null) return formatDate(iso);
+  const age = days === 0 ? "hoy" : days === 1 ? "hace 1 d" : `hace ${days} d`;
+  return `${formatDate(iso)} (${age})`;
+}
+
+function StatTile({ label, value, hint }: { label: string; value: string; hint?: string }) {
+  return (
+    <div className="rounded-2xl border px-4 py-3">
+      <div className="text-xs uppercase tracking-wide text-muted-foreground">{label}</div>
+      <div className="mt-1 text-2xl font-semibold tabular-nums">{value}</div>
+      {hint ? <div className="text-xs text-muted-foreground">{hint}</div> : null}
+    </div>
+  );
+}
+
+function Field({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <div>
+      <dt className="text-xs uppercase tracking-wide text-muted-foreground">{label}</dt>
+      <dd className="mt-0.5 text-sm break-words">{children}</dd>
+    </div>
+  );
+}
+
+function ActivityRow({
+  label,
+  window: w,
+  nowMs,
+}: {
+  label: string;
+  window: ActivityWindow;
+  nowMs: number;
+}) {
+  return (
+    <TableRow>
+      <TableCell>{label}</TableCell>
+      <TableCell className="text-xs text-muted-foreground">
+        {formatDateWithAge(w.lastISO, nowMs)}
+      </TableCell>
+      <TableCell className="text-right tabular-nums">{w.last7Days}</TableCell>
+      <TableCell className="text-right tabular-nums">{w.last30Days}</TableCell>
+      <TableCell className="text-right tabular-nums">{w.total}</TableCell>
+    </TableRow>
+  );
+}
+
+export default async function CoachlessUserDetailPage({
+  params,
+  searchParams,
+}: {
+  params: Promise<{ uid: string }>;
+  searchParams: Promise<Record<string, string | string[] | undefined>>;
+}) {
+  const { uid } = await params;
+
+  try {
+    await getCurrentAdmin();
+  } catch (err) {
+    const message = err instanceof Error ? err.message : "Forbidden";
+    if (message === "Forbidden") {
+      redirect("/gc-fitness/forbidden");
+    }
+    throw err;
+  }
+
+  const sp = await searchParams;
+  const op = typeof sp.op === "string" ? sp.op : null;
+  const actionMessage = op && sp.ok === "1" ? `Action completed: ${op}.` : null;
+
+  let profile: CoachlessUserProfile;
+  try {
+    profile = await getCoachlessUserProfile(uid);
+  } catch {
+    // Unknown uid, or a target that isn't an active coach-less client (a
+    // coached client belongs to their coach's drill-down, not this one).
+    notFound();
+  }
+
+  // Every widget below is scoped by BOTH ids; for a coach-less user the coach
+  // uid IS their own uid (see the header comment).
+  const [logs, photos, assignments, habits] = await Promise.all([
+    listRecentLogsForClientAsAdmin(uid, uid).catch(() => null),
+    listProgressPhotosForClientAsAdmin(uid, uid).catch(() => []),
+    listClientAssignmentsForAdmin(uid, uid).catch(() => []),
+    listClientHabitsForAdmin(uid, uid).catch(() => []),
+  ]);
+
+  const nowMs = Date.now();
+  const tier = resolveDisplayTier(profile.entitlement);
+  const isPremium = tier === "premium";
+  const timezone = profile.timezone ?? "UTC";
+  const displayName = profile.displayName || profile.email || uid;
+
+  async function setTierAction(formData: FormData) {
+    "use server";
+    const targetUid = String(formData.get("uid") ?? "");
+    const nextTier = String(formData.get("tier") ?? "");
+    await setUserEntitlementTier({ uid: targetUid, tier: nextTier });
+    revalidatePath(`${LIST_ROUTE}/${targetUid}`);
+    redirect(`${LIST_ROUTE}/${targetUid}?op=set_${nextTier}&ok=1`);
+  }
+
+  async function deleteUserAction(formData: FormData) {
+    "use server";
+    const targetUid = String(formData.get("uid") ?? "");
+    const emailConfirmation = String(formData.get("emailConfirmation") ?? "");
+    await deleteCoachlessUser({ uid: targetUid, emailConfirmation });
+    revalidatePath(LIST_ROUTE);
+    // The user no longer exists — land back on the list, not on a 404.
+    redirect(`${LIST_ROUTE}?op=delete_user&ok=1`);
+  }
+
+  return (
+    <div className="gc-page flex flex-col gap-6">
+      <Button asChild variant="outline" size="sm" className="self-start rounded-full">
+        <Link href={LIST_ROUTE}>
+          <ArrowLeft className="h-4 w-4" />
+          Back to coach-less users
+        </Link>
+      </Button>
+
+      <PageHeader
+        title={
+          <span className="flex flex-wrap items-center gap-2">
+            {displayName}
+            <Badge variant={isPremium ? "success" : "secondary"}>
+              {isPremium ? "Premium" : "Free"}
+            </Badge>
+            <Badge variant="secondary">Coach-less</Badge>
+          </span>
+        }
+        subtitle={`${profile.email || "no email"} · ${uid}`}
+      />
+
+      {actionMessage ? (
+        <div className="rounded-2xl border border-[color:var(--badge-success-border)] bg-[color:var(--badge-success-bg)] px-4 py-3 text-sm text-[color:var(--badge-success-fg)]">
+          {actionMessage}
+        </div>
+      ) : null}
+
+      <div className="grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-6">
+        <StatTile
+          label="Last active"
+          value={
+            profile.activity.lastActiveISO
+              ? (() => {
+                  const d = daysSince(profile.activity.lastActiveISO, nowMs);
+                  return d === null ? "—" : d === 0 ? "hoy" : `${d} d`;
+                })()
+              : "never"
+          }
+          hint={formatDate(profile.activity.lastActiveISO)}
+        />
+        <StatTile
+          label="Workouts"
+          value={String(profile.activity.workouts.last30Days)}
+          hint={`last 30 d · ${profile.stats.workoutLogs} total`}
+        />
+        <StatTile
+          label="Habit check-ins"
+          value={String(profile.activity.habitCheckIns.last30Days)}
+          hint="last 30 d"
+        />
+        <StatTile label="Routines" value={String(profile.stats.routines)} hint="self-created" />
+        <StatTile label="Habits" value={String(profile.stats.habits)} hint="self-created" />
+        <StatTile
+          label="Photos"
+          value={String(profile.stats.progressPhotos)}
+          hint={`weight logs: ${profile.activity.weightEntries.total}`}
+        />
+      </div>
+
+      <div className="grid gap-6 lg:grid-cols-2">
+        <Card>
+          <CardHeader className="pb-3">
+            <CardTitle className="text-xl">Account</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <dl className="grid grid-cols-2 gap-4">
+              <Field label="Email">{profile.email || "—"}</Field>
+              <Field label="UID">
+                <span className="font-mono text-xs">{uid}</span>
+              </Field>
+              <Field label="Signed up">{formatDateWithAge(profile.createdAtISO, nowMs)}</Field>
+              <Field label="Last sign-in">
+                {formatDateWithAge(profile.auth?.lastSignInISO ?? null, nowMs)}
+              </Field>
+              <Field label="Sign-in providers">
+                {profile.auth && profile.auth.providers.length > 0
+                  ? profile.auth.providers.join(", ")
+                  : "—"}
+              </Field>
+              <Field label="Email verified">
+                {profile.auth ? (profile.auth.emailVerified ? "yes" : "no") : "—"}
+              </Field>
+              <Field label="Timezone">{profile.timezone || "—"}</Field>
+              <Field label="Birth date">{profile.birthDate || "—"}</Field>
+              {profile.auth?.disabled ? (
+                <Field label="Auth status">
+                  <Badge variant="destructive">disabled</Badge>
+                </Field>
+              ) : null}
+            </dl>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader className="pb-3">
+            <CardTitle className="text-xl">Subscription</CardTitle>
+          </CardHeader>
+          <CardContent className="flex flex-col gap-4">
+            <dl className="grid grid-cols-2 gap-4">
+              <Field label="Tier">
+                <Badge variant={isPremium ? "success" : "secondary"}>
+                  {isPremium ? "Premium" : "Free"}
+                </Badge>
+              </Field>
+              <Field label="Source">{profile.entitlement?.source || "—"}</Field>
+              <Field label="Product">{profile.entitlement?.productId || "—"}</Field>
+              <Field label="Expires">{formatDate(profile.entitlement?.expiresAtISO ?? null)}</Field>
+              <Field label="Updated">
+                {formatDateWithAge(profile.entitlement?.updatedAtISO ?? null, nowMs)}
+              </Field>
+            </dl>
+
+            <div className="flex flex-col items-start gap-3 border-t pt-4">
+              <form action={setTierAction}>
+                <input type="hidden" name="uid" value={uid} />
+                <input type="hidden" name="tier" value={isPremium ? "free" : "premium"} />
+                <AdminSubmitButton
+                  idleLabel={isPremium ? "Revoke premium" : "Grant premium"}
+                  pendingLabel="Saving…"
+                  className="h-8 rounded-full border px-3 text-xs hover:bg-muted"
+                />
+              </form>
+
+              <details>
+                <summary className="cursor-pointer text-xs text-destructive underline underline-offset-2">
+                  Delete user
+                </summary>
+                <form action={deleteUserAction} className="mt-2 flex flex-col items-start gap-2">
+                  <input type="hidden" name="uid" value={uid} />
+                  <p className="max-w-md text-[10px] text-muted-foreground">
+                    Irreversible: deletes Auth, all Firestore data, and Storage photos.
+                    Type <span className="font-mono">{profile.email}</span> to confirm.
+                  </p>
+                  <Input
+                    name="emailConfirmation"
+                    placeholder="type email to confirm"
+                    className="h-8 w-64 text-xs"
+                    autoComplete="off"
+                  />
+                  <AdminSubmitButton
+                    idleLabel="Delete forever"
+                    pendingLabel="Deleting…"
+                    className="h-8 rounded-full bg-destructive px-3 text-xs text-destructive-foreground hover:bg-destructive/90"
+                  />
+                </form>
+              </details>
+            </div>
+          </CardContent>
+        </Card>
+      </div>
+
+      <Card>
+        <CardHeader className="pb-3">
+          <CardTitle className="text-xl">Activity</CardTitle>
+        </CardHeader>
+        <CardContent className="p-0">
+          <div className="overflow-x-auto">
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Stream</TableHead>
+                  <TableHead>Last</TableHead>
+                  <TableHead className="text-right">7 d</TableHead>
+                  <TableHead className="text-right">30 d</TableHead>
+                  <TableHead className="text-right">Total</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                <ActivityRow label="Workouts logged" window={profile.activity.workouts} nowMs={nowMs} />
+                <ActivityRow
+                  label="Habit check-ins"
+                  window={profile.activity.habitCheckIns}
+                  nowMs={nowMs}
+                />
+                <ActivityRow label="Progress photos" window={profile.activity.photos} nowMs={nowMs} />
+                <ActivityRow
+                  label="Body-weight entries"
+                  window={profile.activity.weightEntries}
+                  nowMs={nowMs}
+                />
+              </TableBody>
+            </Table>
+          </div>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader className="pb-3">
+          <CardTitle className="text-xl">Routines ({profile.routines.length})</CardTitle>
+        </CardHeader>
+        <CardContent className="p-0">
+          {profile.routines.length === 0 ? (
+            <p className="px-6 pb-6 text-sm text-muted-foreground">
+              No self-created routines yet.
+            </p>
+          ) : (
+            <div className="overflow-x-auto">
+              <Table>
+                <TableHeader>
+                  <TableRow>
+                    <TableHead>Routine</TableHead>
+                    <TableHead>Tags</TableHead>
+                    <TableHead className="text-right">Exercises</TableHead>
+                    <TableHead>Created</TableHead>
+                    <TableHead>Updated</TableHead>
+                    <TableHead>Status</TableHead>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {profile.routines.map((r) => (
+                    <TableRow key={r.id}>
+                      <TableCell>{r.name}</TableCell>
+                      <TableCell className="text-xs text-muted-foreground">
+                        {r.tags.join(", ") || "—"}
+                      </TableCell>
+                      <TableCell className="text-right tabular-nums">{r.exerciseCount}</TableCell>
+                      <TableCell className="text-xs text-muted-foreground">
+                        {formatDate(r.createdAtISO)}
+                      </TableCell>
+                      <TableCell className="text-xs text-muted-foreground">
+                        {formatDate(r.updatedAtISO)}
+                      </TableCell>
+                      <TableCell>
+                        {r.deleted ? (
+                          <Badge variant="secondary">deleted</Badge>
+                        ) : (
+                          <Badge variant="success">active</Badge>
+                        )}
+                      </TableCell>
+                    </TableRow>
+                  ))}
+                </TableBody>
+              </Table>
+            </div>
+          )}
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader className="pb-3">
+          <CardTitle className="text-xl">Habits ({habits.length})</CardTitle>
+        </CardHeader>
+        <CardContent className="p-0">
+          {habits.length === 0 ? (
+            <p className="px-6 pb-6 text-sm text-muted-foreground">No habits yet.</p>
+          ) : (
+            <div className="overflow-x-auto">
+              <Table>
+                <TableHeader>
+                  <TableRow>
+                    <TableHead>Habit</TableHead>
+                    <TableHead>Cadence</TableHead>
+                    <TableHead>Reminder</TableHead>
+                    <TableHead>Status</TableHead>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {habits.map((h) => (
+                    <TableRow key={h.id}>
+                      <TableCell>{h.name}</TableCell>
+                      <TableCell className="text-xs text-muted-foreground">
+                        {[h.scheduleType, h.cadence].filter(Boolean).join(" · ") || "—"}
+                      </TableCell>
+                      <TableCell className="text-xs text-muted-foreground">
+                        {h.reminderEnabled ? "On" : "Off"}
+                      </TableCell>
+                      <TableCell>
+                        {h.deleted ? (
+                          <Badge variant="secondary">deleted</Badge>
+                        ) : (
+                          <Badge variant="success">active</Badge>
+                        )}
+                      </TableCell>
+                    </TableRow>
+                  ))}
+                </TableBody>
+              </Table>
+            </div>
+          )}
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader className="pb-3">
+          <CardTitle className="text-xl">Scheduled workouts ({assignments.length})</CardTitle>
+        </CardHeader>
+        <CardContent className="p-0">
+          {assignments.length === 0 ? (
+            <p className="px-6 pb-6 text-sm text-muted-foreground">
+              Nothing scheduled — this user has never planned a workout.
+            </p>
+          ) : (
+            <div className="overflow-x-auto">
+              <Table>
+                <TableHeader>
+                  <TableRow>
+                    <TableHead>Date</TableHead>
+                    <TableHead>Time</TableHead>
+                    <TableHead>Workout</TableHead>
+                    <TableHead>Status</TableHead>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {assignments.map((a) => (
+                    <TableRow key={a.id}>
+                      <TableCell className="whitespace-nowrap font-mono text-xs">
+                        {a.recurrenceLabel && a.lastDate !== a.firstDate
+                          ? `${a.firstDate} → ${a.lastDate}`
+                          : a.firstDate || "—"}
+                      </TableCell>
+                      <TableCell className="whitespace-nowrap text-xs text-muted-foreground">
+                        {a.scheduledTime ?? "—"}
+                      </TableCell>
+                      <TableCell>
+                        <div className="flex flex-wrap items-center gap-2">
+                          <span>{a.title}</span>
+                          {a.recurrenceLabel ? (
+                            <Badge variant="secondary" className="font-normal">
+                              {a.recurrenceLabel} · ×{a.occurrences}
+                            </Badge>
+                          ) : null}
+                        </div>
+                      </TableCell>
+                      <TableCell>
+                        {a.recurrenceLabel ? (
+                          <span className="text-xs tabular-nums text-muted-foreground">
+                            {a.completedCount}/{a.occurrences} completados
+                          </span>
+                        ) : (
+                          <Badge variant={assignmentStatusVariant(a.status)}>{a.status}</Badge>
+                        )}
+                      </TableCell>
+                    </TableRow>
+                  ))}
+                </TableBody>
+              </Table>
+            </div>
+          )}
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader className="pb-3">
+          <CardTitle className="text-xl">Recent activity</CardTitle>
+        </CardHeader>
+        <CardContent>
+          {logs && logs.logs.length > 0 ? (
+            // showActions=false — admin is read-only and the row action buttons
+            // are trainer-scoped. linkMode="admin" with coachUid = the user's own
+            // uid routes workout + photo rows to the admin-gated detail routes,
+            // which admit them under the same self-as-coach rule.
+            <ClientRecentLogsFeed
+              logs={logs.logs}
+              clientId={uid}
+              timezone={timezone}
+              initialCursor={logs.nextCursor}
+              initialHasMore={logs.hasMore}
+              showActions={false}
+              linkMode="admin"
+              coachUid={uid}
+            />
+          ) : (
+            <p className="text-sm text-muted-foreground">No activity recorded yet.</p>
+          )}
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader className="pb-3">
+          <CardTitle className="text-xl">Body weight</CardTitle>
+        </CardHeader>
+        <CardContent>
+          {profile.activity.weightEntries.total > 0 ? (
+            <BodyWeightTrendChart clientId={uid} timezone={timezone} />
+          ) : (
+            <p className="text-sm text-muted-foreground">No body-weight entries yet.</p>
+          )}
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader className="pb-3">
+          <CardTitle className="text-xl">Progress photos</CardTitle>
+        </CardHeader>
+        <CardContent>
+          {photos.length > 0 ? (
+            <ProgressPhotosGridClient photos={photos} timezone={timezone} />
+          ) : (
+            <p className="text-sm text-muted-foreground">No progress photos yet.</p>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}
+
+function assignmentStatusVariant(
+  status: string,
+): "default" | "secondary" | "destructive" | "success" {
+  switch (status) {
+    case "completed":
+      return "success";
+    case "missed":
+      return "destructive";
+    case "started":
+      return "default";
+    default:
+      return "secondary";
+  }
+}

--- a/backoffice/src/app/gc-fitness/admin/coach-less-users/page.tsx
+++ b/backoffice/src/app/gc-fitness/admin/coach-less-users/page.tsx
@@ -79,7 +79,7 @@ export default async function CoachlessUsersPage({
     <div className="gc-page flex flex-col gap-6">
       <PageHeader
         title="Coach-less users"
-        subtitle="Self-serve clients with no coach — subscription status, content stats, and god-mode actions (grant/revoke premium, delete)."
+        subtitle="Self-serve clients with no coach — subscription status, content stats, and god-mode actions (grant/revoke premium, delete). Click a name to open their full profile."
       />
 
       <Button asChild variant="outline" size="sm" className="self-start rounded-full">
@@ -139,7 +139,15 @@ export default async function CoachlessUsersPage({
                           <div className="h-8 w-8 rounded-full bg-muted" aria-hidden />
                         )}
                         <div>
-                          <div className="font-medium">{row.displayName || "—"}</div>
+                          {/* Row → god-mode profile (activity, routines, habits,
+                              logs, photos). The detail page is the only place
+                              a coach-less user's content is inspectable. */}
+                          <Link
+                            href={`${ROUTE}/${row.uid}`}
+                            className="font-medium underline-offset-2 hover:underline"
+                          >
+                            {row.displayName || row.email || "—"}
+                          </Link>
                           <div className="text-xs text-muted-foreground">{row.email || "—"}</div>
                           <div className="font-mono text-[10px] text-muted-foreground">{row.uid}</div>
                         </div>

--- a/backoffice/src/lib/gc-fitness/__tests__/coachless-user-model.test.ts
+++ b/backoffice/src/lib/gc-fitness/__tests__/coachless-user-model.test.ts
@@ -9,6 +9,10 @@ import {
   firestoreValueToISO,
   toEntitlementInfo,
   isCoachlessClientRow,
+  adminCanViewClientUnderCoach,
+  summarizeCoachlessActivity,
+  bilingualText,
+  daysSince,
   type EntitlementInfo,
 } from "../coachless-user-model";
 
@@ -105,5 +109,166 @@ describe("isCoachlessClientRow", () => {
     expect(isCoachlessClientRow({ role: "trainer", coachId: null, deleted: false })).toBe(false);
     expect(isCoachlessClientRow({ role: null, coachId: null, deleted: false })).toBe(false);
     expect(isCoachlessClientRow({ role: "client", coachId: null, deleted: true })).toBe(false);
+  });
+});
+
+describe("adminCanViewClientUnderCoach", () => {
+  const coached = {
+    coachUidInPath: "coach123",
+    clientId: "client456",
+    clientCoachId: "coach123",
+    clientRole: "client",
+    clientDeleted: false,
+  };
+
+  it("admits the coach of record", () => {
+    expect(adminCanViewClientUnderCoach(coached)).toBe(true);
+  });
+
+  it("denies a coach who does not own the client (URL-edit across coaches)", () => {
+    expect(
+      adminCanViewClientUnderCoach({ ...coached, coachUidInPath: "otherCoach" }),
+    ).toBe(false);
+  });
+
+  it("admits a coach-less user as their own trainer-of-record", () => {
+    expect(
+      adminCanViewClientUnderCoach({
+        coachUidInPath: "selfUid",
+        clientId: "selfUid",
+        clientCoachId: null,
+        clientRole: "client",
+        clientDeleted: false,
+      }),
+    ).toBe(true);
+  });
+
+  it("denies self-as-coach when the target is NOT coach-less", () => {
+    // A coached client's own uid in the path must not unlock their data.
+    expect(
+      adminCanViewClientUnderCoach({
+        coachUidInPath: "client456",
+        clientId: "client456",
+        clientCoachId: "coach123",
+        clientRole: "client",
+        clientDeleted: false,
+      }),
+    ).toBe(false);
+    // Nor a trainer, nor a soft-deleted account.
+    expect(
+      adminCanViewClientUnderCoach({
+        coachUidInPath: "t1",
+        clientId: "t1",
+        clientCoachId: null,
+        clientRole: "trainer",
+        clientDeleted: false,
+      }),
+    ).toBe(false);
+    expect(
+      adminCanViewClientUnderCoach({
+        coachUidInPath: "c1",
+        clientId: "c1",
+        clientCoachId: null,
+        clientRole: "client",
+        clientDeleted: true,
+      }),
+    ).toBe(false);
+  });
+
+  it("denies empty uids", () => {
+    expect(adminCanViewClientUnderCoach({ ...coached, coachUidInPath: "" })).toBe(false);
+    expect(adminCanViewClientUnderCoach({ ...coached, clientId: "" })).toBe(false);
+  });
+});
+
+describe("summarizeCoachlessActivity", () => {
+  // Fixed "now" so the windows are deterministic (no Date.now() in the assert).
+  const nowMs = Date.parse("2026-07-28T12:00:00.000Z");
+  const daysAgo = (n: number) =>
+    new Date(nowMs - n * 24 * 60 * 60 * 1000).toISOString();
+
+  it("buckets each stream into 7d / 30d / total with its own last timestamp", () => {
+    const summary = summarizeCoachlessActivity({
+      nowMs,
+      workoutDates: [daysAgo(1), daysAgo(6), daysAgo(20), daysAgo(90)],
+      habitLogDates: ["2026-07-27", "2026-07-01", "2026-05-01"],
+      photoDates: [daysAgo(45)],
+      weightDates: [],
+    });
+
+    expect(summary.workouts).toEqual({
+      last7Days: 2,
+      last30Days: 3,
+      total: 4,
+      lastISO: daysAgo(1),
+    });
+    // Civil dates parse as UTC midnight — 2026-07-27 is inside 7d, 07-01 is
+    // inside 30d, 05-01 is only in the total.
+    expect(summary.habitCheckIns.last7Days).toBe(1);
+    expect(summary.habitCheckIns.last30Days).toBe(2);
+    expect(summary.habitCheckIns.total).toBe(3);
+    expect(summary.photos).toEqual({
+      last7Days: 0,
+      last30Days: 0,
+      total: 1,
+      lastISO: daysAgo(45),
+    });
+    expect(summary.weightEntries.total).toBe(0);
+    expect(summary.weightEntries.lastISO).toBeNull();
+  });
+
+  it("reports the newest timestamp across ALL streams as lastActive", () => {
+    const summary = summarizeCoachlessActivity({
+      nowMs,
+      workoutDates: [daysAgo(10)],
+      habitLogDates: [],
+      photoDates: [daysAgo(2)],
+      weightDates: [daysAgo(30)],
+    });
+    expect(summary.lastActiveISO).toBe(daysAgo(2));
+  });
+
+  it("returns a null lastActive for a user who never did anything", () => {
+    const summary = summarizeCoachlessActivity({
+      nowMs,
+      workoutDates: [],
+      habitLogDates: [null, undefined, "not-a-date"],
+      photoDates: [],
+      weightDates: [],
+    });
+    expect(summary.lastActiveISO).toBeNull();
+    expect(summary.habitCheckIns.total).toBe(0);
+  });
+});
+
+describe("bilingualText", () => {
+  it("prefers Spanish, then English, then the fallback", () => {
+    expect(bilingualText({ es: "Sentadilla", en: "Squat" }, "—")).toBe("Sentadilla");
+    expect(bilingualText({ en: "Squat" }, "—")).toBe("Squat");
+    expect(bilingualText({ es: "   ", en: "Squat" }, "—")).toBe("Squat");
+    expect(bilingualText({}, "—")).toBe("—");
+    expect(bilingualText(null, "—")).toBe("—");
+  });
+
+  it("passes a legacy bare string through", () => {
+    expect(bilingualText("Push day", "—")).toBe("Push day");
+    expect(bilingualText("  ", "—")).toBe("—");
+  });
+});
+
+describe("daysSince", () => {
+  const nowMs = Date.parse("2026-07-28T12:00:00.000Z");
+
+  it("floors to whole days and never goes negative", () => {
+    expect(daysSince("2026-07-28T00:00:00.000Z", nowMs)).toBe(0);
+    expect(daysSince("2026-07-27T00:00:00.000Z", nowMs)).toBe(1);
+    expect(daysSince("2026-06-28T12:00:00.000Z", nowMs)).toBe(30);
+    // Future-dated (clock skew) clamps to 0 rather than "-2 days ago".
+    expect(daysSince("2026-07-30T12:00:00.000Z", nowMs)).toBe(0);
+  });
+
+  it("returns null for missing / unparseable input", () => {
+    expect(daysSince(null, nowMs)).toBeNull();
+    expect(daysSince("whenever", nowMs)).toBeNull();
   });
 });

--- a/backoffice/src/lib/gc-fitness/admin-actions.ts
+++ b/backoffice/src/lib/gc-fitness/admin-actions.ts
@@ -9,6 +9,7 @@ import { getCurrentAdmin } from "@/lib/gc-fitness/auth-helpers";
 import { FirestoreCollections } from "@/lib/gc-fitness/collections";
 import { recurrenceLabel } from "@/lib/gc-fitness/coach-activity-log";
 import {
+  adminCanViewClientUnderCoach,
   toEntitlementInfo,
   type EntitlementInfo,
 } from "@/lib/gc-fitness/coachless-user-model";
@@ -1095,6 +1096,12 @@ export interface AdminClientHabitRow {
   deleted: boolean;
 }
 
+/**
+ * Admin drill-down gate. Admits the client's coach of record, plus the
+ * coach-less self-as-coach case (`coachUid === clientId` on an active
+ * coach-less client) so the god-mode coach-less profile can reuse these
+ * loaders — see `adminCanViewClientUnderCoach` for the full rule.
+ */
 async function assertClientBelongsToCoach(
   db: FirebaseFirestore.Firestore,
   coachUid: string,
@@ -1104,7 +1111,17 @@ async function assertClientBelongsToCoach(
     .collection(FirestoreCollections.users)
     .doc(clientId)
     .get();
-  if (!snap.exists || snap.get("coachId") !== coachUid) {
+  if (!snap.exists) {
+    throw new Error("Not found");
+  }
+  const allowed = adminCanViewClientUnderCoach({
+    coachUidInPath: coachUid,
+    clientId,
+    clientCoachId: typeof snap.get("coachId") === "string" ? snap.get("coachId") : null,
+    clientRole: typeof snap.get("role") === "string" ? snap.get("role") : null,
+    clientDeleted: snap.get("deleted") === true,
+  });
+  if (!allowed) {
     throw new Error("Not found");
   }
 }

--- a/backoffice/src/lib/gc-fitness/admin-coachless-actions.ts
+++ b/backoffice/src/lib/gc-fitness/admin-coachless-actions.ts
@@ -20,13 +20,17 @@ import { deleteClientCascade } from "@/lib/gc-fitness/admin-actions";
 import { getCurrentAdmin } from "@/lib/gc-fitness/auth-helpers";
 import { FirestoreCollections } from "@/lib/gc-fitness/collections";
 import {
+  bilingualText,
   firestoreValueToISO,
+  summarizeCoachlessActivity,
   toEntitlementInfo,
   isCoachlessClientRow,
+  type CoachlessActivitySummary,
   type CoachlessUserStats,
   type EntitlementInfo,
 } from "@/lib/gc-fitness/coachless-user-model";
 import {
+  gcFitnessAuth,
   gcFitnessFirestore,
   gcFitnessStorage,
 } from "@/lib/firebase/gc-fitness-admin";
@@ -118,6 +122,237 @@ export async function listCoachlessUsersWithStats(): Promise<CoachlessUserRow[]>
 
   rows.sort((a, b) => a.email.localeCompare(b.email));
   return rows;
+}
+
+/** One self-authored workout template (a "routine" in the client app). */
+export interface CoachlessRoutineRow {
+  id: string;
+  name: string;
+  exerciseCount: number;
+  tags: string[];
+  createdAtISO: string | null;
+  updatedAtISO: string | null;
+  deleted: boolean;
+}
+
+/** One body-weight check-in. */
+export interface CoachlessWeightRow {
+  id: string;
+  valueKg: number | null;
+  recordedAtISO: string | null;
+}
+
+/** Firebase Auth facts a Firestore doc can't answer (how they sign in, when). */
+export interface CoachlessAuthInfo {
+  providers: string[];
+  emailVerified: boolean;
+  disabled: boolean;
+  lastSignInISO: string | null;
+  creationISO: string | null;
+}
+
+export interface CoachlessUserProfile {
+  uid: string;
+  email: string;
+  displayName: string;
+  photoURL: string | null;
+  createdAtISO: string | null;
+  timezone: string | null;
+  birthDate: string | null;
+  locale: string | null;
+  entitlement: EntitlementInfo | null;
+  stats: CoachlessUserStats;
+  activity: CoachlessActivitySummary;
+  auth: CoachlessAuthInfo | null;
+  routines: CoachlessRoutineRow[];
+  recentWeights: CoachlessWeightRow[];
+}
+
+/**
+ * How many newest docs per stream we pull to compute the 7d/30d activity
+ * buckets. Generous enough that a heavy user's last 30 days always fit; the
+ * displayed TOTALS come from `.count()` aggregations, so this cap can never
+ * under-report them.
+ */
+const ACTIVITY_WINDOW_LIMIT = 400;
+
+/**
+ * Everything the god-mode profile page shows for ONE coach-less user: identity,
+ * Firebase Auth facts, subscription, content counts, an activity summary, their
+ * self-authored routines and recent body-weight entries.
+ *
+ * Admin-only, and REFUSES a target that isn't an active coach-less client — a
+ * coached client has their own drill-down under
+ * `/admin/coaches/{coachId}/clients/{uid}`, which stays the single surface for
+ * coach-owned data.
+ */
+export async function getCoachlessUserProfile(
+  uid: string,
+): Promise<CoachlessUserProfile> {
+  await getCurrentAdmin();
+  const db = gcFitnessFirestore();
+
+  const userSnap = await db.collection(FirestoreCollections.users).doc(uid).get();
+  if (!userSnap.exists) {
+    throw new Error("User not found.");
+  }
+  const d = userSnap.data() as Record<string, unknown>;
+  if (
+    !isCoachlessClientRow({
+      role: typeof d.role === "string" ? d.role : null,
+      coachId: typeof d.coachId === "string" ? d.coachId : null,
+      deleted: d.deleted === true,
+    })
+  ) {
+    throw new Error("Not a coach-less client.");
+  }
+
+  const [
+    templatesSnap,
+    habitsSnap,
+    photosSnap,
+    logsSnap,
+    habitLogsSnap,
+    weightsSnap,
+    logsCountAgg,
+    photosCountAgg,
+    authRecord,
+  ] = await Promise.all([
+    // Self-authored templates: no orderBy, so no composite index is needed and
+    // client-created docs missing `deleted` aren't filtered out (see the
+    // client-created-habits equality trap).
+    db
+      .collection(FirestoreCollections.workoutTemplates)
+      .where("trainerId", "==", uid)
+      .limit(200)
+      .get(),
+    db.collection(FirestoreCollections.habits).where("clientId", "==", uid).limit(200).get(),
+    // Bounded, newest-first windows — they feed the 7d/30d activity buckets,
+    // NOT the totals (the counts below stay exact).
+    db
+      .collection(FirestoreCollections.progressPhotos)
+      .where("clientId", "==", uid)
+      .orderBy("createdAt", "desc")
+      .limit(ACTIVITY_WINDOW_LIMIT)
+      .get(),
+    db
+      .collection(FirestoreCollections.workoutLogs)
+      .where("clientId", "==", uid)
+      .orderBy("startedAt", "desc")
+      .limit(ACTIVITY_WINDOW_LIMIT)
+      .get(),
+    db
+      .collection(FirestoreCollections.habitLogs)
+      .where("clientId", "==", uid)
+      .orderBy("civilDate", "desc")
+      .limit(ACTIVITY_WINDOW_LIMIT)
+      .get(),
+    db
+      .collection(FirestoreCollections.users)
+      .doc(uid)
+      .collection("body_weight_logs")
+      .orderBy("recordedAt", "desc")
+      .limit(50)
+      .get(),
+    db
+      .collection(FirestoreCollections.workoutLogs)
+      .where("clientId", "==", uid)
+      .count()
+      .get(),
+    db
+      .collection(FirestoreCollections.progressPhotos)
+      .where("clientId", "==", uid)
+      .count()
+      .get(),
+    // Auth is a separate service — never let its outage 500 the whole page.
+    gcFitnessAuth()
+      .getUser(uid)
+      .catch(() => null),
+  ]);
+
+  const routines: CoachlessRoutineRow[] = templatesSnap.docs
+    .map((doc) => {
+      const t = doc.data() as Record<string, unknown>;
+      const rawTags = Array.isArray(t.tags) ? t.tags : [];
+      const tags = rawTags.filter((tag): tag is string => typeof tag === "string");
+      if (tags.length === 0 && typeof t.tag === "string") tags.push(t.tag);
+      return {
+        id: doc.id,
+        name: bilingualText(t.name, "Untitled"),
+        exerciseCount: Array.isArray(t.exercises) ? t.exercises.length : 0,
+        tags,
+        createdAtISO: firestoreValueToISO(t.createdAt),
+        updatedAtISO: firestoreValueToISO(t.updatedAt),
+        deleted: t.deleted === true,
+      } satisfies CoachlessRoutineRow;
+    })
+    // Active first, then most recently touched.
+    .sort((a, b) => {
+      if (a.deleted !== b.deleted) return Number(a.deleted) - Number(b.deleted);
+      return (b.updatedAtISO ?? "").localeCompare(a.updatedAtISO ?? "");
+    });
+
+  const recentWeights: CoachlessWeightRow[] = weightsSnap.docs.map((doc) => {
+    const w = doc.data() as Record<string, unknown>;
+    return {
+      id: doc.id,
+      valueKg: typeof w.valueKg === "number" ? w.valueKg : null,
+      recordedAtISO: firestoreValueToISO(w.recordedAt),
+    } satisfies CoachlessWeightRow;
+  });
+
+  const stats: CoachlessUserStats = {
+    routines: routines.filter((r) => !r.deleted).length,
+    habits: habitsSnap.docs.filter((h) => h.get("clientOwned") === true).length,
+    progressPhotos: photosCountAgg.data().count,
+    workoutLogs: logsCountAgg.data().count,
+  };
+
+  const activity = summarizeCoachlessActivity({
+    nowMs: Date.now(),
+    workoutDates: logsSnap.docs.map((doc) =>
+      firestoreValueToISO(doc.get("startedAt") ?? doc.get("createdAt")),
+    ),
+    // Only completed check-ins count as activity (habits are binary-only).
+    habitLogDates: habitLogsSnap.docs
+      .filter((doc) => doc.get("deleted") !== true && doc.get("value") === true)
+      .map((doc) =>
+        typeof doc.get("civilDate") === "string"
+          ? (doc.get("civilDate") as string)
+          : firestoreValueToISO(doc.get("loggedAt")),
+      ),
+    photoDates: photosSnap.docs.map((doc) => firestoreValueToISO(doc.get("createdAt"))),
+    weightDates: recentWeights.map((w) => w.recordedAtISO),
+  });
+
+  return {
+    uid,
+    email: typeof d.email === "string" ? d.email : "",
+    displayName: typeof d.displayName === "string" ? d.displayName : "",
+    photoURL: typeof d.photoURL === "string" ? d.photoURL : null,
+    createdAtISO: firestoreValueToISO(d.createdAt),
+    timezone: typeof d.timezone === "string" ? d.timezone : null,
+    birthDate: typeof d.birthDate === "string" ? d.birthDate : null,
+    locale: typeof d.locale === "string" ? d.locale : null,
+    entitlement: toEntitlementInfo(d.entitlement),
+    stats,
+    activity,
+    auth: authRecord
+      ? {
+          providers: authRecord.providerData.map((p) => p.providerId),
+          emailVerified: authRecord.emailVerified,
+          disabled: authRecord.disabled,
+          lastSignInISO: authRecord.metadata.lastSignInTime
+            ? new Date(authRecord.metadata.lastSignInTime).toISOString()
+            : null,
+          creationISO: authRecord.metadata.creationTime
+            ? new Date(authRecord.metadata.creationTime).toISOString()
+            : null,
+        }
+      : null,
+    routines,
+    recentWeights,
+  } satisfies CoachlessUserProfile;
 }
 
 const setEntitlementSchema = z.object({

--- a/backoffice/src/lib/gc-fitness/coachless-user-model.ts
+++ b/backoffice/src/lib/gc-fitness/coachless-user-model.ts
@@ -101,3 +101,133 @@ export function isCoachlessClientRow(args: {
   const noCoach = !args.coachId || args.coachId.trim().length === 0;
   return isClient && noCoach && !args.deleted;
 }
+
+/**
+ * The widened admin drill-down gate.
+ *
+ * The god-mode client views live under `/admin/coaches/{coachUid}/clients/{clientId}`
+ * and are gated on `clientCoachId === coachUidInPath` so a URL edit can't read
+ * across coaches. A COACH-LESS user has no `coachId` at all, so that equality
+ * locks the operator out of the exact segment that most needs watching.
+ *
+ * Convention (mirrors the `#392 selfAssigned` wire shape already in the data —
+ * self-created templates / assignments / logs carry `trainerId === clientId`):
+ * **a coach-less user is their own trainer-of-record.** So the path uid may
+ * equal the client uid, but ONLY when the target really is an active coach-less
+ * client. Every other combination stays denied.
+ */
+export function adminCanViewClientUnderCoach(args: {
+  /** The coach uid taken from the URL. */
+  coachUidInPath: string;
+  clientId: string;
+  /** `/users/{clientId}.coachId` — null/empty for a coach-less user. */
+  clientCoachId: string | null;
+  clientRole: string | null;
+  clientDeleted: boolean;
+}): boolean {
+  const { coachUidInPath, clientId, clientCoachId } = args;
+  if (!coachUidInPath || !clientId) return false;
+  if (clientCoachId && clientCoachId === coachUidInPath) return true;
+  return (
+    coachUidInPath === clientId &&
+    isCoachlessClientRow({
+      role: args.clientRole,
+      coachId: clientCoachId,
+      deleted: args.clientDeleted,
+    })
+  );
+}
+
+/** Per-category recency + rolling-window counts for the profile page. */
+export interface CoachlessActivitySummary {
+  /** Most recent activity of ANY kind, ISO — null when the user never acted. */
+  lastActiveISO: string | null;
+  workouts: ActivityWindow;
+  habitCheckIns: ActivityWindow;
+  photos: ActivityWindow;
+  weightEntries: ActivityWindow;
+}
+
+export interface ActivityWindow {
+  last7Days: number;
+  last30Days: number;
+  total: number;
+  lastISO: string | null;
+}
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+function windowFor(dates: Array<string | null | undefined>, nowMs: number): ActivityWindow {
+  const times = dates
+    .map((iso) => (typeof iso === "string" ? Date.parse(iso) : NaN))
+    .filter((ms) => Number.isFinite(ms)) as number[];
+  const newest = times.length > 0 ? Math.max(...times) : null;
+  return {
+    // A future-dated entry (clock skew / manual backfill) still counts as
+    // "within the last N days" — clamping it out would hide real activity.
+    last7Days: times.filter((ms) => ms >= nowMs - 7 * DAY_MS).length,
+    last30Days: times.filter((ms) => ms >= nowMs - 30 * DAY_MS).length,
+    total: times.length,
+    lastISO: newest === null ? null : new Date(newest).toISOString(),
+  };
+}
+
+/**
+ * Fold the four activity streams into per-category windows + an overall
+ * "last active". Inputs are ISO strings (habit check-ins may be civil dates
+ * like "2026-07-24", which `Date.parse` reads as UTC midnight — good enough
+ * for a 7/30-day bucket).
+ */
+export function summarizeCoachlessActivity(args: {
+  nowMs: number;
+  workoutDates: Array<string | null | undefined>;
+  habitLogDates: Array<string | null | undefined>;
+  photoDates: Array<string | null | undefined>;
+  weightDates: Array<string | null | undefined>;
+}): CoachlessActivitySummary {
+  const workouts = windowFor(args.workoutDates, args.nowMs);
+  const habitCheckIns = windowFor(args.habitLogDates, args.nowMs);
+  const photos = windowFor(args.photoDates, args.nowMs);
+  const weightEntries = windowFor(args.weightDates, args.nowMs);
+
+  const lastTimes = [workouts, habitCheckIns, photos, weightEntries]
+    .map((w) => (w.lastISO ? Date.parse(w.lastISO) : NaN))
+    .filter((ms) => Number.isFinite(ms)) as number[];
+
+  return {
+    lastActiveISO:
+      lastTimes.length > 0 ? new Date(Math.max(...lastTimes)).toISOString() : null,
+    workouts,
+    habitCheckIns,
+    photos,
+    weightEntries,
+  };
+}
+
+/**
+ * Resolve a bilingual `{ en, es }` wire value (or a bare legacy string) to
+ * display text, preferring Spanish — the backoffice's primary voice. Same
+ * precedence as `listClientHabitsForAdmin` / the assignment title resolver.
+ */
+export function bilingualText(value: unknown, fallback: string): string {
+  if (typeof value === "string" && value.trim().length > 0) return value;
+  if (value && typeof value === "object") {
+    const v = value as { en?: unknown; es?: unknown };
+    const es = typeof v.es === "string" ? v.es.trim() : "";
+    const en = typeof v.en === "string" ? v.en.trim() : "";
+    if (es) return es;
+    if (en) return en;
+  }
+  return fallback;
+}
+
+/**
+ * Whole days between an ISO instant and `nowMs` (floored, never negative).
+ * Null when the input is unparseable — callers render an em dash.
+ */
+export function daysSince(iso: string | null, nowMs: number): number | null {
+  if (!iso) return null;
+  const ms = Date.parse(iso);
+  if (!Number.isFinite(ms)) return null;
+  return Math.max(0, Math.floor((nowMs - ms) / DAY_MS));
+}

--- a/backoffice/src/lib/gc-fitness/progress-photo-actions.ts
+++ b/backoffice/src/lib/gc-fitness/progress-photo-actions.ts
@@ -3,6 +3,7 @@
 import { gcFitnessFirestore, gcFitnessStorage } from "@/lib/firebase/gc-fitness-admin";
 
 import { getCurrentAdmin, getCurrentTrainer } from "./auth-helpers";
+import { adminCanViewClientUnderCoach } from "./coachless-user-model";
 import { FirestoreCollections } from "./collections";
 
 export interface ProgressPhotoRow {
@@ -97,15 +98,33 @@ export async function listProgressPhotosForClient(
 
 /**
  * Admin god-mode (read-only): a client's progress photos, verifying the client
- * belongs to `coachId` (reusing `assertOwnsClient`, which checks
- * `client.coachId === coachId`) so the route can't read across coaches.
+ * belongs to `coachId` so the route can't read across coaches. Uses the WIDER
+ * `adminCanViewClientUnderCoach` gate rather than the trainer-path
+ * `assertOwnsClient`, so a coach-less user (their own trainer-of-record —
+ * `coachId === clientId`) is admitted too. The trainer path above keeps the
+ * strict `coachId` equality.
  */
 export async function listProgressPhotosForClientAsAdmin(
   coachId: string,
   clientId: string,
 ): Promise<ProgressPhotoRow[]> {
   await getCurrentAdmin();
-  await assertOwnsClient(coachId, clientId);
+  const snap = await gcFitnessFirestore()
+    .collection(FirestoreCollections.users)
+    .doc(clientId)
+    .get();
+  const allowed =
+    snap.exists &&
+    adminCanViewClientUnderCoach({
+      coachUidInPath: coachId,
+      clientId,
+      clientCoachId: typeof snap.get("coachId") === "string" ? snap.get("coachId") : null,
+      clientRole: typeof snap.get("role") === "string" ? snap.get("role") : null,
+      clientDeleted: snap.get("deleted") === true,
+    });
+  if (!allowed) {
+    throw new Error("Forbidden");
+  }
   return loadProgressPhotos(clientId);
 }
 

--- a/backoffice/src/lib/gc-fitness/recent-logs-actions.ts
+++ b/backoffice/src/lib/gc-fitness/recent-logs-actions.ts
@@ -7,6 +7,10 @@ import { gcFitnessFirestore } from "@/lib/firebase/gc-fitness-admin";
 import { getCurrentAdmin, getCurrentTrainer } from "./auth-helpers";
 import { civilDateFormat, civilDateToday } from "./civil-date";
 import { coerceLegacyHabitLogValue } from "./habit-compliance";
+import {
+  adminCanViewClientUnderCoach,
+  isCoachlessClientRow,
+} from "./coachless-user-model";
 import { FirestoreCollections } from "./collections";
 import {
   listClients,
@@ -1463,9 +1467,12 @@ async function buildRecentLogs(params: {
  * null when the doc is missing. `coachId` is returned alongside so callers can
  * authorize (trainer ownership / admin coach-match) without a second read.
  */
-async function loadClientRosterEntry(
-  clientId: string,
-): Promise<{ entry: ClientRosterEntry; coachId: string | null } | null> {
+async function loadClientRosterEntry(clientId: string): Promise<{
+  entry: ClientRosterEntry;
+  coachId: string | null;
+  role: string | null;
+  deleted: boolean;
+} | null> {
   const snap = await gcFitnessFirestore()
     .collection(FirestoreCollections.users)
     .doc(clientId)
@@ -1500,6 +1507,8 @@ async function loadClientRosterEntry(
       autoAssignedCoach: data.autoAssignedCoach === true,
     },
     coachId,
+    role: typeof data.role === "string" ? data.role : null,
+    deleted: data.deleted === true,
   };
 }
 
@@ -1611,6 +1620,11 @@ export async function listRecentLogsForClient(
  * Admin god-mode (read-only): recent activity for ONE client of a SPECIFIC
  * coach. Verifies the client really belongs to `coachId` so the URL can't be
  * edited to read a client outside the coach being inspected.
+ *
+ * Coach-less users are admitted via `coachId === clientId` (they are their own
+ * trainer-of-record — see `adminCanViewClientUnderCoach`). That sentinel is
+ * also the CORRECT `trainerId` to scan by: their self-created content carries
+ * `trainerId === clientId` (#392 selfAssigned).
  */
 export async function listRecentLogsForClientAsAdmin(
   coachId: string,
@@ -1620,10 +1634,24 @@ export async function listRecentLogsForClientAsAdmin(
 ): Promise<RecentLogsResult> {
   await getCurrentAdmin();
   const loaded = await loadClientRosterEntry(clientId);
-  if (!loaded || loaded.coachId !== coachId) {
+  if (
+    !loaded ||
+    !adminCanViewClientUnderCoach({
+      coachUidInPath: coachId,
+      clientId,
+      clientCoachId: loaded.coachId,
+      clientRole: loaded.role,
+      clientDeleted: loaded.deleted,
+    })
+  ) {
     throw new Error("Not found");
   }
-  const timezone = await getTrainerTimezone();
+  // A coach-less user has no coach whose cookie tz we could borrow, so their
+  // own profile timezone drives the civil-date bucketing; the admin cookie tz
+  // is the fallback for the coached path (unchanged).
+  const timezone = loaded.coachId
+    ? await getTrainerTimezone()
+    : (loaded.entry.timezone ?? (await getTrainerTimezone()));
   return buildRecentLogs({
     trainerId: coachId,
     clients: [loaded.entry],
@@ -1704,11 +1732,33 @@ export async function getWorkoutLogDetailAsAdmin(
   }
 
   const data = logSnap.data() as Record<string, unknown>;
-  if (!(await coachCanAccessLog(db, coachId, data))) {
+  // Self-created logs of a coach-less user already pass via `trainerId ===
+  // coachId` (they are their own trainer-of-record). The extra branch covers
+  // logs written while the user still HAD a coach, which would otherwise 404
+  // from their coach-less profile — admin-only, and only for a uid that is
+  // both the path uid and an active coach-less client.
+  const accessible =
+    (await coachCanAccessLog(db, coachId, data)) ||
+    (data.clientId === coachId && (await isActiveCoachlessClient(db, coachId)));
+  if (!accessible) {
     throw new Error("Workout log not found.");
   }
 
   return buildWorkoutLogDetail(db, coachId, logSnap.id, data);
+}
+
+/** True when `/users/{uid}` is an active client with no coach. */
+async function isActiveCoachlessClient(
+  db: FirebaseFirestore.Firestore,
+  uid: string,
+): Promise<boolean> {
+  const snap = await db.collection(FirestoreCollections.users).doc(uid).get();
+  if (!snap.exists) return false;
+  return isCoachlessClientRow({
+    role: typeof snap.get("role") === "string" ? snap.get("role") : null,
+    coachId: typeof snap.get("coachId") === "string" ? snap.get("coachId") : null,
+    deleted: snap.get("deleted") === true,
+  });
 }
 
 /**


### PR DESCRIPTION
## Why

In the coach-less god-mode list, every row is a dead end — an operator sees
"2 routines, 3 habits" and can't open anything. Coached clients already have a
drill-down (`/admin/coaches/{coachId}/clients/{clientId}`); `admin/users` even
documents the gap in a comment:

> `else (admin-only, or a client with no coach) → no dedicated page`

So the one segment with nobody watching it was the only one we couldn't inspect.

## What

New route **`/gc-fitness/admin/coach-less-users/[uid]`**, linked from each row's name:

- **Stat tiles** — last active, workouts (30 d), habit check-ins (30 d), routines, habits, photos
- **Account** — signed up, last sign-in, sign-in providers, email verified, disabled, timezone, birth date (Firebase **Auth** facts no Firestore doc can answer)
- **Subscription** — tier / source / productId / expires / updated, plus the two god-mode mutations moved onto the profile (delete redirects back to the list)
- **Activity** — per-stream last / 7 d / 30 d / total across workouts, habit check-ins, photos, body weight
- **Routines**, **Habits**, **Scheduled workouts** (recurring series collapsed), **Recent activity** feed (rows link into the admin workout-log detail + photo comparator), **Body-weight chart**, **Photo grid**

## Key decision — self-as-coach, not a parallel stack

All the coached loaders gate on `client.coachId === coachUidInPath`, which a
coach-less user can never satisfy. Instead of duplicating those queries the gate
was widened around one idea:

> **A coach-less user is their own trainer-of-record.**

That's not new — it's the `#392 selfAssigned` wire shape already in the data
(`trainerId === clientId` on self-created templates / assignments / logs). The
pure predicate `adminCanViewClientUnderCoach` admits `coachUidInPath === clientId`
**only** for an active coach-less client. Cross-coach URL edits and self-as-coach
on a *coached* client stay denied — both covered by tests.

Payoff: passing `uid` as both ids reuses the feed, workout-log detail route,
photo comparator, assignments and habits with no new plumbing — and the sentinel
is simultaneously the *correct* `trainerId` to scan by.

Trainer-facing gates are untouched: `progress-photo-actions` keeps the strict
`assertOwnsClient` on the trainer path and only the admin path widens.

## Gotchas honored

- **No `deleted` equality filter** on templates/habits — client-created docs omit the field, and `where("deleted","==",false)` would hide exactly the content this page exists to show.
- **No new composite index** — every query maps to an existing one (`clientId+startedAt`, `clientId+civilDate`, `clientId+createdAt`, `clientId+scheduledFor`); template/habit reads are unordered.
- **Totals come from `.count()`** so the 400-doc activity windows can't under-report them.
- **Auth lookup is `.catch(() => null)`** — an Auth outage degrades one card instead of 500-ing the page.

## Testing

- `npx jest` (backoffice): **941 passed**; the 1 failure is the known `client-activity-time` locale flake (pre-existing locally, green in CI).
- `npx next build`: clean, both routes registered.
- Dev-server smoke: unauthenticated GET → 307 `/gc-fitness/login`, no runtime errors.
- **Not verified locally:** the authenticated render (needs an admin session against prod Firebase).