### PR TITLE
feat(gc-fitness/admin): calendar + training analytics on the coach-less profile

### DIFF
--- a/backoffice/src/app/gc-fitness/admin/coach-less-users/[uid]/_components/AdminReadOnlyCalendar.tsx
+++ b/backoffice/src/app/gc-fitness/admin/coach-less-users/[uid]/_components/AdminReadOnlyCalendar.tsx
@@ -1,0 +1,250 @@
+"use client";
+
+// AdminReadOnlyCalendar.tsx
+//
+// Read-only month calendar for the god-mode coach-less profile.
+//
+// WHY NOT REUSE THE COACH'S CALENDAR: `ClientCalendarPeek` / the Agenda
+// `MonthCalendar` carry drag-and-drop rescheduling, move dialogs and assign
+// modals, and refetch through trainer-gated actions. Every admin drill-down in
+// this codebase is deliberately READ-ONLY, so bending those components would
+// both destabilise the coach's surface and hand an operator mutation
+// affordances they must not have. This renders the SAME `MonthCalendarPayload`
+// — the data path is shared, only the interaction surface differs.
+//
+// Month navigation calls `listMonthForClientAsAdmin`, which re-verifies the
+// admin AND the coach/client relationship on every hop (the uid in the closure
+// is never trusted server-side).
+
+import { useState, useTransition } from "react";
+import { useLocale } from "next-intl";
+import { ChevronLeft, ChevronRight, Dumbbell, User } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+import {
+  chunkWeeks,
+  monthGridDays,
+  monthLabel,
+  nextMonthFirst,
+  previousMonthFirst,
+} from "@/lib/gc-fitness/month-grid";
+import {
+  listMonthForClientAsAdmin,
+  type MonthCalendarPayload,
+} from "@/lib/gc-fitness/schedule-month-actions";
+
+const WEEKDAY_KEYS = [
+  "2026-07-06", // Mon … a known Monday-start week, formatted per locale below.
+  "2026-07-07",
+  "2026-07-08",
+  "2026-07-09",
+  "2026-07-10",
+  "2026-07-11",
+  "2026-07-12",
+];
+
+/** Workout chip colouring by status — same semantics as the coach calendar. */
+const WORKOUT_STATUS_CLASS: Record<string, string> = {
+  completed:
+    "border-emerald-500/40 bg-emerald-500/15 text-emerald-800 dark:text-emerald-300",
+  started: "border-sky-500/40 bg-sky-500/15 text-sky-800 dark:text-sky-300",
+  missed: "border-rose-500/40 bg-rose-500/15 text-rose-800 dark:text-rose-300",
+  scheduled: "border-amber-500/40 bg-amber-500/15 text-amber-800 dark:text-amber-300",
+};
+
+const HABIT_STATUS_CLASS: Record<string, string> = {
+  done: "bg-emerald-500",
+  missed: "bg-rose-500",
+  scheduled: "bg-muted-foreground/40",
+};
+
+export function AdminReadOnlyCalendar({
+  coachUid,
+  clientId,
+  todayCivil,
+  initialMonthFirst,
+  initialPayload,
+}: {
+  /** For a coach-less user this equals `clientId` (self-as-coach). */
+  coachUid: string;
+  clientId: string;
+  todayCivil: string;
+  initialMonthFirst: string;
+  initialPayload: MonthCalendarPayload;
+}) {
+  const locale = useLocale();
+  const [monthCivil, setMonthCivil] = useState(initialMonthFirst);
+  const [payload, setPayload] = useState(initialPayload);
+  const [error, setError] = useState<string | null>(null);
+  const [isPending, startTransition] = useTransition();
+
+  function goToMonth(nextMonth: string) {
+    setError(null);
+    startTransition(async () => {
+      try {
+        const next = await listMonthForClientAsAdmin({
+          coachUid,
+          clientId,
+          monthFirstCivil: nextMonth,
+          todayCivil,
+        });
+        setMonthCivil(nextMonth);
+        setPayload(next);
+      } catch {
+        setError("Could not load that month.");
+      }
+    });
+  }
+
+  const weeks = chunkWeeks(monthGridDays(monthCivil));
+  const weekdayLabels = WEEKDAY_KEYS.map((iso) =>
+    new Intl.DateTimeFormat(locale, { weekday: "short", timeZone: "UTC" }).format(
+      new Date(`${iso}T00:00:00Z`),
+    ),
+  );
+
+  const monthWorkouts = Object.entries(payload.workoutsByDay).reduce(
+    (n, [, chips]) => n + chips.length,
+    0,
+  );
+
+  return (
+    <div className="flex flex-col gap-3">
+      <div className="flex flex-wrap items-center justify-between gap-2">
+        <div className="flex items-center gap-1">
+          <Button
+            variant="outline"
+            size="icon"
+            className="size-8 rounded-full"
+            aria-label="Previous month"
+            disabled={isPending}
+            onClick={() => goToMonth(previousMonthFirst(monthCivil))}
+          >
+            <ChevronLeft className="size-4" />
+          </Button>
+          <span className="min-w-[9rem] text-center text-sm font-medium capitalize">
+            {monthLabel(monthCivil, locale)}
+          </span>
+          <Button
+            variant="outline"
+            size="icon"
+            className="size-8 rounded-full"
+            aria-label="Next month"
+            disabled={isPending}
+            onClick={() => goToMonth(nextMonthFirst(monthCivil))}
+          >
+            <ChevronRight className="size-4" />
+          </Button>
+        </div>
+        <span className="text-xs text-muted-foreground">
+          {monthWorkouts} workout{monthWorkouts === 1 ? "" : "s"} this month
+          {isPending ? " · loading…" : ""}
+        </span>
+      </div>
+
+      {error ? (
+        <p className="text-sm text-destructive">{error}</p>
+      ) : null}
+
+      <div className="overflow-x-auto">
+        <div className="min-w-[38rem]">
+          <div className="grid grid-cols-7 gap-1 pb-1">
+            {weekdayLabels.map((label) => (
+              <div
+                key={label}
+                className="text-center text-[11px] font-medium uppercase tracking-wide text-muted-foreground"
+              >
+                {label}
+              </div>
+            ))}
+          </div>
+
+          <div className="grid grid-cols-7 gap-1">
+            {weeks.flat().map((day) => {
+              const workouts = payload.workoutsByDay[day.civil] ?? [];
+              const habits = payload.habitsByDay[day.civil] ?? [];
+              const isToday = day.civil === todayCivil;
+              return (
+                <div
+                  key={day.civil}
+                  className={cn(
+                    "min-h-[5.5rem] rounded-lg border p-1.5 text-xs",
+                    day.inMonth ? "bg-card" : "bg-muted/30 opacity-60",
+                    isToday && "border-primary ring-1 ring-primary/40",
+                  )}
+                >
+                  <div
+                    className={cn(
+                      "mb-1 text-[11px] tabular-nums",
+                      isToday ? "font-semibold text-primary" : "text-muted-foreground",
+                    )}
+                  >
+                    {day.dayOfMonth}
+                  </div>
+
+                  <div className="flex flex-col gap-1">
+                    {workouts.map((chip) => (
+                      <div
+                        key={chip.id}
+                        title={`${chip.templateName} · ${chip.status}`}
+                        className={cn(
+                          "flex items-center gap-1 truncate rounded border px-1 py-0.5",
+                          WORKOUT_STATUS_CLASS[chip.status] ??
+                            WORKOUT_STATUS_CLASS.scheduled,
+                        )}
+                      >
+                        {chip.selfAssigned ? (
+                          <User className="size-3 shrink-0" aria-hidden />
+                        ) : (
+                          <Dumbbell className="size-3 shrink-0" aria-hidden />
+                        )}
+                        <span className="truncate">{chip.templateName}</span>
+                      </div>
+                    ))}
+                  </div>
+
+                  {habits.length > 0 ? (
+                    <div className="mt-1 flex flex-wrap items-center gap-1">
+                      {habits.map((habit) => (
+                        <span
+                          key={habit.id}
+                          title={`${habit.habitName} · ${habit.status}`}
+                          className={cn(
+                            "size-1.5 rounded-full",
+                            HABIT_STATUS_CLASS[habit.status] ??
+                              HABIT_STATUS_CLASS.scheduled,
+                          )}
+                        />
+                      ))}
+                    </div>
+                  ) : null}
+                </div>
+              );
+            })}
+          </div>
+        </div>
+      </div>
+
+      <div className="flex flex-wrap items-center gap-3 text-[11px] text-muted-foreground">
+        <LegendDot className="bg-amber-500" label="scheduled" />
+        <LegendDot className="bg-sky-500" label="started" />
+        <LegendDot className="bg-emerald-500" label="completed" />
+        <LegendDot className="bg-rose-500" label="missed" />
+        <span className="inline-flex items-center gap-1">
+          <User className="size-3" aria-hidden /> self-created
+        </span>
+        <span>· small dots = habits</span>
+      </div>
+    </div>
+  );
+}
+
+function LegendDot({ className, label }: { className: string; label: string }) {
+  return (
+    <span className="inline-flex items-center gap-1">
+      <span className={cn("size-2 rounded-full", className)} />
+      {label}
+    </span>
+  );
+}

