### PR TITLE
Observability: el extendido automático deja de disfrazarse de asignación, + 3 eventos (#682)

### DIFF
--- a/.planning/quick/260801-682-observability-events/PLAN.md
+++ b/.planning/quick/260801-682-observability-events/PLAN.md
@@ -1,0 +1,67 @@
+---
+issue: 682
+repo: golden-crow-website (backoffice)
+---
+
+# 260801-682 — el "extendido automático" en el feed, y tres eventos que faltaban
+
+## Lo que pide el ticket
+
+1. La fila de observability que muestra el screenshot es un **extendido automático** de una
+   rutina recurrente, y el feed la titula como si alguien hubiera asignado un workout.
+   "Chequear bien como es lo del extendido (que es correcto), pero representarlo como tal."
+2. Sumar al feed: usuario nuevo, compra de suscripción, coach agrega un cliente.
+
+## Qué es el extendido (verificado en el código iOS)
+
+`ClientRoutineRepository.topUpRecurringSelfSeries` (iOS/GCFitness/Features/Workouts/ClientRoutinesView.swift)
++ `SelfRoutineHorizon` (GCFitnessCore):
+
+- una rutina propia recurrente materializa **documentos reales**, 90 días hacia adelante;
+- cada vez que la app tiene los assignments en memoria mira la cola de cada serie y, si baja
+  de 45 días, **escribe sola** la próxima tanda hasta hoy + 90;
+- el payload **replica el key set del create original** — mismo `scheduleStartCivil`, mismo
+  `selfAssigned`, misma `recurrence`, sin ningún campo que lo marque.
+
+O sea: el mecanismo está bien, pero es indistinguible de un alta a nivel wire. Por eso el feed
+lo leía como "Se asignó un workout".
+
+## Cómo se distingue sin tocar la app ni las rules
+
+El ancla. `createSelfAssignments` estampa `scheduleStartCivil = startCivil ?? today`, y la hoja
+de agendado sólo ofrece hoy o después → **en un alta real el ancla nunca está en el pasado al
+momento de la escritura**. Una renovación copia el ancla ORIGINAL a documentos escritos meses
+después. Con eso alcanza, es una propiedad del dato (no un marcador nuevo), y **clasifica lo
+que ya está guardado en `audit_log`**, cosa que un campo nuevo no haría.
+
+Margen de 2 días para absorber el desfasaje entre las fechas civiles del doc (timezone del
+cliente) y `occurredAt` (UTC). Conservador a propósito: una renovación con ancla reciente queda
+clasificada como alta normal antes que arriesgar llamar "automático" a algo que hizo una persona.
+
+## Los tres eventos
+
+| Pedido | Estado real | Acción |
+|---|---|---|
+| usuario nuevo | ya existía (`users` create → "Nuevo usuario"/"Nuevo coach") | sumar meta útil (`sin email (Apple)`, rol raro) |
+| compra de suscripción | existía como "Cambió la suscripción" para compra, baja y override de admin — las tres con la misma frase | separar por dirección del tier + `source`; en una compra el actor es el usuario |
+| coach agrega un cliente | **no existía ningún rastro** | evento nuevo `client_added` en `coach_activity` |
+
+El tercero es el hueco real: `provisionClient` tiene dos ramas y ninguna dejaba rastro atribuible
+al coach — la de pre-creado escribe en `user_mirror` (que ningún trigger de audit mira) y la de
+usuario existente escribe el `/users/{uid}` del CLIENTE, así que esa fila se lee como que el
+cliente cambió de coach.
+
+## Tareas
+
+1. `activity-feed-model.ts` — `isAutoExtendedOccurrence()` + rama en el create de
+   `workout_assignments`; copia de suscripción por dirección; meta de usuario nuevo.
+2. `coach-activity-log.ts` — kind `client_added` + `clientAddedEvent()`.
+3. `user-actions.ts` — registrar el evento en las DOS ramas de `provisionClient` (best-effort).
+4. `activity-feed-actions.ts` + `coach-activity-actions.ts` + `MyActivityFeed.tsx` + messages —
+   copia, ícono, chip, filtro e i18n del kind nuevo.
+5. Tests puros del modelo + test del reader para `client_added`.
+
+## Gate
+
+`npx jest` en `backoffice/` verde (menos el flake de locale ya conocido en
+`client-activity-time`), `tsc --noEmit` limpio.

--- a/.planning/quick/260801-682-observability-events/SUMMARY.md
+++ b/.planning/quick/260801-682-observability-events/SUMMARY.md
@@ -1,0 +1,92 @@
+---
+status: complete
+issue: 682
+repo: golden-crow-website (backoffice)
+---
+
+# 260801-682 — el extendido automático deja de disfrazarse de asignación
+
+## El hallazgo
+
+La fila del screenshot no era un bug de copy: era un evento que **nadie generó**. Una rutina
+propia recurrente materializa documentos reales 90 días hacia adelante, y cuando la cola baja de
+45 días la app escribe sola la próxima tanda (`topUpRecurringSelfSeries` +
+`SelfRoutineHorizon.datesToTopUp`). El payload replica el key set del create original — mismo
+`scheduleStartCivil`, mismo `selfAssigned`, misma `recurrence`, **sin ningún campo que lo marque**.
+El feed no tenía cómo saberlo, así que lo tituló "Se asignó un workout" y se lo atribuyó al
+atleta, meses después de que hubiera agendado la rutina.
+
+El mecanismo está bien (lo confirmé leyendo el writer y el planner puro). Lo que estaba mal era
+la representación.
+
+## Cómo se detecta sin tocar la app, las rules ni los datos
+
+**El ancla.** `createSelfAssignments` estampa `scheduleStartCivil = startCivil ?? today` y la hoja
+de agendado sólo ofrece hoy o después → en un alta real el ancla nunca está en el pasado al
+momento de escribir. Una renovación copia el ancla ORIGINAL a docs escritos meses más tarde.
+
+Elegí eso por sobre agregar un campo marcador porque:
+
+- es una propiedad del dato, no un contrato nuevo entre app / rules / backoffice;
+- **clasifica lo que ya está guardado en `audit_log`** — un marcador nuevo sólo serviría de acá
+  en adelante, y el operador está mirando el historial;
+- no toca `firestore.rules` (el create de assignments es la ruta más delicada que hay).
+
+Margen de 2 días para el desfasaje fecha-civil-del-cliente vs `occurredAt` en UTC. Deliberadamente
+conservador: una renovación con ancla reciente queda como alta normal (falso negativo) antes que
+llamar "automático" a algo que hizo una persona (falso positivo).
+
+La fila ahora dice **"Se extendió sola una rutina recurrente"**, con la cadencia, el rango de
+ocurrencias nuevas, `serie desde <ancla>` y `renovación automática del horizonte` — y **sin actor**,
+porque el feed ya aprendió en #671 que atribuirle a alguien una acción que no hizo es peor que
+dejar la fila sin nombre.
+
+## Los tres eventos pedidos: dos existían, uno no
+
+| Pedido | Antes | Ahora |
+|---|---|---|
+| usuario nuevo | ya salía ("Nuevo usuario" / "Nuevo coach") | + meta `sin email (Apple)` y el rol cuando no es client/trainer |
+| compra de suscripción | "Cambió la suscripción" para **compra, baja y override de admin** por igual | "Compró una suscripción" / "Se quedó sin suscripción" / "Le activaron…" / "Le dieron de baja…" según dirección del tier y `source`; en una compra el **actor es el usuario** (aunque la escritura entre por el webhook), en un override de admin no |
+| coach agrega un cliente | **nada** | evento nuevo `client_added` |
+
+El tercero era el hueco real. `provisionClient` tiene dos ramas y ninguna dejaba rastro
+atribuible al coach:
+
+- la de **pre-creado** escribe `/user_mirror/{email}`, y `user_mirror` **no está en
+  `MONITORED_COLLECTIONS`** del trigger de audit → invisible;
+- la de **usuario existente** escribe el `/users/{uid}` del CLIENTE → esa fila se lee como que el
+  cliente cambió de coach, no como que el coach lo agregó.
+
+Ahora las dos ramas escriben un `coach_activity` con kind `client_added`, best-effort (una falla
+de logueo no puede convertir un alta exitosa en un error para el coach). Aparece en el feed de
+admin **y** en "Mi Actividad" del coach, con ícono, chip, filtro e i18n ES/EN.
+
+`eventId` = `client:{coachUid}:{email}` — re-agregar a la misma persona después de un unlink pisa
+la fila anterior en vez de apilar duplicados.
+
+## Archivos
+
+| Archivo | Qué |
+|---|---|
+| `activity-feed-model.ts` | `isAutoExtendedOccurrence()` + rama nueva en el create de assignments; copia de suscripción por dirección; meta de usuario nuevo |
+| `coach-activity-log.ts` | kind `client_added` + `clientAddedEvent()` |
+| `user-actions.ts` | registro del evento en las dos ramas de `provisionClient` |
+| `activity-feed-actions.ts` | categoría / copia / acción / supresión de subject del kind nuevo |
+| `coach-activity-actions.ts`, `MyActivityFeed.tsx`, `messages/{es,en}.json` | tipo, ícono, chip, filtro, labels |
+| `__tests__/activity-feed-model.test.ts` | 3 tests nuevos (renovación, alta real, los tres no-casos) + el de suscripción actualizado |
+| `__tests__/activity-feed-actions.test.ts` | `client_added` con `pendingEmail` y sin uid |
+
+## Gate
+
+`npx jest` en `backoffice/`: **1013 passed, 1 failed** — el failed es el flake de locale ya
+conocido y documentado en `client-activity-time.test.ts` (verde en CI, rojo en máquinas con
+locale ≠ en-US). `tsc --noEmit` limpio.
+
+## Lo que queda anotado
+
+- `user_mirror` sigue fuera de `MONITORED_COLLECTIONS`. Acá se resolvió por el lado del evento de
+  coach, que es el correcto (nombra a quien actuó); sumar la colección al trigger es otra decisión,
+  de costo, y no hacía falta para este ticket.
+- La detección del extendido es una heurística por diseño. Si en algún momento se agrega un campo
+  marcador al payload del top-up, `isAutoExtendedOccurrence` debería preferirlo y dejar el ancla
+  como fallback para lo histórico.

--- a/backoffice/messages/en.json
+++ b/backoffice/messages/en.json
@@ -1932,6 +1932,7 @@
       "habit_assignment": "Habits",
       "progress_photo_request": "Photos requested",
       "weight_request": "Weight requested",
+      "client_added": "Clients added",
       "workout_template": "Workouts",
       "exercise": "Exercises",
       "note": "Notes",
@@ -1945,6 +1946,7 @@
       "habit_assignment": "Habit",
       "progress_photo_request": "Photos",
       "weight_request": "Weight",
+      "client_added": "Client",
       "note": "Note",
       "chat": "Chat"
     }

