### PR TITLE
feat(gc-fitness/admin): assign a coach / remove as client (coach-less ⇄ coached)

### DIFF
--- a/backoffice/src/app/gc-fitness/admin/_components/admin-submit-button.tsx
+++ b/backoffice/src/app/gc-fitness/admin/_components/admin-submit-button.tsx
@@ -9,6 +9,7 @@ export function AdminSubmitButton({
   disabled = false,
   name,
   value,
+  title,
 }: {
   idleLabel: string;
   pendingLabel: string;
@@ -16,6 +17,8 @@ export function AdminSubmitButton({
   disabled?: boolean;
   name?: string;
   value?: string;
+  /** Native tooltip — for actions whose label can't carry the full consequence. */
+  title?: string;
 }) {
   const { pending } = useFormStatus();
   return (
@@ -23,6 +26,7 @@ export function AdminSubmitButton({
       type="submit"
       name={name}
       value={value}
+      title={title}
       disabled={pending || disabled}
       className={`${className} disabled:cursor-not-allowed disabled:opacity-60`}
     >

--- a/backoffice/src/app/gc-fitness/admin/coach-less-users/[uid]/page.tsx
+++ b/backoffice/src/app/gc-fitness/admin/coach-less-users/[uid]/page.tsx
@@ -45,6 +45,8 @@ import { sectionMetadata } from "@/lib/gc-fitness/page-metadata";
 import {
   listClientAssignmentsForAdmin,
   listClientHabitsForAdmin,
+  listCoachOptionsForAdmin,
+  transferClientToCoach,
 } from "@/lib/gc-fitness/admin-actions";
 import {
   deleteCoachlessUser,
@@ -159,11 +161,12 @@ export default async function CoachlessUserDetailPage({
 
   // Every widget below is scoped by BOTH ids; for a coach-less user the coach
   // uid IS their own uid (see the header comment).
-  const [logs, photos, assignments, habits] = await Promise.all([
+  const [logs, photos, assignments, habits, coaches] = await Promise.all([
     listRecentLogsForClientAsAdmin(uid, uid).catch(() => null),
     listProgressPhotosForClientAsAdmin(uid, uid).catch(() => []),
     listClientAssignmentsForAdmin(uid, uid).catch(() => []),
     listClientHabitsForAdmin(uid, uid).catch(() => []),
+    listCoachOptionsForAdmin().catch(() => []),
   ]);
 
   const nowMs = Date.now();
@@ -171,6 +174,20 @@ export default async function CoachlessUserDetailPage({
   const isPremium = tier === "premium";
   const timezone = profile.timezone ?? "UTC";
   const displayName = profile.displayName || profile.email || uid;
+
+  // Assigning a coach IS a transfer — from no coach to one. Reuses the tested
+  // `transferClientToCoach` (doc re-point + chat move + coachId claim resync)
+  // rather than adding a second write path. Afterwards this profile 404s (the
+  // user is no longer coach-less), so land on their coached drill-down instead.
+  async function assignCoachAction(formData: FormData) {
+    "use server";
+    const clientUid = String(formData.get("uid") ?? "");
+    const newCoachUid = String(formData.get("newCoachUid") ?? "");
+    await transferClientToCoach({ clientUid, newCoachUid });
+    revalidatePath(LIST_ROUTE);
+    revalidatePath(`/gc-fitness/admin/coaches/${newCoachUid}`);
+    redirect(`/gc-fitness/admin/coaches/${newCoachUid}/clients/${clientUid}`);
+  }
 
   async function setTierAction(formData: FormData) {
     "use server";
@@ -282,6 +299,48 @@ export default async function CoachlessUserDetailPage({
                 </Field>
               ) : null}
             </dl>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader className="pb-3">
+            <CardTitle className="text-xl">Coach</CardTitle>
+          </CardHeader>
+          <CardContent className="flex flex-col gap-3">
+            <p className="text-sm text-muted-foreground">
+              This user is self-serve — nobody is coaching them. Assigning a coach
+              links them to that coach&apos;s roster, moves their chat thread, and
+              makes them premium for as long as the link lasts. All their existing
+              routines, habits and logs are kept.
+            </p>
+            {coaches.length === 0 ? (
+              <p className="text-sm text-muted-foreground">No coaches available.</p>
+            ) : (
+              <form action={assignCoachAction} className="flex flex-wrap items-center gap-2">
+                <input type="hidden" name="uid" value={uid} />
+                <select
+                  name="newCoachUid"
+                  required
+                  defaultValue=""
+                  aria-label="Assign a coach to this user"
+                  className="h-8 max-w-[16rem] rounded-md border bg-background px-2 text-xs"
+                >
+                  <option value="" disabled>
+                    Choose a coach…
+                  </option>
+                  {coaches.map((coach) => (
+                    <option key={coach.uid} value={coach.uid}>
+                      {coach.displayName || coach.email}
+                    </option>
+                  ))}
+                </select>
+                <AdminSubmitButton
+                  idleLabel="Assign coach"
+                  pendingLabel="Assigning…"
+                  className="h-8 rounded-full border px-3 text-xs hover:bg-muted"
+                />
+              </form>
+            )}
           </CardContent>
         </Card>
 

--- a/backoffice/src/app/gc-fitness/admin/coach-less-users/page.tsx
+++ b/backoffice/src/app/gc-fitness/admin/coach-less-users/page.tsx
@@ -16,6 +16,10 @@ import {
   TableRow,
 } from "@/components/ui/table";
 import { getCurrentAdmin } from "@/lib/gc-fitness/auth-helpers";
+import {
+  listCoachOptionsForAdmin,
+  transferClientToCoach,
+} from "@/lib/gc-fitness/admin-actions";
 import { sectionMetadata } from "@/lib/gc-fitness/page-metadata";
 import {
   listCoachlessUsersWithStats,
@@ -55,7 +59,23 @@ export default async function CoachlessUsersPage({
   const ok = sp.ok === "1";
   const actionMessage = op && ok ? `Action completed: ${op}.` : null;
 
-  const rows = await listCoachlessUsersWithStats();
+  const [rows, coaches] = await Promise.all([
+    listCoachlessUsersWithStats(),
+    listCoachOptionsForAdmin(),
+  ]);
+
+  // Assigning a coach IS a transfer — from no coach to one. `transferClientToCoach`
+  // already handles the null-coach origin (re-points the doc, moves the chat if
+  // one exists, resyncs the coachId custom claim), so there's no second code path.
+  async function assignCoachAction(formData: FormData) {
+    "use server";
+    const clientUid = String(formData.get("uid") ?? "");
+    const newCoachUid = String(formData.get("newCoachUid") ?? "");
+    await transferClientToCoach({ clientUid, newCoachUid });
+    revalidatePath(ROUTE);
+    revalidatePath(`/gc-fitness/admin/coaches/${newCoachUid}`);
+    redirect(`${ROUTE}?op=assign_coach&ok=1`);
+  }
 
   async function setTierAction(formData: FormData) {
     "use server";
@@ -181,6 +201,34 @@ export default async function CoachlessUsersPage({
                     </TableCell>
                     <TableCell className="text-right">
                       <div className="flex flex-col items-end gap-2">
+                        {coaches.length > 0 ? (
+                          <form action={assignCoachAction} className="flex items-center gap-1">
+                            <input type="hidden" name="uid" value={row.uid} />
+                            <select
+                              name="newCoachUid"
+                              required
+                              defaultValue=""
+                              aria-label={`Assign ${row.displayName || row.email} to a coach`}
+                              className="h-8 max-w-[11rem] rounded-md border bg-background px-2 text-xs"
+                            >
+                              <option value="" disabled>
+                                Assign coach…
+                              </option>
+                              {coaches.map((coach) => (
+                                <option key={coach.uid} value={coach.uid}>
+                                  {coach.displayName || coach.email}
+                                </option>
+                              ))}
+                            </select>
+                            <AdminSubmitButton
+                              idleLabel="Assign"
+                              pendingLabel="Assigning…"
+                              title="Links this user to the coach — they stop being coach-less and gain coached premium"
+                              className="h-8 rounded-full border px-3 text-xs hover:bg-muted"
+                            />
+                          </form>
+                        ) : null}
+
                         <form action={setTierAction}>
                           <input type="hidden" name="uid" value={row.uid} />
                           <input type="hidden" name="tier" value={isPremium ? "free" : "premium"} />

--- a/backoffice/src/app/gc-fitness/admin/coaches/[uid]/page.tsx
+++ b/backoffice/src/app/gc-fitness/admin/coaches/[uid]/page.tsx
@@ -26,6 +26,7 @@ import {
   previewClientCascade,
   removePendingClientForCoach,
   transferClientToCoach,
+  unlinkClientFromCoach,
 } from "@/lib/gc-fitness/admin-actions";
 import { AdminSubmitButton } from "../../_components/admin-submit-button";
 import { sectionMetadata } from "@/lib/gc-fitness/page-metadata";
@@ -93,6 +94,16 @@ export default async function CoachAdminDetailPage({
     await transferClientToCoach({ clientUid, newCoachUid });
     revalidatePath(`/gc-fitness/admin/coaches/${coachUid}`);
     redirect(`/gc-fitness/admin/coaches/${coachUid}?op=transfer_client&ok=1`);
+  }
+
+  async function unlinkClientAction(formData: FormData) {
+    "use server";
+    const coachUid = String(formData.get("coachUid") ?? "");
+    const clientUid = String(formData.get("clientUid") ?? "");
+    await unlinkClientFromCoach({ coachUid, clientUid });
+    revalidatePath(`/gc-fitness/admin/coaches/${coachUid}`);
+    revalidatePath("/gc-fitness/admin/coach-less-users");
+    redirect(`/gc-fitness/admin/coaches/${coachUid}?op=unlink_client&ok=1`);
   }
 
   async function removePendingAction(formData: FormData) {
@@ -218,6 +229,19 @@ export default async function CoachAdminDetailPage({
                               />
                             </form>
                           ) : null}
+                          {/* Ends the coaching relationship WITHOUT deleting
+                              anything: the person keeps their data and shows up
+                              under Admin → Coach-less users. */}
+                          <form action={unlinkClientAction}>
+                            <input type="hidden" name="coachUid" value={detail.coach.uid} />
+                            <input type="hidden" name="clientUid" value={client.uid} />
+                            <AdminSubmitButton
+                              idleLabel="Remove as client"
+                              pendingLabel="Removing..."
+                              title="Unlink from this coach — the user becomes coach-less and keeps all their data"
+                              className="inline-flex h-8 items-center rounded-md border px-3 text-xs font-medium hover:bg-muted"
+                            />
+                          </form>
                           {!client.deleted ? (
                             <form action={deactivateClientAction}>
                               <input type="hidden" name="coachUid" value={detail.coach.uid} />

--- a/backoffice/src/lib/gc-fitness/__tests__/coachless-user-model.test.ts
+++ b/backoffice/src/lib/gc-fitness/__tests__/coachless-user-model.test.ts
@@ -10,6 +10,7 @@ import {
   toEntitlementInfo,
   isCoachlessClientRow,
   adminCanViewClientUnderCoach,
+  canUnlinkClientFromCoach,
   summarizeCoachlessActivity,
   bilingualText,
   daysSince,
@@ -178,6 +179,60 @@ describe("adminCanViewClientUnderCoach", () => {
   it("denies empty uids", () => {
     expect(adminCanViewClientUnderCoach({ ...coached, coachUidInPath: "" })).toBe(false);
     expect(adminCanViewClientUnderCoach({ ...coached, clientId: "" })).toBe(false);
+  });
+});
+
+describe("canUnlinkClientFromCoach", () => {
+  it("allows detaching a client from the coach that owns them", () => {
+    expect(
+      canUnlinkClientFromCoach({
+        coachUidInPath: "coach123",
+        clientRole: "client",
+        clientCoachId: "coach123",
+      }),
+    ).toBe(true);
+  });
+
+  it("allows it for a soft-deleted client too", () => {
+    // `deleted` is deliberately not an input — stripping the coach link off a
+    // deactivated client is harmless and sometimes wanted.
+    expect(
+      canUnlinkClientFromCoach({
+        coachUidInPath: "coach123",
+        clientRole: "client",
+        clientCoachId: "coach123",
+      }),
+    ).toBe(true);
+  });
+
+  it("denies detaching from a coach who does not own the client", () => {
+    expect(
+      canUnlinkClientFromCoach({
+        coachUidInPath: "otherCoach",
+        clientRole: "client",
+        clientCoachId: "coach123",
+      }),
+    ).toBe(false);
+  });
+
+  it("denies an already coach-less client (nothing to unlink)", () => {
+    expect(
+      canUnlinkClientFromCoach({
+        coachUidInPath: "coach123",
+        clientRole: "client",
+        clientCoachId: null,
+      }),
+    ).toBe(false);
+  });
+
+  it("denies unlinking a trainer", () => {
+    expect(
+      canUnlinkClientFromCoach({
+        coachUidInPath: "coach123",
+        clientRole: "trainer",
+        clientCoachId: "coach123",
+      }),
+    ).toBe(false);
   });
 });
 

--- a/backoffice/src/lib/gc-fitness/admin-actions.ts
+++ b/backoffice/src/lib/gc-fitness/admin-actions.ts
@@ -10,6 +10,7 @@ import { FirestoreCollections } from "@/lib/gc-fitness/collections";
 import { recurrenceLabel } from "@/lib/gc-fitness/coach-activity-log";
 import {
   adminCanViewClientUnderCoach,
+  canUnlinkClientFromCoach,
   toEntitlementInfo,
   type EntitlementInfo,
 } from "@/lib/gc-fitness/coachless-user-model";
@@ -174,6 +175,43 @@ export async function listCoachesForAdmin(): Promise<CoachAdminRow[]> {
 
   rows.sort((a, b) => a.email.localeCompare(b.email));
   return rows;
+}
+
+/** Minimal coach identity — just enough to fill an assignment `<select>`. */
+export interface CoachOption {
+  uid: string;
+  email: string;
+  displayName: string;
+}
+
+/**
+ * Coaches as pick-list options. Deliberately NOT `listCoachesForAdmin`, which
+ * fans out four reads per coach (client roster + two counts + an Auth lookup)
+ * to build the admin dashboard — far too much work to populate a dropdown.
+ * One projected query, no fan-out.
+ *
+ * `deleted` is filtered in memory rather than via `where("deleted","==",false)`:
+ * an equality filter silently drops docs that never got the field, and a coach
+ * missing from the assignment list is worse than one extra row.
+ */
+export async function listCoachOptionsForAdmin(): Promise<CoachOption[]> {
+  await getCurrentAdmin();
+  const snap = await gcFitnessFirestore()
+    .collection(FirestoreCollections.users)
+    .where("role", "==", "trainer")
+    .select("email", "displayName", "deleted")
+    .get();
+
+  return snap.docs
+    .filter((doc) => doc.get("deleted") !== true)
+    .map((doc) => ({
+      uid: doc.id,
+      email: (doc.get("email") as string | undefined) ?? "",
+      displayName: (doc.get("displayName") as string | undefined) ?? "",
+    }))
+    .sort((a, b) =>
+      (a.displayName || a.email).localeCompare(b.displayName || b.email),
+    );
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -723,7 +761,11 @@ export async function promoteUserToAdmin(input: unknown): Promise<{ ok: true; ui
 
 async function writeAdminOperationLog(args: {
   actorUid: string;
-  kind: "delete_client_cascade" | "delete_coach_cascade" | "transfer_client";
+  kind:
+    | "delete_client_cascade"
+    | "delete_coach_cascade"
+    | "transfer_client"
+    | "unlink_client";
   mode: OperationMode;
   targetUid: string;
   status: "success" | "failed";
@@ -1406,6 +1448,101 @@ export async function transferClientToCoach(
   });
 
   return { ok: true, clientUid: parsed.clientUid, newCoachUid: parsed.newCoachUid };
+}
+
+const unlinkClientSchema = z.object({
+  coachUid: z.string().trim().min(6).max(128),
+  clientUid: z.string().trim().min(6).max(128),
+});
+
+/**
+ * Detach a client from their coach, turning them into a COACH-LESS (self-serve)
+ * user — the inverse of `transferClientToCoach`, and the thing an operator needs
+ * when a coaching relationship ends but the person keeps using the app.
+ *
+ * Clears the link + denormalized coach fields on the canonical client doc and
+ * resyncs the custom claim (firestore.rules compare `request.auth.token.coachId`).
+ *
+ * The 1:1 chat doc is KEPT but has its `coachId` cleared: that removes the
+ * thread from the ex-coach's inbox query (`coachId == me`) AND fails
+ * `isChatParticipant` for them, without destroying the client's message history
+ * — a later `transferClientToCoach` re-points the same doc and the history comes
+ * back. (`deleteClientCascade` is the only path that recursively deletes chats.)
+ *
+ * Like a transfer, content the old coach authored (workout_assignments / habits
+ * carrying their trainerId) is intentionally left in place — the user keeps
+ * their program. Note the user drops to their own entitlement tier once
+ * unlinked: coached ⇒ premium no longer applies, so a client with no
+ * subscription becomes free.
+ */
+export async function unlinkClientFromCoach(
+  input: unknown,
+): Promise<{ ok: true; clientUid: string }> {
+  const admin = await getCurrentAdmin();
+  const parsed = unlinkClientSchema.parse(input);
+  const db = gcFitnessFirestore();
+
+  const clientRef = db.collection(FirestoreCollections.users).doc(parsed.clientUid);
+  const clientSnap = await clientRef.get();
+  if (!clientSnap.exists) {
+    throw new Error("Client not found.");
+  }
+  if (
+    !canUnlinkClientFromCoach({
+      coachUidInPath: parsed.coachUid,
+      clientRole: (clientSnap.get("role") as string | undefined) ?? null,
+      clientCoachId: (clientSnap.get("coachId") as string | undefined) ?? null,
+    })
+  ) {
+    throw new Error("Client is not linked to this coach.");
+  }
+
+  const chatRef = db.collection(FirestoreCollections.chats).doc(parsed.clientUid);
+  const chatSnap = await chatRef.get();
+
+  const batch = db.batch();
+  batch.update(clientRef, {
+    coachId: FieldValue.delete(),
+    coachDisplayName: FieldValue.delete(),
+    coachPhotoURL: FieldValue.delete(),
+    // The "auto-assigned, needs triage" marker is meaningless with no coach.
+    autoAssignedCoach: FieldValue.delete(),
+    updatedAt: FieldValue.serverTimestamp(),
+  });
+  if (chatSnap.exists) {
+    batch.update(chatRef, {
+      coachId: FieldValue.delete(),
+      updatedAt: FieldValue.serverTimestamp(),
+    });
+  }
+  await batch.commit();
+
+  // Fail-soft, same as the transfer path: the Firestore doc is the source of
+  // truth and the claim catches up on the next token refresh.
+  try {
+    const authUser = await gcFitnessAuth().getUser(parsed.clientUid);
+    const { coachId: _dropped, ...rest } = (authUser.customClaims ?? {}) as Record<
+      string,
+      unknown
+    >;
+    await gcFitnessAuth().setCustomUserClaims(parsed.clientUid, {
+      ...rest,
+      role: "client",
+    });
+  } catch {
+    // fail-soft
+  }
+
+  await writeAdminOperationLog({
+    actorUid: admin.uid,
+    kind: "unlink_client",
+    mode: "execute",
+    targetUid: parsed.clientUid,
+    status: "success",
+    summary: { action: "unlink_client", fromCoachId: parsed.coachUid },
+  });
+
+  return { ok: true, clientUid: parsed.clientUid };
 }
 
 const removePendingSchema = z.object({

--- a/backoffice/src/lib/gc-fitness/audit-actions.ts
+++ b/backoffice/src/lib/gc-fitness/audit-actions.ts
@@ -169,8 +169,21 @@ function deletedTitle(title: string): string {
     .replace("Hábito asignado:", "Hábito eliminado:");
 }
 
+/**
+ * Admin operations that CHANGE something rather than remove it. Everything else
+ * logged to `admin_operations` deletes data, which is what drives the audit
+ * dashboard's "deletion" styling + filter.
+ */
+const NON_DELETION_ADMIN_KINDS = new Set([
+  "transfer_client",
+  "unlink_client",
+  "set_entitlement",
+]);
+
 function adminOperationTitle(kind: string, summaryAction: string | null): string {
   if (kind === "transfer_client") return "Transferred client";
+  if (kind === "unlink_client") return "Unlinked client from coach";
+  if (kind === "set_entitlement") return "Changed subscription tier";
   if (kind === "delete_coach_cascade") return "Deleted coach (cascade)";
   if (kind === "delete_client_cascade") {
     if (summaryAction === "deactivate_client") return "Deactivated client";
@@ -551,13 +564,14 @@ async function collectAuditEntries(
       actorEmail: actor?.email ?? null,
       actorRole: "admin",
       kind: r.kind,
-      action: r.kind === "transfer_client" ? "update" : "delete",
+      action: NON_DELETION_ADMIN_KINDS.has(r.kind) ? "update" : "delete",
       title: r.title,
       detail: r.detail,
       clientId: r.targetUid,
       clientLabel: targetUser?.email ?? null,
-      // A transfer is not a deletion; everything else logged here removes data.
-      isDeletion: r.kind !== "transfer_client",
+      // A transfer / unlink / tier change is not a deletion; everything else
+      // logged here removes data.
+      isDeletion: !NON_DELETION_ADMIN_KINDS.has(r.kind),
       status: r.status,
       mode: r.mode,
     });

--- a/backoffice/src/lib/gc-fitness/coachless-user-model.ts
+++ b/backoffice/src/lib/gc-fitness/coachless-user-model.ts
@@ -138,6 +138,29 @@ export function adminCanViewClientUnderCoach(args: {
   );
 }
 
+/**
+ * Whether an admin may UNLINK a client from a coach, turning them coach-less.
+ *
+ * The inverse of an assignment: it only ever detaches a real client from the
+ * coach that actually owns them. Coaches themselves are never unlinkable (a
+ * trainer has no `coachId` to clear), and a client already linked to someone
+ * else must not be detachable from the wrong coach's page.
+ *
+ * Soft-deleted clients ARE unlinkable — an operator may want to strip the coach
+ * link before or after deactivating, and the write is harmless either way.
+ */
+export function canUnlinkClientFromCoach(args: {
+  /** The coach uid whose page the action was invoked from. */
+  coachUidInPath: string;
+  clientRole: string | null;
+  /** `/users/{clientId}.coachId` as stored. */
+  clientCoachId: string | null;
+}): boolean {
+  if (args.clientRole === "trainer") return false;
+  if (!args.clientCoachId || !args.coachUidInPath) return false;
+  return args.clientCoachId === args.coachUidInPath;
+}
+
 /** Per-category recency + rolling-window counts for the profile page. */
 export interface CoachlessActivitySummary {
   /** Most recent activity of ANY kind, ISO — null when the user never acted. */


### PR DESCRIPTION
Follow-up to #286 (merged).

## Why

Both directions of the coaching relationship were unreachable from the backoffice:

1. Coach-less list → no way to give someone a coach.
2. Coach detail → *Deactivate* (soft-delete) and *Delete* (cascade) were the only exits. Nothing expressed "this coaching relationship ended, but the person keeps using the app."

## What

**Assign a coach** — coach `<select>` + Assign on the coach-less list (per row) and on the profile page (new **Coach** card whose copy spells out the consequences). No second write path: assigning *is* `transferClientToCoach` with a null origin, which already re-points the client doc + denormalized coach fields, moves the chat thread, and resyncs the `coachId` custom claim. Assigning from the profile lands you on the now-coached drill-down (the coach-less profile would 404).

**Remove as client** — new `unlinkClientFromCoach`, on every row of the coach's client table. Clears `coachId` / `coachDisplayName` / `coachPhotoURL` / `autoAssignedCoach`, drops the `coachId` claim, logs `unlink_client`. The user shows up under Coach-less users with **all their data intact**.

## Decisions worth a look in review

- **The chat doc is kept, not deleted.** Unlink clears `chats/{clientId}.coachId` rather than `recursiveDelete`. That removes the thread from the ex-coach's inbox query (`coachId == me`) *and* fails `isChatParticipant` for them, without destroying the client's history — and a later assign re-points the same doc, so history returns. `deleteClientCascade` stays the only path that recursively deletes chats.
- **Content authored by the ex-coach is left in place** (`workout_assignments` / `habits` carrying their `trainerId`) — the same convention `transferClientToCoach` already documents. The user keeps their program.
- **Unlinking drops premium** for anyone without their own subscription (coached ⇒ premium stops applying). Stated in the UI copy.

## Drive-by fixes

- `/admin/audit` classified every `admin_operations` row except `transfer_client` as a deletion — so `unlink_client` *and* the already-shipped `set_entitlement` would have rendered as deletions. Replaced with a `NON_DELETION_ADMIN_KINDS` set plus real titles.
- Added `listCoachOptionsForAdmin` (one projected query) instead of reusing `listCoachesForAdmin`, which fans out 4 reads **per coach** to build the dashboard — far too much work to fill a dropdown.

## Testing

- `npx jest`: **946 passed** (+5 new `canUnlinkClientFromCoach` cases). The 1 failure is the known `client-activity-time` locale flake (green in CI).
- `npx next build`: clean.
- **Not verified locally:** the actual assign/unlink round-trip against prod Firebase (needs an admin session).
