### PR TITLE
fix(#697): la edición de recurrencia ya no se come una rutina ni se atribuye a nadie

### DIFF
--- a/backoffice/src/lib/gc-fitness/__tests__/activity-feed-model.test.ts
+++ b/backoffice/src/lib/gc-fitness/__tests__/activity-feed-model.test.ts
@@ -12,6 +12,7 @@ import {
   durationLabel,
   habitFrequencyLabel,
   isElided,
+  isRecurringAssignment,
   mergeWorkoutWriteBacks,
   occurrenceDateFromId,
   recurrenceLabel,
@@ -211,6 +212,87 @@ describe("classifyAuditRecord — scheduling", () => {
     );
     expect(byCoach.title).toBe("Asignó un workout");
     expect(byCoach.isSelfService).toBe(false);
+  });
+
+  // ── The one-day assignment does not start anything ─────────────────────
+  //
+  // Reported on #697: the feed read "Manolo se asignó un workout · desde
+  // 2026-08-02" for an assignment that was ONE day. "desde" promises dates
+  // after it.
+  it("says a one-off assignment's date bare, and only a series gets a 'desde'", () => {
+    const oneOff = classifyAuditRecord(
+      record({
+        op: "create",
+        changedFields: ["selfAssigned", "scheduledFor", "templateId"],
+        after: { selfAssigned: true, scheduledFor: "2026-08-02", templateId: "tpl-1" },
+        clientId: CLIENT,
+        trainerId: CLIENT,
+      }),
+    );
+    expect(oneOff.title).toBe("Se asignó un workout");
+    expect(oneOff.meta).toEqual(["2026-08-02"]);
+
+    // An explicit `.single` map is the same one day, spelled out.
+    const single = classifyAuditRecord(
+      record({
+        op: "create",
+        changedFields: ["scheduledFor", "recurrence"],
+        after: {
+          scheduledFor: "2026-08-02",
+          templateId: "tpl-1",
+          recurrence: { kind: "single" },
+        },
+        clientId: "client9",
+        trainerId: COACH,
+      }),
+    );
+    expect(single.meta).toEqual(["2026-08-02"]);
+
+    // A real series keeps it: there IS something after that date.
+    const series = classifyAuditRecord(
+      record({
+        op: "create",
+        changedFields: ["scheduledFor", "recurrence"],
+        after: {
+          scheduledFor: "2026-08-05",
+          templateId: "tpl-1",
+          recurrence: { kind: "weekly", weekday: 3 },
+        },
+        clientId: "client9",
+        trainerId: COACH,
+      }),
+    );
+    expect(series.meta).toContain("desde 2026-08-05");
+  });
+
+  it("drops the head's own date when the collapsed group already spells the span", () => {
+    // Groups keep input order (newest-first), so the head's `scheduledFor` is
+    // usually the LAST occurrence — "desde <last>" named the wrong end.
+    const collapsed = classifyAuditRecord(
+      record({
+        op: "create",
+        changedFields: ["scheduledFor", "recurrence"],
+        after: {
+          scheduledFor: "2026-10-28",
+          templateId: "tpl-1",
+          recurrence: { kind: "weekly", weekday: 3 },
+        },
+        clientId: "client9",
+        trainerId: COACH,
+      }),
+      { count: 12, dates: ["20260805", "20261028"] },
+    );
+    expect(collapsed.meta).toEqual(["todas las semanas (mié)", "2026-08-05 → 2026-10-28"]);
+    expect(collapsed.meta.some((m) => m.includes("desde"))).toBe(false);
+  });
+
+  it("reads an unknown recurrence kind as a series, not as a one-off", () => {
+    // `recurrenceLabel` returns null for a kind it doesn't know — which is why
+    // the "is this a series?" question gets its own predicate.
+    expect(recurrenceLabel({ kind: "biweekly" })).toBeNull();
+    expect(isRecurringAssignment({ kind: "biweekly" })).toBe(true);
+    expect(isRecurringAssignment({ kind: "single" })).toBe(false);
+    expect(isRecurringAssignment(undefined)).toBe(false);
   });
 
   // ── #682 — the automatic horizon renewal ───────────────────────────────
@@ -510,6 +592,41 @@ describe("classifyAuditRecord — habits, exercises, accounts", () => {
     );
     expect(event.title).toBe("Asignó un hábito");
     expect(event.action).toBe("assign");
+  });
+
+  it("does not say a one-time habit's single day twice, once prefixed with 'desde'", () => {
+    // Same reading as the one-off assignment (#697): `habitFrequencyLabel`
+    // already prints the date as "una vez (…)", and there is no "desde" about
+    // a day that is also the end.
+    const oneTime = classifyAuditRecord(
+      record({
+        collection: "habits",
+        op: "create",
+        changedFields: ["name", "scheduleType", "startsOn"],
+        after: { name: { es: "Turno médico" }, scheduleType: "one-time", startsOn: "2026-08-02" },
+        clientId: "c1",
+        trainerId: COACH,
+      }),
+    );
+    expect(oneTime.meta).toEqual(["una vez (2026-08-02)"]);
+
+    // A recurring habit does start on a day, so it keeps the prefix.
+    const recurring = classifyAuditRecord(
+      record({
+        collection: "habits",
+        op: "create",
+        changedFields: ["name", "scheduleCadence", "startsOn"],
+        after: {
+          name: { es: "Agua" },
+          scheduleCadence: "daily",
+          scheduleType: "recurring",
+          startsOn: "2026-08-02",
+        },
+        clientId: "c1",
+        trainerId: COACH,
+      }),
+    );
+    expect(recurring.meta).toEqual(["diario", "desde 2026-08-02"]);
   });
 
   it('reads "borrar el hábito desde este día" (an endsOn cap) as a removal, not a schedule tweak', () => {

--- a/backoffice/src/lib/gc-fitness/__tests__/activity-feed-model.test.ts
+++ b/backoffice/src/lib/gc-fitness/__tests__/activity-feed-model.test.ts
@@ -417,6 +417,62 @@ describe("classifyAuditRecord — scheduling", () => {
   });
 });
 