--- a/backoffice/messages/es.json
+++ b/backoffice/messages/es.json
@@ -1932,6 +1932,7 @@
       "habit_assignment": "Hábitos",
       "progress_photo_request": "Fotos pedidas",
       "weight_request": "Peso pedido",
+      "client_added": "Clientes agregados",
       "workout_template": "Entrenamientos",
       "exercise": "Ejercicios",
       "note": "Notas",
@@ -1945,6 +1946,7 @@
       "habit_assignment": "Hábito",
       "progress_photo_request": "Fotos",
       "weight_request": "Peso",
+      "client_added": "Cliente",
       "note": "Nota",
       "chat": "Chat"
     }

--- a/backoffice/src/app/gc-fitness/my-activity/MyActivityFeed.tsx
+++ b/backoffice/src/app/gc-fitness/my-activity/MyActivityFeed.tsx
@@ -14,6 +14,7 @@ import {
   Scale,
   Timer,
   Trash2,
+  UserPlus,
 } from "lucide-react";
 
 import { useTranslations } from "next-intl";
@@ -49,6 +50,8 @@ const TYPE_OPTION_KEYS: string[] = [
   "workout_template",
   "exercise",
   "note",
+  // #682 — the coach linking a client to their roster.
+  "client_added",
   "chat",
 ];
 
