### PR TITLE
Feed de actividad: atribuir cada evento a quien lo hizo + skeleton de avatar (#671)

### DIFF
--- a/backoffice/src/components/gc-fitness/ClientAvatar.tsx
+++ b/backoffice/src/components/gc-fitness/ClientAvatar.tsx
@@ -9,12 +9,17 @@
 // client's initials when there is no photoURL or the image fails to load
 // (404 / expired Storage signature / CORS) instead of a broken-image icon.
 //
+// While a photo is still decoding the circle renders as a PULSING SKELETON: a
+// custom (Storage-hosted) photo goes through the optimizer or the same-origin
+// proxy, and the empty circle it used to leave behind read as broken rather
+// than as loading.
+//
 // Hosts must be allow-listed in `next.config.ts` `images.remotePatterns`
 // (`lh3.googleusercontent.com` for Google photos, `storage.googleapis.com` for
 // uploads) — both are present. A photoURL on any other host won't optimize and
 // will trigger the initials fallback via the error path rather than throwing.
 
-import { useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import Image from "next/image";
 
 import { cn } from "@/lib/utils";
@@ -77,10 +82,35 @@ export function ClientAvatar({
   // Local per-render error flag: if the optimized image fails (expired URL,
   // CORS, host not allow-listed), fall back to initials.
   const [failed, setFailed] = useState(false);
+  // A custom (Storage-hosted) photo goes through the optimizer / the
+  // same-origin proxy, so it can take a beat. Until it decodes we showed an
+  // EMPTY circle; now the circle pulses as a skeleton so the row reads as
+  // "loading" instead of "broken".
+  const [loaded, setLoaded] = useState(false);
   const px = SIZE_PX[size];
   const resolvedSrc = photoURL ? resolveAvatarSrc(photoURL) : null;
   const showImage = !!resolvedSrc && !failed;
   const bypassOptimizer = resolvedSrc ? shouldBypassOptimizer(resolvedSrc) : false;
+
+  const imageElement = useRef<HTMLImageElement | null>(null);
+
+  // `onLoad` does not fire for an image the browser already had decoded (cache
+  // hit before hydration), which would leave the skeleton pulsing forever — so
+  // read `complete` as soon as the element is attached.
+  const imageRef = useCallback((node: HTMLImageElement | null) => {
+    imageElement.current = node;
+    if (node?.complete) setLoaded(true);
+  }, []);
+
+  // A recycled avatar (a list row re-rendered for a different client) must not
+  // inherit the previous photo's state. Runs AFTER the DOM has the new `src`,
+  // so `complete` answers for the NEW image (true only on a cache hit).
+  useEffect(() => {
+    setFailed(false);
+    setLoaded(imageElement.current?.complete === true);
+  }, [resolvedSrc]);
+
+  const pending = showImage && !loaded;
 
   return (
     <div
@@ -88,6 +118,9 @@ export function ClientAvatar({
       className={cn(
         "flex shrink-0 items-center justify-center overflow-hidden rounded-full font-medium",
         SIZE_CLASS[size],
+        // Skeleton while the photo decodes: same muted disc as the initials
+        // fallback, pulsing.
+        pending && "animate-pulse bg-muted ring-1 ring-inset ring-border",
         // Initials-only styling (a photo covers the circle entirely, so photo
         // avatars keep their bare look). The old `bg-primary/10` + `text-primary`
         // was gold-on-gold: it vanished on the gold `bg-primary` chip these
@@ -102,12 +135,19 @@ export function ClientAvatar({
     >
       {showImage ? (
         <Image
+          ref={imageRef}
           src={resolvedSrc!}
           alt=""
           width={px}
           height={px}
-          className="h-full w-full rounded-full object-cover"
+          className={cn(
+            "h-full w-full rounded-full object-cover transition-opacity duration-200",
+            // Hidden (not unmounted) while decoding: the skeleton owns the
+            // circle, and a half-painted image never flashes.
+            loaded ? "opacity-100" : "opacity-0",
+          )}
           unoptimized={bypassOptimizer}
+          onLoad={() => setLoaded(true)}
           onError={() => setFailed(true)}
         />
       ) : (

--- a/backoffice/src/lib/gc-fitness/__tests__/activity-feed-actions.test.ts
+++ b/backoffice/src/lib/gc-fitness/__tests__/activity-feed-actions.test.ts
@@ -156,6 +156,38 @@ describe("workout finished", () => {
   });
 });
 
+describe("a coached client's workout", () => {
+  beforeEach(() => {
+    queryGet.audit_log = async () => ({
+      docs: [
+        doc("a-log", {
+          collection: "workout_logs",
+          docId: "log-2",
+          op: "create",
+          changedFields: ["status", "duration_seconds"],
+          changedFieldCount: 2,
+          after: { status: "completed", duration_seconds: 2040 },
+          // Coach-owned doc: `trainerId` is the COACH, `clientId` the athlete.
+          trainerId: "coach1",
+          clientId: "client1",
+          occurredAt: ts("2026-07-29T23:24:00.000Z"),
+        }),
+      ],
+    });
+  });
+
+  it("says the CLIENT finished it, and does not repeat them as the target", async () => {
+    const [finish] = await listActivityFeed();
+    expect(finish.title).toBe("Terminó un workout");
+    // The regression: this read "Coach One terminó un workout … → Client One".
+    expect(finish.actor?.name).toBe("Client One");
+    expect(finish.client).toBeNull();
+    expect(finish.href).toBe(
+      "/gc-fitness/admin/coaches/coach1/clients/client1/workouts/log-2",
+    );
+  });
+});
+
 describe("assignments, habits and accounts", () => {
   beforeEach(() => {
     queryGet.audit_log = async () => ({

--- a/backoffice/src/lib/gc-fitness/__tests__/activity-feed-model.test.ts
+++ b/backoffice/src/lib/gc-fitness/__tests__/activity-feed-model.test.ts
@@ -129,6 +129,39 @@ describe("classifyAuditRecord — workouts", () => {
     });
   });
 
+  it("attributes a COACHED client's session to the client, not to their coach", () => {
+    // The regression: `trainerId` is stamped on every coach-owned doc, so the
+    // feed read "Ana Oller terminó un workout" about her client's session.
+    const event = classifyAuditRecord(
+      record({
+        collection: "workout_logs",
+        docId: "log-2",
+        op: "create",
+        changedFields: ["status"],
+        after: { status: "completed" },
+        clientId: "ailen",
+        trainerId: "ana-coach",
+      }),
+    );
+    expect(event.actorUid).toBe("ailen");
+    expect(event.isSelfService).toBe(false);
+  });
+
+  it("honours an explicit actor stamp over any inference", () => {
+    const event = classifyAuditRecord(
+      record({
+        collection: "workout_logs",
+        op: "create",
+        changedFields: ["status"],
+        after: { status: "completed" },
+        actorUid: "someone-else",
+        clientId: "ailen",
+        trainerId: "ana-coach",
+      }),
+    );
+    expect(event.actorUid).toBe("someone-else");
+  });
+
   it("treats per-set / RPE log updates as low-signal noise", () => {
     const event = classifyAuditRecord(
       record({
@@ -193,6 +226,55 @@ describe("classifyAuditRecord — scheduling", () => {
     expect(event.meta[0]).toBe("2026-08-01 → 2026-08-03");
   });
 
+  it("credits a move to the athlete only when iOS stamped originallyScheduledFor", () => {
+    const byAthlete = classifyAuditRecord(
+      record({
+        changedFields: ["scheduledFor", "originallyScheduledFor", "updatedAt"],
+        before: { scheduledFor: "2026-08-01" },
+        after: { scheduledFor: "2026-08-03", originallyScheduledFor: "2026-08-01" },
+        clientId: "ailen",
+        trainerId: "ana-coach",
+      }),
+    );
+    expect(byAthlete.actorUid).toBe("ailen");
+
+    const byCoach = classifyAuditRecord(
+      record({
+        changedFields: ["scheduledFor", "updatedAt"],
+        before: { scheduledFor: "2026-08-01" },
+        after: { scheduledFor: "2026-08-03" },
+        clientId: "ailen",
+        trainerId: "ana-coach",
+      }),
+    );
+    expect(byCoach.actorUid).toBe("ana-coach");
+  });
+
+  it("splits the client's reminder edit from the coach's meeting time", () => {
+    const reminder = classifyAuditRecord(
+      record({
+        changedFields: ["reminderUpdatedAt", "reminderEnabled", "reminderTime"],
+        after: { reminderEnabled: false },
+        clientId: "ailen",
+        trainerId: "ana-coach",
+      }),
+    );
+    expect(reminder.title).toBe("Apagó el recordatorio del workout");
+    expect(reminder.actorUid).toBe("ailen");
+
+    const meetingTime = classifyAuditRecord(
+      record({
+        changedFields: ["scheduledTime", "updatedAt"],
+        before: { scheduledTime: "18:00" },
+        after: { scheduledTime: "19:00" },
+        clientId: "ailen",
+        trainerId: "ana-coach",
+      }),
+    );
+    expect(meetingTime.title).toBe("Cambió el horario del workout");
+    expect(meetingTime.actorUid).toBe("ana-coach");
+  });
+
   it("names the prescription write-back instead of dumping field names (#671 item 3)", () => {
     const event = classifyAuditRecord(
       record({
@@ -208,6 +290,20 @@ describe("classifyAuditRecord — scheduling", () => {
     expect(event.title).toBe("Actualizó la rutina");
     expect(event.correlation).toBe("prescription_writeback");
     expect(event.meta).toContain("3 ocurrencias");
+    // Snapshot-only write = the client's write-back from the app.
+    expect(event.actorUid).toBe(CLIENT);
+  });
+
+  it("credits a prescription rewrite that re-stamps prescriptionUpdatedAt to the coach", () => {
+    const event = classifyAuditRecord(
+      record({
+        changedFields: ["templateSnapshot", "prescriptionUpdatedAt", "updatedAt"],
+        after: { templateSnapshot: "[omitted: 900 chars]", templateId: "tpl-1" },
+        clientId: "ailen",
+        trainerId: "ana-coach",
+      }),
+    );
+    expect(event.actorUid).toBe("ana-coach");
   });
 
   it("demotes the assignment's own completed stamp (the log event already says it)", () => {
@@ -260,6 +356,67 @@ describe("classifyAuditRecord — habits, exercises, accounts", () => {
     );
     expect(event.title).toBe("Asignó un hábito");
     expect(event.action).toBe("assign");
+  });
+
+  it('reads "borrar el hábito desde este día" (an endsOn cap) as a removal, not a schedule tweak', () => {
+    // deleteHabitRecurrenceFromDate never sets `deleted` — it caps `endsOn` so
+    // past logs survive. Reported as a schedule change it read as "cambió la
+    // programación" when the coach had actually removed the habit.
+    const event = classifyAuditRecord(
+      record({
+        collection: "habits",
+        changedFields: ["endsOn", "updatedAt"],
+        before: { endsOn: null, name: { es: "1 Fruit" } },
+        after: { endsOn: "2026-07-30", name: { es: "1 Fruit" } },
+        clientId: "pato",
+        trainerId: "manu-coach",
+      }),
+    );
+    expect(event.title).toBe("Dio de baja un hábito");
+    expect(event.isDeletion).toBe(true);
+    expect(event.meta).toContain("hasta 2026-07-30");
+    expect(event.actorUid).toBe("manu-coach");
+  });
+
+  it("tells extending a habit apart from ending it", () => {
+    const extended = classifyAuditRecord(
+      record({
+        collection: "habits",
+        changedFields: ["endsOn", "updatedAt"],
+        before: { endsOn: "2026-07-30" },
+        after: { endsOn: "2026-12-31" },
+        clientId: "pato",
+        trainerId: "manu-coach",
+      }),
+    );
+    expect(extended.title).toBe("Extendió un hábito");
+    expect(extended.isDeletion).toBe(false);
+
+    const reopened = classifyAuditRecord(
+      record({
+        collection: "habits",
+        changedFields: ["endsOn", "updatedAt"],
+        before: { endsOn: "2026-07-30" },
+        after: { endsOn: null },
+        clientId: "pato",
+        trainerId: "manu-coach",
+      }),
+    );
+    expect(reopened.title).toBe("Reactivó un hábito");
+  });
+
+  it("credits a habit reminder edit to the client even on a coach-assigned habit", () => {
+    const event = classifyAuditRecord(
+      record({
+        collection: "habits",
+        changedFields: ["reminderEnabled", "reminderTime", "reminderUpdatedAt"],
+        after: { reminderEnabled: true, reminderTime: "08:00" },
+        clientId: "pato",
+        trainerId: "manu-coach",
+      }),
+    );
+    expect(event.title).toBe("Cambió el recordatorio de un hábito");
+    expect(event.actorUid).toBe("pato");
   });
 
   it("treats a soft-deleted habit as a deletion", () => {

--- a/backoffice/src/lib/gc-fitness/__tests__/client-avatar.test.tsx
+++ b/backoffice/src/lib/gc-fitness/__tests__/client-avatar.test.tsx
@@ -11,7 +11,7 @@
 // colors so the initials stay legible on any chip background.
 
 import "@testing-library/jest-dom";
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import React from "react";
 
 import { ClientAvatar } from "@/components/gc-fitness/ClientAvatar";
@@ -42,5 +42,57 @@ describe("ClientAvatar initials fallback", () => {
     );
     expect(container.querySelector("img")).not.toBeNull();
     expect(screen.queryByText("DH")).toBeNull();
+  });
+});
+
+describe("ClientAvatar loading skeleton", () => {
+  const PHOTO = "https://lh3.googleusercontent.com/x";
+
+  it("pulses a skeleton disc (and hides the image) while the photo decodes", () => {
+    const { container } = render(<ClientAvatar name="Manu" photoURL={PHOTO} />);
+    const circle = container.firstElementChild as HTMLElement;
+    // An empty transparent circle read as "broken"; now it reads as "loading".
+    expect(circle.className).toContain("animate-pulse");
+    expect(circle.className).toContain("bg-muted");
+    expect(container.querySelector("img")?.className).toContain("opacity-0");
+  });
+
+  it("stops pulsing and reveals the photo once it loads", async () => {
+    const { container } = render(<ClientAvatar name="Manu" photoURL={PHOTO} />);
+    // next/image routes its own load handler through `img.decode()`, so the
+    // callback lands a microtask later — hence waitFor, not a bare assertion.
+    fireEvent.load(container.querySelector("img")!);
+
+    await waitFor(() => {
+      expect((container.firstElementChild as HTMLElement).className).not.toContain(
+        "animate-pulse",
+      );
+    });
+    expect(container.querySelector("img")?.className).toContain("opacity-100");
+  });
+
+  it("shows initials — never a stuck skeleton — when the photo fails", () => {
+    const { container } = render(<ClientAvatar name="Manu Herrera" photoURL={PHOTO} />);
+    fireEvent.error(container.querySelector("img")!);
+
+    expect(screen.getByText("MH")).toBeInTheDocument();
+    expect((container.firstElementChild as HTMLElement).className).not.toContain(
+      "animate-pulse",
+    );
+  });
+
+  it("re-arms the skeleton when the row is recycled for another client", async () => {
+    const { container, rerender } = render(<ClientAvatar name="Manu" photoURL={PHOTO} />);
+    fireEvent.load(container.querySelector("img")!);
+    await waitFor(() => {
+      expect((container.firstElementChild as HTMLElement).className).not.toContain(
+        "animate-pulse",
+      );
+    });
+
+    rerender(<ClientAvatar name="Otro" photoURL="https://lh3.googleusercontent.com/y" />);
+    expect((container.firstElementChild as HTMLElement).className).toContain(
+      "animate-pulse",
+    );
   });
 });

--- a/backoffice/src/lib/gc-fitness/activity-feed-actions.ts
+++ b/backoffice/src/lib/gc-fitness/activity-feed-actions.ts
@@ -693,14 +693,12 @@ async function collectFeed(
 
   for (const { group, event } of classified) {
     const head = group.head;
-    // A background trigger has no auth principal: attribute the write to the
-    // doc's owner. For self-service (client === trainer) that IS the client.
-    const actorUid =
-      head.actorUid ??
-      (event.isSelfService ? head.clientId : null) ??
-      head.trainerId ??
-      head.coachId ??
-      (head.collection === "users" ? head.docId : null);
+    // WHO did it comes from the classifier (see `ClassifiedEvent.actorUid`) —
+    // NOT from whoever owns the doc. `trainerId` is stamped on every coach-owned
+    // doc, so falling back to it made the feed say "Ana Oller terminó un
+    // workout" about her client's session. An unattributable write renders with
+    // no name at all.
+    const actorUid = event.actorUid;
     const clientUid =
       head.clientId ?? (head.collection === "users" ? head.docId : null);
     events.push({
@@ -714,7 +712,7 @@ async function collectFeed(
       subject: event.subject,
       subjectRef: event.subjectRef,
       meta: event.meta,
-      actor: person(actorUid, event.isSelfService ? "client" : "coach", users),
+      actor: person(actorUid, actorUid === clientUid ? "client" : "coach", users),
       client:
         clientUid && clientUid !== actorUid ? person(clientUid, "client", users) : null,
       href: targetHref(event.target, users),

--- a/backoffice/src/lib/gc-fitness/activity-feed-model.ts
+++ b/backoffice/src/lib/gc-fitness/activity-feed-model.ts
@@ -103,6 +103,20 @@ export interface ClassifiedEvent {
   /** Short supporting facts, rendered as a "·"-joined line. */
   meta: string[];
   target: FeedTarget | null;
+  /**
+   * WHO did it. A background trigger carries no auth principal, so this is
+   * derived from what the event IS, not from who owns the doc: a workout log is
+   * always written by the client performing it, an assignment is created by
+   * whoever it belongs to (`selfAssigned`), a reschedule stamped with
+   * `originallyScheduledFor` came from the athlete's phone, and so on. `null`
+   * when the write is genuinely unattributable (a server/webhook write) — the
+   * row then renders without a name rather than blaming the wrong person.
+   *
+   * Before this existed the actor fell back to `trainerId`, which is stamped on
+   * every coach-owned doc — so the feed said "Ana Oller terminó un workout"
+   * about a session her CLIENT had done.
+   */
+  actorUid: string | null;
   /** True when the acting principal is the client themself (self-serve). */
   isSelfService: boolean;
   isDeletion: boolean;
@@ -258,6 +272,14 @@ const PRESCRIPTION_FIELDS = ["templateSnapshot", "updatedAt", "prescriptionUpdat
 /** The assignment's own "done" stamp — the workout-log event already says it. */
 const ASSIGNMENT_DONE_FIELDS = ["status", "completed_at", "completedAt", "updatedAt"];
 
+/** Written by the CLIENT's iOS reminder editor, never by the backoffice. */
+const REMINDER_FIELDS = [
+  "reminderUpdatedAt",
+  "reminderEnabled",
+  "reminderTime",
+  "reminderScope",
+];
+
 function subjectOf(data: Record<string, unknown> | null): string | null {
   if (!data) return null;
   const raw = data.name;
@@ -290,6 +312,12 @@ export function classifyAuditRecord(
   const fields = record.changedFields;
   const selfService =
     !!record.clientId && !!record.trainerId && record.clientId === record.trainerId;
+  // Actor resolution (see ClassifiedEvent.actorUid). An explicit `updatedBy` /
+  // `deletedBy` stamp on the doc always wins; otherwise each branch says whether
+  // the CLIENT or the COACH performs that kind of write.
+  const stamped = record.actorUid;
+  const byClient = stamped ?? record.clientId ?? record.trainerId ?? null;
+  const byTrainer = stamped ?? record.trainerId ?? record.coachId ?? null;
   // The row carries an "×N" badge, so the meta line only needs to say WHICH
   // occurrences a collapsed group covers — the date span, not the count again.
   const occurrences =
@@ -317,6 +345,7 @@ export function classifyAuditRecord(
           target: record.clientId
             ? { kind: "workoutLog", logId: record.docId, clientId: record.clientId }
             : null,
+          actorUid: byClient,
           isSelfService: selfService,
           isDeletion: false,
           correlation: done ? "workout_finished" : null,
@@ -332,6 +361,7 @@ export function classifyAuditRecord(
           subjectRef: null,
           meta: [],
           target: record.clientId ? { kind: "user", uid: record.clientId } : null,
+          actorUid: byClient,
           isSelfService: selfService,
           isDeletion: true,
           correlation: null,
@@ -350,6 +380,7 @@ export function classifyAuditRecord(
         target: record.clientId
           ? { kind: "workoutLog", logId: record.docId, clientId: record.clientId }
           : null,
+        actorUid: byClient,
         isSelfService: selfService,
         isDeletion: false,
         correlation: null,
@@ -376,6 +407,7 @@ export function classifyAuditRecord(
           significance: "key",
           action: "assign",
           title: isSelf ? "Se asignó un workout" : "Asignó un workout",
+          actorUid: isSelf ? byClient : byTrainer,
           subject: null,
           subjectRef: ref,
           meta,
@@ -392,6 +424,7 @@ export function classifyAuditRecord(
           significance: "key",
           action: "delete",
           title: group.count > 1 ? "Eliminó workouts agendados" : "Eliminó un workout agendado",
+          actorUid: isSelf ? byClient : byTrainer,
           subject: null,
           subjectRef: ref,
           meta: [
@@ -405,8 +438,13 @@ export function classifyAuditRecord(
         };
       }
 
-      // Re-scheduled: the civil date moved.
+      // Re-scheduled: the civil date moved. The ATHLETE's move (calendar
+      // long-press / "start and move to today") stamps `originallyScheduledFor`
+      // from iOS — that field is the only thing that tells a client move apart
+      // from a coach rescheduling the same doc from the backoffice.
       if (fields.includes("scheduledFor") && str(before.scheduledFor) !== str(after.scheduledFor)) {
+        const movedByClient =
+          isSelf || fields.includes("originallyScheduledFor") || !!str(after.originallyScheduledFor);
         return {
           category: "schedule",
           significance: "key",
@@ -416,6 +454,7 @@ export function classifyAuditRecord(
           subjectRef: ref,
           meta: [`${str(before.scheduledFor) ?? "—"} → ${str(after.scheduledFor) ?? "—"}`],
           target: record.clientId ? { kind: "user", uid: record.clientId } : null,
+          actorUid: movedByClient ? byClient : byTrainer,
           isSelfService: isSelf,
           isDeletion: false,
           correlation: null,
@@ -427,6 +466,10 @@ export function classifyAuditRecord(
       // useless `templateSnapshot, updatedAt` row from the ticket; named, and
       // folded into the finish it followed, it answers "¿actualizó el template?".
       if (changedOnly(fields, PRESCRIPTION_FIELDS) && fields.includes("templateSnapshot")) {
+        // A COACH rewriting the prescription always goes through a server write
+        // that re-stamps `prescriptionUpdatedAt`; the client's write-back from
+        // iOS touches only the snapshot.
+        const byCoachEdit = fields.includes("prescriptionUpdatedAt");
         return {
           category: "routine",
           significance: "key",
@@ -436,6 +479,7 @@ export function classifyAuditRecord(
           subjectRef: ref,
           meta: occurrences,
           target: record.clientId ? { kind: "user", uid: record.clientId } : null,
+          actorUid: byCoachEdit ? byTrainer : byClient,
           isSelfService: isSelf,
           isDeletion: false,
           correlation: "prescription_writeback",
@@ -453,13 +497,38 @@ export function classifyAuditRecord(
           subjectRef: ref,
           meta: [],
           target: record.clientId ? { kind: "user", uid: record.clientId } : null,
+          actorUid: byClient,
           isSelfService: isSelf,
           isDeletion: false,
           correlation: "assignment_completed",
         };
       }
 
-      if (fields.includes("scheduledTime") || fields.includes("reminderEnabled")) {
+      // The client's reminder edit from iOS stamps `reminderUpdatedAt` (+
+      // reminderEnabled / reminderTime / reminderScope); `scheduledTime` is the
+      // coach's meeting time. Two different actions by two different people.
+      if (REMINDER_FIELDS.some((f) => fields.includes(f))) {
+        const enabled = after.reminderEnabled;
+        return {
+          category: "schedule",
+          significance: "key",
+          action: "update",
+          title:
+            enabled === false ? "Apagó el recordatorio del workout" : "Cambió el recordatorio del workout",
+          subject: null,
+          subjectRef: ref,
+          meta: [str(after.reminderTime), ...occurrences].filter(
+            (m): m is string => !!m,
+          ),
+          target: record.clientId ? { kind: "user", uid: record.clientId } : null,
+          actorUid: byClient,
+          isSelfService: isSelf,
+          isDeletion: false,
+          correlation: null,
+        };
+      }
+
+      if (fields.includes("scheduledTime")) {
         return {
           category: "schedule",
           significance: "key",
@@ -472,6 +541,7 @@ export function classifyAuditRecord(
             ...occurrences,
           ],
           target: record.clientId ? { kind: "user", uid: record.clientId } : null,
+          actorUid: byTrainer,
           isSelfService: isSelf,
           isDeletion: false,
           correlation: null,
@@ -487,6 +557,8 @@ export function classifyAuditRecord(
         subjectRef: ref,
         meta: [fields.join(", "), ...occurrences],
         target: record.clientId ? { kind: "user", uid: record.clientId } : null,
+        // Unattributable: a low-signal field write could come from either side.
+        actorUid: stamped,
         isSelfService: isSelf,
         isDeletion: false,
         correlation: null,
@@ -497,6 +569,9 @@ export function classifyAuditRecord(
     case "habits": {
       const name = subjectOf(subject);
       const clientOwned = after.clientOwned === true || before.clientOwned === true || selfService;
+      // A client-owned habit is managed by the client; a coach-assigned one by
+      // the coach — except the reminder, which only the client's app writes.
+      const byOwner = clientOwned ? byClient : byTrainer;
       if (record.op === "create") {
         return {
           category: "habit",
@@ -511,6 +586,7 @@ export function classifyAuditRecord(
             str(after.endsOn) ? `hasta ${str(after.endsOn)}` : null,
           ].filter((m): m is string => !!m),
           target: record.clientId ? { kind: "user", uid: record.clientId } : null,
+          actorUid: byOwner,
           isSelfService: clientOwned,
           isDeletion: false,
           correlation: null,
@@ -527,11 +603,76 @@ export function classifyAuditRecord(
           subjectRef: refFor("habits", record.docId, name),
           meta: [],
           target: record.clientId ? { kind: "user", uid: record.clientId } : null,
+          actorUid: byOwner,
           isSelfService: clientOwned,
           isDeletion: true,
           correlation: null,
         };
       }
+
+      // "Eliminar el hábito desde este día" does NOT set `deleted` — it caps the
+      // recurrence by writing `endsOn` (see deleteHabitRecurrenceFromDate), so
+      // past occurrences and logs survive. Reported as a schedule tweak it read
+      // as "cambió la programación" when the operator had actually removed the
+      // habit; this is the same action, named.
+      if (changedOnly(fields, ["endsOn", "updatedAt"]) && fields.includes("endsOn")) {
+        const beforeEnd = str(before.endsOn);
+        const afterEnd = str(after.endsOn);
+        if (!afterEnd) {
+          return {
+            category: "habit",
+            significance: "key",
+            action: "update",
+            title: "Reactivó un hábito",
+            subject: name,
+            subjectRef: refFor("habits", record.docId, name),
+            meta: ["sin fecha de fin"],
+            target: record.clientId ? { kind: "user", uid: record.clientId } : null,
+            actorUid: byOwner,
+            isSelfService: clientOwned,
+            isDeletion: false,
+            correlation: null,
+          };
+        }
+        const shortened = !beforeEnd || afterEnd < beforeEnd;
+        return {
+          category: "habit",
+          significance: "key",
+          action: shortened ? "delete" : "update",
+          title: shortened ? "Dio de baja un hábito" : "Extendió un hábito",
+          subject: name,
+          subjectRef: refFor("habits", record.docId, name),
+          meta: [`hasta ${afterEnd}`],
+          target: record.clientId ? { kind: "user", uid: record.clientId } : null,
+          actorUid: byOwner,
+          isSelfService: clientOwned,
+          // Shortening removes future occurrences — it belongs in Eliminaciones.
+          isDeletion: shortened,
+          correlation: null,
+        };
+      }
+
+      if (REMINDER_FIELDS.some((f) => fields.includes(f))) {
+        return {
+          category: "habit",
+          significance: "key",
+          action: "update",
+          title:
+            after.reminderEnabled === false
+              ? "Apagó el recordatorio de un hábito"
+              : "Cambió el recordatorio de un hábito",
+          subject: name,
+          subjectRef: refFor("habits", record.docId, name),
+          meta: [str(after.reminderTime)].filter((m): m is string => !!m),
+          target: record.clientId ? { kind: "user", uid: record.clientId } : null,
+          // Reminder edits come from the client's app, even on a coach habit.
+          actorUid: byClient,
+          isSelfService: clientOwned,
+          isDeletion: false,
+          correlation: null,
+        };
+      }
+
       const scheduleTouched = fields.some((f) =>
         ["startsOn", "endsOn", "scheduleCadence", "scheduleType", "scheduleWeekdays", "scheduleMonthDays", "skippedDates"].includes(f),
       );
@@ -544,6 +685,7 @@ export function classifyAuditRecord(
         subjectRef: refFor("habits", record.docId, name),
         meta: scheduleTouched ? [habitFrequencyLabel(after)] : [fields.join(", ")],
         target: record.clientId ? { kind: "user", uid: record.clientId } : null,
+        actorUid: byOwner,
         isSelfService: clientOwned,
         isDeletion: false,
         correlation: null,
@@ -553,7 +695,10 @@ export function classifyAuditRecord(
     // ── Exercise library ─────────────────────────────────────────────────
     case "exercises": {
       const name = subjectOf(subject);
-      const owner = str(subject?.ownerId);
+      // `ownerId` is the exact author of a custom exercise (a shared-library doc
+      // has none, so a library edit stays unattributed rather than guessed).
+      const owner = str(subject?.ownerId) ?? str(after.ownerId) ?? str(before.ownerId);
+      const byOwner = stamped ?? owner;
       const target: FeedTarget = { kind: "exercise", exerciseId: record.docId };
       if (record.op === "create") {
         return {
@@ -563,6 +708,7 @@ export function classifyAuditRecord(
           title: "Creó un ejercicio",
           subject: name,
           subjectRef: refFor("exercises", record.docId, name),
+          actorUid: byOwner,
           meta: [str(subject?.primaryMuscleGroup), owner ? null : "biblioteca"].filter(
             (m): m is string => !!m,
           ),
@@ -581,6 +727,7 @@ export function classifyAuditRecord(
           title: "Eliminó un ejercicio",
           subject: name,
           subjectRef: refFor("exercises", record.docId, name),
+          actorUid: byOwner,
           meta: [],
           target,
           isSelfService: false,
@@ -595,6 +742,7 @@ export function classifyAuditRecord(
         title: "Editó un ejercicio",
         subject: name,
         subjectRef: refFor("exercises", record.docId, name),
+        actorUid: byOwner,
         meta: [fields.join(", ")],
         target,
         isSelfService: false,
@@ -613,6 +761,7 @@ export function classifyAuditRecord(
           significance: "key",
           action: "create",
           title: role === "trainer" ? "Nuevo coach" : "Nuevo usuario",
+          actorUid: record.docId,
           subject: (str(after.displayName) ?? str(after.email) ?? record.docId).trim(),
           subjectRef: null,
           meta: [
@@ -632,6 +781,7 @@ export function classifyAuditRecord(
           significance: "key",
           action: "delete",
           title: "Cuenta eliminada",
+          actorUid: stamped,
           subject: str(before.displayName) ?? str(before.email) ?? record.docId,
           subjectRef: null,
           meta: [],
@@ -652,6 +802,8 @@ export function classifyAuditRecord(
           significance: changed ? "key" : "low",
           action: "update",
           title: changed ? "Cambió la suscripción" : "Refrescó la suscripción",
+          // RevenueCat webhook / admin override — not the user tapping a button.
+          actorUid: stamped,
           subject: `${beforeTier ?? "sin plan"} → ${afterTier ?? "sin plan"}`,
           subjectRef: null,
           meta: [str(afterEnt.source), str(afterEnt.productId)].filter(
@@ -672,6 +824,7 @@ export function classifyAuditRecord(
           significance: "key",
           action: "update",
           title: nowCoached ? "Cambió de coach" : "Quedó sin coach",
+          actorUid: stamped,
           subject: nowCoached
             ? (str(after.coachDisplayName) ?? str(after.coachId))
             : null,
@@ -690,6 +843,7 @@ export function classifyAuditRecord(
           significance: "key",
           action: "update",
           title: "Cambió de rol",
+          actorUid: stamped,
           subject: `${str(before.role) ?? "—"} → ${str(after.role) ?? "—"}`,
           subjectRef: null,
           meta: [],
@@ -706,6 +860,7 @@ export function classifyAuditRecord(
           significance: "key",
           action: "delete",
           title: "Cuenta desactivada",
+          actorUid: stamped,
           subject: null,
           subjectRef: null,
           meta: [],
@@ -724,6 +879,7 @@ export function classifyAuditRecord(
         significance: "low",
         action: "update",
         title: profileTouched ? "Actualizó su perfil" : "Actualizó su cuenta",
+        actorUid: record.docId,
         subject: null,
         subjectRef: null,
         meta: [fields.join(", ")],
@@ -740,6 +896,7 @@ export function classifyAuditRecord(
         significance: "low",
         action: record.op === "create" ? "create" : record.op === "delete" ? "delete" : "update",
         title: `${record.op} ${record.collection}`,
+        actorUid: stamped,
         subject: null,
         subjectRef: null,
         meta: [fields.join(", ")],


### PR DESCRIPTION
Sigue a #291 (ya mergeado). Dos correcciones sobre el feed nuevo, más el skeleton de avatar que quedó fuera de aquel merge.

## 1. El coach aparecía terminando los workouts de sus clientes

> `Ana Oller terminó un workout DIA 3 / Ailen → Ailen`

El actor caía por defecto a `trainerId`, que el trigger estampa en **todo** doc de un cliente con coach. Como un `workout_logs` lo escribe la app del cliente, la sesión terminaba firmada por el coach — y encima el cliente se repetía como destino.

Ahora **quién hizo cada cosa lo decide el clasificador a partir de qué es el evento**, no de quién es dueño del doc. Un sello explícito (`updatedBy` / `deletedBy`) siempre gana; si no:

| evento | autor | por qué |
|---|---|---|
| `workout_logs` (cualquier op) | cliente | lo escribe la app al entrenar |
| asignación creada / eliminada | dueño (`selfAssigned` → cliente, si no coach) | |
| workout movido de día | cliente **solo** si trae `originallyScheduledFor` | ese campo lo estampa iOS cuando el atleta mueve; sin él fue el coach desde el backoffice |
| `templateSnapshot` reescrito | coach si re-estampa `prescriptionUpdatedAt`, si no cliente | el server re-estampa ese campo en todo write de prescripción; el write-back de iOS toca solo el snapshot |
| recordatorios (`reminder*`, workout y hábito) | cliente | los escribe la app; el backoffice solo los lee |
| hábito creado / editado / dado de baja | dueño (`clientOwned` → cliente, si no coach) | |
| ejercicio | su `ownerId` | dato exacto en el doc |
| alta de usuario | esa persona | |
| suscripción, cambio de coach, cambio de rol | **nadie** | webhook de RevenueCat / acción de servidor: mejor sin nombre que con el equivocado |

Cuando el actor ES el cliente ya no se lo repite como destino.

## 2. "cambió la programación" cuando en realidad eliminaron el hábito

> `Manu cambió la programación de un hábito 1 Fruit → Pato`

"Eliminar el hábito desde este día" **no** escribe `deleted`: `deleteHabitRecurrenceFromDate` recorta la recurrencia poniendo `endsOn` al día anterior, justamente para no borrar el historial. El feed veía un campo de programación y lo reportaba como un retoque de agenda.

Ahora ese write se lee como **"Dio de baja un hábito · hasta 2026-07-30"** y cuenta como eliminación (aparece en la pestaña Eliminaciones), distinguiendo recortar de **extender** (`endsOn` más lejano) y de **reactivar** (`endsOn` borrado).

De paso separa dos cosas que caían en el mismo renglón: el **recordatorio** que configura el cliente desde la app ("Cambió / Apagó el recordatorio del workout") y el **horario** de la sesión que fija el coach ("Cambió el horario del workout").

## 3. Skeleton mientras carga la foto del avatar

El commit que ya habías pedido y que no entró en el merge de #291: `ClientAvatar` pulsa el disco muted mientras la foto decodifica en vez de dejar el círculo vacío. Chequea `complete` en el ref (si no, un cache hit dejaba el skeleton pulsando para siempre) y re-arma el estado cuando una fila de lista se recicla para otro cliente.

## Tests

- `npx jest` → **1009 pass**, 1 fail: `client-activity-time`, la flake de locale local ya documentada (verde en CI), ajena a este PR.
- `npx tsc --noEmit` limpio, `next build` compila.
- 9 casos nuevos en `activity-feed-model` (atribución por tipo de evento, sello explícito, move con/sin `originallyScheduledFor`, prescripción coach vs cliente, recordatorio vs horario, baja/extensión/reactivación de hábito) y 1 en `activity-feed-actions` que reproduce la fila del reporte: el workout de un cliente CON coach debe decir el cliente y no duplicarlo como destino.
- Verifiqué el resultado contra 300 writes reales de producción: los workouts pasan a estar firmados por el cliente, las bajas de hábito por el coach que las hizo, y los cambios de suscripción quedan sin actor.