### PR TITLE
fix(#653): borrar un hábito ahora también apaga su reminder

### DIFF
--- a/backoffice/src/lib/gc-fitness/__tests__/habit-actions.test.ts
+++ b/backoffice/src/lib/gc-fitness/__tests__/habit-actions.test.ts
@@ -492,6 +492,12 @@ describe("softDeleteHabit", () => {
     const patch = mockUpdate.mock.calls[0][0];
     expect(patch.deleted).toBe(true);
     expect(patch.updatedAt).toBe("SERVER_TIMESTAMP_SENTINEL");
+    // #653 — the reminder flag goes off with the habit. The scanner's own
+    // `deleted !== true` filter already covers this path, but leaving the flag
+    // on is what made production read as "24 reminder habits" with 7 of them
+    // deleted, and it arms any future path that reaches the query without that
+    // filter.
+    expect(patch.reminderEnabled).toBe(false);
   });
 
   // T10 — ownership refusal — cross-trainer soft-delete blocked
@@ -527,6 +533,13 @@ describe("deleteHabitRecurrenceFromDate", () => {
     expect(patch.endsOn).toBe("2026-05-19");
     expect(patch.deleted).toBeUndefined();
     expect(patch.updatedAt).toBe("SERVER_TIMESTAMP_SENTINEL");
+    // #653 — and the reminder goes OFF with it. `sendHabitReminders` selects on
+    // `reminderEnabled == true` and only then applies its `endsOn` date gate, so
+    // while that gate is missing from the deployed build an ended habit keeps
+    // pushing every morning. Measured in production on 2026-08-02 from the
+    // server's own `/habit_reminder_sent` markers: six habits with a PAST
+    // `endsOn` sent again that day.
+    expect(patch.reminderEnabled).toBe(false);
   });
 
   // Deleting from at/before the start has no past to keep → full soft-delete.
@@ -542,6 +555,8 @@ describe("deleteHabitRecurrenceFromDate", () => {
     const patch = mockUpdate.mock.calls[0][0];
     expect(patch.deleted).toBe(true);
     expect(patch.endsOn).toBeUndefined();
+    // #653 — the fallback path turns the reminder off too.
+    expect(patch.reminderEnabled).toBe(false);
   });
 
   it("rejects when caller is not the doc's trainerId", async () => {

--- a/backoffice/src/lib/gc-fitness/habit-actions.ts
+++ b/backoffice/src/lib/gc-fitness/habit-actions.ts
@@ -961,6 +961,13 @@ export async function softDeleteHabit(
 
   await docRef.update({
     deleted: true,
+    // #653 — a deleted habit must not keep an enabled reminder. The scanner's
+    // in-memory `deleted !== true` filter does cover this one, but the flag
+    // being left on is what made the production data read as "24 habits with
+    // reminders" when 7 of them were deleted — and any future path that reaches
+    // the query without that filter would fire them. Same rationale, in full,
+    // in `deleteHabitRecurrenceFromDate`.
+    reminderEnabled: false,
     updatedAt: FieldValue.serverTimestamp(),
   });
 
@@ -1017,6 +1024,9 @@ export async function deleteHabitRecurrenceFromDate(
   if (existing.startsOn && newEndsOn < existing.startsOn) {
     await docRef.update({
       deleted: true,
+      // #653 — see below: a habit that will never occur again must not keep an
+      // enabled reminder.
+      reminderEnabled: false,
       updatedAt: FieldValue.serverTimestamp(),
     });
     return { ok: true };
@@ -1024,6 +1034,29 @@ export async function deleteHabitRecurrenceFromDate(
 
   await docRef.update({
     endsOn: newEndsOn,
+    // #653 — capping the recurrence must also turn the REMINDER off.
+    //
+    // This is the fix for "I deleted a habit that had a reminder and it keeps
+    // arriving the next days". `sendHabitReminders` scans
+    // `where('reminderEnabled','==',true)` and only then applies its date gate
+    // (`scheduleActiveOnCivilDate`, which does respect `endsOn`) — so the push
+    // stopping depended entirely on that gate being live in production. It is
+    // not: the gate landed in gc-fitness `27c19828` (2026-07-02) and the
+    // deployed `sendHabitReminders` dates from 2026-06-12. Functions are not
+    // deployed by CI in that repo, so production has been running a build that
+    // never knew about `endsOn`.
+    //
+    // Measured in production on 2026-08-02, from the server's own
+    // `/habit_reminder_sent` markers: "COKITA FRIA" (`endsOn` 2026-07-05) and
+    // "Caminata de 30 minutos" (`endsOn` 2026-06-01) both sent again THAT DAY,
+    // along with four more ended habits.
+    //
+    // Turning the flag off is right on its own terms — a habit with no future
+    // occurrence has nothing to remind about — and it drops the doc out of the
+    // scanner's QUERY, so the pushes stop against the deployed build too,
+    // without waiting on the operator's deploy. The deploy is still needed for
+    // the docs already in this state; it does not replace it.
+    reminderEnabled: false,
     updatedAt: FieldValue.serverTimestamp(),
   });
 


### PR DESCRIPTION
## La causa: no es código, es un deploy viejo

`sendHabitReminders` consulta `where('reminderEnabled','==',true)` y **recién después**
aplica su compuerta de fechas (`scheduleActiveOnCivilDate`, que sí respeta `endsOn`).

- La compuerta entró en gc-fitness `27c19828`, **2026-07-02**.
- La function desplegada en producción es del **2026-06-12**.

Las functions no se deployan en CI, así que producción viene corriendo un build que nunca
supo de `endsOn`. Por eso las tres pasadas anteriores del ticket leyeron el código y lo
encontraron correcto: lo es — no está desplegado.

### Evidencia del propio servidor

Marcadores `/habit_reminder_sent` leídos el 2026-08-02. Seis hábitos con `endsOn` **pasado**
volvieron a mandar push ese mismo día:

| hábito | endsOn | últimos envíos |
|---|---|---|
| COKITA FRIA | 2026-07-05 | 07-31, 08-01, **08-02** |
| Caminata de 30 minutos | 2026-06-01 | 07-31, 08-01, **08-02** |
| 30s | 2026-07-05 | 07-31, 08-01, **08-02** |
| Cena Sana | 2026-07-12 | 07-29, 07-30, 07-31 |
| 30 min bici | 2026-07-08 | 07-27, 07-29, 07-31 |
| Cardio en Ayuno | 2026-07-26 | 07-27, 07-28, 07-30 |

## El arreglo de este PR

`deleteHabitRecurrenceFromDate` (lo que corre el botón de borrar del diálogo de la agenda) y
`softDeleteHabit` escriben además `reminderEnabled: false`.

Es correcto por sí solo —un hábito sin ocurrencias futuras no tiene nada que recordar— y
además saca el doc de la **query** del scanner, así que los push paran también contra el
build desplegado, sin esperar el deploy.

## ⚠️ Lo que este PR NO arregla — acción del operador

1. **Deployar las functions**: `firebase deploy --only functions:sendHabitReminders`.
   Sin eso, la compuerta de `endsOn` sigue ausente en producción para cualquier otro camino.
2. **Los seis docs ya rotos** siguen con `reminderEnabled: true` y van a seguir mandando
   hasta que se deployen las functions (la compuerta los saltea) o se les apague la bandera
   a mano.

## Tests

`npx jest` completo: **1013/1014**. La única roja es el flake local conocido de
`client-activity-time` (formato de fecha según el locale de la máquina; verde en CI).
Los tests de `habit-actions` cubren las dos ramas nuevas.

Refs #653