+describe("classifyAuditRecord — #697 recurrence edits", () => {
+  /** The re-expansion half of `editAssignmentRecurrence`. */
+  const reExpansion = record({
+    op: "create",
+    after: {
+      selfAssigned: true,
+      templateId: "tpl-pullin",
+      scheduledFor: "2027-01-06",
+      // ⚠️ The ORIGINAL anchor, months before this write: a recurrence edit
+      // preserves the series window on purpose. That is precisely the shape
+      // `isAutoExtendedOccurrence` reads as an automatic top-up.
+      scheduleStartCivil: "2026-07-31",
+      recurrence: { kind: "weekly", weekday: 3 },
+    },
+    clientId: CLIENT,
+    trainerId: CLIENT,
+    occurredAtISO: "2027-01-02T10:00:05.000Z",
+  });
+
+  it("was indistinguishable from the automatic renewal by the anchor alone", () => {
+    // Not a bug being asserted — the reason the fix needs the paired delete.
+    expect(isAutoExtendedOccurrence(reExpansion)).toBe(true);
+  });
+
+  it("reads as the person's change, with the weekday move, when paired", () => {
+    const event = classifyAuditRecord(reExpansion, {
+      count: 3,
+      dates: [],
+      recurrenceEdit: { previousRecurrence: { kind: "weekly", weekday: 5 } },
+    });
+    expect(event.title).toBe("Cambió la recurrencia de una rutina");
+    // The report's core complaint: the change had NO actor, because the renewal
+    // branch deliberately credits nobody.
+    expect(event.actorUid).toBe(CLIENT);
+    expect(event.action).toBe("move");
+    expect(event.isDeletion).toBe(false);
+    expect(event.meta[0]).toBe("todas las semanas (vie) → todas las semanas (mié)");
+  });
+
+  it("still calls a genuine top-up automatic when nothing was deleted", () => {
+    const event = classifyAuditRecord(reExpansion, { count: 3, dates: [] });
+    expect(event.title).toBe("Se extendió sola una rutina recurrente");
+    expect(event.actorUid).toBeNull();
+  });
+
+  it("shows a single label when only the weekday list is unavailable", () => {
+    const event = classifyAuditRecord(reExpansion, {
+      count: 1,
+      dates: [],
+      recurrenceEdit: { previousRecurrence: null },
+    });
+    expect(event.title).toBe("Cambió la recurrencia de una rutina");
+    expect(event.meta[0]).toBe("todas las semanas (mié)");
+  });
+});
+
 describe("classifyAuditRecord — habits, exercises, accounts", () => {
   it("names a client-created habit and its frequency", () => {
     const event = classifyAuditRecord(

--- a/backoffice/src/lib/gc-fitness/__tests__/audit-grouping.test.ts
+++ b/backoffice/src/lib/gc-fitness/__tests__/audit-grouping.test.ts
@@ -6,7 +6,9 @@
 // the dashboard must collapse them back into one row.
 
 import {
+  assignmentTemplateId,
   dateRangeLabel,
+  findRecurrenceEdits,
   fmtYmd,
   groupRecurringAuditEntries,
   recurringSeries,
@@ -130,5 +132,133 @@ describe("groupRecurringAuditEntries", () => {
     expect(groups[0].count).toBe(2);
     expect(groups[0].head.op).toBe("create");
     expect(groups[0].root).toBe("asg-NEW");
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// #697 — two routines swapped between weekdays, and only one showed up
+// ─────────────────────────────────────────────────────────────────────────────
+
+/** A self-created occurrence: `asg-<uid>-<YYYYMMDD>-self-<uuid>` (#392). */
+function selfOccurrence(
+  over: Partial<RawAuditLogEntry> & { id: string; date: string; templateId: string },
+): RawAuditLogEntry {
+  const { date, templateId, ...rest } = over;
+  const snapshot = { templateId, recurrence: { kind: "weekly", weekdays: [5] } };
+  return raw({
+    docId: `asg-uidClient-${date}-self-${UUID}`,
+    op: "create",
+    trainerId: "uidClient",
+    clientId: "uidClient",
+    after: snapshot,
+    ...rest,
+  });
+}
+
+describe("assignmentTemplateId", () => {
+  it("reads the routine from either snapshot", () => {
+    expect(assignmentTemplateId(raw({ id: "a", after: { templateId: "tpl-1" } }))).toBe("tpl-1");
+    expect(assignmentTemplateId(raw({ id: "b", before: { templateId: "tpl-2" } }))).toBe("tpl-2");
+    expect(assignmentTemplateId(raw({ id: "c" }))).toBeNull();
+  });
+});
+
+describe("groupRecurringAuditEntries — #697 different routines, same client", () => {
+  /**
+   * The reported bug. Every assignment id is `asg-<clientUid>-…`, so the "series
+   * root" is the PERSON: two routines edited in the same minute collapsed into
+   * one row and only the newest one's name survived — "faltan entries".
+   */
+  it("keeps two routines of the same client in the same minute apart", () => {
+    const groups = groupRecurringAuditEntries([
+      selfOccurrence({ id: "1", date: "20270107", templateId: "tpl-pullin" }),
+      selfOccurrence({ id: "2", date: "20270108", templateId: "tpl-piernubis" }),
+    ]);
+    expect(groups).toHaveLength(2);
+    expect(groups.map((g) => g.count)).toEqual([1, 1]);
+  });
+
+  it("still collapses the many occurrences of ONE routine's edit", () => {
+    const groups = groupRecurringAuditEntries([
+      selfOccurrence({ id: "1", date: "20270107", templateId: "tpl-pullin" }),
+      selfOccurrence({ id: "2", date: "20270114", templateId: "tpl-pullin" }),
+      selfOccurrence({ id: "3", date: "20270121", templateId: "tpl-pullin" }),
+    ]);
+    expect(groups).toHaveLength(1);
+    expect(groups[0].count).toBe(3);
+  });
+
+  it("falls back to the old client-wide collapse when the routine is unknown", () => {
+    // An UPDATE only snapshots the fields that changed, so `templateId` is
+    // usually absent. Splitting on "unknown" would explode one edit into a row
+    // per occurrence — the exact noise #671 removed.
+    const groups = groupRecurringAuditEntries([
+      raw({ id: "1", docId: `asg-uidClient-20270107-${UUID}` }),
+      raw({ id: "2", docId: `asg-uidClient-20270114-${UUID}` }),
+    ]);
+    expect(groups).toHaveLength(1);
+    expect(groups[0].count).toBe(2);
+  });
+});
+
+describe("findRecurrenceEdits", () => {
+  const deleted = (id: string, date: string, templateId: string, atISO: string) =>
+    raw({
+      id,
+      docId: `asg-uidClient-${date}-self-${UUID}`,
+      op: "delete",
+      trainerId: "uidClient",
+      clientId: "uidClient",
+      occurredAtISO: atISO,
+      before: { templateId, recurrence: { kind: "weekly", weekdays: [5] } },
+    });
+  const created = (id: string, date: string, templateId: string, atISO: string) =>
+    selfOccurrence({ id, date, templateId, occurredAtISO: atISO });
+
+  it("pairs the delete batch with the re-expansion of the SAME routine", () => {
+    const groups = groupRecurringAuditEntries([
+      created("c1", "20270106", "tpl-pullin", "2027-01-02T10:00:05.000Z"),
+      deleted("d1", "20270108", "tpl-pullin", "2027-01-02T10:00:01.000Z"),
+    ]);
+    expect(findRecurrenceEdits(groups)).toEqual([{ createIndex: 0, deleteIndex: 1 }]);
+  });
+
+  it("does not pair a delete of a DIFFERENT routine", () => {
+    // The ticket's scenario: one routine moved off Friday while another moved
+    // onto it. Pairing on the series root alone (= the client) would cross the
+    // wires and report each change against the other routine.
+    const groups = groupRecurringAuditEntries([
+      created("c1", "20270106", "tpl-piernubis", "2027-01-02T10:00:05.000Z"),
+      deleted("d1", "20270108", "tpl-pullin", "2027-01-02T10:00:01.000Z"),
+    ]);
+    expect(findRecurrenceEdits(groups)).toEqual([]);
+  });
+
+  it("leaves an automatic horizon top-up alone — it only ever adds", () => {
+    const groups = groupRecurringAuditEntries([
+      created("c1", "20270106", "tpl-pullin", "2027-01-02T10:00:05.000Z"),
+    ]);
+    expect(findRecurrenceEdits(groups)).toEqual([]);
+  });
+
+  it("does not reach across an unrelated delete minutes away", () => {
+    const groups = groupRecurringAuditEntries([
+      created("c1", "20270106", "tpl-pullin", "2027-01-02T10:30:00.000Z"),
+      deleted("d1", "20270108", "tpl-pullin", "2027-01-02T10:00:00.000Z"),
+    ]);
+    expect(findRecurrenceEdits(groups)).toEqual([]);
+  });
+
+  it("never claims one delete for two creates", () => {
+    const groups = groupRecurringAuditEntries([
+      created("c1", "20270106", "tpl-pullin", "2027-01-02T10:00:05.000Z"),
+      created("c2", "20270106", "tpl-pullin", "2027-01-02T10:00:06.000Z"),
+      deleted("d1", "20270108", "tpl-pullin", "2027-01-02T10:00:01.000Z"),
+    ]);
+    // The two creates land in separate groups only because their ids differ;
+    // whichever pairs first owns the delete, and the other stays unpaired.
+    const links = findRecurrenceEdits(groups);
+    expect(links).toHaveLength(1);
+    expect(new Set(links.map((l) => l.deleteIndex)).size).toBe(1);
   });
 });

--- a/backoffice/src/lib/gc-fitness/activity-feed-actions.ts
+++ b/backoffice/src/lib/gc-fitness/activity-feed-actions.ts
@@ -39,13 +39,17 @@ import {
   classifyAuditRecord,
   mergeWorkoutWriteBacks,
   type AuditRecord,
+  type ClassifiedEvent,
   type FeedAction,
   type FeedCategory,
   type FeedSignificance,
   type FeedSubjectRef,
   type FeedTarget,
 } from "@/lib/gc-fitness/activity-feed-model";
-import { groupRecurringAuditEntries } from "@/lib/gc-fitness/audit-grouping";
+import {
+  findRecurrenceEdits,
+  groupRecurringAuditEntries,
+} from "@/lib/gc-fitness/audit-grouping";
 import { getCurrentAdmin } from "@/lib/gc-fitness/auth-helpers";
 import { COACH_ACTIVITY_COLLECTION } from "@/lib/gc-fitness/coach-activity-log";
 import { FirestoreCollections } from "@/lib/gc-fitness/collections";
@@ -96,11 +100,9 @@ export interface ActivityFeedEvent {
   kind: string;
   // Fields the pure merge step reads.
   clientUid: string | null;
-  correlation:
-    | "workout_finished"
-    | "prescription_writeback"
-    | "assignment_completed"
-    | null;
+  // Mirrored from the classifier rather than re-listed, so a new tag (e.g.
+  // #697's `recurrence_edit`) cannot be added on one side only.
+  correlation: ClassifiedEvent["correlation"];
 }
 
 export interface ActivityFeedFilters {
@@ -665,10 +667,33 @@ async function collectFeed(
 
   // Collapse recurring-series writes (one coach edit → one doc per occurrence).
   const auditGroups = groupRecurringAuditEntries(auditRaw);
-  const classified = auditGroups.map((group) => ({
-    group,
-    event: classifyAuditRecord(group.head, { count: group.count, dates: group.dates }),
-  }));
+
+  // #697 — a recurrence change arrives as "delete the future occurrences" plus
+  // "write the new ones". Pair the halves so the row says what was actually done
+  // (and so the re-expansion stops being read as the automatic horizon renewal),
+  // then drop the delete half: on its own it reads as "eliminó workouts
+  // agendados", which is the opposite of what the user did.
+  const recurrenceEdits = findRecurrenceEdits(auditGroups);
+  const editByCreate = new Map(recurrenceEdits.map((l) => [l.createIndex, l.deleteIndex]));
+  const absorbedDeletes = new Set(recurrenceEdits.map((l) => l.deleteIndex));
+
+  const classified = auditGroups
+    .map((group, index) => ({ group, index }))
+    .filter(({ index }) => !absorbedDeletes.has(index))
+    .map(({ group, index }) => {
+      const deleteIndex = editByCreate.get(index);
+      const previous =
+        deleteIndex === undefined ? null : auditGroups[deleteIndex].head.before?.recurrence;
+      return {
+        group,
+        event: classifyAuditRecord(group.head, {
+          count: group.count,
+          dates: group.dates,
+          recurrenceEdit:
+            deleteIndex === undefined ? null : { previousRecurrence: previous ?? null },
+        }),
+      };
+    });
 
   // ── identities ──
   const uids = new Set<string>();

--- a/backoffice/src/lib/gc-fitness/activity-feed-model.ts
+++ b/backoffice/src/lib/gc-fitness/activity-feed-model.ts
@@ -170,6 +170,20 @@ const WEEKDAY_SUN_FIRST = ["dom", "lun", "mar", "mié", "jue", "vie", "sáb"];
 const WEEKDAY_ISO = ["", "lun", "mar", "mié", "jue", "vie", "sáb", "dom"];
 
 /**
+ * Whether a `workout_assignments.recurrence` map describes a SERIES.
+ *
+ * Deliberately not `recurrenceLabel(...) !== null`: the label is also null for
+ * a kind this reader doesn't know yet, and an unknown kind is still a series.
+ * The only shape that means "one day and that's it" is `kind: "single"` (or no
+ * recurrence map at all).
+ */
+export function isRecurringAssignment(recurrence: unknown): boolean {
+  if (!recurrence || typeof recurrence !== "object") return false;
+  const kind = str((recurrence as Record<string, unknown>).kind);
+  return !!kind && kind !== "single";
+}
+
+/**
  * Spanish label for a `workout_assignments.recurrence` map.
  *
  * Weekday convention here is JS `getDay()` (Sun=0 … Sat=6) — the one
@@ -533,10 +547,23 @@ export function classifyAuditRecord(
           };
         }
 
+        // "desde <fecha>" promises more dates after it. A one-day assignment has
+        // no more dates, so it just reads as a series that never ends — say the
+        // date bare. And when the group already spells the occurrence span out,
+        // the head's own `scheduledFor` adds nothing: it is one of those dates,
+        // and since groups keep input order (newest-first) it is usually the
+        // LAST one, so "desde" would name the wrong end of the range.
+        const scheduledFor = str(after.scheduledFor);
+        const scheduledForLabel =
+          !scheduledFor || occurrences.length > 0
+            ? null
+            : isRecurringAssignment(after.recurrence)
+              ? `desde ${scheduledFor}`
+              : scheduledFor;
         const meta = [
           recurrenceLabel(after.recurrence),
           ...occurrences,
-          str(after.scheduledFor) ? `desde ${str(after.scheduledFor)}` : null,
+          scheduledForLabel,
           str(after.scheduledTime),
         ].filter((m): m is string => !!m);
         return {
@@ -719,7 +746,12 @@ export function classifyAuditRecord(
           subjectRef: refFor("habits", record.docId, name),
           meta: [
             habitFrequencyLabel(after),
-            str(after.startsOn) ? `desde ${str(after.startsOn)}` : null,
+            // Same rule as the assignment above: a one-time habit has no "desde"
+            // — and `habitFrequencyLabel` already printed that date as
+            // "una vez (2026-08-02)", so repeating it prefixed says it twice.
+            str(after.startsOn) && str(after.scheduleType) !== "one-time"
+              ? `desde ${str(after.startsOn)}`
+              : null,
             str(after.endsOn) ? `hasta ${str(after.endsOn)}` : null,
           ].filter((m): m is string => !!m),
           target: record.clientId ? { kind: "user", uid: record.clientId } : null,

--- a/backoffice/src/lib/gc-fitness/activity-feed-model.ts
+++ b/backoffice/src/lib/gc-fitness/activity-feed-model.ts
@@ -120,8 +120,18 @@ export interface ClassifiedEvent {
   /** True when the acting principal is the client themself (self-serve). */
   isSelfService: boolean;
   isDeletion: boolean;
-  /** Tag used by `mergeWorkoutWriteBacks` to fold related rows together. */
-  correlation: "workout_finished" | "prescription_writeback" | "assignment_completed" | null;
+  /**
+   * Tag used by `mergeWorkoutWriteBacks` to fold related rows together.
+   * `recurrence_edit` is not one of its inputs — it is folded at the GROUP level
+   * (`findRecurrenceEdits`), before classification — and is carried only so the
+   * row is identifiable downstream.
+   */
+  correlation:
+    | "workout_finished"
+    | "prescription_writeback"
+    | "assignment_completed"
+    | "recurrence_edit"
+    | null;
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -363,7 +373,17 @@ function refFor(
  */
 export function classifyAuditRecord(
   record: AuditRecord,
-  group: { count: number; dates: string[] } = { count: 1, dates: [] },
+  group: {
+    count: number;
+    dates: string[];
+    /**
+     * #697 — set when this create is the re-expansion half of a recurrence edit
+     * (see `findRecurrenceEdits`), carrying what the series looked like BEFORE.
+     * Its presence is what tells an edit apart from the automatic horizon
+     * renewal, which the anchor alone cannot do.
+     */
+    recurrenceEdit?: { previousRecurrence: unknown } | null;
+  } = { count: 1, dates: [] },
 ): ClassifiedEvent {
   const subject = record.op === "delete" ? record.before : record.after;
   const before = record.before ?? {};
@@ -455,6 +475,36 @@ export function classifyAuditRecord(
       const isSelf = after.selfAssigned === true || before.selfAssigned === true || selfService;
 
       if (record.op === "create") {
+        // #697 — a recurrence EDIT (delete-future then re-expand), not a fresh
+        // assignment and not the automatic renewal below. It has to be checked
+        // first: `editAssignmentRecurrence` preserves the original
+        // `scheduleStartCivil` to keep the series window, so the re-expanded
+        // occurrences match `isAutoExtendedOccurrence` exactly and every edit
+        // rendered as "se extendió sola", with no actor — the report's other
+        // half. Only the paired delete distinguishes them.
+        if (group.recurrenceEdit) {
+          const from = recurrenceLabel(group.recurrenceEdit.previousRecurrence);
+          const to = recurrenceLabel(after.recurrence);
+          return {
+            category: "schedule",
+            significance: "key",
+            action: "move",
+            title: "Cambió la recurrencia de una rutina",
+            subject: null,
+            subjectRef: ref,
+            meta: [
+              from && to && from !== to ? `${from} → ${to}` : (to ?? from),
+              ...occurrences,
+              str(after.scheduledTime),
+            ].filter((m): m is string => !!m),
+            target: record.clientId ? { kind: "user", uid: record.clientId } : null,
+            actorUid: isSelf ? byClient : byTrainer,
+            isSelfService: isSelf,
+            isDeletion: false,
+            correlation: "recurrence_edit",
+          };
+        }
+
         // The horizon renewal (see `isAutoExtendedOccurrence`). NOBODY did this
         // — the app topped the series back up on its own — so it renders with
         // no actor rather than crediting the athlete with an assignment they

--- a/backoffice/src/lib/gc-fitness/audit-grouping.ts
+++ b/backoffice/src/lib/gc-fitness/audit-grouping.ts
@@ -57,6 +57,34 @@ export function recurringSeries(
   return m ? { root: m[1], date: m[2] } : null;
 }
 
+/**
+ * #697 — which ROUTINE an assignment write is about.
+ *
+ * ⚠️ **The id's "series root" does not identify a series.** Both id shapes are
+ * `asg-<clientUid>-<YYYYMMDD>-…` (coach-assigned) and
+ * `asg-<clientUid>-<YYYYMMDD>-self-…` (client-created, #392), so the root
+ * captured above is `asg-<clientUid>` — the **person**, shared by every routine
+ * they own. Grouping on it alone merged writes to DIFFERENT routines whenever
+ * they landed in the same minute under the same actor and op, and only the
+ * newest member's name survived: that is the literal missing-entries report in
+ * #697, where moving one routine off Friday and another onto it showed as a
+ * single row naming one of them.
+ *
+ * `templateId` is the discriminator, and it is reliably present exactly where it
+ * matters: `onAuditableWrite` snapshots ALL keys on a create and on a delete
+ * (`changedFields` = every key of after/before), which is the shape a recurrence
+ * edit produces. On an update it is only there if it changed — so an unknown
+ * template falls back to the old client-wide behavior rather than splitting
+ * every occurrence of one edit into its own row.
+ */
+export function assignmentTemplateId(entry: RawAuditLogEntry): string | null {
+  for (const snapshot of [entry.after, entry.before]) {
+    const value = snapshot?.templateId;
+    if (typeof value === "string" && value.length > 0) return value;
+  }
+  return null;
+}
+
 /** "20270503" → "2027-05-03". */
 export function fmtYmd(yyyymmdd: string): string {
   return `${yyyymmdd.slice(0, 4)}-${yyyymmdd.slice(4, 6)}-${yyyymmdd.slice(6, 8)}`;
@@ -92,7 +120,9 @@ export function groupRecurringAuditEntries<T extends RawAuditLogEntry>(
     const key = series
       ? `rec|${r.collection}|${r.op}|${r.actorUid ?? ""}|${r.trainerId ?? ""}|${
           r.clientId ?? ""
-        }|${series.root}|${(r.occurredAtISO ?? "").slice(0, 16)}`
+        }|${series.root}|${assignmentTemplateId(r) ?? ""}|${
+          (r.occurredAtISO ?? "").slice(0, 16)
+        }`
       : `solo|${r.id}`;
     const at = indexByKey.get(key);
     if (at === undefined) {
@@ -117,4 +147,77 @@ export function groupRecurringAuditEntries<T extends RawAuditLogEntry>(
         : [],
     };
   });
+}
+
+/**
+ * How far apart the delete batch and the re-expansion of one recurrence edit may
+ * land and still be recognised as the same action. `editAssignmentRecurrence`
+ * issues them back to back, but they are separate batches whose `occurredAt`
+ * stamps can straddle a minute boundary — which is also why this cannot key on
+ * the minute bucket the grouping above uses.
+ */
+const RECURRENCE_EDIT_WINDOW_MS = 2 * 60 * 1000;
+
+export interface RecurrenceEditLink {
+  /** Index of the create group that re-expanded the series. */
+  createIndex: number;
+  /** Index of the delete group it replaced — folded away by the caller. */
+  deleteIndex: number;
+}
+
+/**
+ * #697 — pair "deleted the future occurrences" with "wrote the new ones".
+ *
+ * Changing a recurring routine's weekday is `editAssignmentRecurrence`:
+ * delete-future, then re-expand. The feed showed the halves as two unrelated
+ * rows, and — worse — the re-expansion tripped `isAutoExtendedOccurrence`,
+ * because that heuristic reads a `scheduleStartCivil` anchor older than the
+ * write as "the app topped the horizon up by itself". A recurrence edit
+ * deliberately CARRIES the original anchor (it preserves the series window), so
+ * every edit looked automatic and rendered with no actor at all. That is the
+ * "solo aparece que se extendió" half of the report.
+ *
+ * The tell an anchor cannot give: an automatic top-up only ever ADDS. A delete
+ * batch for the same series, same routine and same client, moments before the
+ * creates, means a person changed something. Pairing them here also lets the two
+ * rows render as the single action they were.
+ */
+export function findRecurrenceEdits<T extends RawAuditLogEntry>(
+  groups: Array<AuditLogGroup<T>>,
+): RecurrenceEditLink[] {
+  const links: RecurrenceEditLink[] = [];
+  const claimedDeletes = new Set<number>();
+
+  groups.forEach((createGroup, createIndex) => {
+    const head = createGroup.head;
+    if (head.collection !== "workout_assignments" || head.op !== "create") return;
+    const series = recurringSeries(head.docId);
+    if (!series) return;
+    const at = Date.parse(head.occurredAtISO ?? "");
+    if (Number.isNaN(at)) return;
+    const templateId = assignmentTemplateId(head);
+
+    const deleteIndex = groups.findIndex((candidate, i) => {
+      if (i === createIndex || claimedDeletes.has(i)) return false;
+      const d = candidate.head;
+      if (d.collection !== "workout_assignments" || d.op !== "delete") return false;
+      if ((d.clientId ?? null) !== (head.clientId ?? null)) return false;
+      if (recurringSeries(d.docId)?.root !== series.root) return false;
+      // Same routine. Both sides are full snapshots (create and delete capture
+      // every key), so an unknown template here means the pairing genuinely
+      // cannot be established — not that it should be assumed.
+      const otherTemplate = assignmentTemplateId(d);
+      if (!templateId || !otherTemplate || otherTemplate !== templateId) return false;
+      const dAt = Date.parse(d.occurredAtISO ?? "");
+      if (Number.isNaN(dAt)) return false;
+      return Math.abs(at - dAt) <= RECURRENCE_EDIT_WINDOW_MS;
+    });
+
+    if (deleteIndex >= 0) {
+      claimedDeletes.add(deleteIndex);
+      links.push({ createIndex, deleteIndex });
+    }
+  });
+
+  return links;
 }


### PR DESCRIPTION
Cierra **mdb1/gc-fitness#697**.

El user movió **Piernubis** de viernes a miércoles y **PULLIN'** de miércoles a viernes. Cuatro
escrituras, dos rutinas — y `/admin/audit` mostró **dos filas, las dos sobre PULLIN'**: "se
extendió" y "se eliminó". Son **dos bugs independientes** que se combinaron.

## Bug 1 — el "series root" no identifica una serie: identifica a la PERSONA

El colapso de ocurrencias agrupa por `(collection, op, actor, client, seriesRoot, minuto)`, y el
root sale del id del doc. Pero los dos formatos son iguales hasta la fecha:

```
asg-<clientUid>-<YYYYMMDD>-<uuid>          coach-assigned
asg-<clientUid>-<YYYYMMDD>-self-<uuid>     client-created (#392)
```

El root es `asg-<clientUid>` — **el cliente**, compartido por todas sus rutinas. Dos rutinas
editadas en el mismo minuto con el mismo op caían en un solo grupo, y el `head` (el más nuevo)
le ponía el nombre a la fila. **Piernubis no faltaba: estaba absorbida dentro de la fila de
PULLIN'.**

Ahora el `templateId` entra en la clave del grupo. Está garantizado justo donde importa:
`onAuditableWrite` snapshotea **todas** las keys en un `create` y en un `delete`, que es
exactamente la forma que produce una edición de recurrencia. En un `update` sólo está si cambió,
y ahí un template desconocido **cae al comportamiento viejo** en vez de partir cada ocurrencia
de una edición en su propia fila (el ruido que #671 sacó).

## Bug 2 — la re-expansión se leía como la renovación automática del horizonte

Editar la recurrencia es *borrar-futuras + re-expandir*, y la re-expansión **conserva el
`scheduleStartCivil` original a propósito** (preserva la ventana de la serie). Eso es
exactamente la señal que usa `isAutoExtendedOccurrence` (#682) para decir "esto lo hizo la app
sola": ancla más vieja que la escritura.

Resultado: toda edición decía **"Se extendió sola una rutina recurrente"** y salía **sin actor**
— esa rama acredita a nadie deliberadamente, porque nadie hace la renovación. El usuario movió
su rutina y la pantalla dijo que se movió sola.

El ancla no puede distinguirlos. Lo que sí: **una renovación automática sólo AGREGA**. Un batch
de deletes de la misma serie, la misma rutina y el mismo cliente, segundos antes de los creates,
significa que hubo una persona. Eso es `findRecurrenceEdits`.

## Y ya que están apareadas, se muestran como lo que son

Las dos mitades se funden en una fila:

> **Cambió la recurrencia de una rutina** · `todas las semanas (vie) → todas las semanas (mié)`

La mitad de delete se descarta: sola decía "eliminó workouts agendados", que es lo contrario de
lo que el usuario hizo. El apareo **exige que coincida el `templateId`**, y no es un detalle: en
el caso del ticket una rutina sale del viernes mientras otra entra, así que aparear por el root
(= el cliente) cruzaría los cables y reportaría cada cambio contra la otra rutina.

## Tests (+13)

`audit-grouping.test.ts` y `activity-feed-model.test.ts`.

**Verificado que fallan contra el código viejo**: sacando el `templateId` de la clave, el test de
las dos rutinas del mismo cliente colapsa a 1 grupo en vez de 2.

Queda asserteado **a propósito** que `isAutoExtendedOccurrence` sigue devolviendo `true` para la
forma de una edición — no es un bug, es *la razón* por la que el arreglo necesita el delete
apareado; si algún día deja de ser cierto, conviene enterarse ahí.

## Gate

- `npx tsc --noEmit` limpio.
- `npx jest`: **1026/1027**. La única roja es `client-activity-time.test.ts`, el flake de locale
  ya conocido (verde en CI) — confirmado pre-existente corriéndolo con los cambios stasheados.
- **Sin cambios de reglas, de índices ni de wire**: esto es sólo el lector.