--- a/backoffice/src/app/gc-fitness/admin/coach-less-users/[uid]/page.tsx
+++ b/backoffice/src/app/gc-fitness/admin/coach-less-users/[uid]/page.tsx
@@ -17,6 +17,7 @@
 // client, so this URL can't be used to read a coached client's data.
 
 import { revalidatePath } from "next/cache";
+import { getTranslations } from "next-intl/server";
 import Link from "next/link";
 import { notFound, redirect } from "next/navigation";
 import { ArrowLeft } from "lucide-react";
@@ -59,10 +60,21 @@ import {
   resolveDisplayTier,
   type ActivityWindow,
 } from "@/lib/gc-fitness/coachless-user-model";
+import { civilDateToday } from "@/lib/gc-fitness/civil-date";
+import { getClientExerciseProgressAsAdmin } from "@/lib/gc-fitness/exercise-progress-actions";
+import { listClientPersonalRecordsAsAdmin } from "@/lib/gc-fitness/personal-records-actions";
 import { listProgressPhotosForClientAsAdmin } from "@/lib/gc-fitness/progress-photo-actions";
 import { listRecentLogsForClientAsAdmin } from "@/lib/gc-fitness/recent-logs-actions";
+import { listMonthForClientAsAdmin } from "@/lib/gc-fitness/schedule-month-actions";
 
 import { BodyWeightTrendChart } from "@/app/gc-fitness/clients/[id]/_components/BodyWeightTrendChart";
