### PR TITLE
fix(gc-fitness/progress): ofrecer todos los grupos musculares, también los que el cliente no entrena

### DIFF
--- a/backoffice/src/lib/gc-fitness/__tests__/muscle-group-weeks.test.ts
+++ b/backoffice/src/lib/gc-fitness/__tests__/muscle-group-weeks.test.ts
@@ -142,7 +142,17 @@ describe("buildMuscleGroupWeeks — actuals (#480 behavior preserved)", () => {
     // Untrained week in the middle stays present and empty.
     expect(muscleGroupWeeks[1].byGroup).toEqual({});
     expect(muscleGroupWeeks[2].byGroup).toEqual({ back: { sets: 1, volume: 500 } });
-    expect(availableMuscleGroups).toEqual(["back", "chest", "triceps", "shoulders"]);
+    // Untrained coarse groups are offered too, flat at 0 (see
+    // buildMuscleGroupWeeks — "pecho ausente" vs "pecho en cero").
+    expect(availableMuscleGroups).toEqual([
+      "back",
+      "chest",
+      "biceps",
+      "triceps",
+      "shoulders",
+      "legs",
+      "core",
+    ]);
   });
 
   it("returns nothing when there is neither actual nor projected data", () => {
@@ -234,17 +244,46 @@ describe("buildMuscleGroupWeeks — projection (#568)", () => {
     expect(muscleGroupWeeks[0].projectedByGroup).toEqual({
       back: { sets: 2, volume: 1000 },
     });
-    expect(availableMuscleGroups).toEqual(["back", "chest", "triceps", "shoulders"]);
+    // Untrained coarse groups are offered too, flat at 0 (see
+    // buildMuscleGroupWeeks — "pecho ausente" vs "pecho en cero").
+    expect(availableMuscleGroups).toEqual([
+      "back",
+      "chest",
+      "biceps",
+      "triceps",
+      "shoulders",
+      "legs",
+      "core",
+    ]);
   });
 
   it("ignores exercises with no resolvable muscle metadata", () => {
-    const { muscleGroupWeeks } = buildMuscleGroupWeeks(
+    const { muscleGroupWeeks, availableMuscleGroups } = buildMuscleGroupWeeks(
       [],
       [set("2026-07-30", "ghost", 999)],
       META,
       "2026-07-27",
     );
     expect(muscleGroupWeeks).toEqual([]);
+    // Nothing attributable → the caller's "sin datos" state, NOT seven flat
+    // zero lines.
+    expect(availableMuscleGroups).toEqual([]);
+  });
+
+  it("offers a group the client never trained, so it can plot a flat 0", () => {
+    // Only a bench press (chest primary, triceps + shoulders secondary) — the
+    // client has no back / biceps / legs / core work at all in the window.
+    const { availableMuscleGroups, muscleGroupWeeks } = buildMuscleGroupWeeks(
+      [set("2026-07-27", "bench", 600)],
+      [],
+      META,
+      "2026-07-27",
+    );
+    expect(availableMuscleGroups).toContain("legs");
+    expect(availableMuscleGroups).toContain("back");
+    // …and the week itself still carries ONLY the trained groups, so the chart
+    // reads the untrained ones as the 0 default rather than an invented cell.
+    expect(muscleGroupWeeks[0].byGroup.legs).toBeUndefined();
   });
 });
 

--- a/backoffice/src/lib/gc-fitness/muscle-group-weeks.ts
+++ b/backoffice/src/lib/gc-fitness/muscle-group-weeks.ts
@@ -335,9 +335,19 @@ export function buildMuscleGroupWeeks(
     cursor = shiftCivilDays(cursor, 7);
   }
 
-  const availableMuscleGroups = COARSE_MUSCLE_GROUPS.filter((g) =>
-    groupsWithData.has(g),
-  );
+  // Every coarse group is offered — INCLUDING the ones this client never
+  // trained in the window, which plot a flat 0. A muscle group that is missing
+  // from the chart reads as "no aplica"; a group sitting on 0 reads as "no lo
+  // estás entrenando", which is the whole point of the breakdown (pecho ausente
+  // era indistinguible de pecho en cero).
+  //
+  // The `groupsWithData` gate keeps the two empty states honest: a client with
+  // NO attributable training at all (no logs, or logs whose exercises carry no
+  // muscle metadata) still gets an empty list → the caller's "sin datos" state,
+  // not seven flat zero lines. Twinned with iOS/Android
+  // `MuscleGroupProgress.zeroFillingCoarseGroups`.
+  const availableMuscleGroups =
+    groupsWithData.size > 0 ? [...COARSE_MUSCLE_GROUPS] : [];
 
   return { muscleGroupWeeks: weeks, availableMuscleGroups };
 }


### PR DESCRIPTION
Gemelo backoffice de gc-fitness#599 (mismo reporte: *"no muestra pecho acá… igual deberíamos mostrarlo y computar 0"*).

## Causa

`buildMuscleGroupWeeks` devolvía `availableMuscleGroups` filtrado a los grupos **con datos**, así que un cliente sin trabajo de pecho en la ventana no veía Pecho en el selector. Ausente es indistinguible de cero — y el cero es la señal útil.

## Cambio

Devuelve los 7 grupos coarse siempre que haya algo atribuible. Los buckets semanales siguen llevando **solo** los grupos entrenados: la UI ya resuelve el resto como 0 (`buildChartRows` y el legend usan `?? 0`), así que no se inventan celdas.

El gate `groupsWithData` mantiene honestos los dos estados vacíos: un cliente sin entrenamientos atribuibles (sin logs, o con logs cuyos ejercicios no tienen metadata muscular) sigue devolviendo lista vacía y cae en el estado "sin datos" en vez de mostrar siete líneas planas.

## Gates

- `npx jest` → 958/959 (el único rojo es el flake conocido de `client-activity-time` con locale no-en-US, verde en CI). Suite de muscle-groups: 57/57, con 2 casos nuevos (grupo no entrenado ofrecido; nada atribuible → lista vacía).
- `npx tsc --noEmit` limpio.

Sin cambios de rules, índices ni lecturas nuevas de Firestore.