### PR TITLE
fix: el "flake" de locale del backoffice tapaba una clave de agrupación que dependía del locale

### DIFF
--- a/backoffice/src/lib/gc-fitness/__tests__/client-activity-time.test.ts
+++ b/backoffice/src/lib/gc-fitness/__tests__/client-activity-time.test.ts
@@ -5,40 +5,65 @@ import {
   formatClientActivityTime,
 } from "@/lib/gc-fitness/client-activity-time";
 
+/**
+ * ⚠️ **Every assertion on a rendered string passes an EXPLICIT locale.**
+ *
+ * `Intl` with an `undefined` locale resolves to the RUNTIME's, so these tests used to assert
+ * CI's `en-US` output ("Jun 2") and fail on any machine whose default is something else
+ * ("2 jun") — same code, same input, different environment. It read as a flake, it got
+ * documented as one ("don't chase it"), and it sat red locally for two months while staying
+ * green in CI. A test nobody trusts is a test that has stopped working.
+ *
+ * The display helpers still resolve to the viewer's locale in production, which is what a
+ * coach should see; the locale argument exists so a test can say WHICH rendering it means.
+ * What these tests are actually about — that the TIMEZONE moves the instant onto the right
+ * civil day and hour — is untouched by that choice.
+ */
+const LOCALE = "en-US";
+const BUENOS_AIRES = "America/Argentina/Buenos_Aires";
+
 describe("client activity timezone helpers", () => {
   test("formats instants in the provided timezone", () => {
     expect(
       formatClientActivityDateTime(
         "2026-06-03T14:08:00.000Z",
-        "America/Argentina/Buenos_Aires",
+        BUENOS_AIRES,
+        LOCALE,
       ),
     ).toContain("11:08");
   });
 
   test("uses the provided timezone for time-only labels", () => {
     expect(
-      formatClientActivityTime(
-        "2026-06-03T14:08:00.000Z",
-        "America/Argentina/Buenos_Aires",
-      ),
+      formatClientActivityTime("2026-06-03T14:08:00.000Z", BUENOS_AIRES, LOCALE),
     ).toContain("11:08");
   });
 
   test("uses the provided timezone for fallback photo dates", () => {
     expect(
-      formatClientActivityDate(
-        "2026-06-03T02:59:00.000Z",
-        "America/Argentina/Buenos_Aires",
-      ),
+      formatClientActivityDate("2026-06-03T02:59:00.000Z", BUENOS_AIRES, LOCALE),
     ).toBe("Jun 2");
   });
 
   test("groups messages by local day and hour rather than UTC", () => {
-    expect(
-      clientActivityGroupKey(
-        "2026-06-03T02:59:00.000Z",
-        "America/Argentina/Buenos_Aires",
-      ),
-    ).toBe("2026-06-02T23");
+    expect(clientActivityGroupKey("2026-06-03T02:59:00.000Z", BUENOS_AIRES)).toBe(
+      "2026-06-02T23",
+    );
+  });
+
+  /**
+   * The group key is a KEY, so it must not move with whoever is looking at it.
+   *
+   * `clientActivityGroupKey` takes no locale on purpose — it pins its own — and this is the
+   * test that holds that in place. Midnight is the case that actually breaks: `hour12: false`
+   * renders `24` under the `h24` cycle some locales resolve to and `00` under `h23`, which
+   * would drop the same message into two different buckets for two coaches looking at the
+   * same client.
+   */
+  test("the group key is stable at midnight regardless of the viewer's locale", () => {
+    // 03:00Z on Jun 3 is exactly 00:00 on Jun 3 in Buenos Aires (UTC-3).
+    expect(clientActivityGroupKey("2026-06-03T03:00:00.000Z", BUENOS_AIRES)).toBe(
+      "2026-06-03T00",
+    );
   });
 });

--- a/backoffice/src/lib/gc-fitness/client-activity-time.ts
+++ b/backoffice/src/lib/gc-fitness/client-activity-time.ts
@@ -1,5 +1,17 @@
 import { civilDateFormat } from "./civil-date";
 