+import { HabitTrendsWidget } from "@/app/gc-fitness/clients/[id]/_components/HabitTrendsWidget";
+import { WorkoutTrendsWidget } from "@/app/gc-fitness/clients/[id]/_components/WorkoutTrendsWidget";
+import { PersonalRecordsClient } from "@/app/gc-fitness/clients/[id]/_components/PersonalRecordsClient";
+import { ExerciseProgressClient } from "@/app/gc-fitness/clients/[id]/progress/ExerciseProgressClient";
+import { MuscleGroupProgressClient } from "@/app/gc-fitness/clients/[id]/progress/MuscleGroupProgressClient";
+import { addCivilDays } from "@/app/gc-fitness/clients/[id]/_components/trend-range";
+import { AdminReadOnlyCalendar } from "./_components/AdminReadOnlyCalendar";
 import { ClientRecentLogsFeed } from "@/app/gc-fitness/clients/[id]/_components/ClientRecentLogsFeed";
 import { ProgressPhotosGridClient } from "@/app/gc-fitness/clients/[id]/_components/ProgressPhotosGridClient";
 
@@ -161,18 +173,87 @@ export default async function CoachlessUserDetailPage({
 
   // Every widget below is scoped by BOTH ids; for a coach-less user the coach
   // uid IS their own uid (see the header comment).
-  const [logs, photos, assignments, habits, coaches] = await Promise.all([
+  const timezone = profile.timezone ?? "UTC";
+  const todayCivil = civilDateToday(timezone);
+  const thisMonthFirst = `${todayCivil.slice(0, 7)}-01`;
+
+  const [
+    logs,
+    photos,
+    assignments,
+    habits,
+    coaches,
+    calendar,
+    exerciseProgress,
+    personalRecords,
+  ] = await Promise.all([
     listRecentLogsForClientAsAdmin(uid, uid).catch(() => null),
     listProgressPhotosForClientAsAdmin(uid, uid).catch(() => []),
     listClientAssignmentsForAdmin(uid, uid).catch(() => []),
     listClientHabitsForAdmin(uid, uid).catch(() => []),
     listCoachOptionsForAdmin().catch(() => []),
+    // Every one of these degrades to "empty section" rather than 500-ing the
+    // whole profile — an operator inspecting a broken account needs the parts
+    // that DO load, especially then.
+    listMonthForClientAsAdmin({
+      coachUid: uid,
+      clientId: uid,
+      monthFirstCivil: thisMonthFirst,
+      todayCivil,
+    }).catch(() => null),
+    getClientExerciseProgressAsAdmin(uid, uid, timezone).catch(() => null),
+    listClientPersonalRecordsAsAdmin(uid, uid).catch(() => ({ clientId: uid, records: [] })),
   ]);
+
+  // The chart components take their copy as props (they are shared client
+  // components); pull the SAME i18n namespaces the coach progress page uses so
+  // the two surfaces never drift in wording.
+  const tProgress = await getTranslations("clients.exerciseProgress");
+  const tRecords = await getTranslations("clients.detail.personalRecords");
+  const exerciseProgressLabels = {
+    exercisePickerLabel: tProgress("exercisePickerLabel"),
+    metricTopSet: tProgress("metricTopSet"),
+    metricE1rm: tProgress("metricE1rm"),
+    metricVolume: tProgress("metricVolume"),
+    weightUnit: tProgress("weightUnit"),
+    volumeUnit: tProgress("volumeUnit"),
+    latestPrefix: tProgress("latestPrefix"),
+    emptyNoExercises: tProgress("emptyNoExercises"),
+    emptyNoData: tProgress("emptyNoData"),
+    tooltipTopSet: tProgress("tooltipTopSet"),
+    tooltipE1rm: tProgress("tooltipE1rm"),
+    tooltipVolume: tProgress("tooltipVolume"),
+    ranges: {
+      all: tProgress("rangeAll"),
+      "90": tProgress("range90"),
+      "30": tProgress("range30"),
+      "7": tProgress("range7"),
+    },
+  };
+  const personalRecordLabels = {
+    empty: tRecords("empty"),
+    muscleGroupLabel: tRecords("muscleGroupLabel"),
+    muscleGroupAll: tRecords("muscleGroupAll"),
+    sortLabel: tRecords("sortLabel"),
+    sortRecent: tRecords("sortRecent"),
+    sortMostCommon: tRecords("sortMostCommon"),
+    previousLabel: tRecords.raw("previousLabel") as string,
+    estOneRm: tRecords.raw("estOneRm") as string,
+    noDate: tRecords("noDate"),
+  };
+
+  // Range anchors shared by the per-exercise + muscle-group charts, matching the
+  // coach progress page so both surfaces bucket identically.
+  const rangeStarts = {
+    all: addCivilDays(todayCivil, -364),
+    "90": addCivilDays(todayCivil, -89),
+    "30": addCivilDays(todayCivil, -29),
+    "7": addCivilDays(todayCivil, -6),
+  };
 
   const nowMs = Date.now();
   const tier = resolveDisplayTier(profile.entitlement);
   const isPremium = tier === "premium";
-  const timezone = profile.timezone ?? "UTC";
   const displayName = profile.displayName || profile.email || uid;
 
   // Assigning a coach IS a transfer — from no coach to one. Reuses the tested
@@ -594,6 +675,28 @@ export default async function CoachlessUserDetailPage({
 
       <Card>
         <CardHeader className="pb-3">
+          <CardTitle className="text-xl">Calendar</CardTitle>
+        </CardHeader>
+        <CardContent>
+          {calendar ? (
+            // READ-ONLY by construction — the coach's calendar's drag-to-move /
+            // assign affordances are deliberately absent from every god-mode
+            // drill-down.
+            <AdminReadOnlyCalendar
+              coachUid={uid}
+              clientId={uid}
+              todayCivil={todayCivil}
+              initialMonthFirst={thisMonthFirst}
+              initialPayload={calendar}
+            />
+          ) : (
+            <p className="text-sm text-muted-foreground">Calendar unavailable.</p>
+          )}
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader className="pb-3">
           <CardTitle className="text-xl">Recent activity</CardTitle>
         </CardHeader>
         <CardContent>
@@ -615,6 +718,80 @@ export default async function CoachlessUserDetailPage({
           ) : (
             <p className="text-sm text-muted-foreground">No activity recorded yet.</p>
           )}
+        </CardContent>
+      </Card>
+
+      {/* Training analytics — the surfaces a coach gets on their own client
+          detail, which a coach-less user had nobody to look at them for. All of
+          these are the coach components verbatim; only the data gate differs. */}
+      <Card>
+        <CardHeader className="pb-3">
+          <CardTitle className="text-xl">Workout trends</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <WorkoutTrendsWidget clientId={uid} timezone={timezone} />
+        </CardContent>
+      </Card>
+
+      {exerciseProgress && exerciseProgress.availableMuscleGroups.length > 0 ? (
+        <Card>
+          <CardHeader className="pb-3">
+            <CardTitle className="text-xl">Weekly volume &amp; sets by muscle group</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <MuscleGroupProgressClient
+              weeks={exerciseProgress.muscleGroupWeeks}
+              availableGroups={exerciseProgress.availableMuscleGroups}
+              currentWeekStart={exerciseProgress.currentWeekStart}
+              rangeStarts={rangeStarts}
+            />
+          </CardContent>
+        </Card>
+      ) : null}
+
+      {exerciseProgress && exerciseProgress.exercises.length > 0 ? (
+        <Card>
+          <CardHeader className="pb-3">
+            <CardTitle className="text-xl">Progress by exercise</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <ExerciseProgressClient
+              exercises={exerciseProgress.exercises}
+              points={exerciseProgress.points}
+              setSessions={exerciseProgress.exerciseSetSessions}
+              truncatedSetHistoryExerciseIds={
+                exerciseProgress.truncatedSetHistoryExerciseIds
+              }
+              today={todayCivil}
+              rangeStarts={rangeStarts}
+              labels={exerciseProgressLabels}
+            />
+          </CardContent>
+        </Card>
+      ) : null}
+
+      {personalRecords.records.length > 0 ? (
+        <Card>
+          <CardHeader className="pb-3">
+            <CardTitle className="text-xl">
+              Personal records ({personalRecords.records.length})
+            </CardTitle>
+          </CardHeader>
+          <CardContent>
+            <PersonalRecordsClient
+              records={personalRecords.records}
+              labels={personalRecordLabels}
+            />
+          </CardContent>
+        </Card>
+      ) : null}
+
+      <Card>
+        <CardHeader className="pb-3">
+          <CardTitle className="text-xl">Habit adherence</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <HabitTrendsWidget clientId={uid} timezone={timezone} />
         </CardContent>
       </Card>
 

--- a/backoffice/src/lib/gc-fitness/__tests__/month-grid.test.ts
+++ b/backoffice/src/lib/gc-fitness/__tests__/month-grid.test.ts
@@ -1,0 +1,100 @@
+// __tests__/month-grid.test.ts
+//
+// Locks the Monday-first month grid behind the read-only admin calendar. Pure
+// civil-date math — no firebase, no timezone, no mocks.
+
+import {
+  chunkWeeks,
+  monthFirst,
+  monthGridDays,
+  monthLabel,
+  nextMonthFirst,
+  previousMonthFirst,
+  shiftCivil,
+} from "../month-grid";
+
+describe("shiftCivil", () => {
+  it("crosses month and year boundaries", () => {
+    expect(shiftCivil("2026-07-28", 1)).toBe("2026-07-29");
+    expect(shiftCivil("2026-07-31", 1)).toBe("2026-08-01");
+    expect(shiftCivil("2026-01-01", -1)).toBe("2025-12-31");
+  });
+
+  it("handles a leap day", () => {
+    expect(shiftCivil("2028-02-28", 1)).toBe("2028-02-29");
+    expect(shiftCivil("2028-02-29", 1)).toBe("2028-03-01");
+  });
+});
+
+describe("previousMonthFirst / nextMonthFirst", () => {
+  it("steps months without overflowing on short or long months", () => {
+    expect(nextMonthFirst("2026-01-31")).toBe("2026-02-01");
+    expect(nextMonthFirst("2026-02-01")).toBe("2026-03-01");
+    expect(previousMonthFirst("2026-03-15")).toBe("2026-02-01");
+    expect(previousMonthFirst("2026-01-05")).toBe("2025-12-01");
+  });
+
+  it("is stable when applied repeatedly (no drift)", () => {
+    let civil = "2026-07-01";
+    for (let i = 0; i < 12; i += 1) civil = nextMonthFirst(civil);
+    expect(civil).toBe("2027-07-01");
+    for (let i = 0; i < 12; i += 1) civil = previousMonthFirst(civil);
+    expect(civil).toBe("2026-07-01");
+  });
+});
+
+describe("monthGridDays", () => {
+  it("starts on the Monday on or before the 1st", () => {
+    // 2026-07-01 is a Wednesday → the grid opens on Monday 2026-06-29.
+    const days = monthGridDays("2026-07-15");
+    expect(days[0].civil).toBe("2026-06-29");
+    expect(days[0].inMonth).toBe(false);
+    expect(days[2].civil).toBe("2026-07-01");
+    expect(days[2].inMonth).toBe(true);
+  });
+
+  it("always emits whole weeks", () => {
+    for (const civil of ["2026-01-10", "2026-02-10", "2028-02-10", "2026-08-10"]) {
+      expect(monthGridDays(civil).length % 7).toBe(0);
+    }
+  });
+
+  it("covers every day of the month exactly once", () => {
+    const days = monthGridDays("2026-07-01").filter((d) => d.inMonth);
+    expect(days).toHaveLength(31);
+    expect(days[0].civil).toBe("2026-07-01");
+    expect(days[30].civil).toBe("2026-07-31");
+    expect(new Set(days.map((d) => d.civil)).size).toBe(31);
+  });
+
+  it("never renders a week made entirely of adjacent-month days", () => {
+    // A 28-day February that starts on a Monday fits in exactly 4 rows; the
+    // naive fixed-6-week grid would render two empty trailing weeks.
+    const days = monthGridDays("2027-02-10");
+    const weeks = chunkWeeks(days);
+    expect(weeks.every((w) => w.some((d) => d.inMonth))).toBe(true);
+  });
+
+  it("marks leading and trailing days as out-of-month", () => {
+    const days = monthGridDays("2026-07-15");
+    expect(days.filter((d) => d.inMonth)).toHaveLength(31);
+    expect(days.filter((d) => !d.inMonth).length).toBeGreaterThan(0);
+  });
+});
+
+describe("chunkWeeks", () => {
+  it("splits into rows of 7 preserving order", () => {
+    const weeks = chunkWeeks(monthGridDays("2026-07-15"));
+    expect(weeks[0]).toHaveLength(7);
+    expect(weeks[0][0].civil).toBe("2026-06-29");
+    expect(weeks[0][6].civil).toBe("2026-07-05");
+  });
+});
+
+describe("monthLabel", () => {
+  it("renders the month of the civil date, not the local-timezone month", () => {
+    // A UTC-midnight parse read in a negative-offset zone would slip to June.
+    expect(monthLabel("2026-07-01", "en-US")).toBe("July 2026");
+    expect(monthLabel("2026-07-31", "en-US")).toBe("July 2026");
+  });
+});

--- a/backoffice/src/lib/gc-fitness/exercise-progress-actions.ts
+++ b/backoffice/src/lib/gc-fitness/exercise-progress-actions.ts
@@ -24,9 +24,11 @@
 // crosses to the browser; the client only re-filters by date range locally.
 
 import {
+  getCurrentAdmin,
   getCurrentTrainer,
   type CurrentTrainer,
 } from "@/lib/gc-fitness/auth-helpers";
+import { adminCanViewClientUnderCoach } from "@/lib/gc-fitness/coachless-user-model";
 import { gcFitnessFirestore } from "@/lib/firebase/gc-fitness-admin";
 import { FirestoreCollections } from "@/lib/gc-fitness/collections";
 import { civilDateFormat, civilDateToday } from "@/lib/gc-fitness/civil-date";
@@ -210,25 +212,77 @@ export async function getClientExerciseProgress(
 
   // Ownership gate at the query layer — only read this client's logs when the
   // logged-in trainer owns them (the page already verifies coachId too).
-  const today = civilDateToday(timezone);
-  const currentWeekStart = civilWeekStart(today);
-
   const clientSnap = await db
     .collection(FirestoreCollections.users)
     .doc(clientId)
     .get();
   if (!clientSnap.exists || clientSnap.get("coachId") !== trainer.uid) {
-    return {
-      clientId,
-      exercises: [],
-      points: [],
-      muscleGroupWeeks: [],
-      availableMuscleGroups: [],
-      currentWeekStart,
-      exerciseSetSessions: [],
-      truncatedSetHistoryExerciseIds: [],
-    };
+    return emptyExerciseProgress(clientId, timezone);
   }
+
+  return loadClientExerciseProgress(clientId, timezone);
+}
+
+/**
+ * Admin god-mode (READ-ONLY): the same per-exercise progress for ONE client,
+ * gated by `adminCanViewClientUnderCoach` — the coach of record, or a coach-less
+ * user under the self-as-coach rule (`coachUid === clientId`).
+ */
+export async function getClientExerciseProgressAsAdmin(
+  coachUid: string,
+  clientId: string,
+  timezone: string,
+): Promise<ClientExerciseProgress> {
+  await getCurrentAdmin();
+  const db = gcFitnessFirestore();
+  const clientSnap = await db
+    .collection(FirestoreCollections.users)
+    .doc(clientId)
+    .get();
+  const allowed =
+    clientSnap.exists &&
+    adminCanViewClientUnderCoach({
+      coachUidInPath: coachUid,
+      clientId,
+      clientCoachId:
+        typeof clientSnap.get("coachId") === "string" ? clientSnap.get("coachId") : null,
+      clientRole: typeof clientSnap.get("role") === "string" ? clientSnap.get("role") : null,
+      clientDeleted: clientSnap.get("deleted") === true,
+    });
+  if (!allowed) {
+    return emptyExerciseProgress(clientId, timezone);
+  }
+  return loadClientExerciseProgress(clientId, timezone);
+}
+
+/** The "nothing to show" payload — shared by both gates' deny paths. */
+function emptyExerciseProgress(
+  clientId: string,
+  timezone: string,
+): ClientExerciseProgress {
+  return {
+    clientId,
+    exercises: [],
+    points: [],
+    muscleGroupWeeks: [],
+    availableMuscleGroups: [],
+    currentWeekStart: civilWeekStart(civilDateToday(timezone)),
+    exerciseSetSessions: [],
+    truncatedSetHistoryExerciseIds: [],
+  };
+}
+
+/**
+ * Auth-FREE aggregation core. CALLERS MUST GATE — the two exported entry points
+ * above are the only ones.
+ */
+async function loadClientExerciseProgress(
+  clientId: string,
+  timezone: string,
+): Promise<ClientExerciseProgress> {
+  const db = gcFitnessFirestore();
+  const today = civilDateToday(timezone);
+  const currentWeekStart = civilWeekStart(today);
 
   const windowStartDate = new Date(
     Date.now() - MAX_LOOKBACK_DAYS * 24 * 60 * 60 * 1000,

--- a/backoffice/src/lib/gc-fitness/month-grid.ts
+++ b/backoffice/src/lib/gc-fitness/month-grid.ts
@@ -1,0 +1,112 @@
+// month-grid.ts
+//
+// Pure civil-date math for a Monday-first month grid — the read-only admin
+// calendar's layout, and the prev/next-month arrows behind it.
+//
+// Firebase-free and timezone-free ON PURPOSE: every date here is a CIVIL date
+// string (`YYYY-MM-DD`) already resolved in the client's timezone upstream.
+// Doing the arithmetic on strings (via UTC-noon Dates) is what keeps a DST
+// boundary from shifting a cell — the trap a naive `new Date(y, m, d)` walk
+// falls into.
+//
+// Week starts MONDAY, matching every other week boundary in this codebase
+// (`DashboardAggregator.weekStart` / `civilWeekStart`).
+
+/** A single cell of the rendered grid. */
+export interface MonthGridDay {
+  /** Civil date `YYYY-MM-DD`. */
+  civil: string;
+  /** Day-of-month number to print. */
+  dayOfMonth: number;
+  /** False for the leading/trailing days that belong to the adjacent months. */
+  inMonth: boolean;
+}
+
+const DAY_MS = 86_400_000;
+
+/** `YYYY-MM-DD` → a UTC Date at midnight (no local-timezone drift). */
+function parseCivil(civil: string): Date {
+  const [y, m, d] = civil.split("-").map(Number);
+  return new Date(Date.UTC(y, (m ?? 1) - 1, d ?? 1));
+}
+
+/** UTC Date → `YYYY-MM-DD`. */
+function formatCivil(date: Date): string {
+  const y = date.getUTCFullYear();
+  const m = String(date.getUTCMonth() + 1).padStart(2, "0");
+  const d = String(date.getUTCDate()).padStart(2, "0");
+  return `${y}-${m}-${d}`;
+}
+
+/** Shift a civil date by whole days. */
+export function shiftCivil(civil: string, days: number): string {
+  return formatCivil(new Date(parseCivil(civil).getTime() + days * DAY_MS));
+}
+
+/** The first day of the month a civil date falls in (`YYYY-MM-01`). */
+export function monthFirst(civil: string): string {
+  return `${civil.slice(0, 7)}-01`;
+}
+
+/** The first day of the PREVIOUS month, relative to any day in this one. */
+export function previousMonthFirst(civil: string): string {
+  // Step back one day from the 1st — always lands in the previous month, for
+  // any month length, without month-arithmetic overflow.
+  return monthFirst(shiftCivil(monthFirst(civil), -1));
+}
+
+/** The first day of the NEXT month, relative to any day in this one. */
+export function nextMonthFirst(civil: string): string {
+  // 31 days past the 1st always lands in the next month (max month length),
+  // then snap to its 1st.
+  return monthFirst(shiftCivil(monthFirst(civil), 31));
+}
+
+/**
+ * The Monday-first grid for the month containing `civil`: leading days from the
+ * previous month, every day of this month, then trailing days to complete the
+ * final week. Always a whole number of weeks, so the caller can chunk by 7.
+ */
+export function monthGridDays(civil: string): MonthGridDay[] {
+  const first = parseCivil(monthFirst(civil));
+  // getUTCDay(): 0=Sun … 6=Sat. Monday-first offset: Mon→0 … Sun→6.
+  const leading = (first.getUTCDay() + 6) % 7;
+  const monthKey = monthFirst(civil).slice(0, 7);
+
+  const days: MonthGridDay[] = [];
+  let cursor = new Date(first.getTime() - leading * DAY_MS);
+  // 6 weeks covers every possible month layout (31 days + 6 leading).
+  for (let i = 0; i < 42; i += 1) {
+    const value = formatCivil(cursor);
+    days.push({
+      civil: value,
+      dayOfMonth: cursor.getUTCDate(),
+      inMonth: value.slice(0, 7) === monthKey,
+    });
+    cursor = new Date(cursor.getTime() + DAY_MS);
+  }
+
+  // Drop trailing all-adjacent-month weeks (a 28-day February starting Monday
+  // needs 4 rows, not 6) so the grid never renders an empty week.
+  while (days.length > 7 && days.slice(-7).every((d) => !d.inMonth)) {
+    days.length -= 7;
+  }
+  return days;
+}
+
+/** Split the flat grid into weeks of 7 for rendering. */
+export function chunkWeeks(days: MonthGridDay[]): MonthGridDay[][] {
+  const weeks: MonthGridDay[][] = [];
+  for (let i = 0; i < days.length; i += 7) weeks.push(days.slice(i, i + 7));
+  return weeks;
+}
+
+/** "2026-07" → a display label, e.g. "julio 2026" / "July 2026". */
+export function monthLabel(civil: string, locale: string): string {
+  const date = parseCivil(monthFirst(civil));
+  return new Intl.DateTimeFormat(locale, {
+    month: "long",
+    year: "numeric",
+    timeZone: "UTC",
+  }).format(date);
+}

--- a/backoffice/src/lib/gc-fitness/personal-records-actions.ts
+++ b/backoffice/src/lib/gc-fitness/personal-records-actions.ts
@@ -10,7 +10,8 @@
 // composite index; no date bound so a long-standing record still surfaces) +
 // ONE batched getAll for the PR exercises' muscle groups.
 
-import { getCurrentTrainer } from "@/lib/gc-fitness/auth-helpers";
+import { getCurrentAdmin, getCurrentTrainer } from "@/lib/gc-fitness/auth-helpers";
+import { adminCanViewClientUnderCoach } from "@/lib/gc-fitness/coachless-user-model";
 import { gcFitnessFirestore } from "@/lib/firebase/gc-fitness-admin";
 import { FirestoreCollections } from "@/lib/gc-fitness/collections";
 import {
@@ -56,6 +57,49 @@ export async function listClientPersonalRecords(
   if (!clientSnap.exists || clientSnap.get("coachId") !== trainer.uid) {
     return { clientId, records: [] };
   }
+
+  return loadClientPersonalRecords(clientId);
+}
+
+/**
+ * Admin god-mode (READ-ONLY): the same records for ONE client, gated by
+ * `adminCanViewClientUnderCoach` — the coach of record, or a coach-less user
+ * under the self-as-coach rule (`coachUid === clientId`).
+ */
+export async function listClientPersonalRecordsAsAdmin(
+  coachUid: string,
+  clientId: string,
+): Promise<ClientPersonalRecords> {
+  await getCurrentAdmin();
+  const db = gcFitnessFirestore();
+  const clientSnap = await db
+    .collection(FirestoreCollections.users)
+    .doc(clientId)
+    .get();
+  const allowed =
+    clientSnap.exists &&
+    adminCanViewClientUnderCoach({
+      coachUidInPath: coachUid,
+      clientId,
+      clientCoachId:
+        typeof clientSnap.get("coachId") === "string" ? clientSnap.get("coachId") : null,
+      clientRole: typeof clientSnap.get("role") === "string" ? clientSnap.get("role") : null,
+      clientDeleted: clientSnap.get("deleted") === true,
+    });
+  if (!allowed) {
+    return { clientId, records: [] };
+  }
+  return loadClientPersonalRecords(clientId);
+}
+
+/**
+ * Auth-FREE core. CALLERS MUST GATE — the two exported entry points above are
+ * the only ones.
+ */
+async function loadClientPersonalRecords(
+  clientId: string,
+): Promise<ClientPersonalRecords> {
+  const db = gcFitnessFirestore();
 
   const snap = await db
     .collection(FirestoreCollections.workoutLogs)

--- a/backoffice/src/lib/gc-fitness/schedule-month-actions.ts
+++ b/backoffice/src/lib/gc-fitness/schedule-month-actions.ts
@@ -22,7 +22,8 @@ import { FieldValue } from "firebase-admin/firestore";
 
 import { gcFitnessFirestore } from "@/lib/firebase/gc-fitness-admin";
 
-import { getCurrentTrainer } from "./auth-helpers";
+import { getCurrentAdmin, getCurrentTrainer } from "./auth-helpers";
+import { adminCanViewClientUnderCoach } from "./coachless-user-model";
 import { FirestoreCollections } from "./collections";
 import { civilDateFormat } from "./civil-date";
 import { coachVisibleClientName } from "./client-name";
@@ -624,7 +625,7 @@ async function fetchLastLoggedSetsByExercise(
   return out;
 }
 
-export async function listMonthForClients(input: {
+export interface MonthForClientsInput {
   /** Month mode: any day in the target month (YYYY-MM-01 typical). */
   monthFirstCivil?: string;
   /** Range mode (week / 3-day views): explicit inclusive civil-date bounds. */
@@ -632,8 +633,69 @@ export async function listMonthForClients(input: {
   endCivil?: string;
   clientIds: string[];
   todayCivil: string;
-}): Promise<MonthCalendarPayload> {
+}
+
+export async function listMonthForClients(
+  input: MonthForClientsInput,
+): Promise<MonthCalendarPayload> {
   const trainer = await getCurrentTrainer();
+  return loadMonthForClients({ ...input, viewerUid: trainer.uid });
+}
+
+/**
+ * Admin god-mode (READ-ONLY): one client's month calendar. Verifies the client
+ * really belongs to `coachUid` — or, via the self-as-coach rule, that
+ * `coachUid === clientId` on an active coach-less client — so the URL can't be
+ * edited to read across coaches.
+ *
+ * Read-only by construction: this returns the same payload the coach's calendar
+ * renders, but no admin surface ships the move/assign mutations.
+ */
+export async function listMonthForClientAsAdmin(input: {
+  coachUid: string;
+  clientId: string;
+  monthFirstCivil?: string;
+  todayCivil: string;
+}): Promise<MonthCalendarPayload> {
+  await getCurrentAdmin();
+  const db = gcFitnessFirestore();
+  const snap = await db
+    .collection(FirestoreCollections.users)
+    .doc(input.clientId)
+    .get();
+  const allowed =
+    snap.exists &&
+    adminCanViewClientUnderCoach({
+      coachUidInPath: input.coachUid,
+      clientId: input.clientId,
+      clientCoachId: typeof snap.get("coachId") === "string" ? snap.get("coachId") : null,
+      clientRole: typeof snap.get("role") === "string" ? snap.get("role") : null,
+      clientDeleted: snap.get("deleted") === true,
+    });
+  if (!allowed) {
+    throw new Error("Not found");
+  }
+  return loadMonthForClients({
+    monthFirstCivil: input.monthFirstCivil,
+    clientIds: [input.clientId],
+    todayCivil: input.todayCivil,
+    viewerUid: input.coachUid,
+  });
+}
+
+/**
+ * Auth-FREE core of the month calendar. CALLERS MUST GATE — `listMonthForClients`
+ * (trainer) and `listMonthForClientAsAdmin` (admin) are the only entry points.
+ *
+ * `viewerUid` is the uid the assignment chips are filtered against: a doc is
+ * admitted when `trainerId === viewerUid` OR it is self-assigned. For a
+ * coach-less user the admin path passes their OWN uid, which satisfies BOTH
+ * branches (their content carries `trainerId === clientId`) — the same
+ * self-as-coach convention the rest of the god-mode drill-down uses.
+ */
+async function loadMonthForClients(
+  input: MonthForClientsInput & { viewerUid: string },
+): Promise<MonthCalendarPayload> {
   const db = gcFitnessFirestore();
 
   // Either an explicit [startCivil, endCivil] range (week / 3-day views) or a
@@ -740,7 +802,7 @@ export async function listMonthForClients(input: {
       typeof data.clientId === "string" &&
       data.clientId.length > 0 &&
       data.trainerId === data.clientId;
-    if (data.trainerId !== trainer.uid && !isSelfAssigned) continue;
+    if (data.trainerId !== input.viewerUid && !isSelfAssigned) continue;
     const clientId = typeof data.clientId === "string" ? data.clientId : "";
     const civil = typeof data.scheduledFor === "string" ? data.scheduledFor : "";
     if (!clientId || !civil) continue;


### PR DESCRIPTION
Follow-up to #286 / #287.

## Why

The god-mode coach-less profile had identity, subscription, content counts and a recent-activity feed — but none of the **analytical** surfaces a coach gets on their own client detail. Which is backwards: a self-serve user is precisely the one with nobody watching their training.

## What the profile gained

In render order, after the existing identity / coach / subscription / activity / routines / habits / assignments blocks:

1. **Calendar** — read-only month grid: workouts + habits per day, status colouring, self-created badge, prev/next month.
2. **Workout trends** — sessions, completed sets and tonnage over All / 90 / 30 / 7d.
3. **Weekly volume & sets by muscle group** — the charts asked for.
4. **Progress by exercise** — top-set / est. 1RM / volume per exercise + set history.
5. **Personal records** — with the record each one beat.
6. **Habit adherence** — per-habit compliance over the same ranges.

(then the pre-existing body-weight chart and progress photos.)

## Reuse over fork

`WorkoutTrendsWidget`, `HabitTrendsWidget` and `BodyWeightTrendChart` take `{clientId, timezone}` and gate nothing themselves — they trust the parent page — so they dropped in unchanged.

The other three loaders were trainer-gated and got the treatment this repo already established for `*AsAdmin` actions: extract the auth-free core, leave the trainer wrapper's behaviour byte-identical, add an admin wrapper gated by `adminCanViewClientUnderCoach`.

| Loader | Core extracted |
|---|---|
| `listMonthForClients` | `loadMonthForClients({…, viewerUid})` |
| `getClientExerciseProgress` | `loadClientExerciseProgress` |
| `listClientPersonalRecords` | `loadClientPersonalRecords` |

`listMonthForClients` used `trainer.uid` in **exactly one line** — the `trainerId === me OR selfAssigned` chip filter. Passing the coach-less user's own uid satisfies *both* branches, since their content carries `trainerId === clientId` (#392).

## The calendar is new on purpose

`ClientCalendarPeek` is 495 lines of drag-to-move, move dialogs and a trainer-gated refetch. Every god-mode drill-down here is deliberately **read-only**, so bending it would (a) risk the coach's live calendar and (b) hand an operator mutation affordances they must not have. `AdminReadOnlyCalendar` renders the **same** `MonthCalendarPayload` — shared data path, different interaction surface.

Month math lives in a pure `month-grid.ts`: Monday-first, all arithmetic on civil-date strings via UTC (a naive `new Date(y, m, d)` walk shifts a cell across a DST boundary). 11 unit tests, including that a 28-day February starting on a Monday renders **4 rows, not 6 with two empty weeks**.

## Resilience

Every new fetch is `.catch()`-ed to an empty state rather than allowed to reject the page — an operator inspecting a broken account needs the parts that *do* load, especially then.

## Testing

- `npx jest`: **957 pass** (+11). The 1 failure is the known `client-activity-time` locale flake (green in CI).
- `npx next build`: clean.
- Dev-server smoke: unauthenticated GET → 307 `/gc-fitness/login`, no runtime errors.
- **Not verified locally:** the authenticated render (needs an admin session against prod Firebase). `manu@goldenbay.tech` has routines + logs, so the calendar and every chart should have data there.