@@ -63,6 +66,7 @@ const KIND_ICON = {
   progress_photo_request: Camera,
   weight_request: Scale,
   note: NotebookPen,
+  client_added: UserPlus,
   chat: MessageSquare,
 } satisfies Record<CoachActivityKind, ComponentType<{ className?: string }>>;
 
@@ -89,6 +93,8 @@ const KIND_CHIP: Record<CoachActivityKind, string> = {
     "border-[color:var(--badge-violet-border)] bg-[color:var(--badge-violet-bg)] text-[color:var(--badge-violet-fg)]",
   weight_request:
     "border-[color:var(--badge-warning-border)] bg-[color:var(--badge-warning-bg)] text-[color:var(--badge-warning-fg)]",
+  client_added:
+    "border-[color:var(--badge-success-border)] bg-[color:var(--badge-success-bg)] text-[color:var(--badge-success-fg)]",
 };
 
 // Deletion rows (coach removed something) use the rose token so they stand out.

--- a/backoffice/src/lib/gc-fitness/__tests__/activity-feed-actions.test.ts
+++ b/backoffice/src/lib/gc-fitness/__tests__/activity-feed-actions.test.ts
@@ -346,6 +346,35 @@ describe("other sources", () => {
     expect(event.client?.name).toBe("Client One");
   });
 