+/**
+ * The locale for values that are DATA, not presentation.
+ *
+ * `Intl` with an `undefined` locale resolves to the RUNTIME's locale, which is the right
+ * behaviour for anything a coach reads — they should see their own formatting — and the wrong
+ * behaviour for anything used as a key, where the output has to be identical everywhere.
+ *
+ * It is also what made `client-activity-time.test.ts` fail on a developer machine and pass in
+ * CI for two months: same code, same input, different default locale.
+ */
+const KEY_LOCALE = "en-US";
+
 function formatInZone(
   iso: string | null,
   timezone: string,
@@ -23,33 +35,51 @@ function formatInZone(
 export function formatClientActivityDateTime(
   iso: string | null,
   timezone: string,
+  locale?: string,
 ): string {
-  return formatInZone(iso, timezone, {
-    month: "short",
-    day: "2-digit",
-    hour: "2-digit",
-    minute: "2-digit",
-  });
+  return formatInZone(
+    iso,
+    timezone,
+    {
+      month: "short",
+      day: "2-digit",
+      hour: "2-digit",
+      minute: "2-digit",
+    },
+    locale,
+  );
 }
 
 export function formatClientActivityTime(
   iso: string | null,
   timezone: string,
+  locale?: string,
 ): string {
-  return formatInZone(iso, timezone, {
-    hour: "2-digit",
-    minute: "2-digit",
-  });
+  return formatInZone(
+    iso,
+    timezone,
+    {
+      hour: "2-digit",
+      minute: "2-digit",
+    },
+    locale,
+  );
 }
 
 export function formatClientActivityDate(
   iso: string | null,
   timezone: string,
+  locale?: string,
 ): string {
-  return formatInZone(iso, timezone, {
-    month: "short",
-    day: "numeric",
-  });
+  return formatInZone(
+    iso,
+    timezone,
+    {
+      month: "short",
+      day: "numeric",
+    },
+    locale,
+  );
 }
 
 export function formatClientActivityFullDate(
@@ -72,14 +102,29 @@ export function formatClientActivityFullDate(
 export function formatClientActivityDayHeader(
   iso: string | null,
   timezone: string,
+  locale?: string,
 ): string {
-  return formatInZone(iso, timezone, {
-    month: "short",
-    day: "numeric",
-    hour: "2-digit",
-  });
+  return formatInZone(
+    iso,
+    timezone,
+    {
+      month: "short",
+      day: "numeric",
+      hour: "2-digit",
+    },
+    locale,
+  );
 }
 
+/**
+ * Bucket an instant into `YYYY-MM-DDTHH` in the client's timezone.
+ *
+ * ⚠️ **Locale-pinned on purpose: this is a KEY.** `ChatHistoryWidget` groups messages by this
+ * value, so it has to depend on the instant and the timezone and on nothing else. Left to the
+ * runtime locale, the hour part is not stable — `hour12: false` yields `24` at midnight under
+ * the `h24` cycle some locales resolve to, and `00` under `h23` — so the same message could
+ * land in a different bucket for two coaches looking at the same client.
+ */
 export function clientActivityGroupKey(
   iso: string | null,
   timezone: string,
@@ -88,10 +133,17 @@ export function clientActivityGroupKey(
   const date = new Date(iso);
   if (Number.isNaN(date.getTime())) return iso.slice(0, 10);
   const day = civilDateFormat(date, timezone);
-  const hour = formatInZone(iso, timezone, {
-    hour: "2-digit",
-    hour12: false,
-  });
+  const hour = formatInZone(
+    iso,
+    timezone,
+    {
+      hour: "2-digit",
+      // `hourCycle` rather than `hour12: false`, which is what leaves the 24-vs-00 choice to
+      // the locale in the first place.
+      hourCycle: "h23",
+    },
+    KEY_LOCALE,
+  );
   return `${day}T${hour}`;
 }
 


### PR DESCRIPTION
El único rojo de `npx jest` en el backoffice era `client-activity-time`, anotado hace tiempo como flake de locale ("verde en CI, no lo persigas"). **No era un flake, y adentro había un defecto real.**

## Qué pasaba

`Intl` con un locale `undefined` resuelve al del **runtime**. El test asertaba la salida de CI (`en-US` → `"Jun 2"`) y fallaba en cualquier máquina cuyo default fuera otro (`"2 jun"`). Mismo código, misma entrada, distinto entorno — así que estuvo rojo localmente dos meses mientras seguía verde en CI. Un test que nadie cree es un test que dejó de andar.

## El defecto que tapaba

`clientActivityGroupKey` es una **CLAVE** — `ChatHistoryWidget` agrupa los mensajes por ese valor — y también resolvía el locale del runtime. Corriendo la suite vieja bajo `ja_JP` fallan **dos** de los cuatro tests, no uno:

```
BEFORE the fix, ja_JP → Tests: 2 failed, 2 passed, 4 total
```

O sea: **la agrupación dependía de quién estaba mirando.** El caso que rompe de verdad es medianoche — `hour12: false` renderiza `24` bajo el ciclo `h24` que algunos locales resuelven y `00` bajo `h23`, así que el mismo mensaje podía caer en dos buckets distintos para dos coaches viendo al mismo cliente.

## El arreglo

- **`clientActivityGroupKey` fija su locale** y pide `hourCycle: "h23"` explícito, porque es data y no presentación. Test nuevo anclado justo en medianoche (`03:00Z` = `00:00` en Buenos Aires).
- **Los helpers de presentación no cambian de comportamiento**: siguen resolviendo al locale del que mira, que es lo que un coach tiene que ver. Se les agregó un parámetro `locale` opcional para que un test pueda decir QUÉ renderizado está asertando.

## Gates

- `client-activity-time` verificado bajo **`en_US`, `es_AR`, `ja_JP` y `de_DE`**: 5/5 en las cuatro.
- `npx jest` completo: **1043/1043, 92/92 suites** — la suite del backoffice queda verde entera.
