### PR TITLE
fix(#713): el feed de monitoring no decía qué rutina se editó ni qué cambió

### DIFF
--- a/backoffice/src/lib/gc-fitness/__tests__/activity-feed-model.test.ts
+++ b/backoffice/src/lib/gc-fitness/__tests__/activity-feed-model.test.ts
@@ -15,6 +15,8 @@ import {
   isRecurringAssignment,
   mergeWorkoutWriteBacks,
   occurrenceDateFromId,
+  recurrenceChangeLabel,
+  recurrenceDescribe,
   recurrenceLabel,
   volumeLabel,
   type AuditRecord,
@@ -551,7 +553,189 @@ describe("classifyAuditRecord — #697 recurrence edits", () => {
       recurrenceEdit: { previousRecurrence: null },
     });
     expect(event.title).toBe("Cambió la recurrencia de una rutina");
-    expect(event.meta[0]).toBe("todas las semanas (mié)");
+    // #713 — "ahora" makes it unambiguous that this is the DESTINATION and not
+    // the origin, which a bare cadence next to "cambió la recurrencia" is not.
+    expect(event.meta[0]).toBe("ahora todas las semanas (mié)");
+  });
+
+  // ── #713: "no me muestra cuál fue el cambio de recurrencia" ──────────────
+  //
+  // The old meta expression was
+  //   from && to && from !== to ? `${from} → ${to}` : (to ?? from)
+  // and `recurrenceLabel` is null for BOTH `single` and any kind it does not
+  // know — so a row could say "cambió la recurrencia de una rutina" and then
+  // print nothing at all, which is the report verbatim.
+
+  it("never renders an empty change line, whatever the two rules are", () => {
+    const cases: Array<[unknown, unknown]> = [
+      [{ kind: "single" }, { kind: "single" }],
+      [{ kind: "biweekly" }, { kind: "trimonthly" }],
+      [null, { kind: "single" }],
+      [{ kind: "weekly", weekday: 3 }, { kind: "single" }],
+    ];
+    for (const [previous, next] of cases) {
+      const event = classifyAuditRecord(
+        record({
+          op: "create",
+          after: { templateId: "tpl-pullin", scheduledFor: "2027-01-06", recurrence: next },
+          clientId: CLIENT,
+          trainerId: CLIENT,
+        }),
+        { count: 1, dates: [], recurrenceEdit: { previousRecurrence: previous } },
+      );
+      expect(event.title).toBe("Cambió la recurrencia de una rutina");
+      expect(event.meta.length).toBeGreaterThan(0);
+      expect(event.meta[0]!.trim()).not.toBe("");
+    }
+  });
+
+  it("collapsing a series to one date reads as such instead of blank", () => {
+    const event = classifyAuditRecord(
+      record({
+        op: "create",
+        after: {
+          templateId: "tpl-pullin",
+          scheduledFor: "2027-01-06",
+          recurrence: { kind: "single" },
+        },
+        clientId: CLIENT,
+        trainerId: CLIENT,
+      }),
+      {
+        count: 1,
+        dates: [],
+        recurrenceEdit: { previousRecurrence: { kind: "weekly", weekday: 3 } },
+      },
+    );
+    expect(event.meta[0]).toBe("todas las semanas (mié) → una sola vez");
+  });
+
+  it("says the dates moved when the cadence itself did not", () => {
+    const event = classifyAuditRecord(reExpansion, {
+      count: 4,
+      dates: ["2027-01-06", "2027-01-13", "2027-01-20", "2027-01-27"],
+      recurrenceEdit: { previousRecurrence: { kind: "weekly", weekday: 3 } },
+    });
+    expect(event.meta[0]).toBe("todas las semanas (mié) (cambiaron las fechas)");
+  });
+
+  /**
+   * The occurrence span used to appear only for a COLLAPSED group, so a
+   * recurrence edit that produced a single future date said nothing about WHEN.
+   */
+  it("names the affected date even for a one-occurrence edit", () => {
+    const event = classifyAuditRecord(reExpansion, {
+      count: 1,
+      dates: [],
+      recurrenceEdit: { previousRecurrence: { kind: "weekly", weekday: 5 } },
+    });
+    expect(event.meta).toContain("2027-01-06");
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// #713 — "tocar Ver detalle me lleva al detalle del cliente, pero no puedo ver
+// ni cuál workout editó ni qué cambios hizo"
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("classifyAuditRecord — #713 routine edits are identifiable", () => {
+  /**
+   * The real production shape: an UPDATE snapshots only the CHANGED fields, so
+   * a routine edit carries `templateSnapshot` (elided) and nothing else. There
+   * is no `templateId` in it — which is why the row had no name to render and
+   * fell back to a bare "ver detalle" link to the client.
+   */
+  const routineEdit = record({
+    docId: "asg-oi1SgX6-20260807-DF2F1298",
+    changedFields: ["templateSnapshot", "updatedAt"],
+    before: { templateSnapshot: "[omitted: 2107 chars]" },
+    after: { templateSnapshot: "[omitted: 2190 chars]" },
+    clientId: CLIENT,
+    trainerId: "ana-coach",
+  });
+
+  it("points at the assignment doc so the routine can be named", () => {
+    const event = classifyAuditRecord(routineEdit, { count: 1, dates: [] });
+    expect(event.title).toBe("Actualizó la rutina");
+    expect(event.subject).toBeNull();
+    expect(event.subjectRef).toEqual({
+      collection: "workout_assignments",
+      id: "asg-oi1SgX6-20260807-DF2F1298",
+    });
+  });
+
+  it("prefers the template when the snapshot does carry a templateId", () => {
+    const event = classifyAuditRecord(
+      record({
+        changedFields: ["templateSnapshot", "updatedAt"],
+        after: { templateSnapshot: "[omitted: 900 chars]", templateId: "tpl-1" },
+        clientId: CLIENT,
+      }),
+      { count: 1, dates: [] },
+    );
+    expect(event.subjectRef).toEqual({ collection: "workout_templates", id: "tpl-1" });
+  });
+
+  it("never points at a deleted assignment (the doc is gone by read time)", () => {
+    const event = classifyAuditRecord(
+      record({
+        op: "delete",
+        before: { recurrence: { kind: "weekly", weekday: 3 } },
+        clientId: CLIENT,
+      }),
+    );
+    expect(event.subjectRef).toBeNull();
+  });
+
+  it("says which kind of edit it was, since the snapshot diff is elided", () => {
+    const byClient = classifyAuditRecord(routineEdit, { count: 1, dates: [] });
+    expect(byClient.actorUid).toBe(CLIENT);
+    expect(byClient.meta).toContain("pesos y repes registrados en el entreno");
+
+    const byCoach = classifyAuditRecord(
+      record({
+        changedFields: ["templateSnapshot", "prescriptionUpdatedAt", "updatedAt"],
+        after: { templateSnapshot: "[omitted: 900 chars]" },
+        clientId: CLIENT,
+        trainerId: "ana-coach",
+      }),
+      { count: 1, dates: [] },
+    );
+    expect(byCoach.actorUid).toBe("ana-coach");
+    expect(byCoach.meta).toContain("nueva prescripción del coach");
+  });
+
+  it("keeps the occurrence span alongside the new detail", () => {
+    // `group.dates` are the COMPACT ids the doc name carries ("20260807"),
+    // which `dateRangeLabel` formats — not already-hyphenated civil dates.
+    const event = classifyAuditRecord(routineEdit, {
+      count: 12,
+      dates: ["20260807", "20261030"],
+    });
+    expect(event.meta).toContain("pesos y repes registrados en el entreno");
+    expect(event.meta.some((m) => m.includes("2026-08-07"))).toBe(true);
+  });
+});
+
+describe("recurrenceDescribe / recurrenceChangeLabel — #713", () => {
+  it("describes what recurrenceLabel deliberately leaves unsaid", () => {
+    // Unchanged contract: `recurrenceLabel` stays null for these, because next
+    // to an ASSIGNMENT there is nothing worth printing.
+    expect(recurrenceLabel({ kind: "single" })).toBeNull();
+    expect(recurrenceLabel({ kind: "biweekly" })).toBeNull();
+
+    expect(recurrenceDescribe({ kind: "single" })).toBe("una sola vez");
+    expect(recurrenceDescribe({ kind: "biweekly" })).toBe("biweekly");
+    expect(recurrenceDescribe({ kind: "daily" })).toBe("todos los días");
+    // Genuinely nothing to describe.
+    expect(recurrenceDescribe(null)).toBeNull();
+    expect(recurrenceDescribe({})).toBeNull();
+  });
+
+  it("degrades to one side when the other is unknown", () => {
+    expect(recurrenceChangeLabel(null, { kind: "daily" })).toBe("ahora todos los días");
+    expect(recurrenceChangeLabel({ kind: "daily" }, null)).toBe("antes todos los días");
+    expect(recurrenceChangeLabel(null, null)).toBeNull();
   });
 });
 

--- a/backoffice/src/lib/gc-fitness/activity-feed-actions.ts
+++ b/backoffice/src/lib/gc-fitness/activity-feed-actions.ts
@@ -433,9 +433,14 @@ async function resolveEntityNames(
         .catch(() => null);
       if (!snap || !snap.exists) return;
       const d = snap.data() as Record<string, unknown>;
+      // A log and an assignment both carry the workout's name inside their
+      // `templateSnapshot`; a template / habit / exercise carries it top-level.
+      // #713 — assignments were not in this list, so a routine edit (whose
+      // changed-field snapshot has no `templateId` to point at a template) had
+      // no way to be named at all.
       const raw =
-        ref.collection === "workout_logs"
-          ? snapshotRecord(d.templateSnapshot)?.name
+        ref.collection === "workout_logs" || ref.collection === "workout_assignments"
+          ? (snapshotRecord(d.templateSnapshot)?.name ?? d.name)
           : d.name;
       const name = bilingualText(raw, "");
       if (name) out.set(`${ref.collection}:${ref.id}`, name);

--- a/backoffice/src/lib/gc-fitness/activity-feed-model.ts
+++ b/backoffice/src/lib/gc-fitness/activity-feed-model.ts
@@ -69,7 +69,12 @@ export type FeedTarget =
  * touch `name` (an update only snapshots the CHANGED fields).
  */
 export interface FeedSubjectRef {
-  collection: "workout_templates" | "workout_logs" | "habits" | "exercises";
+  collection:
+    | "workout_templates"
+    | "workout_logs"
+    | "workout_assignments"
+    | "habits"
+    | "exercises";
   id: string;
 }
 
@@ -221,6 +226,45 @@ export function recurrenceLabel(recurrence: unknown): string | null {
     default:
       return null;
   }
+}
+
+/**
+ * #713 — a TOTAL recurrence label: every present map gets words, including the
+ * ones `recurrenceLabel` deliberately returns null for.
+ *
+ * `recurrenceLabel` answers "is there a cadence worth printing next to an
+ * assignment?", so `single` → null (nothing to add) and an unrecognized kind →
+ * null (say nothing rather than something wrong). Both are right there and both
+ * are wrong when the recurrence IS the subject of the sentence: a row that says
+ * "cambió la recurrencia" and then prints nothing is exactly the report — the
+ * operator cannot see WHAT it changed to.
+ *
+ * Returns null only when there is genuinely no map to describe.
+ */
+export function recurrenceDescribe(recurrence: unknown): string | null {
+  if (!recurrence || typeof recurrence !== "object") return null;
+  const known = recurrenceLabel(recurrence);
+  if (known) return known;
+  const kind = str((recurrence as Record<string, unknown>).kind);
+  if (!kind) return null;
+  // `single` is a real answer here ("ahora una sola vez"), not an absence.
+  return kind === "single" ? "una sola vez" : kind;
+}
+
+/**
+ * #713 — "de X a Y" for a recurrence edit, degrading gracefully.
+ *
+ * The delete half of the edit is what carries the previous rule, so when the
+ * pairing found no delete (or that snapshot had no map) `from` is unknown and
+ * we print the destination alone rather than swallowing the line. When both
+ * sides describe the same cadence the change was in the WINDOW, not the rule —
+ * say so, instead of printing "semanal (lun) → semanal (lun)".
+ */
+export function recurrenceChangeLabel(previous: unknown, next: unknown): string | null {
+  const from = recurrenceDescribe(previous);
+  const to = recurrenceDescribe(next);
+  if (from && to) return from === to ? `${to} (cambiaron las fechas)` : `${from} → ${to}`;
+  return to ? `ahora ${to}` : from ? `antes ${from}` : null;
 }
 
 /** Spanish frequency label for a habit doc (`scheduleType` + `scheduleCadence`). */
@@ -483,9 +527,18 @@ export function classifyAuditRecord(
     // ── Scheduling ───────────────────────────────────────────────────────
     case "workout_assignments": {
       const templateId = str(after.templateId) ?? str(before.templateId);
+      // #713 — an UPDATE only snapshots the CHANGED fields, so a routine edit
+      // (`templateSnapshot, updatedAt, prescriptionUpdatedAt`) carries no
+      // `templateId` and the row had NOTHING to name: it rendered as a bare
+      // "actualizó la rutina · ver detalle". Fall back to the assignment doc
+      // itself — the reader point-reads its `templateSnapshot.name`. Not for a
+      // delete: that doc is gone by the time the feed loads, and its `before`
+      // is a full snapshot that already has the templateId anyway.
       const ref: FeedSubjectRef | null = templateId
         ? { collection: "workout_templates", id: templateId }
-        : null;
+        : record.op === "delete" || !record.docId || record.docId === "?"
+          ? null
+          : { collection: "workout_assignments", id: record.docId };
       const isSelf = after.selfAssigned === true || before.selfAssigned === true || selfService;
 
       if (record.op === "create") {
@@ -497,8 +550,6 @@ export function classifyAuditRecord(
         // rendered as "se extendió sola", with no actor — the report's other
         // half. Only the paired delete distinguishes them.
         if (group.recurrenceEdit) {
-          const from = recurrenceLabel(group.recurrenceEdit.previousRecurrence);
-          const to = recurrenceLabel(after.recurrence);
           return {
             category: "schedule",
             significance: "key",
@@ -507,8 +558,18 @@ export function classifyAuditRecord(
             subject: null,
             subjectRef: ref,
             meta: [
-              from && to && from !== to ? `${from} → ${to}` : (to ?? from),
-              ...occurrences,
+              // #713 — the old expression could evaluate to nothing at all
+              // (`recurrenceLabel` is null for `single` and for any kind it does
+              // not know), so the row said "cambió la recurrencia" and then
+              // printed no change whatsoever. This one always says something
+              // when there is a map on either side.
+              recurrenceChangeLabel(group.recurrenceEdit.previousRecurrence, after.recurrence),
+              // The new date set IS the change the operator wants to see, so it
+              // is printed for a one-occurrence edit too — `occurrences` only
+              // covers the collapsed case.
+              ...(occurrences.length > 0
+                ? occurrences
+                : [str(after.scheduledFor) ?? occurrenceDateFromId(record.docId)]),
               str(after.scheduledTime),
             ].filter((m): m is string => !!m),
             target: record.clientId ? { kind: "user", uid: record.clientId } : null,
@@ -641,7 +702,19 @@ export function classifyAuditRecord(
           title: "Actualizó la rutina",
           subject: null,
           subjectRef: ref,
-          meta: occurrences,
+          // #713 — "no puedo ver qué cambios hizo". The `templateSnapshot`
+          // itself is elided by the capture (512-char cap), so the field-level
+          // diff is genuinely not in `audit_log` — but WHICH KIND of edit this
+          // was is, and it is the operator's actual question. It comes from the
+          // same signal the actor attribution above already trusts: only a
+          // server-side coach write re-stamps `prescriptionUpdatedAt`; the
+          // client's write-back from iOS touches the snapshot alone.
+          meta: [
+            byCoachEdit
+              ? "nueva prescripción del coach"
+              : "pesos y repes registrados en el entreno",
+            ...occurrences,
+          ],
           target: record.clientId ? { kind: "user", uid: record.clientId } : null,
           actorUid: byCoachEdit ? byTrainer : byClient,
           isSelfService: isSelf,


### PR DESCRIPTION
Cierra mdb1/gc-fitness#713.

Dos filas del feed de admin (`/gc-fitness/admin/audit`) no respondían la pregunta que las hace
útiles.

---

## 1. "Manolo actualizó la rutina · **ver detalle**"

> Tocar en ese Ver detalle me lleva al detalle del cliente, pero no puedo ver ni cuál workout
> editó ni qué cambios hizo.

**Por qué no había nombre.** Un UPDATE de Firestore sólo snapshotea los campos **que cambiaron**.
Una edición de rutina llega como `templateSnapshot` + `updatedAt` (+ `prescriptionUpdatedAt`) y
**no trae `templateId`** — así que el clasificador no tenía a qué apuntar y devolvía
`subjectRef: null`. Y sin `subject`, el renderer cae al link genérico "ver detalle", que apunta
al único drill-down admin-safe que existe: el cliente.

Ahora, cuando no hay `templateId`, el `subjectRef` apunta al **propio doc de assignment**, y el
reader hidrata su `templateSnapshot.name` — el mismo camino que ya usaba `workout_logs`. Con la
rutina nombrada, la fila deja de mostrar "ver detalle" y muestra el nombre del workout.

(No para un `delete`: ese doc ya no existe cuando el feed carga, y su `before` es un snapshot
completo que de todos modos ya trae el `templateId`.)

**Por qué no se puede mostrar el diff campo a campo.** El trigger de captura elide
`templateSnapshot` a 512 chars (`[omitted: 2107 chars]`), así que el diff **no está** en
`audit_log`. Lo que sí está es **qué tipo** de edición fue, que es la pregunta real del operador,
y sale de la misma señal en la que ya confiaba la atribución de actor: sólo una escritura
server-side del coach re-estampa `prescriptionUpdatedAt`; el write-back del cliente desde iOS
(#567) toca únicamente el snapshot. La fila ahora lo dice:

- `nueva prescripción del coach`
- `pesos y repes registrados en el entreno`

---

## 2. "Manolo cambió la recurrencia de una rutina · **Hombros + triceps + core**"

> No me muestra cuál fue el cambio de recurrencia.

La expresión vieja era

```ts
from && to && from !== to ? `${from} → ${to}` : (to ?? from)
```

y `recurrenceLabel` devuelve `null` **tanto para `single` como para cualquier `kind` que no
conoce** — por diseño, porque al lado de una *asignación* no hay nada que imprimir. Pero cuando la
recurrencia **es** el sujeto de la oración, esa misma decisión hace que la fila diga "cambió la
recurrencia" y después no imprima nada. Eso es el reporte, literal.

Se agregan dos helpers puros:

- `recurrenceDescribe` — **total**: `single` → `"una sola vez"`, kind desconocido → el kind crudo,
  `null` sólo cuando genuinamente no hay mapa que describir.
- `recurrenceChangeLabel` — degrada a `"ahora X"` / `"antes X"` cuando falta un lado, y dice
  `"X (cambiaron las fechas)"` cuando la cadencia es la misma y lo que se movió fue la ventana.

Además la **fecha afectada ahora se imprime también cuando la edición tocó una sola ocurrencia**:
el span sólo salía en grupos colapsados (`count > 1`), así que una edición de una fecha no decía
*cuándo*.

`recurrenceLabel` queda **intacto** — al lado de una asignación, `null` para `single` sigue siendo
la respuesta correcta, y hay un test que fija ese contrato.

## Tests

`npx jest` — **+11 casos** en `activity-feed-model.test.ts`, incluido uno que barre las cuatro
combinaciones que podían producir la línea vacía (`single→single`, dos kinds desconocidos,
`null→single`, `weekly→single`) y afirma que **ninguna** renderiza vacío.

Total: **1041/1042 verdes.** El único rojo es el flake conocido de locale en
`client-activity-time.test.ts` (`"Jun 2"` vs `"2 June"`), pre-existente y verde en CI.

`npx tsc --noEmit` limpio.

## Alcance

Backoffice-only, capa de lectura. No toca `firestore.rules`, ni el trigger de captura, ni ningún
writer — sólo cómo se leen los docs que ya están en `audit_log`.