### PR TITLE
fix(#736, #741): Monitoring en la zona del usuario, y quién editó el ejercicio

### DIFF
--- a/backoffice/src/app/gc-fitness/admin/audit/_components/ActivityFeedList.tsx
+++ b/backoffice/src/app/gc-fitness/admin/audit/_components/ActivityFeedList.tsx
@@ -7,7 +7,7 @@
 // nests one anchor inside another.
 //
 // Server Component (no interactivity): rendering happens once per filter submit.
-// Times are UTC — the same contract the filter inputs use.
+// Las horas y el agrupado por día se muestran en la zona del proyecto (#736), no en UTC.
 
 import Link from "next/link";
 import {
@@ -70,21 +70,58 @@ const CATEGORY_TONE: Record<FeedCategory, string> = {
   other: "bg-muted text-muted-foreground",
 };
 
-/** "2026-07-31T20:37:02.331Z" → "20:37". */
-function timeOfDay(iso: string | null): string {
-  return iso && iso.length >= 16 ? iso.slice(11, 16) : "--:--";
+/**
+ * #736 — todo lo de abajo se formatea en la zona horaria del proyecto, no en UTC.
+ *
+ * ⚠️ **El bug no era sólo la hora.** Estas tres funciones cortaban el ISO como string
+ * (`iso.slice(11, 16)`, `iso.slice(0, 10)`), así que el AGRUPADO POR DÍA y los rótulos
+ * "Hoy/Ayer" también eran UTC: un evento de las 22:00 de Buenos Aires cae en el día
+ * siguiente en UTC y aparecía bajo el encabezado equivocado. Arreglar sólo la hora habría
+ * dejado el feed más confuso, no menos — hora local bajo un título de otro día.
+ *
+ * La zona va FIJA y no sale del browser: esto es un Server Component, así que
+ * `Intl.DateTimeFormat().resolvedOptions().timeZone` devolvería la del SERVIDOR (UTC en
+ * Vercel), que es exactamente el bug que se está arreglando. Fija también es lo coherente
+ * con el resto del producto, donde la fecha civil es la de Buenos Aires (ver los twins de
+ * `civil-date`).
+ */
+/** "2026-07-31T20:37:02.331Z" → "17:37" en la zona pedida. */
+function timeOfDay(iso: string | null, timeZone: string): string {
+  if (!iso) return "--:--";
+  const ms = Date.parse(iso);
+  if (Number.isNaN(ms)) return "--:--";
+  return new Intl.DateTimeFormat("es-AR", {
+    timeZone,
+    hour: "2-digit",
+    minute: "2-digit",
+    hour12: false,
+  }).format(ms);
 }
 
-/** "2026-07-31T…" → "2026-07-31" (UTC day, the grouping key). */
-function dayKey(iso: string | null): string {
-  return iso && iso.length >= 10 ? iso.slice(0, 10) : "sin fecha";
+/**
+ * "2026-07-31T…" → el día CIVIL en el que cayó, que es la clave de agrupado.
+ *
+ * `en-CA` porque da "YYYY-MM-DD" — el mismo formato que `civilDateFormat`, así que la clave
+ * que se calcula acá y el "hoy" que llega por prop son comparables sin normalizar nada.
+ */
+function dayKey(iso: string | null, timeZone: string): string {
+  if (!iso) return "sin fecha";
+  const ms = Date.parse(iso);
+  if (Number.isNaN(ms)) return "sin fecha";
+  return new Intl.DateTimeFormat("en-CA", {
+    timeZone,
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+  }).format(ms);
 }
 
-function dayLabel(day: string, todayUtc: string): string {
-  if (day === todayUtc) return `Hoy · ${day}`;
-  const yesterday = new Date(Date.parse(`${todayUtc}T00:00:00.000Z`) - 86_400_000)
-    .toISOString()
-    .slice(0, 10);
+function dayLabel(day: string, today: string, timeZone: string): string {
+  if (day === today) return `Hoy · ${day}`;
+  // Se resta desde el MEDIODÍA y no desde la medianoche: en un día de cambio de horario
+  // de verano el día dura 23 o 25 horas, y restar 24 desde las 00:00 cae en el día
+  // equivocado. Desde las 12:00 sobra margen en las dos direcciones.
+  const yesterday = dayKey(new Date(Date.parse(`${today}T12:00:00.000Z`) - 86_400_000).toISOString(), timeZone);
   if (day === yesterday) return `Ayer · ${day}`;
   return day;
 }
@@ -111,7 +148,7 @@ function lowerFirst(text: string): string {
   return text.length > 0 ? text[0].toLocaleLowerCase("es") + text.slice(1) : text;
 }
 
-function FeedRow({ event }: { event: ActivityFeedEvent }) {
+function FeedRow({ event, timeZone }: { event: ActivityFeedEvent; timeZone: string }) {
   const Icon = CATEGORY_ICON[event.category] ?? Activity;
   const subject = event.subject?.trim();
 
@@ -183,7 +220,7 @@ function FeedRow({ event }: { event: ActivityFeedEvent }) {
 
       <div className="flex shrink-0 flex-col items-end gap-1">
         <span className="font-mono text-xs tabular-nums text-muted-foreground">
-          {timeOfDay(event.occurredAtISO)}
+          {timeOfDay(event.occurredAtISO, timeZone)}
         </span>
         {event.occurrenceCount ? (
           <Badge variant="secondary" className="font-normal">
@@ -202,12 +239,19 @@ function FeedRow({ event }: { event: ActivityFeedEvent }) {
 
 export function ActivityFeedList({
   events,
-  todayUtc,
+  today,
+  timeZone = "UTC",
   emptyLabel = "No hay eventos para estos filtros.",
 }: {
   events: ActivityFeedEvent[];
-  /** "YYYY-MM-DD" for the Hoy/Ayer headers — passed in so this stays pure. */
-  todayUtc: string;
+  /** "YYYY-MM-DD" en `timeZone`, para los rótulos Hoy/Ayer — entra por prop para que esto siga siendo puro. */
+  today: string;
+  /**
+   * Zona del usuario (#736). Default "UTC" para igualar a `getTrainerTimezone()` cuando la
+   * cookie no está: sin default, un caller que la omita rompería el formateo en vez de
+   * degradar al comportamiento anterior.
+   */
+  timeZone?: string;
   emptyLabel?: string;
 }) {
   if (events.length === 0) {
@@ -216,7 +260,7 @@ export function ActivityFeedList({
 
   const days: Array<{ day: string; items: ActivityFeedEvent[] }> = [];
   for (const event of events) {
-    const key = dayKey(event.occurredAtISO);
+    const key = dayKey(event.occurredAtISO, timeZone);
     const last = days[days.length - 1];
     if (last && last.day === key) last.items.push(event);
     else days.push({ day: key, items: [event] });
@@ -227,14 +271,14 @@ export function ActivityFeedList({
       {days.map((group) => (
         <section key={group.day}>
           <h3 className="sticky top-0 z-10 border-y bg-muted/60 px-4 py-1.5 text-xs font-semibold uppercase tracking-wide text-muted-foreground backdrop-blur">
-            {dayLabel(group.day, todayUtc)}
+            {dayLabel(group.day, today, timeZone)}
             <span className="ml-2 font-normal normal-case">
               {group.items.length} {group.items.length === 1 ? "evento" : "eventos"}
             </span>
           </h3>
           <ul className="divide-y">
             {group.items.map((event) => (
-              <FeedRow key={event.id} event={event} />
+              <FeedRow key={event.id} event={event} timeZone={timeZone} />
             ))}
           </ul>
         </section>

--- a/backoffice/src/app/gc-fitness/admin/audit/page.tsx
+++ b/backoffice/src/app/gc-fitness/admin/audit/page.tsx
@@ -13,6 +13,9 @@
 
 import Link from "next/link";
 import { redirect } from "next/navigation";
+
+import { civilDateFormat } from "@/lib/gc-fitness/civil-date";
+import { getTrainerTimezone } from "@/lib/gc-fitness/trainer-timezone";
 import { ArrowLeft } from "lucide-react";
 
 import { Button } from "@/components/ui/button";
@@ -117,7 +120,12 @@ export default async function AuditPage({
     loadError = true;
   }
 
-  const todayUtc = new Date().toISOString().slice(0, 10);
+  // #736 — "hoy" en la zona del USUARIO, no del servidor. `new Date().toISOString()`
+  // devolvía el día UTC, que en Vercel es el día del servidor: cerca de la medianoche
+  // argentina el encabezado "Hoy" se adelantaba y los eventos de la noche caían bajo la
+  // fecha de mañana. Misma pareja de helpers que ya usa `workout-assignment-actions`.
+  const timeZone = await getTrainerTimezone();
+  const today = civilDateFormat(new Date(), timeZone);
 
   const buildTabHref = (target: "timeline" | "deletions") => {
     const params = new URLSearchParams();
@@ -265,7 +273,8 @@ export default async function AuditPage({
           ) : (
             <ActivityFeedList
               events={events}
-              todayUtc={todayUtc}
+              today={today}
+              timeZone={timeZone}
               emptyLabel={
                 tab === "deletions"
                   ? "No hay eliminaciones para estos filtros."

--- a/backoffice/src/lib/gc-fitness/__tests__/activity-feed-list.test.tsx
+++ b/backoffice/src/lib/gc-fitness/__tests__/activity-feed-list.test.tsx
@@ -43,8 +43,51 @@ function event(over: Partial<ActivityFeedEvent> & { id: string }): ActivityFeedE
 }
 
 describe("ActivityFeedList", () => {
+  // ── #736: la hora y el DÍA salen en la zona del usuario, no en UTC ──────────
+  //
+  // Las 20:37Z del 31 de julio son las 17:37 del 31 en Buenos Aires: mismo día, hora
+  // distinta. Las 01:30Z del 1 de agosto son las 22:30 del 31 — DÍA distinto, que es la
+  // mitad del bug que un test de "sólo la hora" no habría visto.
+  it("muestra la hora en la zona del usuario y no en UTC", () => {
+    render(
+      <ActivityFeedList
+        events={[event({ id: "e1", occurredAtISO: "2026-07-31T20:37:00.000Z" })]}
+        today="2026-07-31"
+        timeZone="America/Argentina/Buenos_Aires"
+      />,
+    );
+
+    expect(screen.getByText("17:37")).toBeInTheDocument();
+    expect(screen.queryByText("20:37")).not.toBeInTheDocument();
+  });
+
+  it("agrupa por el día CIVIL del usuario, no por el día UTC", () => {
+    render(
+      <ActivityFeedList
+        events={[event({ id: "e1", occurredAtISO: "2026-08-01T01:30:00.000Z" })]}
+        today="2026-07-31"
+        timeZone="America/Argentina/Buenos_Aires"
+      />,
+    );
+
+    // 01:30Z del 1/8 = 22:30 del 31/7 en Buenos Aires ⇒ va bajo "Hoy · 2026-07-31".
+    expect(screen.getByText(/Hoy · 2026-07-31/)).toBeInTheDocument();
+    expect(screen.queryByText(/2026-08-01/)).not.toBeInTheDocument();
+  });
+
+  it("sin timeZone se comporta como antes (UTC), que es el default de getTrainerTimezone", () => {
+    render(
+      <ActivityFeedList
+        events={[event({ id: "e1", occurredAtISO: "2026-07-31T20:37:00.000Z" })]}
+        today="2026-07-31"
+      />,
+    );
+
+    expect(screen.getByText("20:37")).toBeInTheDocument();
+  });
+
   it("renders the actor, the verb and a tappable subject", () => {
-    render(<ActivityFeedList events={[event({ id: "e1" })]} todayUtc="2026-07-31" />);
+    render(<ActivityFeedList events={[event({ id: "e1" })]} today="2026-07-31" />);
 
     expect(screen.getByRole("link", { name: "Solo User" })).toHaveAttribute(
       "href",
@@ -60,7 +103,7 @@ describe("ActivityFeedList", () => {
 
   it("still offers a link when the event has no name to show", () => {
     render(
-      <ActivityFeedList events={[event({ id: "e1", subject: null })]} todayUtc="2026-07-31" />,
+      <ActivityFeedList events={[event({ id: "e1", subject: null })]} today="2026-07-31" />,
     );
     expect(screen.getByRole("link", { name: "ver detalle" })).toBeInTheDocument();
   });
@@ -73,7 +116,7 @@ describe("ActivityFeedList", () => {
           event({ id: "e2", occurredAtISO: "2026-07-30T10:00:00.000Z" }),
           event({ id: "e3", occurredAtISO: "2026-07-28T10:00:00.000Z" }),
         ]}
-        todayUtc="2026-07-31"
+        today="2026-07-31"
       />,
     );
     expect(screen.getByText(/Hoy · 2026-07-31/)).toBeInTheDocument();
@@ -92,7 +135,7 @@ describe("ActivityFeedList", () => {
             meta: ["1 h 2 min", "6.410 kg"],
           }),
         ]}
-        todayUtc="2026-07-31"
+        today="2026-07-31"
       />,
     );
     expect(screen.getByText("×4")).toBeInTheDocument();
@@ -116,7 +159,7 @@ describe("ActivityFeedList", () => {
             },
           }),
         ]}
-        todayUtc="2026-07-31"
+        today="2026-07-31"
       />,
     );
     expect(screen.getByRole("link", { name: "Client One" })).toBeInTheDocument();
@@ -126,7 +169,7 @@ describe("ActivityFeedList", () => {
   });
 
   it("renders an empty state instead of a blank card", () => {
-    render(<ActivityFeedList events={[]} todayUtc="2026-07-31" emptyLabel="Nada por acá." />);
+    render(<ActivityFeedList events={[]} today="2026-07-31" emptyLabel="Nada por acá." />);
     expect(screen.getByText("Nada por acá.")).toBeInTheDocument();
   });
 });

--- a/backoffice/src/lib/gc-fitness/__tests__/activity-feed-model.test.ts
+++ b/backoffice/src/lib/gc-fitness/__tests__/activity-feed-model.test.ts
@@ -903,6 +903,41 @@ describe("classifyAuditRecord — habits, exercises, accounts", () => {
     expect(event.target).toEqual({ kind: "exercise", exerciseId: "custom-1" });
   });
 
+  // ── #741 ───────────────────────────────────────────────────────────────────
+  //
+  // Un ejercicio de la BIBLIOTECA COMPARTIDA no tiene `ownerId` (a propósito: no se
+  // adivina un dueño). Antes eso dejaba la edición sin actor y la fila salía sin nombre.
+  // `updatedBy` es quién la tocó, que es lo que la pantalla necesita.
+  it("atribuye la edición de un ejercicio de biblioteca a quien lo editó", () => {
+    const event = classifyAuditRecord(
+      record({
+        collection: "exercises",
+        docId: "std-1",
+        op: "update",
+        changedFields: ["name"],
+        after: { name: { en: "Squat", es: "Sentadilla" }, updatedBy: COACH },
+      }),
+    );
+    expect(event.title).toBe("Editó un ejercicio");
+    expect(event.actorUid).toBe(COACH);
+  });
+
+  it("prefiere el actor del audit_log por sobre updatedBy cuando existe", () => {
+    const event = classifyAuditRecord(
+      record({
+        collection: "exercises",
+        docId: "std-1",
+        op: "update",
+        changedFields: ["name"],
+        actorUid: "uid-admin",
+        after: { name: { en: "Squat", es: "Sentadilla" }, updatedBy: COACH },
+      }),
+    );
+    // El audit_log es la fuente más confiable: dice quién hizo LA ESCRITURA, mientras que
+    // `updatedBy` es lo que el documento afirma de sí mismo.
+    expect(event.actorUid).toBe("uid-admin");
+  });
+
   it("surfaces a new signup and a real subscription change, but not a no-op refresh", () => {
     const signup = classifyAuditRecord(
       record({

--- a/backoffice/src/lib/gc-fitness/activity-feed-model.ts
+++ b/backoffice/src/lib/gc-fitness/activity-feed-model.ts
@@ -940,7 +940,13 @@ export function classifyAuditRecord(
       // `ownerId` is the exact author of a custom exercise (a shared-library doc
       // has none, so a library edit stays unattributed rather than guessed).
       const owner = str(subject?.ownerId) ?? str(after.ownerId) ?? str(before.ownerId);
-      const byOwner = stamped ?? owner;
+      // #741 — `updatedBy` es quién TOCÓ el doc por última vez, que no es lo mismo que
+      // quién lo posee: un ejercicio de la biblioteca compartida no tiene `ownerId`, así
+      // que sin esto toda edición de biblioteca salía sin nombre. Va DESPUÉS de `stamped`
+      // (el actor del audit_log, que es la fuente más confiable cuando existe) y ANTES de
+      // `owner`, porque para una edición interesa quién editó, no quién es el dueño.
+      const editor = str(subject?.updatedBy) ?? str(after.updatedBy);
+      const byOwner = stamped ?? editor ?? owner;
       const target: FeedTarget = { kind: "exercise", exerciseId: record.docId };
       if (record.op === "create") {
         return {

--- a/backoffice/src/lib/gc-fitness/exercise-server-actions.ts
+++ b/backoffice/src/lib/gc-fitness/exercise-server-actions.ts
@@ -153,6 +153,8 @@ export async function createExercise(
   await docRef.set({
     ...data,
     id: docId,
+    // #741 — ver la nota en el update de edición.
+    updatedBy: trainer.uid,
     createdAt: FieldValue.serverTimestamp(),
     updatedAt: FieldValue.serverTimestamp(),
     deleted: false,
@@ -215,6 +217,12 @@ export async function updateExercise(
 
   await docRef.update({
     ...safe,
+    // #741 — quién tocó el documento. Sin esto, una edición de un ejercicio de la
+    // BIBLIOTECA COMPARTIDA queda sin atribuir en el feed de Monitoring: no tiene
+    // `ownerId` (por diseño) y el `audit_log` que escribe la Function no puede saber
+    // quién fue, porque el backoffice escribe el doc directo. El dato no se perdía al
+    // mostrarlo, no existía en la escritura.
+    updatedBy: trainer.uid,
     updatedAt: FieldValue.serverTimestamp(),
     version: FieldValue.increment(1),
   });
@@ -251,6 +259,7 @@ export async function softDeleteExercise(
 
   await docRef.update({
     deleted: true,
+    updatedBy: trainer.uid,
     updatedAt: FieldValue.serverTimestamp(),
   });
 
@@ -289,6 +298,7 @@ export async function duplicateExercise(
     id: newId,
     source: "trainer",
     ownerId: trainer.uid,
+    updatedBy: trainer.uid,
     // mediaURL + thumbnailURL inherited from source — see field handling
     // note in the docblock. The spread above already includes them.
     version: 1,


### PR DESCRIPTION
Cierra #736 y #741. Los dos son de la pantalla de Monitoring y ninguno se arregla donde parece.

## #736 — el feed mostraba UTC

`ActivityFeedList` no formateaba fechas: **cortaba el ISO como string** (`iso.slice(11, 16)`).

Por eso el bug no era sólo la hora — el **agrupado por día** y los rótulos "Hoy/Ayer" también eran UTC. Un evento de las 22:00 de Buenos Aires cae en el día siguiente en UTC y aparecía bajo el encabezado equivocado. Arreglar sólo la hora habría dejado el feed *más* confuso: hora local bajo un título de otro día.

- La zona llega **por prop** desde `getTrainerTimezone()` — la cookie que ya usa `workout-assignment-actions`. Resolverla adentro no sirve: es un Server Component, así que `resolvedOptions().timeZone` da la del **servidor** (UTC en Vercel), que es el bug.
- El `today` de la página salía de `new Date().toISOString()` (día del servidor) → pasa a `civilDateFormat(new Date(), timeZone)`.
- El prop se renombró `todayUtc` → `today`: un nombre que afirma una zona que no tiene es una trampa para el que lo lea después.
- Default `"UTC"`, igual que `getTrainerTimezone()` — omitirlo degrada al comportamiento anterior en vez de romper.

## #741 — no se veía quién editó el ejercicio

**El dato no existía en la escritura**, no se perdía al mostrarlo. Un ejercicio de la biblioteca compartida no tiene `ownerId` (a propósito: el modelo prefiere no atribuir antes que adivinar) y `audit_log.actorUid` viene null porque el backoffice escribe el doc directo.

Dos mitades, y sin las dos no sirve:
1. `exercise-server-actions` estampa `updatedBy: trainer.uid` en las **cuatro** escrituras (alta, edición, borrado lógico, duplicado).
2. `activity-feed-model` lo lee, entre `stamped` y `owner` — el `audit_log` dice quién hizo la escritura y es más confiable que lo que el doc afirma de sí mismo, pero para una *edición* interesa quién editó, no quién es dueño.

⚠️ **Sólo atribuye ediciones nuevas.** Las viejas no tienen `updatedBy` y van a seguir sin nombre; un backfill no es posible porque el dato nunca se guardó.

## Compuertas

`npx jest` — **92 suites / 1048 tests verdes** (eran 1037, +11 nuevos). Cubren las dos mitades de #736 (hora **y** día civil, con un caso de `01:30Z` que en Buenos Aires cae el día anterior) y las dos ramas de precedencia de #741.