### PR TITLE
fix(site): project cards de la misma altura en el carrusel

### DIFF
--- a/pocket-genes/src/components/Carousel.astro
+++ b/pocket-genes/src/components/Carousel.astro
@@ -151,6 +151,11 @@ const wrapperStyle = [
 
   .carousel-track {
     display: flex;
+    /* Todas las slides de una fila miden lo mismo de alto: la más alta define
+       la línea y el resto se estira. Explícito (y no sólo el `stretch` por
+       defecto) porque es la mitad del arreglo — la otra mitad es el
+       `height: auto` de la regla de abajo. */
+    align-items: stretch;
     gap: var(--carousel-gap, 1.5rem);
     overflow-x: auto;
     scroll-snap-type: x mandatory;

--- a/pocket-genes/src/components/ProjectCard.astro
+++ b/pocket-genes/src/components/ProjectCard.astro
@@ -92,7 +92,21 @@ const linkProps = wholeCardIsLink
     overflow: hidden;
     transition: transform 0.3s ease, box-shadow 0.3s ease;
     display: block;
-    height: 100%;
+    /* Alturas parejas en los DOS contextos donde vive la card:
+       - grid (WorkFilterGrid): la card es un hijo en flujo normal de
+         `.work-item`, que el grid ya estiró; `min-height: 100%` la hace llenar
+         la celda (es lo que hacía el viejo `height: 100%`).
+       - carrusel (SuccessCarousel): acá la card ES el ítem flex. Una ALTURA
+         explícita cancela el `align-items: stretch` del contenedor, así que
+         cada card medía su propio contenido y quedaban desparejas. Con
+         `height: auto` + `align-self: stretch` la más alta define la fila y el
+         resto se estira; el `min-height: 100%` no molesta porque el track no
+         tiene alto definido.
+       No se arregla desde Carousel.astro: el selector de ahí empata en
+       especificidad con este y pierde por orden de fuente. */
+    height: auto;
+    min-height: 100%;
+    align-self: stretch;
   }
 
   .project-card:hover {


### PR DESCRIPTION
Las tres cards visibles del carrusel de proyectos tenían alturas distintas.

## Causa

`ProjectCard` declara `height: 100%`. Es lo correcto en `WorkFilterGrid`, donde la card es un hijo en flujo normal de `.work-item` (un grid item ya estirado) y necesita la altura explícita para llenar la celda.

En `SuccessCarousel`, en cambio, la card **es** el ítem flex de `.carousel-track`, y en flexbox una altura explícita **cancela** el `align-items: stretch`: el ítem deja de estirarse, el `100%` se resuelve contra un contenedor de alto automático y cada card mide su propio contenido.

Arreglarlo desde `Carousel.astro` no alcanza — verifiqué en el CSS compilado que el selector scopeado de Astro (`.carousel-track[data-astro-cid-…] > *`) empata en especificidad con `.project-card[data-astro-cid-…]` y pierde por orden de fuente.

## Cambio

- `ProjectCard.astro`: `height: 100%` → `height: auto` + `min-height: 100%` + `align-self: stretch` (cubre grid y carrusel).
- `Carousel.astro`: `align-items: stretch` explícito, documentando la intención.

## Verificación

`npm run build` verde (70 páginas) y el CSS compilado sale con `height:auto;min-height:100%;align-self:stretch`.

⚠️ Falta el chequeo visual: no hay browser headless en el entorno donde corrí esto.