+  // #682 — "cuando un coach agrega un cliente". Before this event existed the
+  // action left NO coach-attributed trail: the pre-create branch writes to
+  // `user_mirror` (no audit trigger watches it) and the existing-user branch
+  // writes the CLIENT's own `/users` doc, so the only row that ever appeared
+  // read as the client changing coach.
+  it("shows a coach adding a client, with the pending email when there is no uid yet", async () => {
+    queryGet.coach_activity = async () => ({
+      docs: [
+        doc("ca3", {
+          trainerId: "coach1",
+          kind: "client_added",
+          title: "Cliente agregado: nuevo@x.com",
+          detail: "nuevo@x.com · pre-creado (se vincula al primer ingreso)",
+          clientId: null,
+          pendingEmail: "nuevo@x.com",
+          occurredAt: ts("2026-07-20T10:00:00.000Z"),
+        }),
+      ],
+    });
+    const [event] = await listActivityFeed({ source: "coach_activity" });
+    expect(event.title).toBe("Agregó un cliente");
+    expect(event.actor?.name).toBe("Coach One");
+    // No uid yet — the row still names WHO was added.
+    expect(event.client?.name).toBe("nuevo@x.com");
+    expect(event.category).toBe("account");
+    // The stored title repeats the person the client chip already names.
+    expect(event.subject).toBeNull();
+  });
+
   it("collapses a photo check-in set into one event that links to the gallery", async () => {
     const events = await listActivityFeed({ source: "progress_photos" });
     expect(events).toHaveLength(1);

--- a/backoffice/src/lib/gc-fitness/__tests__/activity-feed-model.test.ts
+++ b/backoffice/src/lib/gc-fitness/__tests__/activity-feed-model.test.ts
@@ -8,6 +8,7 @@
 
 import {
   classifyAuditRecord,
+  isAutoExtendedOccurrence,
   durationLabel,
   habitFrequencyLabel,
   isElided,
@@ -210,6 +211,103 @@ describe("classifyAuditRecord — scheduling", () => {
     );
     expect(byCoach.title).toBe("Asignó un workout");
     expect(byCoach.isSelfService).toBe(false);
+  });
+
+  // ── #682 — the automatic horizon renewal ───────────────────────────────
+  //
+  // A recurring self-routine materializes 90 days of real docs and the app
+  // silently writes the next batch once the tail drops under 45 days
+  // (`topUpRecurringSelfSeries`). The payload is indistinguishable from the
+  // original create EXCEPT that it carries the ORIGINAL `scheduleStartCivil`
+  // anchor onto docs written months later — which is the whole tell.
+  it("calls the app's horizon renewal what it is, and credits nobody with it", () => {
+    const renewal = classifyAuditRecord(
+      record({
+        op: "create",
+        changedFields: ["scheduleStartCivil", "selfAssigned", "recurrence", "scheduledFor"],
+        after: {
+          selfAssigned: true,
+          templateId: "tpl-1",
+          scheduledFor: "2026-10-15",
+          scheduleStartCivil: "2026-04-02",
+          recurrence: { kind: "weekly", weekday: 4 },
+        },
+        clientId: CLIENT,
+        trainerId: CLIENT,
+        occurredAtISO: "2026-07-31T20:37:02.331Z",
+      }),
+      { count: 12, dates: ["20261015", "20261022"] },
+    );
+    expect(renewal.title).toBe("Se extendió sola una rutina recurrente");
+    // Nobody did this. Crediting the athlete would put an assignment they never
+    // made under their name, months after they scheduled the routine.
+    expect(renewal.actorUid).toBeNull();
+    expect(renewal.meta).toContain("serie desde 2026-04-02");
+    expect(renewal.meta).toContain("renovación automática del horizonte");
+  });
+
+  it("still calls a real scheduling an assignment when the anchor is today's", () => {
+    const scheduled = classifyAuditRecord(
+      record({
+        op: "create",
+        changedFields: ["scheduleStartCivil", "selfAssigned", "recurrence", "scheduledFor"],
+        after: {
+          selfAssigned: true,
+          templateId: "tpl-1",
+          scheduledFor: "2026-07-31",
+          scheduleStartCivil: "2026-07-31",
+          recurrence: { kind: "weekly", weekday: 5 },
+        },
+        clientId: CLIENT,
+        trainerId: CLIENT,
+        occurredAtISO: "2026-07-31T20:37:02.331Z",
+      }),
+    );
+    expect(scheduled.title).toBe("Se asignó un workout");
+    expect(scheduled.actorUid).toBe(CLIENT);
+  });
+
+  it("never mistakes a coach assignment or a one-off for a renewal", () => {
+    // A `.single` self-assignment carries no recurrence map at all, and a coach
+    // assignment is not `selfAssigned` — neither is ever topped up.
+    const single = record({
+      op: "create",
+      after: {
+        selfAssigned: true,
+        scheduledFor: "2026-10-15",
+        scheduleStartCivil: "2026-04-02",
+      },
+      clientId: CLIENT,
+      trainerId: CLIENT,
+    });
+    const byCoach = record({
+      op: "create",
+      after: {
+        scheduledFor: "2026-10-15",
+        scheduleStartCivil: "2026-04-02",
+        recurrence: { kind: "weekly", weekday: 4 },
+      },
+      clientId: "client9",
+      trainerId: COACH,
+    });
+    expect(isAutoExtendedOccurrence(single)).toBe(false);
+    expect(isAutoExtendedOccurrence(byCoach)).toBe(false);
+    // One day of drift between the doc's civil dates (client timezone) and
+    // `occurredAt` (UTC) must not read as a renewal.
+    expect(
+      isAutoExtendedOccurrence(
+        record({
+          op: "create",
+          after: {
+            selfAssigned: true,
+            scheduledFor: "2026-08-01",
+            scheduleStartCivil: "2026-07-30",
+            recurrence: { kind: "daily" },
+          },
+          occurredAtISO: "2026-07-31T02:00:00.000Z",
+        }),
+      ),
+    ).toBe(false);
   });
 
   it("reports a re-scheduled workout as a move with both dates", () => {
@@ -477,9 +575,13 @@ describe("classifyAuditRecord — habits, exercises, accounts", () => {
         after: { entitlement: { tier: "premium", source: "revenuecat" } },
       }),
     );
-    expect(upgrade.title).toBe("Cambió la suscripción");
+    // #682 — the direction of the tier move names the action. A store-sourced
+    // free → premium is a PURCHASE, and the buyer is the actor even though the
+    // write arrives through the RevenueCat webhook.
+    expect(upgrade.title).toBe("Compró una suscripción");
     expect(upgrade.subject).toBe("free → premium");
     expect(upgrade.significance).toBe("key");
+    expect(upgrade.actorUid).toBe("u1");
 
     const refresh = classifyAuditRecord(
       record({

--- a/backoffice/src/lib/gc-fitness/activity-feed-actions.ts
+++ b/backoffice/src/lib/gc-fitness/activity-feed-actions.ts
@@ -514,6 +514,7 @@ const COACH_KIND_CATEGORY: Record<string, FeedCategory> = {
   note: "coach",
   progress_photo_request: "coach",
   weight_request: "coach",
+  client_added: "account",
 };
 
 function coachKindAction(kind: string, deleted: boolean): FeedAction {
@@ -531,6 +532,8 @@ function coachKindAction(kind: string, deleted: boolean): FeedAction {
     case "progress_photo_request":
     case "weight_request":
       return "request";
+    case "client_added":
+      return "create";
     default:
       return "other";
   }
@@ -551,6 +554,7 @@ const COACH_KIND_TITLE: Record<string, { active: string; deleted: string }> = {
   note: { active: "Escribió una nota", deleted: "Eliminó una nota" },
   progress_photo_request: { active: "Pidió fotos de progreso", deleted: "Canceló el pedido de fotos" },
   weight_request: { active: "Pidió el peso", deleted: "Canceló el pedido de peso" },
+  client_added: { active: "Agregó un cliente", deleted: "Quitó un cliente" },
 };
 
 /** Kinds whose stored title names the CLIENT, not an entity — the row already
@@ -559,6 +563,9 @@ const COACH_KINDS_WITHOUT_SUBJECT = new Set([
   "progress_photo_request",
   "weight_request",
   "note",
+  // "Cliente agregado: Manu" — the row already links the client (or their
+  // pending email) as the target chip.
+  "client_added",
 ]);
 
 /** "Workout asignado: Full Body" → "Full Body". */

--- a/backoffice/src/lib/gc-fitness/activity-feed-model.ts
+++ b/backoffice/src/lib/gc-fitness/activity-feed-model.ts
@@ -251,6 +251,65 @@ export function occurrenceDateFromId(docId: string): string | null {
   return `${d.slice(0, 4)}-${d.slice(4, 6)}-${d.slice(6, 8)}`;
 }
 
+/** UTC civil day of an ISO instant: "2026-08-01T20:37:02.331Z" → "2026-08-01". */
+function civilOf(iso: string | null): string | null {
+  const m = iso ? /^(\d{4}-\d{2}-\d{2})/.exec(iso) : null;
+  return m ? m[1] : null;
+}
+
+/** Whole days from `from` to `to` (both "YYYY-MM-DD"), or null if unparsable. */
+function civilDaysBetween(from: string, to: string): number | null {
+  const a = Date.parse(`${from}T00:00:00.000Z`);
+  const b = Date.parse(`${to}T00:00:00.000Z`);
+  if (Number.isNaN(a) || Number.isNaN(b)) return null;
+  return Math.round((b - a) / 86_400_000);
+}
+
+/**
+ * Days the anchor must predate the write by before we call it a renewal. Two
+ * absorbs the ±1-day slop between the doc's civil dates (client timezone) and
+ * `occurredAt` (UTC), which is the only reason this isn't a strict `<`.
+ */
+const AUTO_EXTENSION_MIN_LAG_DAYS = 2;
+
+/**
+ * #682 — is this `workout_assignments` create the app's **automatic horizon
+ * renewal**, rather than a person scheduling something?
+ *
+ * A recurring self-created routine is stored as one real doc per occurrence,
+ * materialized 90 days ahead (`SelfRoutineHorizon.horizonDays`). When the tail
+ * of a series drops under 45 days the app silently writes the next batch —
+ * `topUpRecurringSelfSeries` — with no user action behind it. The payload is a
+ * byte-for-byte replay of the original create (same key set, same
+ * `scheduleStartCivil` anchor, no marker field), which is why the feed titled it
+ * "Se asignó un workout" months after the person had actually scheduled it.
+ *
+ * The tell is the anchor. `createSelfAssignments` stamps
+ * `scheduleStartCivil = requestedStartCivil ?? today`, and the scheduling sheet
+ * only offers today or later — so on a genuine scheduling the anchor is never
+ * in the past at write time. A renewal copies the ORIGINAL anchor onto docs
+ * written months later, so the anchor sits well before the write. That is a
+ * property of the data, not a marker we have to add, which also means it
+ * classifies the writes already sitting in `audit_log`.
+ *
+ * Deliberately conservative: a renewal whose anchor is recent stays classified
+ * as a normal assignment (under-claiming), rather than risk calling a real
+ * scheduling automatic.
+ */
+export function isAutoExtendedOccurrence(record: AuditRecord): boolean {
+  if (record.collection !== "workout_assignments" || record.op !== "create") return false;
+  const after = record.after;
+  if (!after || after.selfAssigned !== true) return false;
+  // Only a SERIES is ever topped up; `.single` never carries a recurrence map.
+  const kind = str((after.recurrence as Record<string, unknown> | null)?.kind);
+  if (!kind || kind === "single") return false;
+  const anchor = str(after.scheduleStartCivil);
+  const wroteOn = civilOf(record.occurredAtISO);
+  if (!anchor || !wroteOn) return false;
+  const lag = civilDaysBetween(anchor, wroteOn);
+  return lag !== null && lag >= AUTO_EXTENSION_MIN_LAG_DAYS;
+}
+
 // ─────────────────────────────────────────────────────────────────────────────
 // Classification
 // ─────────────────────────────────────────────────────────────────────────────
@@ -396,6 +455,34 @@ export function classifyAuditRecord(
       const isSelf = after.selfAssigned === true || before.selfAssigned === true || selfService;
 
       if (record.op === "create") {
+        // The horizon renewal (see `isAutoExtendedOccurrence`). NOBODY did this
+        // — the app topped the series back up on its own — so it renders with
+        // no actor rather than crediting the athlete with an assignment they
+        // did not make. Kept at "key": it materializes ~90 days of calendar and
+        // fires roughly once every 45 days per series, so it is rare enough to
+        // read and load-bearing enough to want to see when a calendar changes.
+        if (isAutoExtendedOccurrence(record)) {
+          return {
+            category: "schedule",
+            significance: "key",
+            action: "other",
+            title: "Se extendió sola una rutina recurrente",
+            subject: null,
+            subjectRef: ref,
+            meta: [
+              recurrenceLabel(after.recurrence),
+              ...(group.count > 1 ? occurrences : [str(after.scheduledFor)]),
+              `serie desde ${str(after.scheduleStartCivil)}`,
+              "renovación automática del horizonte",
+            ].filter((m): m is string => !!m),
+            target: record.clientId ? { kind: "user", uid: record.clientId } : null,
+            actorUid: null,
+            isSelfService: false,
+            isDeletion: false,
+            correlation: null,
+          };
+        }
+
         const meta = [
           recurrenceLabel(after.recurrence),
           ...occurrences,
@@ -766,8 +853,13 @@ export function classifyAuditRecord(
           subjectRef: null,
           meta: [
             str(after.email),
+            // #682 — an Apple sign-in only hands over the email on the FIRST
+            // auth, so a re-provisioned Apple user lands without one. That is
+            // exactly the kind of thing "un usuario nuevo" needs to show.
+            after.needsEmail === true ? "sin email (Apple)" : null,
             str(after.coachDisplayName) ? `coach: ${str(after.coachDisplayName)}` : null,
             after.autoAssignedCoach === true ? "coach auto-asignado" : null,
+            role !== "client" && role !== "trainer" ? `rol: ${role}` : null,
           ].filter((m): m is string => !!m),
           target,
           isSelfService: true,
@@ -797,18 +889,43 @@ export function classifyAuditRecord(
         const afterEnt = (after.entitlement ?? {}) as Record<string, unknown>;
         const afterTier = str(afterEnt.tier);
         const changed = beforeTier !== afterTier;
+        const source = str(afterEnt.source);
+        // #682 — "cuando un usuario compra una subscripción" needs to read as a
+        // PURCHASE, not as the generic "cambió la suscripción" that covered a
+        // buy, a lapse and an operator override with one sentence. The direction
+        // of the tier move says which of the three it was; `source` says whether
+        // the store or an admin did it (`revenuecat` is the webhook writing what
+        // the user bought — the only branch where the user is the actor).
+        const boughtIn = afterTier === "premium" && beforeTier !== "premium";
+        const lapsed = beforeTier === "premium" && afterTier !== "premium";
+        const byAdmin = source !== null && source !== "revenuecat";
+        const title = !changed
+          ? "Refrescó la suscripción"
+          : boughtIn
+            ? byAdmin
+              ? "Le activaron la suscripción"
+              : "Compró una suscripción"
+            : lapsed
+              ? byAdmin
+                ? "Le dieron de baja la suscripción"
+                : "Se quedó sin suscripción"
+              : "Cambió la suscripción";
         return {
           category: "account",
           significance: changed ? "key" : "low",
           action: "update",
-          title: changed ? "Cambió la suscripción" : "Refrescó la suscripción",
-          // RevenueCat webhook / admin override — not the user tapping a button.
-          actorUid: stamped,
+          title,
+          // A store purchase IS the user's action, even though the write lands
+          // via the RevenueCat webhook. An admin override is not — it keeps the
+          // stamped actor (or none) so the row never credits the wrong person.
+          actorUid: changed && !byAdmin ? record.docId : stamped,
           subject: `${beforeTier ?? "sin plan"} → ${afterTier ?? "sin plan"}`,
           subjectRef: null,
-          meta: [str(afterEnt.source), str(afterEnt.productId)].filter(
-            (m): m is string => !!m,
-          ),
+          meta: [
+            source,
+            str(afterEnt.productId),
+            str(afterEnt.expiresAt) ? `vence ${str(afterEnt.expiresAt)?.slice(0, 10)}` : null,
+          ].filter((m): m is string => !!m),
           target,
           isSelfService: false,
           isDeletion: false,

--- a/backoffice/src/lib/gc-fitness/coach-activity-actions.ts
+++ b/backoffice/src/lib/gc-fitness/coach-activity-actions.ts
@@ -15,6 +15,7 @@ export type CoachActivityKind =
   | "note"
   | "progress_photo_request"
   | "weight_request"
+  | "client_added"
   | "chat";
 
 export interface MyCoachActivityRow {

--- a/backoffice/src/lib/gc-fitness/coach-activity-log.ts
+++ b/backoffice/src/lib/gc-fitness/coach-activity-log.ts
@@ -35,7 +35,13 @@ export type CoachActivityLogKind =
   | "habit_assignment"
   | "note"
   | "progress_photo_request"
-  | "weight_request";
+  | "weight_request"
+  // #682 — the coach linking a client to themselves (`provisionClient`). It is
+  // the only coach action that had NO trail at all: the mirror branch writes to
+  // `user_mirror`, which no audit trigger watches, and the existing-user branch
+  // writes `/users/{uid}` whose audit row is attributed to the CLIENT (it is
+  // their doc), so the feed never showed the coach doing anything.
+  | "client_added";
 
 export interface CoachActivityEvent {
   /** Deterministic id so re-runs / per-occurrence triggers are idempotent. */
@@ -250,6 +256,41 @@ export function weightRequestedEvent(args: {
     clientId: args.clientId,
     pendingEmail: null,
     occurredAt: args.requestedAt,
+  };
+}
+
+/**
+ * Coach linked a client to their roster. eventId `client:{coachUid}:{email}` —
+ * keyed by the pair, so re-adding the same person after an unlink overwrites
+ * the previous row instead of stacking duplicates.
+ *
+ * `mode` is which branch of `provisionClient` ran, and it is the whole point of
+ * the detail line: "existente" means the person already had an account and is
+ * now on the roster, "pre-creado" means only a `user_mirror` placeholder exists
+ * and the link completes on their first sign-in.
+ */
+export function clientAddedEvent(args: {
+  trainerId: string;
+  email: string;
+  displayName: string | null;
+  /** Resolved uid on the existing-user branch; null for a mirror pre-create. */
+  clientId: string | null;
+  mode: "attached-existing-user" | "precreated-mirror";
+  occurredAt?: Date | null;
+}): CoachActivityEvent {
+  const who = args.displayName?.trim() || args.email;
+  return {
+    eventId: `client:${args.trainerId}:${args.email}`,
+    trainerId: args.trainerId,
+    kind: "client_added",
+    title: `Cliente agregado: ${who}`,
+    detail:
+      args.mode === "attached-existing-user"
+        ? `${args.email} · cuenta existente`
+        : `${args.email} · pre-creado (se vincula al primer ingreso)`,
+    clientId: args.clientId,
+    pendingEmail: args.clientId ? null : args.email,
+    occurredAt: args.occurredAt ?? null,
   };
 }
 

--- a/backoffice/src/lib/gc-fitness/user-actions.ts
+++ b/backoffice/src/lib/gc-fitness/user-actions.ts
@@ -61,6 +61,10 @@ import {
 
 import { getCurrentTrainer } from "./auth-helpers";
 import {
+  clientAddedEvent,
+  recordCoachActivityEvent,
+} from "./coach-activity-log";
+import {
   decideLinkOutcome,
   LinkRefusedError,
   type LinkOutcome,
@@ -514,6 +518,18 @@ export async function provisionClient(input: unknown): Promise<
     if (mirrorOutcomeKind === "alreadyYours") {
       return { ok: true, mode: "already-linked" };
     }
+    // #682 — leave a coach-attributed trail. Best-effort by contract: a logging
+    // failure must never turn a completed link into an error for the coach.
+    await recordCoachActivityEvent(
+      db,
+      clientAddedEvent({
+        trainerId: session.uid,
+        email: parsed.email,
+        displayName,
+        clientId: null,
+        mode: "precreated-mirror",
+      }),
+    );
     revalidateTag("gc-fitness-roster", "max");
     return { ok: true, mode: "precreated-mirror" };
   }
@@ -658,6 +674,20 @@ export async function provisionClient(input: unknown): Promise<
   if (userOutcomeKind === "alreadyYours") {
     return { ok: true, mode: "already-linked" };
   }
+
+  // #682 — same trail as the mirror branch above. The `/users/{uid}` write this
+  // action performs DOES reach `audit_log`, but it is the client's own doc, so
+  // that row reads as the client changing coach; this one names the coach.
+  await recordCoachActivityEvent(
+    db,
+    clientAddedEvent({
+      trainerId: session.uid,
+      email: parsed.email,
+      displayName,
+      clientId: authUser.uid,
+      mode: "attached-existing-user",
+    }),
+  );
 
   revalidateTag("gc-fitness-roster", "max");
   return { ok: true, mode: "attached-existing-user" };


### PR DESCRIPTION
Cierra #682.

## El hallazgo

La fila del screenshot no era un problema de copy: era un evento que **nadie generó**.

Una rutina propia recurrente materializa **documentos reales** 90 días hacia adelante, y cuando la cola baja de 45 días la app escribe sola la próxima tanda (`topUpRecurringSelfSeries` + `SelfRoutineHorizon.datesToTopUp`). El mecanismo está bien —lo verifiqué leyendo el writer y el planner puro, que es lo que pedía el ticket—, pero el payload **replica el key set del create original**: mismo `scheduleStartCivil`, mismo `selfAssigned`, misma `recurrence`, sin ningún campo que lo marque. El feed no tenía cómo saberlo, así que lo tituló "Se asignó un workout" y se lo atribuyó al atleta, meses después de que hubiera agendado la rutina.

## Cómo se distingue, sin tocar la app ni las rules

**El ancla.** `createSelfAssignments` estampa `scheduleStartCivil = startCivil ?? today` y la hoja de agendado sólo ofrece hoy o después → en un alta real el ancla nunca está en el pasado al momento de escribir. Una renovación copia el ancla **original** a documentos escritos meses más tarde.

Elegí eso por sobre agregar un campo marcador al payload porque:

- es una propiedad del dato, no un contrato nuevo entre app / rules / backoffice;
- **clasifica lo que ya está guardado en `audit_log`** — un marcador nuevo sólo serviría de acá en adelante, y el operador está mirando el historial;
- no toca `firestore.rules` (el create de assignments es la ruta más delicada que hay).

Margen de 2 días para absorber el desfasaje entre las fechas civiles del doc (timezone del cliente) y `occurredAt` (UTC). Conservador a propósito: una renovación con ancla reciente queda clasificada como alta normal antes que arriesgar llamarle "automático" a algo que hizo una persona.

La fila ahora dice **"Se extendió sola una rutina recurrente"**, con la cadencia, el rango de ocurrencias nuevas, `serie desde <ancla>` y `renovación automática del horizonte` — y **sin actor**, porque #671 ya dejó la lección de que atribuirle a alguien una acción que no hizo es peor que dejar la fila sin nombre.

## Los tres eventos: dos existían, uno no

| Pedido | Antes | Ahora |
|---|---|---|
| usuario nuevo | ya salía ("Nuevo usuario" / "Nuevo coach") | + meta `sin email (Apple)` y el rol cuando no es client/trainer |
| compra de suscripción | "Cambió la suscripción" para **compra, baja y override de admin** por igual | se separan por dirección del tier + `source`; en una compra el **actor es el usuario**, aunque la escritura entre por el webhook |
| coach agrega un cliente | **nada** | evento nuevo `client_added` |

El tercero era el hueco real. `provisionClient` tiene dos ramas y ninguna dejaba rastro atribuible al coach:

- la de **pre-creado** escribe `/user_mirror/{email}`, y `user_mirror` **no está en `MONITORED_COLLECTIONS`** del trigger de audit → invisible;
- la de **usuario existente** escribe el `/users/{uid}` del **cliente** → esa fila se lee como que el cliente cambió de coach, no como que el coach lo agregó.

Ahora las dos ramas escriben un `coach_activity` con kind `client_added` (best-effort: una falla de logueo no puede convertir un alta exitosa en un error para el coach). Aparece en el feed de admin **y** en "Mi Actividad" del coach, con ícono, chip, filtro e i18n ES/EN. `eventId = client:{coachUid}:{email}`, así que re-agregar a la misma persona después de un unlink pisa la fila en vez de apilar duplicados.

## Tests

- `activity-feed-model.test.ts`: renovación reconocida y sin actor; alta real con ancla de hoy que **sigue** siendo "Se asignó un workout"; los tres no-casos (`.single`, asignación de coach, un día de drift de timezone); el test de suscripción actualizado a "Compró una suscripción" + actor.
- `activity-feed-actions.test.ts`: `client_added` con `pendingEmail` y sin uid todavía.

## Gate

`npx jest` en `backoffice/`: **1013 passed, 1 failed**. El rojo es el flake de locale ya conocido de `client-activity-time.test.ts` (verde en CI, rojo en máquinas con locale ≠ en-US), preexistente y no tocado por este cambio. `tsc --noEmit` limpio.

## Anotado para después

- `user_mirror` sigue fuera de `MONITORED_COLLECTIONS`. Acá se resolvió por el lado del evento de coach, que es el correcto porque nombra a quien actuó; sumar la colección al trigger es otra decisión, de costo, y no hacía falta para este ticket.
- Si algún día el payload del top-up gana un campo marcador, `isAutoExtendedOccurrence` debería preferirlo y dejar el ancla como fallback para lo histórico.