### PR TITLE
fix(#748, #747): un evento, una fila — y ninguna fecha en UTC

### DIFF
--- a/backoffice/src/app/gc-fitness/admin/app-config/app-version-form.tsx
+++ b/backoffice/src/app/gc-fitness/admin/app-config/app-version-form.tsx
@@ -75,6 +75,8 @@ const formSchema = z.object({
 
 export interface AppVersionFormProps {
   initialConfig: AppVersionConfig;
+  /** The admin's IANA zone, resolved server-side (#747). */
+  timezone: string;
 }
 
 const PLATFORMS = [
@@ -92,7 +94,7 @@ const PLATFORMS = [
   },
 ];
 
-export function AppVersionForm({ initialConfig }: AppVersionFormProps) {
+export function AppVersionForm({ initialConfig, timezone }: AppVersionFormProps) {
   const router = useRouter();
   const [pending, startTransition] = useTransition();
 
@@ -203,7 +205,12 @@ export function AppVersionForm({ initialConfig }: AppVersionFormProps) {
         <div className="flex items-center justify-end gap-3">
           {initialConfig.updatedAtISO ? (
             <span className="text-xs text-muted-foreground">
-              Last updated {new Date(initialConfig.updatedAtISO).toLocaleString()}
+              Last updated{" "}
+              {new Date(initialConfig.updatedAtISO).toLocaleString(undefined, {
+                dateStyle: "medium",
+                timeStyle: "short",
+                timeZone: timezone,
+              })}
               {initialConfig.updatedBy ? ` by ${initialConfig.updatedBy}` : ""}
             </span>
           ) : null}

--- a/backoffice/src/app/gc-fitness/admin/app-config/page.tsx
+++ b/backoffice/src/app/gc-fitness/admin/app-config/page.tsx
@@ -7,6 +7,7 @@ import {
   type AppVersionConfig,
 } from "@/lib/gc-fitness/admin-actions";
 import { getCurrentAdmin } from "@/lib/gc-fitness/auth-helpers";
+import { getTrainerTimezone } from "@/lib/gc-fitness/trainer-timezone";
 import { PageHeader } from "@/components/gc-fitness/page-header";
 import { AppVersionForm } from "./app-version-form";
 import { sectionMetadata } from "@/lib/gc-fitness/page-metadata";
@@ -59,7 +60,7 @@ export default async function AppConfigPage() {
         Back to Admin Console
       </Link>
 
-      <AppVersionForm initialConfig={config} />
+      <AppVersionForm initialConfig={config} timezone={await getTrainerTimezone()} />
     </div>
   );
 }

--- a/backoffice/src/app/gc-fitness/admin/coach-less-users/[uid]/page.tsx
+++ b/backoffice/src/app/gc-fitness/admin/coach-less-users/[uid]/page.tsx
@@ -60,7 +60,8 @@ import {
   resolveDisplayTier,
   type ActivityWindow,
 } from "@/lib/gc-fitness/coachless-user-model";
-import { civilDateToday } from "@/lib/gc-fitness/civil-date";
+import { civilDateFormat, civilDateToday } from "@/lib/gc-fitness/civil-date";
+import { getTrainerTimezone } from "@/lib/gc-fitness/trainer-timezone";
 import { getClientExerciseProgressAsAdmin } from "@/lib/gc-fitness/exercise-progress-actions";
 import { listClientPersonalRecordsAsAdmin } from "@/lib/gc-fitness/personal-records-actions";
 import { listProgressPhotosForClientAsAdmin } from "@/lib/gc-fitness/progress-photo-actions";
@@ -84,18 +85,29 @@ export const dynamic = "force-dynamic";
 
 const LIST_ROUTE = "/gc-fitness/admin/coach-less-users";
 
-/** Stable YYYY-MM-DD (avoids the server-locale flake seen in date tests). */
-function formatDate(iso: string | null): string {
-  return iso ? iso.slice(0, 10) : "—";
+/**
+ * Stable YYYY-MM-DD — locale-independent by construction (no server-locale
+ * flake), and #747: in the ADMIN's zone. `iso.slice(0, 10)` was stable and
+ * wrong; the first 10 chars of an ISO instant are its UTC day.
+ */
+function formatDate(iso: string | null, timezone: string): string {
+  if (!iso) return "—";
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return iso.slice(0, 10);
+  return civilDateFormat(d, timezone);
 }
 
 /** "2026-07-26 (hace 2 d)" — absolute date first, recency in parentheses. */
-function formatDateWithAge(iso: string | null, nowMs: number): string {
+function formatDateWithAge(
+  iso: string | null,
+  nowMs: number,
+  timezone: string,
+): string {
   if (!iso) return "—";
   const days = daysSince(iso, nowMs);
-  if (days === null) return formatDate(iso);
+  if (days === null) return formatDate(iso, timezone);
   const age = days === 0 ? "hoy" : days === 1 ? "hace 1 d" : `hace ${days} d`;
-  return `${formatDate(iso)} (${age})`;
+  return `${formatDate(iso, timezone)} (${age})`;
 }
 
 function StatTile({ label, value, hint }: { label: string; value: string; hint?: string }) {
@@ -121,16 +133,18 @@ function ActivityRow({
   label,
   window: w,
   nowMs,
+  timezone,
 }: {
   label: string;
   window: ActivityWindow;
   nowMs: number;
+  timezone: string;
 }) {
   return (
     <TableRow>
       <TableCell>{label}</TableCell>
       <TableCell className="text-xs text-muted-foreground">
-        {formatDateWithAge(w.lastISO, nowMs)}
+        {formatDateWithAge(w.lastISO, nowMs, timezone)}
       </TableCell>
       <TableCell className="text-right tabular-nums">{w.last7Days}</TableCell>
       <TableCell className="text-right tabular-nums">{w.last30Days}</TableCell>
@@ -173,7 +187,8 @@ export default async function CoachlessUserDetailPage({
 
   // Every widget below is scoped by BOTH ids; for a coach-less user the coach
   // uid IS their own uid (see the header comment).
-  const timezone = profile.timezone ?? "UTC";
+  // #747 — the admin's own zone when the user has none, never UTC.
+  const timezone = profile.timezone ?? (await getTrainerTimezone());
   const todayCivil = civilDateToday(timezone);
   const thisMonthFirst = `${todayCivil.slice(0, 7)}-01`;
 
@@ -328,7 +343,7 @@ export default async function CoachlessUserDetailPage({
                 })()
               : "never"
           }
-          hint={formatDate(profile.activity.lastActiveISO)}
+          hint={formatDate(profile.activity.lastActiveISO, timezone)}
         />
         <StatTile
           label="Workouts"
@@ -360,9 +375,9 @@ export default async function CoachlessUserDetailPage({
               <Field label="UID">
                 <span className="font-mono text-xs">{uid}</span>
               </Field>
-              <Field label="Signed up">{formatDateWithAge(profile.createdAtISO, nowMs)}</Field>
+              <Field label="Signed up">{formatDateWithAge(profile.createdAtISO, nowMs, timezone)}</Field>
               <Field label="Last sign-in">
-                {formatDateWithAge(profile.auth?.lastSignInISO ?? null, nowMs)}
+                {formatDateWithAge(profile.auth?.lastSignInISO ?? null, nowMs, timezone)}
               </Field>
               <Field label="Sign-in providers">
                 {profile.auth && profile.auth.providers.length > 0
@@ -438,9 +453,9 @@ export default async function CoachlessUserDetailPage({
               </Field>
               <Field label="Source">{profile.entitlement?.source || "—"}</Field>
               <Field label="Product">{profile.entitlement?.productId || "—"}</Field>
-              <Field label="Expires">{formatDate(profile.entitlement?.expiresAtISO ?? null)}</Field>
+              <Field label="Expires">{formatDate(profile.entitlement?.expiresAtISO ?? null, timezone)}</Field>
               <Field label="Updated">
-                {formatDateWithAge(profile.entitlement?.updatedAtISO ?? null, nowMs)}
+                {formatDateWithAge(profile.entitlement?.updatedAtISO ?? null, nowMs, timezone)}
               </Field>
             </dl>
 
@@ -500,17 +515,17 @@ export default async function CoachlessUserDetailPage({
                 </TableRow>
               </TableHeader>
               <TableBody>
-                <ActivityRow label="Workouts logged" window={profile.activity.workouts} nowMs={nowMs} />
+                <ActivityRow label="Workouts logged" window={profile.activity.workouts} nowMs={nowMs} timezone={timezone} />
                 <ActivityRow
                   label="Habit check-ins"
                   window={profile.activity.habitCheckIns}
-                  nowMs={nowMs}
+                  nowMs={nowMs} timezone={timezone}
                 />
-                <ActivityRow label="Progress photos" window={profile.activity.photos} nowMs={nowMs} />
+                <ActivityRow label="Progress photos" window={profile.activity.photos} nowMs={nowMs} timezone={timezone} />
                 <ActivityRow
                   label="Body-weight entries"
                   window={profile.activity.weightEntries}
-                  nowMs={nowMs}
+                  nowMs={nowMs} timezone={timezone}
                 />
               </TableBody>
             </Table>
@@ -549,10 +564,10 @@ export default async function CoachlessUserDetailPage({
                       </TableCell>
                       <TableCell className="text-right tabular-nums">{r.exerciseCount}</TableCell>
                       <TableCell className="text-xs text-muted-foreground">
-                        {formatDate(r.createdAtISO)}
+                        {formatDate(r.createdAtISO, timezone)}
                       </TableCell>
                       <TableCell className="text-xs text-muted-foreground">
-                        {formatDate(r.updatedAtISO)}
+                        {formatDate(r.updatedAtISO, timezone)}
                       </TableCell>
                       <TableCell>
                         {r.deleted ? (

--- a/backoffice/src/app/gc-fitness/admin/coach-less-users/_components/CoachlessUsersTable.tsx
+++ b/backoffice/src/app/gc-fitness/admin/coach-less-users/_components/CoachlessUsersTable.tsx
@@ -37,6 +37,7 @@ import {
   type CoachlessSortKey,
 } from "@/lib/gc-fitness/coachless-user-table";
 import { cn } from "@/lib/utils";
+import { civilDateFormat } from "@/lib/gc-fitness/civil-date";
 
 const ROUTE = "/gc-fitness/admin/coach-less-users";
 
@@ -52,11 +53,19 @@ export interface CoachlessUsersTableProps {
   assignCoachAction: (formData: FormData) => Promise<void>;
   setTierAction: (formData: FormData) => Promise<void>;
   deleteUserAction: (formData: FormData) => Promise<void>;
+  /** The admin's IANA zone, resolved server-side (#747). */
+  timezone: string;
 }
 
-function formatDate(iso: string | null): string {
-  // Stable YYYY-MM-DD (avoids the server-locale flake seen in date tests).
-  return iso ? iso.slice(0, 10) : "—";
+// Stable YYYY-MM-DD — locale-independent by construction, so it never picks up
+// the server-locale flake that date tests hit. #747: the `iso.slice(0, 10)`
+// this replaced was stable AND wrong, since the first 10 chars of an ISO
+// instant are its UTC day, not the admin's.
+function formatDate(iso: string | null, timezone: string): string {
+  if (!iso) return "—";
+  const date = new Date(iso);
+  if (Number.isNaN(date.getTime())) return iso.slice(0, 10);
+  return civilDateFormat(date, timezone);
 }
 
 function SortableHead({
@@ -99,6 +108,7 @@ export function CoachlessUsersTable({
   assignCoachAction,
   setTierAction,
   deleteUserAction,
+  timezone,
 }: CoachlessUsersTableProps) {
   const [query, setQuery] = useState("");
   const [sort, setSort] = useState<CoachlessSort>(DEFAULT_COACHLESS_SORT);
@@ -207,7 +217,7 @@ export function CoachlessUsersTable({
                         <div className="mt-1 space-y-0.5 text-[10px] text-muted-foreground">
                           <div>source: {row.entitlement.source || "—"}</div>
                           {row.entitlement.expiresAtISO ? (
-                            <div>expires: {formatDate(row.entitlement.expiresAtISO)}</div>
+                            <div>expires: {formatDate(row.entitlement.expiresAtISO, timezone)}</div>
                           ) : null}
                         </div>
                       ) : null}
@@ -221,7 +231,7 @@ export function CoachlessUsersTable({
                       {row.stats.workoutLogs}
                     </TableCell>
                     <TableCell className="text-xs text-muted-foreground">
-                      {formatDate(row.createdAtISO)}
+                      {formatDate(row.createdAtISO, timezone)}
                     </TableCell>
                     <TableCell className="text-right">
                       <div className="flex flex-col items-end gap-2">

--- a/backoffice/src/app/gc-fitness/admin/coach-less-users/page.tsx
+++ b/backoffice/src/app/gc-fitness/admin/coach-less-users/page.tsx
@@ -18,6 +18,7 @@ import {
 } from "@/lib/gc-fitness/admin-coachless-actions";
 
 import { CoachlessUsersTable } from "./_components/CoachlessUsersTable";
+import { getTrainerTimezone } from "@/lib/gc-fitness/trainer-timezone";
 
 export const generateMetadata = () => sectionMetadata("adminPanel");
 
@@ -109,6 +110,7 @@ export default async function CoachlessUsersPage({
         assignCoachAction={assignCoachAction}
         setTierAction={setTierAction}
         deleteUserAction={deleteUserAction}
+        timezone={await getTrainerTimezone()}
       />
     </div>
   );

--- a/backoffice/src/app/gc-fitness/admin/coaches/[uid]/clients/[clientId]/page.tsx
+++ b/backoffice/src/app/gc-fitness/admin/coaches/[uid]/clients/[clientId]/page.tsx
@@ -14,6 +14,7 @@ import Link from "next/link";
 import { notFound, redirect } from "next/navigation";
 
 import { getCurrentAdmin } from "@/lib/gc-fitness/auth-helpers";
+import { getTrainerTimezone } from "@/lib/gc-fitness/trainer-timezone";
 import { FirestoreCollections } from "@/lib/gc-fitness/collections";
 import { listRecentLogsForClientAsAdmin } from "@/lib/gc-fitness/recent-logs-actions";
 import { listProgressPhotosForClientAsAdmin } from "@/lib/gc-fitness/progress-photo-actions";
@@ -89,8 +90,12 @@ export default async function AdminCoachClientPage({
     .doc(clientId)
     .get();
   const storedTimezone = clientSnap.get("timezone");
+  // #747 — falls back to the ADMIN's own zone, never UTC. See the note in
+  // `clients/[id]/page.tsx`.
   const timezone =
-    typeof storedTimezone === "string" && storedTimezone ? storedTimezone : "UTC";
+    typeof storedTimezone === "string" && storedTimezone
+      ? storedTimezone
+      : await getTrainerTimezone();
 
   return (
     <div className="gc-page flex flex-col gap-6">

--- a/backoffice/src/app/gc-fitness/checklist/CoachChecklistClient.tsx
+++ b/backoffice/src/app/gc-fitness/checklist/CoachChecklistClient.tsx
@@ -18,6 +18,7 @@ import { useLocale, useTranslations } from "next-intl";
 
 import { Button } from "@/components/ui/button";
 import { ChecklistEditDialog } from "@/components/gc-fitness/ChecklistEditDialog";
+import { civilDateFormat, civilDateToday } from "@/lib/gc-fitness/civil-date";
 import { ChecklistClientPicker } from "@/components/gc-fitness/ChecklistClientPicker";
 import { ChecklistRecurrenceFields } from "@/components/gc-fitness/ChecklistRecurrenceFields";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
@@ -42,6 +43,13 @@ export interface ChecklistClientOption {
 interface Props {
   items: CoachChecklistItem[];
   clients: ChecklistClientOption[];
+  /**
+   * The coach's IANA zone, resolved server-side (#747). Every civil day and
+   * every displayed hour below is keyed off it — the host getters this replaced
+   * were UTC on the server render, so an item due at 21:00 in Buenos Aires
+   * headed the WRONG day until hydration corrected it.
+   */
+  timezone: string;
 }
 
 const RECURRENCE_LABEL: Record<string, string> = {
@@ -69,7 +77,7 @@ function recurrenceSummary(item: CoachChecklistItem): string {
   return base;
 }
 
-export function CoachChecklistClient({ items, clients }: Props) {
+export function CoachChecklistClient({ items, clients, timezone }: Props) {
   const t = useTranslations("coachChecklist");
   const locale = useLocale();
   const router = useRouter();
@@ -90,8 +98,8 @@ export function CoachChecklistClient({ items, clients }: Props) {
   );
   const visibleItems = showCompleted ? items : activeItems;
   const groups = useMemo(
-    () => groupItemsByDate(visibleItems, now, locale, t),
-    [locale, now, t, visibleItems],
+    () => groupItemsByDate(visibleItems, now, locale, t, timezone),
+    [locale, now, t, timezone, visibleItems],
   );
 
   function handleSubmit(event: FormEvent<HTMLFormElement>) {
@@ -326,13 +334,14 @@ export function CoachChecklistClient({ items, clients }: Props) {
                           >
                             <CalendarClock className="size-3.5" />
                             {item.dueAt
-                              ? formatDateTime(item.dueAt, locale)
+                              ? formatDateTime(item.dueAt, locale, timezone)
                               : t("noDueAt")}
                           </p>
                         </div>
                         <div className="flex shrink-0 items-center gap-1">
                           <ChecklistEditDialog
                             item={item}
+                            timezone={timezone}
                             clients={clients}
                             trigger={
                               <Button
@@ -382,11 +391,12 @@ function groupItemsByDate(
   now: Date,
   locale: string,
   t: ReturnType<typeof useTranslations>,
+  timezone: string,
 ): ChecklistGroup[] {
   const sorted = [...items].sort(compareItems);
   const groups = new Map<string, ChecklistGroup>();
   for (const item of sorted) {
-    const groupMeta = groupForItem(item, now, locale, t);
+    const groupMeta = groupForItem(item, now, locale, t, timezone);
     const existing = groups.get(groupMeta.key);
     if (existing) existing.items.push(item);
     else groups.set(groupMeta.key, { ...groupMeta, items: [item] });
@@ -399,6 +409,7 @@ function groupForItem(
   now: Date,
   locale: string,
   t: ReturnType<typeof useTranslations>,
+  timezone: string,
 ): Omit<ChecklistGroup, "items"> {
   if (item.completed) {
     return {
@@ -425,10 +436,10 @@ function groupForItem(
     };
   }
 
-  const dateKey = civilDateKey(item.dueAt);
+  const dateKey = civilDateKey(item.dueAt, timezone);
   return {
     key: dateKey,
-    label: formatDateHeading(item.dueAt, now, locale, t),
+    label: formatDateHeading(item.dueAt, now, locale, t, timezone),
     overdue: false,
     completed: false,
   };
@@ -454,13 +465,10 @@ function isOverdue(item: CoachChecklistItem, now: Date): boolean {
   return Number.isFinite(dueMs) && dueMs < now.getTime();
 }
 
-function civilDateKey(iso: string): string {
+function civilDateKey(iso: string, timezone: string): string {
   const date = new Date(iso);
   if (Number.isNaN(date.getTime())) return iso;
-  const year = date.getFullYear();
-  const month = `${date.getMonth() + 1}`.padStart(2, "0");
-  const day = `${date.getDate()}`.padStart(2, "0");
-  return `${year}-${month}-${day}`;
+  return civilDateFormat(date, timezone);
 }
 
 function formatDateHeading(
@@ -468,28 +476,31 @@ function formatDateHeading(
   now: Date,
   locale: string,
   t: ReturnType<typeof useTranslations>,
+  timezone: string,
 ): string {
   const date = new Date(iso);
   if (Number.isNaN(date.getTime())) return iso;
-  const itemKey = civilDateKey(iso);
-  const todayKey = civilDateKey(now.toISOString());
-  const tomorrow = new Date(now);
-  tomorrow.setDate(tomorrow.getDate() + 1);
-  const tomorrowKey = civilDateKey(tomorrow.toISOString());
+  const itemKey = civilDateKey(iso, timezone);
+  const todayKey = civilDateToday(timezone, now);
+  // +24h rather than `setDate(getDate() + 1)`: the latter steps the HOST
+  // calendar, which is not the calendar the heading is keyed on.
+  const tomorrowKey = civilDateFormat(new Date(now.getTime() + 86_400_000), timezone);
   if (itemKey === todayKey) return t("todayTitle");
   if (itemKey === tomorrowKey) return t("tomorrowTitle");
   return new Intl.DateTimeFormat(locale, {
     weekday: "long",
     month: "long",
     day: "numeric",
+    timeZone: timezone,
   }).format(date);
 }
 
-function formatDateTime(iso: string, locale: string): string {
+function formatDateTime(iso: string, locale: string, timezone: string): string {
   const date = new Date(iso);
   if (Number.isNaN(date.getTime())) return iso;
   return new Intl.DateTimeFormat(locale, {
     dateStyle: "medium",
     timeStyle: "short",
+    timeZone: timezone,
   }).format(date);
 }

--- a/backoffice/src/app/gc-fitness/checklist/page.tsx
+++ b/backoffice/src/app/gc-fitness/checklist/page.tsx
@@ -5,6 +5,7 @@ import { PageHeader } from "@/components/gc-fitness/page-header";
 import { getCurrentTrainer } from "@/lib/gc-fitness/auth-helpers";
 import { listCoachChecklistItems } from "@/lib/gc-fitness/coach-checklist-actions";
 import { listClients } from "@/lib/gc-fitness/client-roster";
+import { getTrainerTimezone } from "@/lib/gc-fitness/trainer-timezone";
 import { CoachChecklistClient } from "./CoachChecklistClient";
 import { sectionMetadata } from "@/lib/gc-fitness/page-metadata";
 
@@ -24,9 +25,12 @@ export default async function CoachChecklistPage() {
     throw err;
   }
   const t = await getTranslations("coachChecklist");
-  const [items, roster] = await Promise.all([
+  const [items, roster, timezone] = await Promise.all([
     listCoachChecklistItems(),
     listClients(),
+    // #747 — the page groups by civil day and prints hours; both need the
+    // coach's zone, which a Server Component cannot infer.
+    getTrainerTimezone(),
   ]);
   // Only real (signed-in) clients can be linked — pending/mirror entries have a
   // synthetic `mirror:` uid that isn't a valid client route.
@@ -41,7 +45,7 @@ export default async function CoachChecklistPage() {
   return (
     <div className="gc-page flex flex-col gap-6">
       <PageHeader title={t("title")} subtitle={t("headerSubtitle")} />
-      <CoachChecklistClient items={items} clients={clients} />
+      <CoachChecklistClient items={items} clients={clients} timezone={timezone} />
     </div>
   );
 }

--- a/backoffice/src/app/gc-fitness/clients/[id]/_components/ClientRecentLogsFeed.tsx
+++ b/backoffice/src/app/gc-fitness/clients/[id]/_components/ClientRecentLogsFeed.tsx
@@ -28,6 +28,10 @@ import {
   type RecentLogRow,
 } from "@/lib/gc-fitness/recent-logs-actions";
 import { formatCivilDateLabel } from "@/lib/gc-fitness/civil-date";
+// #747 — the shared helper the timezone policy mandates. The local copy this
+// replaced passed `undefined` as the locale, so a Spanish UI rendered "Aug 04,
+// 09:04 PM" — and rendered it differently on the server than after hydration.
+import { formatClientActivityDateTime } from "@/lib/gc-fitness/client-activity-time";
 
 // Must match the server page size (listRecentLogsForClient default). The feed
 // pages through already-loaded rows in memory; only when the user crosses the
@@ -270,7 +274,7 @@ export function ClientRecentLogsFeed({
                   ) : null}
                 </div>
                 <p className="mt-0.5 truncate text-xs text-muted-foreground">
-                  {formatDateTime(row.eventAt, timezone)}
+                  {formatClientActivityDateTime(row.eventAt, timezone, locale)}
                   {row.detail ? ` · ${row.detail}` : ""}
                 </p>
               </RowShell>
@@ -361,18 +365,6 @@ function RowShell({
       <ChevronRight className="h-4 w-4 shrink-0 text-muted-foreground opacity-0 transition-opacity group-hover:opacity-100" />
     </Link>
   );
-}
-
-function formatDateTime(iso: string, timeZone: string): string {
-  const date = new Date(iso);
-  if (Number.isNaN(date.getTime())) return iso;
-  return date.toLocaleString(undefined, {
-    month: "short",
-    day: "2-digit",
-    hour: "2-digit",
-    minute: "2-digit",
-    timeZone,
-  });
 }
 
 // Render a "YYYY-MM-DD" civil date as a short day label. Construct from parts

--- a/backoffice/src/app/gc-fitness/clients/[id]/_components/PendingClientPreload.tsx
+++ b/backoffice/src/app/gc-fitness/clients/[id]/_components/PendingClientPreload.tsx
@@ -28,6 +28,8 @@ import { listWorkoutTemplates } from "@/lib/gc-fitness/workout-template-actions"
 import { revalidatePath } from "next/cache";
 import { PendingWorkoutAssignForm } from "./PendingWorkoutAssignForm";
 import { PendingHabitPreloadForm } from "./PendingHabitPreloadForm";
+import { civilDateToday } from "@/lib/gc-fitness/civil-date";
+import { getTrainerTimezone } from "@/lib/gc-fitness/trainer-timezone";
 
 const WEEKDAY_LABELS_WORKOUT: Record<number, string> = {
   0: "Dom",
@@ -138,7 +140,8 @@ export async function PendingClientPreload({
       ? habitTemplates.find((template) => template.id === templateId)
       : null;
     if (!selectedTemplate && !name) return;
-    const startsOnValue = startsOn || new Date().toISOString().slice(0, 10);
+    // #747 — the coach's civil day, not the server's UTC one.
+    const startsOnValue = startsOn || civilDateToday(await getTrainerTimezone());
     const resolvedType = "binary" as const;
     const resolvedScheduleType = scheduleType === "one-time" ? "one-time" : "recurring";
     const resolvedCadence =

--- a/backoffice/src/app/gc-fitness/clients/[id]/page.tsx
+++ b/backoffice/src/app/gc-fitness/clients/[id]/page.tsx
@@ -29,6 +29,7 @@ import {
   type CurrentTrainer,
 } from "@/lib/gc-fitness/auth-helpers";
 import { civilDateToday } from "@/lib/gc-fitness/civil-date";
+import { getTrainerTimezone } from "@/lib/gc-fitness/trainer-timezone";
 import { evaluateProgressPhotoCheckIn } from "@/lib/gc-fitness/progress-photo-checkin-policy";
 import { gcFitnessFirestore } from "@/lib/firebase/gc-fitness-admin";
 import { FirestoreCollections } from "@/lib/gc-fitness/collections";
@@ -145,7 +146,12 @@ export default async function ClientDetailPage({
     email: client.email ?? "",
     coachNickname: client.coachNickname ?? null,
   });
-  const timezone = client.timezone ?? "UTC";
+  // #747 — the client's own zone when we know it, the COACH's otherwise. The
+  // old `?? "UTC"` was not a neutral default: a client who has not opened the
+  // app yet (or signed up before the field existed) has no `timezone`, so every
+  // instant on this page rendered in UTC — "09:04 PM" for an action taken at
+  // 18:04 in Buenos Aires. Nobody reading this screen lives in UTC.
+  const timezone = client.timezone ?? (await getTrainerTimezone());
   // Contract: every client activity surface below reads this explicit IANA
   // timezone. Leaf components must not infer UTC or the host timezone.
   const todayCivil = civilDateToday(timezone);

--- a/backoffice/src/app/gc-fitness/clients/_components/RosterTable.tsx
+++ b/backoffice/src/app/gc-fitness/clients/_components/RosterTable.tsx
@@ -47,6 +47,8 @@ export interface RosterTableProps {
   rows: ClientRosterRow[];
   trainerUid: string;
   initialNeedsAttentionOnly?: boolean;
+  /** The coach's IANA zone, resolved server-side (#747). */
+  timezone: string;
 }
 
 function GoalPill({ label, count }: { label: string; count: number }) {
@@ -85,6 +87,7 @@ function ComplianceBar({ pct, good }: { pct: number; good: boolean }) {
 export function RosterTable({
   rows,
   initialNeedsAttentionOnly = false,
+  timezone,
 }: RosterTableProps) {
   const router = useRouter();
   const locale = useLocale();
@@ -322,7 +325,7 @@ export function RosterTable({
                         </>
                       ) : (
                         <>
-                          {tTable("joined")}: {formatRosterDate(row.createdAt, locale)}
+                          {tTable("joined")}: {formatRosterDate(row.createdAt, locale, timezone)}
                         </>
                       )}
                     </p>
@@ -344,11 +347,15 @@ export function RosterTable({
   );
 }
 
-function formatRosterDate(iso: string | null, locale: string): string {
+// #747 — `timeZone` is explicit. Without it this rendered the UTC day on the
+// server pass, so a client who joined at 21:30 in Buenos Aires was listed as
+// having joined the NEXT day until hydration corrected it.
+function formatRosterDate(iso: string | null, locale: string, timeZone: string): string {
   if (!iso) return "—";
   const date = new Date(iso);
   if (Number.isNaN(date.getTime())) return iso;
   return new Intl.DateTimeFormat(locale === "es" ? "es-AR" : "en-US", {
     dateStyle: "medium",
+    timeZone,
   }).format(date);
 }

--- a/backoffice/src/app/gc-fitness/clients/page.tsx
+++ b/backoffice/src/app/gc-fitness/clients/page.tsx
@@ -17,6 +17,7 @@ import {
   type CurrentTrainer,
 } from "@/lib/gc-fitness/auth-helpers";
 import { listClientsForRoster } from "@/lib/gc-fitness/client-roster";
+import { getTrainerTimezone } from "@/lib/gc-fitness/trainer-timezone";
 import { AddClientPanel } from "./_components/AddClientPanel";
 import { RosterTable } from "./_components/RosterTable";
 import { RosterQueryProvider } from "./providers";
@@ -90,6 +91,7 @@ export default async function ClientsPage({
           rows={rows}
           trainerUid={trainer.uid}
           initialNeedsAttentionOnly={initialNeedsAttentionOnly}
+          timezone={await getTrainerTimezone()}
         />
       </RosterQueryProvider>
     </div>

--- a/backoffice/src/app/gc-fitness/dashboard/_components/checklist-pending-list.tsx
+++ b/backoffice/src/app/gc-fitness/dashboard/_components/checklist-pending-list.tsx
@@ -14,6 +14,8 @@ import { setCoachChecklistItemCompleted } from "@/lib/gc-fitness/coach-checklist
 
 interface Props {
   items: PendingChecklistItem[];
+  /** The coach's IANA zone. Explicit, never inferred here (#747). */
+  timezone: string;
 }
 
 /**
@@ -23,7 +25,7 @@ interface Props {
  * by construction (the server only feeds overdue + due-today), so the checkbox
  * always starts unchecked and a tick completes the item.
  */
-export function ChecklistPendingList({ items }: Props) {
+export function ChecklistPendingList({ items, timezone }: Props) {
   const td = useTranslations("dashboard");
   const tc = useTranslations("coachChecklist");
   const locale = useLocale();
@@ -33,6 +35,7 @@ export function ChecklistPendingList({ items }: Props) {
   const timeFormatter = new Intl.DateTimeFormat(locale, {
     hour: "numeric",
     minute: "2-digit",
+    timeZone: timezone,
   });
 
   function complete(item: PendingChecklistItem) {
@@ -92,6 +95,7 @@ export function ChecklistPendingList({ items }: Props) {
               </span>
               <ChecklistEditDialog
                 item={item}
+                timezone={timezone}
                 trigger={
                   <Button
                     type="button"

--- a/backoffice/src/app/gc-fitness/dashboard/_components/checklist-pending.tsx
+++ b/backoffice/src/app/gc-fitness/dashboard/_components/checklist-pending.tsx
@@ -10,6 +10,7 @@ import {
   CardTitle,
 } from "@/components/ui/card";
 import type { PendingChecklistItem } from "@/lib/gc-fitness/coach-checklist-actions";
+import { getTrainerTimezone } from "@/lib/gc-fitness/trainer-timezone";
 
 import { ChecklistPendingList } from "./checklist-pending-list";
 
@@ -27,7 +28,11 @@ interface Props {
 export async function ChecklistPending({ items }: Props) {
   if (items.length === 0) return null;
 
-  const t = await getTranslations("dashboard");
+  // #747 — the due HOUR has to read in the coach's zone, not the server's.
+  const [t, timezone] = await Promise.all([
+    getTranslations("dashboard"),
+    getTrainerTimezone(),
+  ]);
 
   return (
     <Card>
@@ -41,7 +46,7 @@ export async function ChecklistPending({ items }: Props) {
         </Button>
       </CardHeader>
       <CardContent>
-        <ChecklistPendingList items={items} />
+        <ChecklistPendingList items={items} timezone={timezone} />
       </CardContent>
     </Card>
   );

--- a/backoffice/src/app/gc-fitness/habits/[id]/edit/page.tsx
+++ b/backoffice/src/app/gc-fitness/habits/[id]/edit/page.tsx
@@ -20,6 +20,8 @@ import {
 import { gcFitnessFirestore } from "@/lib/firebase/gc-fitness-admin";
 import { FirestoreCollections } from "@/lib/gc-fitness/collections";
 import { listClients } from "@/lib/gc-fitness/client-roster";
+import { civilDateToday } from "@/lib/gc-fitness/civil-date";
+import { getTrainerTimezone } from "@/lib/gc-fitness/trainer-timezone";
 import type {
   HabitCreateInput,
   HabitType,
@@ -104,7 +106,9 @@ export default async function EditHabitPage({ params }: PageParams) {
         ? [data.reminderDayOfMonth]
         : undefined),
     scheduleType: data.scheduleType ?? "recurring",
-    startsOn: data.startsOn ?? new Date().toISOString().slice(0, 10),
+    // #747 — the UTC day, not the coach's: at 21:30 in Buenos Aires the form
+    // defaulted a habit to start TOMORROW.
+    startsOn: data.startsOn ?? civilDateToday(await getTrainerTimezone()),
     endsOn: data.endsOn,
     scheduleCadence: data.scheduleCadence ?? "daily",
     scheduleWeekdays: data.scheduleWeekdays,

--- a/backoffice/src/app/gc-fitness/notifications/page.tsx
+++ b/backoffice/src/app/gc-fitness/notifications/page.tsx
@@ -353,7 +353,7 @@ export default async function NotificationsPage({
         </div>
       ) : null}
 
-      <UpcomingWorkoutAlerts />
+      <UpcomingWorkoutAlerts timezone={trainerTimezone} />
 
       <Card>
         <CardHeader>

--- a/backoffice/src/app/gc-fitness/qa-tools/page.tsx
+++ b/backoffice/src/app/gc-fitness/qa-tools/page.tsx
@@ -41,6 +41,7 @@ import {
   getCurrentTrainer,
   type CurrentTrainer,
 } from "@/lib/gc-fitness/auth-helpers";
+import { getTrainerTimezone } from "@/lib/gc-fitness/trainer-timezone";
 import { FirestoreCollections } from "@/lib/gc-fitness/collections";
 import { listEngineeringUsers } from "@/lib/gc-fitness/engineering-actions";
 import { EngineeringAccessCard } from "./_components/EngineeringAccessCard";
@@ -161,6 +162,8 @@ async function fetchRecentTrainerActivity(
 }
 
 export default async function GCFitnessQAToolsPage() {
+  // #747 — every timestamp on this page renders in the engineer's zone.
+  const timezone = await getTrainerTimezone();
   let trainer: CurrentTrainer;
   try {
     trainer = await getCurrentTrainer();
@@ -241,6 +244,9 @@ export default async function GCFitnessQAToolsPage() {
                       ? row.updatedAt.toLocaleString("es-AR", {
                           dateStyle: "short",
                           timeStyle: "short",
+                          // #747 — a Server Component formats in the SERVER's
+                          // zone (UTC on Vercel) unless told otherwise.
+                          timeZone: timezone,
                         })
                       : "(no timestamp)"}
                   </span>

--- a/backoffice/src/components/gc-fitness/ChecklistEditDialog.tsx
+++ b/backoffice/src/components/gc-fitness/ChecklistEditDialog.tsx
@@ -21,6 +21,8 @@ import { ChecklistClientPicker } from "@/components/gc-fitness/ChecklistClientPi
 import { ChecklistRecurrenceFields } from "@/components/gc-fitness/ChecklistRecurrenceFields";
 import type { CoachChecklistItem } from "@/lib/gc-fitness/coach-checklist-actions";
 import { updateCoachChecklistItem } from "@/lib/gc-fitness/coach-checklist-actions";
+import { civilDateFormat } from "@/lib/gc-fitness/civil-date";
+import { formatClientActivityTime } from "@/lib/gc-fitness/client-activity-time";
 
 interface Props {
   item: CoachChecklistItem;
@@ -28,18 +30,27 @@ interface Props {
   trigger: ReactNode;
   /** Linkable clients. When empty (e.g. the dashboard widget) the picker is hidden. */
   clients?: Array<{ uid: string; displayName: string }>;
+  /** The coach's IANA zone — the one the due time was typed in (#747). */
+  timezone: string;
 }
 
-// Split a stored ISO `dueAt` into the local date/time strings the
+// Split a stored ISO `dueAt` back into the date/time strings the
 // <input type="date"|"time"> controls expect. Empty when there's no due date.
-function splitDueAt(iso: string | null): { date: string; time: string } {
+//
+// #747 — explicitly in the coach's zone. The host getters this replaced happen
+// to agree in the browser and disagree on the server render, so a reminder set
+// for 18:00 flashed as a different hour before hydration — and the value the
+// form posted back was whatever the flash had computed.
+function splitDueAt(
+  iso: string | null,
+  timezone: string,
+): { date: string; time: string } {
   if (!iso) return { date: "", time: "" };
   const d = new Date(iso);
   if (Number.isNaN(d.getTime())) return { date: "", time: "" };
-  const pad = (n: number) => String(n).padStart(2, "0");
   return {
-    date: `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}`,
-    time: `${pad(d.getHours())}:${pad(d.getMinutes())}`,
+    date: civilDateFormat(d, timezone),
+    time: formatClientActivityTime(iso, timezone, "en-GB"),
   };
 }
 
@@ -48,13 +59,13 @@ function splitDueAt(iso: string | null): { date: string; time: string } {
  * checklist page and the dashboard "Pendientes" widget. Uncontrolled form
  * whose defaults are reset on every open via a `key` tied to open state.
  */
-export function ChecklistEditDialog({ item, trigger, clients = [] }: Props) {
+export function ChecklistEditDialog({ item, trigger, clients = [], timezone }: Props) {
   const t = useTranslations("coachChecklist");
   const router = useRouter();
   const [open, setOpen] = useState(false);
   const [pending, startTransition] = useTransition();
   const [recurrenceValid, setRecurrenceValid] = useState(true);
-  const initial = splitDueAt(item.dueAt);
+  const initial = splitDueAt(item.dueAt, timezone);
 
   function handleSubmit(event: FormEvent<HTMLFormElement>) {
     event.preventDefault();

--- a/backoffice/src/components/gc-fitness/upcoming-workout-alerts.tsx
+++ b/backoffice/src/components/gc-fitness/upcoming-workout-alerts.tsx
@@ -20,6 +20,7 @@ import {
   type UpcomingWorkout,
 } from "@/lib/gc-fitness/live-workout-actions";
 import { useActiveWorkoutSummaries } from "@/lib/gc-fitness/live-workout-listener";
+import { civilDateToday } from "@/lib/gc-fitness/civil-date";
 
 const THRESHOLDS = [30, 10, 1] as const;
 
@@ -27,24 +28,26 @@ function isUrl(value: string): boolean {
   return /^https?:\/\//i.test(value.trim());
 }
 
-function firedStorageKey(): string {
-  const today = new Date().toISOString().slice(0, 10);
-  return `gcf-workout-alerts-fired-${today}`;
+// #747 — the "already alerted today" set has to roll over at the COACH's
+// midnight. Keyed on the UTC day, a coach at UTC-3 kept yesterday's fired set
+// through their evening and started a fresh one at 21:00 local.
+function firedStorageKey(timezone: string): string {
+  return `gcf-workout-alerts-fired-${civilDateToday(timezone)}`;
 }
 
-function loadFired(): Set<string> {
+function loadFired(timezone: string): Set<string> {
   if (typeof window === "undefined") return new Set();
   try {
-    const raw = window.localStorage.getItem(firedStorageKey());
+    const raw = window.localStorage.getItem(firedStorageKey(timezone));
     return new Set(raw ? (JSON.parse(raw) as string[]) : []);
   } catch {
     return new Set();
   }
 }
 
-function persistFired(fired: Set<string>) {
+function persistFired(fired: Set<string>, timezone: string) {
   try {
-    window.localStorage.setItem(firedStorageKey(), JSON.stringify([...fired]));
+    window.localStorage.setItem(firedStorageKey(timezone), JSON.stringify([...fired]));
   } catch {
     /* storage unavailable — alerts still fire in-session via the ref */
   }
@@ -59,7 +62,7 @@ function countdownLabel(minutes: number): string {
   return m === 0 ? `en ${h} h` : `en ${h} h ${m} min`;
 }
 
-export function UpcomingWorkoutAlerts() {
+export function UpcomingWorkoutAlerts({ timezone }: { timezone: string }) {
   const { data } = useQuery({
     queryKey: ["live-workout", "upcoming-alerts"],
     queryFn: () => listUpcomingScheduledWorkouts(),
@@ -74,9 +77,9 @@ export function UpcomingWorkoutAlerts() {
   const firedRef = useRef<Set<string>>(new Set());
 
   useEffect(() => {
-    firedRef.current = loadFired();
+    firedRef.current = loadFired(timezone);
     if (typeof Notification !== "undefined") setPermission(Notification.permission);
-  }, []);
+  }, [timezone]);
 
   useEffect(() => {
     const t = setInterval(() => setNow(Date.now()), 15_000);
@@ -111,8 +114,8 @@ export function UpcomingWorkoutAlerts() {
         }
       }
     }
-    if (changed) persistFired(firedRef.current);
-  }, [items, now]);
+    if (changed) persistFired(firedRef.current, timezone);
+  }, [items, now, timezone]);
 
   const visible = items.filter((i) => {
     const minutes = (i.scheduledEpochMs - now) / 60_000;

--- a/backoffice/src/components/gc-fitness/workout-log-detail-view.tsx
+++ b/backoffice/src/components/gc-fitness/workout-log-detail-view.tsx
@@ -18,7 +18,7 @@
 // fine inside both server pages and client dialogs.
 
 import { Trophy, Dumbbell, Gauge, NotebookText } from "lucide-react";
-import { useTranslations } from "next-intl";
+import { useLocale, useTranslations } from "next-intl";
 
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
@@ -93,12 +93,16 @@ function groupSetsByExercise(sets: WorkoutLogDetail["sets"]): ExerciseGroup[] {
 
 export function WorkoutLogDetailView({ detail }: { detail: WorkoutLogDetail }) {
   const t = useTranslations("recentLogs.workoutDetail");
+  // #747 sibling: the zone was already explicit here, the LOCALE was not — an
+  // `undefined` locale is the runtime's, so a Spanish UI printed "Aug 04".
+  const locale = useLocale();
   const groups = groupSetsByExercise(detail.sets);
   const restMap = restBySetLogId(detail.sets);
   const completedAtForDisplay = resolveCompletedAtForDisplay(detail);
   const sessionDate = formatDateOnly(
     completedAtForDisplay ?? detail.startedAt,
     detail.clientTimezone,
+    locale,
   );
 
   return (
@@ -126,10 +130,10 @@ export function WorkoutLogDetailView({ detail }: { detail: WorkoutLogDetail }) {
                 : t("statusStarted")
             }
           />
-          <Metric label={t("metricStarted")} value={formatDateTime(detail.startedAt, detail.clientTimezone)} />
+          <Metric label={t("metricStarted")} value={formatDateTime(detail.startedAt, detail.clientTimezone, locale)} />
           <Metric
             label={t("metricCompleted")}
-            value={formatDateTime(completedAtForDisplay, detail.clientTimezone)}
+            value={formatDateTime(completedAtForDisplay, detail.clientTimezone, locale)}
           />
           <Metric label={t("metricExercises")} value={String(detail.exerciseCount)} />
           <Metric label={t("metricSetsLogged")} value={`${detail.completedSetCount}/${detail.setCount}`} />
@@ -313,7 +317,7 @@ export function WorkoutLogDetailView({ detail }: { detail: WorkoutLogDetail }) {
                                   </td>
                                 ) : null}
                                 <td className="py-2 pr-3 text-muted-foreground">
-                                  {formatTimeOnly(set.completedAt, detail.clientTimezone)}
+                                  {formatTimeOnly(set.completedAt, detail.clientTimezone, locale)}
                                 </td>
                                 <td className="py-2 pr-3 text-muted-foreground">
                                   {restMap.has(set.setLogId)
@@ -376,11 +380,11 @@ function RpeMeter({ value, label }: { value: number; label: string }) {
 // `timeZone` is the CLIENT's IANA zone — REQUIRED. Omitting it would format
 // in the host tz (UTC). The recent-logs server page resolves it; the calendar
 // dialog gets it from the same WorkoutLogDetail builder.
-function formatDateTime(iso: string | null, timeZone: string): string {
+function formatDateTime(iso: string | null, timeZone: string, locale: string): string {
   if (!iso) return "-";
   const date = new Date(iso);
   if (Number.isNaN(date.getTime())) return "-";
-  return date.toLocaleString(undefined, {
+  return date.toLocaleString(locale, {
     year: "numeric",
     month: "short",
     day: "2-digit",
@@ -392,22 +396,22 @@ function formatDateTime(iso: string | null, timeZone: string): string {
 
 // Per-row timestamps only need the time — the date is shown once in the
 // section header (it's the same day for the whole workout).
-function formatTimeOnly(iso: string | null, timeZone: string): string {
+function formatTimeOnly(iso: string | null, timeZone: string, locale: string): string {
   if (!iso) return "-";
   const date = new Date(iso);
   if (Number.isNaN(date.getTime())) return "-";
-  return date.toLocaleString(undefined, {
+  return date.toLocaleString(locale, {
     hour: "2-digit",
     minute: "2-digit",
     timeZone,
   });
 }
 
-function formatDateOnly(iso: string | null, timeZone: string): string | null {
+function formatDateOnly(iso: string | null, timeZone: string, locale: string): string | null {
   if (!iso) return null;
   const date = new Date(iso);
   if (Number.isNaN(date.getTime())) return null;
-  return date.toLocaleDateString(undefined, {
+  return date.toLocaleDateString(locale, {
     weekday: "long",
     year: "numeric",
     month: "long",

--- a/backoffice/src/lib/gc-fitness/__tests__/activity-feed-actions.test.ts
+++ b/backoffice/src/lib/gc-fitness/__tests__/activity-feed-actions.test.ts
@@ -407,3 +407,92 @@ describe("other sources", () => {
     ]);
   });
 });
+
+// ─────────────────────────────────────────────────────────────────────────────
+// #748 — the same coach action reaching the feed through two recorders
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("cross-source duplicates", () => {
+  const SERIES = "6b1f2a34-0c9d-4f11-9d0e-51b7b2a4c8f0";
+
+  /** The audit half: one doc per occurrence, collapsed by the series grouping. */
+  const occurrence = (date: string, seconds: string) =>
+    doc(`a-${date}`, {
+      collection: "workout_assignments",
+      docId: `asg-client1-${date}-${UUID}`,
+      op: "create",
+      changedFields: ["templateId", "seriesId", "recurrence", "scheduledFor"],
+      changedFieldCount: 4,
+      after: {
+        templateId: "tpl-1",
+        seriesId: SERIES,
+        scheduledFor: `${date.slice(0, 4)}-${date.slice(4, 6)}-${date.slice(6, 8)}`,
+        recurrence: { kind: "weekly", weekday: 6 },
+      },
+      trainerId: "coach1",
+      clientId: "client1",
+      occurredAt: ts(`2026-08-04T17:31:${seconds}.000Z`),
+    });
+
+  beforeEach(() => {
+    queryGet.audit_log = async () => ({
+      docs: [occurrence("20260905", "10"), occurrence("20260808", "10")],
+    });
+    // The coach half: ONE hand-written event for the whole series, appended
+    // after the batches commit — same action, other dialect.
+    queryGet.coach_activity = async () => ({
+      docs: [
+        doc(`asg:${SERIES}`, {
+          trainerId: "coach1",
+          kind: "workout_assignment",
+          title: "Workout asignado: Full Body A",
+          detail: "Recurrencia: semanal · 5 fechas · 2026-08-08 a 2026-09-05",
+          clientId: "client1",
+          occurredAt: ts("2026-08-04T17:31:12.000Z"),
+          deleted: false,
+        }),
+      ],
+    });
+  });
+
+  it("shows one row for one assign, and keeps the richer audit one", async () => {
+    const events = await listActivityFeed();
+    expect(events.map((e) => e.id)).toEqual(["audit_log:a-20260905"]);
+
+    const [assign] = events;
+    expect(assign.source).toBe("audit_log");
+    expect(assign.title).toBe("Asignó un workout");
+    expect(assign.subject).toBe("Full Body A");
+    // What the coach half could not say: the weekday and the ×N badge.
+    expect(assign.meta).toContain("todas las semanas (sáb)");
+    expect(assign.occurrenceCount).toBe(2);
+    // And it must not carry the coach half's phrasing of the same fact.
+    expect(assign.meta.join(" ")).not.toContain("Recurrencia: semanal");
+  });
+
+  it("keeps the coach row when the audit half is missing", async () => {
+    // Trigger not deployed, or the audit half fell off the per-source cap.
+    queryGet.audit_log = async () => ({ docs: [] });
+    const events = await listActivityFeed();
+    expect(events.map((e) => e.id)).toEqual([`coach_activity:asg:${SERIES}`]);
+    expect(events[0].meta).toEqual([
+      "Recurrencia: semanal · 5 fechas · 2026-08-08 a 2026-09-05",
+    ]);
+  });
+
+  it("still shows the coach row for an unrelated series", async () => {
+    queryGet.coach_activity = async () => ({
+      docs: [
+        doc("asg:other-series", {
+          trainerId: "coach1",
+          kind: "workout_assignment",
+          title: "Workout asignado: Otra",
+          clientId: "client1",
+          occurredAt: ts("2026-08-04T17:31:12.000Z"),
+        }),
+      ],
+    });
+    const events = await listActivityFeed();
+    expect(events.map((e) => e.id)).toContain("coach_activity:asg:other-series");
+  });
+});

--- a/backoffice/src/lib/gc-fitness/__tests__/activity-feed-model.test.ts
+++ b/backoffice/src/lib/gc-fitness/__tests__/activity-feed-model.test.ts
@@ -8,6 +8,8 @@
 
 import {
   classifyAuditRecord,
+  coachActivityKeysFor,
+  findDuplicateCoachEventIds,
   isAutoExtendedOccurrence,
   durationLabel,
   habitFrequencyLabel,
@@ -20,6 +22,7 @@ import {
   recurrenceLabel,
   volumeLabel,
   type AuditRecord,
+  type CrossSourceRow,
   type MergeableEvent,
 } from "@/lib/gc-fitness/activity-feed-model";
 
@@ -1046,5 +1049,121 @@ describe("mergeWorkoutWriteBacks", () => {
       { id: "finish", ...base, correlation: "workout_finished" as const },
     ]);
     expect(merged.map((e) => e.id)).toEqual(["wb", "finish"]);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// #748 — one action, one row, across sources
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("coachActivityKeysFor", () => {
+  const SERIES = "6b1f2a34-0c9d-4f11-9d0e-51b7b2a4c8f0";
+
+  it("bridges an assignment by BOTH its series and its doc id", () => {
+    // The coach log keys a recurring series by seriesId and a one-off by the
+    // assignment id — a row that only emitted one of them would miss half.
+    expect(
+      coachActivityKeysFor(
+        record({
+          collection: "workout_assignments",
+          docId: `asg-${CLIENT}-20260808-${SERIES}`,
+          op: "create",
+          after: { seriesId: SERIES, templateId: "tpl-1" },
+        }),
+      ),
+    ).toEqual([`asg:asg-${CLIENT}-20260808-${SERIES}`, `asg:${SERIES}`]);
+  });
+
+  it("reads the series off `before` on a delete, where `after` is gone", () => {
+    expect(
+      coachActivityKeysFor(
+        record({
+          collection: "workout_assignments",
+          docId: "asg-1",
+          op: "delete",
+          before: { seriesId: SERIES },
+          after: null,
+        }),
+      ),
+    ).toContain(`asg:${SERIES}`);
+  });
+
+  it("bridges exercises and habits on the CREATE only", () => {
+    const exercise = { collection: "exercises", docId: "exr-1" } as const;
+    const habit = { collection: "habits", docId: "hab-1" } as const;
+    expect(coachActivityKeysFor(record({ ...exercise, op: "create" }))).toEqual(["exr:exr-1"]);
+    expect(coachActivityKeysFor(record({ ...habit, op: "create" }))).toEqual(["hab:hab-1"]);
+    // `exerciseCreatedEvent` / `habitAssignedEvent` never fire on an edit, so an
+    // edit landing minutes after the create must not swallow the creation row.
+    expect(coachActivityKeysFor(record({ ...exercise, op: "update" }))).toEqual([]);
+    expect(coachActivityKeysFor(record({ ...habit, op: "delete" }))).toEqual([]);
+  });
+
+  it("has no opinion on collections the coach log does not mirror", () => {
+    expect(coachActivityKeysFor(record({ collection: "workout_logs", op: "create" }))).toEqual([]);
+    expect(coachActivityKeysFor(record({ collection: "users", op: "update" }))).toEqual([]);
+    // `docId: "?"` is the reader's fallback for a malformed capture — it must
+    // not become a key that matches other malformed captures.
+    expect(
+      coachActivityKeysFor(record({ collection: "workout_assignments", docId: "?", op: "create" })),
+    ).toEqual([]);
+  });
+});
+
+describe("findDuplicateCoachEventIds", () => {
+  const SERIES = "6b1f2a34-0c9d-4f11-9d0e-51b7b2a4c8f0";
+
+  /** The screenshot in #748: the same assign, told twice. */
+  const auditHalf: CrossSourceRow = {
+    id: "audit_log:a1",
+    source: "audit_log",
+    occurredAtISO: "2026-08-04T17:31:10.000Z",
+    clientUid: CLIENT,
+    entityKeys: [`asg:asg-${CLIENT}-20260808-${SERIES}`, `asg:${SERIES}`],
+  };
+  const coachHalf: CrossSourceRow = {
+    id: `coach_activity:asg:${SERIES}`,
+    source: "coach_activity",
+    occurredAtISO: "2026-08-04T17:31:12.000Z",
+    clientUid: CLIENT,
+    entityKeys: [`asg:${SERIES}`],
+  };
+
+  it("drops the coach half when the audit half already told the same assign", () => {
+    expect([...findDuplicateCoachEventIds([auditHalf, coachHalf])]).toEqual([coachHalf.id]);
+  });
+
+  it("keeps the coach row when NO audit row tells it", () => {
+    // The trigger is not deployed, the collection is not monitored, or the audit
+    // half fell off the per-source cap. Showing it twice beats losing it.
+    expect(findDuplicateCoachEventIds([coachHalf]).size).toBe(0);
+  });
+
+  it("never folds a horizon renewal into a months-old assign", () => {
+    // Same series, same client — but the app topping the series back up on its
+    // own is a different fact from the coach assigning it.
+    const renewal = { ...auditHalf, occurredAtISO: "2026-10-02T04:00:00.000Z" };
+    expect(findDuplicateCoachEventIds([renewal, coachHalf]).size).toBe(0);
+  });
+
+  it("never folds two rows about different clients", () => {
+    const other = { ...auditHalf, clientUid: "someone-else" };
+    expect(findDuplicateCoachEventIds([other, coachHalf]).size).toBe(0);
+  });
+
+  it("keeps the coach row for a client who has no uid yet", () => {
+    // The pending client is named ONLY by the email on the coach event; the
+    // audit row has nowhere to put it, so folding would erase who it was about.
+    const pending = { ...coachHalf, clientUid: null, hasPendingClient: true };
+    const audit = { ...auditHalf, clientUid: null };
+    expect(findDuplicateCoachEventIds([audit, pending]).size).toBe(0);
+  });
+
+  it("folds the series event into a DELETE of the same series", () => {
+    // `deleteAssignment` marks the coach event deleted and the trigger captures
+    // the occurrence deletions — the same pair of halves, one row.
+    const deletion = { ...auditHalf, id: "audit_log:a-del" };
+    const coachDeleted = { ...coachHalf, occurredAtISO: "2026-08-04T17:31:11.000Z" };
+    expect([...findDuplicateCoachEventIds([deletion, coachDeleted])]).toEqual([coachHalf.id]);
   });
 });

--- a/backoffice/src/lib/gc-fitness/__tests__/client-activity-time.test.ts
+++ b/backoffice/src/lib/gc-fitness/__tests__/client-activity-time.test.ts
@@ -67,3 +67,36 @@ describe("client activity timezone helpers", () => {
     );
   });
 });
+
+// ─────────────────────────────────────────────────────────────────────────────
+// #747 — the row the ticket screenshotted
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("#747 — a client activity row never reads in UTC", () => {
+  // The screenshotted row: "Perfil actualizado · Aug 04, 09:04 PM". The coach
+  // made the change at 18:04 in Buenos Aires; the client doc had no `timezone`,
+  // the route fell back to "UTC", and 21:04Z printed as 09:04 PM.
+  const EVENING = "2026-08-04T21:04:00.000Z";
+  // Late enough that UTC has already rolled to the next civil day.
+  const LATE_NIGHT = "2026-08-05T01:00:00.000Z";
+
+  test("renders the hour the coach acted, not the server's", () => {
+    expect(formatClientActivityDateTime(EVENING, BUENOS_AIRES, LOCALE)).toContain("06:04 PM");
+    // What the screenshot showed, kept here as the thing NOT to render.
+    expect(formatClientActivityDateTime(EVENING, "UTC", LOCALE)).toContain("09:04 PM");
+  });
+
+  test("keeps the civil day the UTC reading had already left", () => {
+    // Still Aug 4 for the coach, already Aug 5 in UTC — which is why fixing the
+    // hour without fixing the day would put a row under the wrong heading.
+    expect(formatClientActivityDate(LATE_NIGHT, BUENOS_AIRES, LOCALE)).toBe("Aug 4");
+    expect(formatClientActivityDate(LATE_NIGHT, "UTC", LOCALE)).toBe("Aug 5");
+  });
+
+  test("honours the app locale rather than the runtime's", () => {
+    // The same row rendered "Aug 04" under a Spanish UI, because the leaf passed
+    // `undefined` as the locale.
+    expect(formatClientActivityDateTime(EVENING, BUENOS_AIRES, "es-AR")).not.toContain("Aug");
+    expect(formatClientActivityDateTime(EVENING, BUENOS_AIRES, "en-US")).toContain("Aug");
+  });
+});

--- a/backoffice/src/lib/gc-fitness/__tests__/coachless-users-table.test.tsx
+++ b/backoffice/src/lib/gc-fitness/__tests__/coachless-users-table.test.tsx
@@ -64,6 +64,7 @@ function renderTable() {
       assignCoachAction={noop}
       setTierAction={noop}
       deleteUserAction={noop}
+      timezone="America/Argentina/Buenos_Aires"
     />,
   );
 }

--- a/backoffice/src/lib/gc-fitness/__tests__/zoned-instant.test.ts
+++ b/backoffice/src/lib/gc-fitness/__tests__/zoned-instant.test.ts
@@ -1,0 +1,67 @@
+// __tests__/zoned-instant.test.ts
+//
+// #747 — a wall clock the coach typed has to come back as the same wall clock.
+
+import { zonedWallClockInstant } from "@/lib/gc-fitness/zoned-instant";
+
+const BA = "America/Argentina/Buenos_Aires"; // UTC-3, no DST
+const MADRID = "Europe/Madrid"; // UTC+1 / UTC+2 across DST
+
+function wallClockIn(instant: Date, timezone: string): string {
+  return new Intl.DateTimeFormat("en-GB", {
+    timeZone: timezone,
+    hourCycle: "h23",
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+  }).format(instant);
+}
+
+describe("zonedWallClockInstant", () => {
+  it("reads the wall clock in the coach's zone, not the server's", () => {
+    // The bug: `new Date("2026-08-05T18:00:00")` on Vercel is 18:00Z, which the
+    // coach then reads back as 15:00.
+    expect(zonedWallClockInstant("2026-08-05", "18:00", BA)?.toISOString()).toBe(
+      "2026-08-05T21:00:00.000Z",
+    );
+    expect(zonedWallClockInstant("2026-08-05", "18:00", "UTC")?.toISOString()).toBe(
+      "2026-08-05T18:00:00.000Z",
+    );
+  });
+
+  it("round-trips: what was typed is what is displayed", () => {
+    for (const [date, time, zone] of [
+      ["2026-08-05", "18:00", BA],
+      ["2026-01-15", "09:00", MADRID],
+      ["2026-07-15", "09:00", MADRID],
+      ["2026-12-31", "23:30", "Asia/Tokyo"],
+      ["2026-03-01", "00:00", "America/Los_Angeles"],
+    ] as const) {
+      const instant = zonedWallClockInstant(date, time, zone)!;
+      expect(wallClockIn(instant, zone)).toBe(
+        `${date.slice(8, 10)}/${date.slice(5, 7)}/${date.slice(0, 4)}, ${time}`,
+      );
+    }
+  });
+
+  it("lands on the right side of a DST transition", () => {
+    // Madrid springs forward 2026-03-29 at 02:00 → 03:00. A single-pass offset
+    // guess (read at the UTC instant) puts 12:00 an hour off.
+    const before = zonedWallClockInstant("2026-03-28", "12:00", MADRID)!;
+    const after = zonedWallClockInstant("2026-03-30", "12:00", MADRID)!;
+    expect(before.toISOString()).toBe("2026-03-28T11:00:00.000Z"); // UTC+1
+    expect(after.toISOString()).toBe("2026-03-30T10:00:00.000Z"); // UTC+2
+  });
+
+  it("rejects a malformed date or time instead of inventing one", () => {
+    expect(zonedWallClockInstant("nope", "18:00", BA)).toBeNull();
+    expect(zonedWallClockInstant("2026-08-05", "6pm", BA)).toBeNull();
+    expect(zonedWallClockInstant("2026-13-45", "18:00", BA)).toBeNull();
+  });
+
+  it("falls back to the host zone for an unknown identifier rather than throwing", () => {
+    expect(zonedWallClockInstant("2026-08-05", "18:00", "Mars/Olympus")).toBeInstanceOf(Date);
+  });
+});

--- a/backoffice/src/lib/gc-fitness/activity-feed-actions.ts
+++ b/backoffice/src/lib/gc-fitness/activity-feed-actions.ts
@@ -37,6 +37,8 @@ import { Timestamp, type Firestore } from "firebase-admin/firestore";
 import { gcFitnessFirestore } from "@/lib/firebase/gc-fitness-admin";
 import {
   classifyAuditRecord,
+  coachActivityKeysFor,
+  findDuplicateCoachEventIds,
   mergeWorkoutWriteBacks,
   type AuditRecord,
   type ClassifiedEvent,
@@ -221,6 +223,9 @@ async function fetchAuditRecords(
   });
 }
 
+/** Namespaces the coach eventId inside the feed's global id space. */
+const COACH_EVENT_ID_PREFIX = "coach_activity:";
+
 interface RawCoachEvent {
   id: string;
   trainerId: string | null;
@@ -251,7 +256,7 @@ async function fetchCoachEvents(
     const d = doc.data() as Record<string, unknown>;
     const deleted = d.deleted === true;
     return {
-      id: `coach_activity:${doc.id}`,
+      id: `${COACH_EVENT_ID_PREFIX}${doc.id}`,
       trainerId: typeof d.trainerId === "string" ? d.trainerId : null,
       clientId: typeof d.clientId === "string" ? d.clientId : null,
       pendingEmail: typeof d.pendingEmail === "string" ? d.pendingEmail : null,
@@ -727,6 +732,11 @@ async function collectFeed(
   const users = await resolveUsers(db, uids);
 
   const events: ActivityFeedEvent[] = [];
+  // #748 — the tokens each row can be recognised by across sources. Kept beside
+  // the events rather than on them: the feed is serialised to the client, and
+  // this is scaffolding for the merge, not something a row renders.
+  const entityKeys = new Map<string, string[]>();
+  const pendingClientEvents = new Set<string>();
 
   for (const { group, event } of classified) {
     const head = group.head;
@@ -738,6 +748,7 @@ async function collectFeed(
     const actorUid = event.actorUid;
     const clientUid =
       head.clientId ?? (head.collection === "users" ? head.docId : null);
+    entityKeys.set(head.id, coachActivityKeysFor(head));
     events.push({
       id: head.id,
       source: "audit_log",
@@ -763,6 +774,10 @@ async function collectFeed(
 
   for (const c of coachRaw) {
     const { title, subject } = coachEventCopy(c);
+    // The doc id IS the eventId (`asg:<seriesId>`, `exr:<id>`, …) — that is the
+    // whole bridge to the audit half. See `coachActivityKeysFor`.
+    entityKeys.set(c.id, [c.id.slice(COACH_EVENT_ID_PREFIX.length)]);
+    if (c.pendingEmail) pendingClientEvents.add(c.id);
     events.push({
       id: c.id,
       source: "coach_activity",
@@ -832,7 +847,21 @@ async function collectFeed(
   }
 
   events.sort((a, b) => (b.occurredAtISO ?? "").localeCompare(a.occurredAtISO ?? ""));
-  return mergeWorkoutWriteBacks(events);
+
+  // #748 — the same coach action reaches the feed through two independent
+  // recorders. Drop the coach-log half wherever the audit half already told it.
+  const duplicates = findDuplicateCoachEventIds(
+    events.map((e) => ({
+      id: e.id,
+      source: e.source,
+      occurredAtISO: e.occurredAtISO,
+      clientUid: e.clientUid,
+      entityKeys: entityKeys.get(e.id) ?? [],
+      hasPendingClient: pendingClientEvents.has(e.id),
+    })),
+  );
+
+  return mergeWorkoutWriteBacks(events.filter((e) => !duplicates.has(e.id)));
 }
 
 function applyFilters(

--- a/backoffice/src/lib/gc-fitness/activity-feed-model.ts
+++ b/backoffice/src/lib/gc-fitness/activity-feed-model.ts
@@ -1187,6 +1187,123 @@ export function classifyAuditRecord(
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
+// Post-merge: one action, one row, across sources (#748)
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * #748 — the `coach_activity` eventId(s) an audit record is the OTHER HALF of.
+ *
+ * A coach action is recorded twice ON PURPOSE, by two mechanisms that know
+ * nothing about each other: the server action appends a hand-written event to
+ * `coach_activity` (so My Activity can read one row per action instead of
+ * scanning thousands of occurrence docs), and the `onAuditableWrite` trigger
+ * captures every underlying document write into `audit_log`. Monitoring merges
+ * both, so one assignment rendered as two rows saying the same thing in two
+ * dialects — "todas las semanas (sáb) · 2026-08-08 → 2026-09-05" from the audit
+ * side and "Recurrencia: semanal · 5 fechas · 2026-08-08 a 2026-09-05" from the
+ * coach side.
+ *
+ * The bridge is the coach eventId, which is built from the very id the audit
+ * row carries: `asg:${seriesId}` / `asg:${assignmentId}`, `exr:${exerciseId}`,
+ * `hab:${habitId}` (see `coach-activity-log.ts`). `tpl:` has no twin —
+ * `workout_templates` is not in `MONITORED_COLLECTIONS`.
+ *
+ * BOTH assignment keys are emitted because the coach side keys a recurring
+ * series by `seriesId` and a one-off by the assignment doc id.
+ */
+export function coachActivityKeysFor(record: AuditRecord): string[] {
+  if (!record.docId || record.docId === "?") return [];
+  switch (record.collection) {
+    case "workout_assignments": {
+      const seriesId = str(record.after?.seriesId) ?? str(record.before?.seriesId);
+      return seriesId ? [`asg:${record.docId}`, `asg:${seriesId}`] : [`asg:${record.docId}`];
+    }
+    // `exerciseCreatedEvent` / `habitAssignedEvent` fire ONLY on the create, so
+    // a later update to the same doc must not be read as its twin.
+    case "exercises":
+      return record.op === "create" ? [`exr:${record.docId}`] : [];
+    case "habits":
+      return record.op === "create" ? [`hab:${record.docId}`] : [];
+    default:
+      return [];
+  }
+}
+
+/**
+ * How far apart the two halves may land. The coach event is appended AFTER the
+ * batches commit and the audit rows are stamped by the trigger, so in practice
+ * they are seconds apart; the window is generous because a wrong split shows a
+ * duplicate (annoying) while a wrong merge hides an event (a lie).
+ *
+ * It also has to be SHORT relative to the horizon renewal: an auto-extension
+ * writes new occurrences of a series whose coach event may be months old, and
+ * that pair must NOT collapse — "se extendió sola" is a different fact from
+ * "asignó un workout".
+ */
+const COACH_DUPLICATE_WINDOW_MS = 10 * 60 * 1000;
+
+/** The shape `findDuplicateCoachEventIds` needs — a subset of the rendered event. */
+export interface CrossSourceRow {
+  id: string;
+  source: string;
+  occurredAtISO: string | null;
+  clientUid: string | null;
+  /**
+   * For an `audit_log` row: the coach eventIds it would collide with
+   * (`coachActivityKeysFor`). For a `coach_activity` row: its own eventId.
+   */
+  entityKeys: string[];
+  /**
+   * `coach_activity` only — the row names a client who has no uid yet (a
+   * pre-created mirror). The audit row has nowhere to put that email, so
+   * folding it away would lose the only thing identifying the person.
+   */
+  hasPendingClient?: boolean;
+}
+
+/**
+ * Which `coach_activity` rows are already told by an `audit_log` row.
+ *
+ * The AUDIT row survives because it is strictly richer: it knows the weekday
+ * (`todas las semanas (sáb)`, not just `semanal`), carries the ×N occurrence
+ * badge and the template link, and distinguishes a recurrence EDIT from a fresh
+ * assignment — the coach log re-publishes the same "Workout asignado" copy for
+ * both (`editAssignmentRecurrence` merges into the same `asg:` doc).
+ *
+ * When no audit row matches — the trigger is not deployed, the collection is
+ * not monitored, the audit half fell off the per-source cap — the coach row
+ * stays. Losing an event is worse than showing it twice.
+ */
+export function findDuplicateCoachEventIds(rows: CrossSourceRow[]): Set<string> {
+  const audits = rows.filter((r) => r.source === "audit_log" && r.entityKeys.length > 0);
+  const duplicates = new Set<string>();
+  if (audits.length === 0) return duplicates;
+
+  for (const coach of rows) {
+    if (coach.source !== "coach_activity" || coach.hasPendingClient) continue;
+    const key = coach.entityKeys[0];
+    if (!key) continue;
+    const coachMs = coach.occurredAtISO ? Date.parse(coach.occurredAtISO) : NaN;
+    if (!Number.isFinite(coachMs)) continue;
+
+    const twin = audits.some((audit) => {
+      if (!audit.entityKeys.includes(key)) return false;
+      // Same entity AND same client. The ids are unique, so this only ever
+      // rejects a row the audit side could not attribute — where dropping the
+      // coach row would take the client chip with it.
+      if ((audit.clientUid ?? null) !== (coach.clientUid ?? null)) return false;
+      const auditMs = audit.occurredAtISO ? Date.parse(audit.occurredAtISO) : NaN;
+      if (!Number.isFinite(auditMs)) return false;
+      return Math.abs(coachMs - auditMs) <= COACH_DUPLICATE_WINDOW_MS;
+    });
+
+    if (twin) duplicates.add(coach.id);
+  }
+
+  return duplicates;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
 // Post-merge: fold the write-back + the "done" stamp into the finish event
 // ─────────────────────────────────────────────────────────────────────────────
 

--- a/backoffice/src/lib/gc-fitness/client-notes-actions.ts
+++ b/backoffice/src/lib/gc-fitness/client-notes-actions.ts
@@ -6,6 +6,8 @@ import { z } from "zod";
 import { gcFitnessFirestore } from "@/lib/firebase/gc-fitness-admin";
 
 import { getCurrentTrainer } from "./auth-helpers";
+import { civilDateToday } from "./civil-date";
+import { getTrainerTimezone } from "./trainer-timezone";
 import { recordCoachActivityEvent, noteAddedEvent } from "./coach-activity-log";
 import { FirestoreCollections } from "./collections";
 
@@ -113,7 +115,10 @@ export async function updateClientNotes(input: unknown): Promise<{
   const entryCreatedAt = new Date().toISOString();
   const snap = await ref.get();
   const entry = {
-    date: parsed.date ?? new Date().toISOString().slice(0, 10),
+    // #747 — `toISOString().slice(0, 10)` is the UTC day, so a note written at
+    // 21:30 in Buenos Aires was dated TOMORROW. `civilDateToday` is the same
+    // helper the rest of the trainer surface dates things with.
+    date: parsed.date ?? civilDateToday(await getTrainerTimezone()),
     notes: parsed.notes,
     createdAt: entryCreatedAt,
   };

--- a/backoffice/src/lib/gc-fitness/coach-checklist-actions.ts
+++ b/backoffice/src/lib/gc-fitness/coach-checklist-actions.ts
@@ -10,6 +10,7 @@ import { civilDateFormat, civilDateToday } from "./civil-date";
 import { listClients } from "./client-roster";
 import { FirestoreCollections } from "./collections";
 import { getTrainerTimezone } from "./trainer-timezone";
+import { zonedWallClockInstant } from "./zoned-instant";
 
 const CHECKLIST_COLLECTION = "coach_checklist";
 const MAX_CHECKLIST_ITEMS = 50;
@@ -112,21 +113,27 @@ function advanceDueDate(
   return null;
 }
 
-/** Parse a "YYYY-MM-DD" end date into an end-of-day Date, or null. */
-function parseRecurrenceEnd(endsOn?: string): Date | null {
+/**
+ * Parse a "YYYY-MM-DD" end date into the last instant of that day IN THE
+ * COACH'S ZONE — not in the server's (#747).
+ */
+function parseRecurrenceEnd(endsOn: string | undefined, timezone: string): Date | null {
   if (!endsOn || !/^\d{4}-\d{2}-\d{2}$/.test(endsOn)) return null;
-  const d = new Date(`${endsOn}T23:59:59`);
-  return Number.isNaN(d.getTime()) ? null : d;
+  const lastMinute = zonedWallClockInstant(endsOn, "23:59", timezone);
+  return lastMinute ? new Date(lastMinute.getTime() + 59_000) : null;
 }
 
-/** Render a stored Timestamp/Date back to a civil "YYYY-MM-DD" string. */
-function toCivilDate(value: unknown): string | null {
+/**
+ * Render a stored Timestamp/Date back to a civil "YYYY-MM-DD" string, in the
+ * coach's zone. The host getters this replaced read UTC on Vercel, so the edit
+ * form's "ends on" could show the day AFTER the one that was saved (#747).
+ */
+function toCivilDate(value: unknown, timezone: string): string | null {
   const iso = toIso(value);
   if (!iso) return null;
   const d = new Date(iso);
   if (Number.isNaN(d.getTime())) return null;
-  const pad = (n: number) => String(n).padStart(2, "0");
-  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}`;
+  return civilDateFormat(d, timezone);
 }
 
 const itemIdSchema = z.string().trim().min(1).max(160);
@@ -140,7 +147,10 @@ function revalidateChecklistSurfaces() {
 }
 
 export async function listCoachChecklistItems(): Promise<CoachChecklistItem[]> {
-  const trainer = await getCurrentTrainer();
+  const [trainer, timezone] = await Promise.all([
+    getCurrentTrainer(),
+    getTrainerTimezone(),
+  ]);
   const snap = await checklistCollection(trainer.uid)
     .orderBy("dueAt", "asc")
     .limit(MAX_CHECKLIST_ITEMS)
@@ -171,7 +181,7 @@ export async function listCoachChecklistItems(): Promise<CoachChecklistItem[]> {
         createdAt: toIso(data.createdAt),
         clients: [] as Array<{ id: string; name: string }>,
         recurrence: normalizeRecurrence(data.recurrence),
-        recurrenceEndsOn: toCivilDate(data.recurrenceEndsAt),
+        recurrenceEndsOn: toCivilDate(data.recurrenceEndsAt, timezone),
         recurrenceWeekdays: sanitizeIntArray(data.recurrenceWeekdays, 1, 7),
         recurrenceMonthDays: sanitizeIntArray(data.recurrenceMonthDays, 1, 31),
       } satisfies CoachChecklistItem,
@@ -249,13 +259,16 @@ export async function listPendingChecklistItems(): Promise<
 export async function createCoachChecklistItem(
   input: unknown,
 ): Promise<{ ok: true }> {
-  const trainer = await getCurrentTrainer();
+  const [trainer, timezone] = await Promise.all([
+    getCurrentTrainer(),
+    getTrainerTimezone(),
+  ]);
   const parsed = createChecklistItemSchema.parse(input);
-  const dueAt = parseDueAt(parsed.dueDate, parsed.dueTime);
+  const dueAt = parseDueAt(parsed.dueDate, parsed.dueTime, timezone);
 
   const recurrence = parsed.recurrence ?? "none";
   const recurrenceEndsAt =
-    recurrence !== "none" ? parseRecurrenceEnd(parsed.recurrenceEndsOn) : null;
+    recurrence !== "none" ? parseRecurrenceEnd(parsed.recurrenceEndsOn, timezone) : null;
 
   await checklistCollection(trainer.uid).add({
     title: parsed.title,
@@ -285,17 +298,20 @@ export async function updateCoachChecklistItem(
   itemId: unknown,
   input: unknown,
 ): Promise<{ ok: true }> {
-  const trainer = await getCurrentTrainer();
+  const [trainer, timezone] = await Promise.all([
+    getCurrentTrainer(),
+    getTrainerTimezone(),
+  ]);
   const parsedItemId = itemIdSchema.parse(itemId);
   const parsed = createChecklistItemSchema.parse(input);
-  const dueAt = parseDueAt(parsed.dueDate, parsed.dueTime);
+  const dueAt = parseDueAt(parsed.dueDate, parsed.dueTime, timezone);
 
   // Empty notes / cleared date are intentional removals, not "leave as-is":
   // delete the notes field and null out dueAt so the item drops back to the
   // "Sin fecha" group. `completed`/`createdAt` are left untouched.
   const recurrence = parsed.recurrence ?? "none";
   const recurrenceEndsAt =
-    recurrence !== "none" ? parseRecurrenceEnd(parsed.recurrenceEndsOn) : null;
+    recurrence !== "none" ? parseRecurrenceEnd(parsed.recurrenceEndsOn, timezone) : null;
   const weekdays =
     recurrence === "weekly" ? parsed.recurrenceWeekdays ?? [] : [];
   const monthDays =
@@ -398,11 +414,23 @@ function checklistCollection(uid: string) {
     .collection(CHECKLIST_COLLECTION);
 }
 
-function parseDueAt(date?: string, time?: string): Date | null {
+/**
+ * The instant a coach means by "this day at this time".
+ *
+ * #747 — this used to be `new Date(`${date}T${time}:00`)`, a date-time string
+ * with no offset, which JS resolves in the HOST zone: UTC on Vercel. A coach in
+ * Buenos Aires setting a reminder for 18:00 stored 18:00Z and read it back as
+ * 15:00. The bucketing already worked in their zone (`listPendingChecklist`
+ * calls `getTrainerTimezone`), so the stored instant was the odd one out.
+ */
+function parseDueAt(
+  date: string | undefined,
+  time: string | undefined,
+  timezone: string,
+): Date | null {
   if (!date) return null;
   const normalizedTime = time && /^\d{2}:\d{2}$/.test(time) ? time : "09:00";
-  const dueAt = new Date(`${date}T${normalizedTime}:00`);
-  return Number.isNaN(dueAt.getTime()) ? null : dueAt;
+  return zonedWallClockInstant(date, normalizedTime, timezone);
 }
 
 function toIso(value: unknown): string | null {

--- a/backoffice/src/lib/gc-fitness/progress-photo-actions.ts
+++ b/backoffice/src/lib/gc-fitness/progress-photo-actions.ts
@@ -4,7 +4,9 @@ import { gcFitnessFirestore, gcFitnessStorage } from "@/lib/firebase/gc-fitness-
 
 import { getCurrentAdmin, getCurrentTrainer } from "./auth-helpers";
 import { adminCanViewClientUnderCoach } from "./coachless-user-model";
+import { civilDateFormat } from "./civil-date";
 import { FirestoreCollections } from "./collections";
+import { getTrainerTimezone } from "./trainer-timezone";
 
 export interface ProgressPhotoRow {
   id: string;
@@ -77,15 +79,11 @@ async function signedUrlForPath(storagePath: string): Promise<string | null> {
  * wire shape, same TZ-current projection. Returns null when the input
  * is null or unparseable.
  */
-function civilDateFromIso(iso: string | null): string | null {
+function civilDateFromIso(iso: string | null, timezone: string): string | null {
   if (!iso) return null;
   const parsed = new Date(iso);
   if (Number.isNaN(parsed.getTime())) return null;
-  return new Intl.DateTimeFormat("en-CA", {
-    year: "numeric",
-    month: "2-digit",
-    day: "2-digit",
-  }).format(parsed);
+  return civilDateFormat(parsed, timezone);
 }
 
 export async function listProgressPhotosForClient(
@@ -135,6 +133,10 @@ export async function listProgressPhotosForClientAsAdmin(
 async function loadProgressPhotos(
   clientId: string,
 ): Promise<ProgressPhotoRow[]> {
+  // #747 — the fallback sort key is a CIVIL day, so it needs the zone the
+  // uploader lives in. The doc comment on `civilDateFromIso` always promised
+  // "the trainer's local timezone"; the call never passed one, so it was UTC.
+  const timezone = await getTrainerTimezone();
   // Sort dimension lives client-side, not server-side: we want photos
   // ordered by the client-picked check-in date, not by upload time. A
   // server-side `orderBy("checkInDate")` would silently drop legacy docs
@@ -175,8 +177,8 @@ async function loadProgressPhotos(
   // arguments yields chronological-descending order. Rows missing both
   // fields sort to the end via the empty-string fallback.
   rows.sort((a, b) => {
-    const aKey = a.checkInDate ?? civilDateFromIso(a.createdAt) ?? "";
-    const bKey = b.checkInDate ?? civilDateFromIso(b.createdAt) ?? "";
+    const aKey = a.checkInDate ?? civilDateFromIso(a.createdAt, timezone) ?? "";
+    const bKey = b.checkInDate ?? civilDateFromIso(b.createdAt, timezone) ?? "";
     return bKey.localeCompare(aKey);
   });
 

--- a/backoffice/src/lib/gc-fitness/zoned-instant.ts
+++ b/backoffice/src/lib/gc-fitness/zoned-instant.ts
@@ -1,0 +1,83 @@
+// zoned-instant.ts
+//
+// The one direction `civil-date.ts` deliberately does not go: a WALL CLOCK the
+// coach typed ("2026-08-05" + "18:00") back to the instant it denotes in their
+// IANA zone.
+//
+// Why it is not in civil-date.ts: that file is a locked cross-platform twin of
+// CivilDate.swift / CivilDate.kt, with a source-contract test forbidding
+// `toISOString`. This is backoffice-only (form input → Firestore timestamp) and
+// has no mobile counterpart, so it stays out of the twin.
+//
+// Why it exists (#747): `new Date("2026-08-05T18:00:00")` — a date-time string
+// with NO offset — is interpreted in the HOST zone, which on Vercel is UTC. A
+// coach in Buenos Aires setting a checklist reminder for 18:00 stored 18:00Z
+// and then read it back as 15:00. The value was never in their timezone at any
+// point of the round trip.
+
+/**
+ * The offset (ms) between `timezone` and UTC AT a given instant. Positive east
+ * of Greenwich. Derived by formatting the instant in the zone and reading the
+ * result back as if it were UTC — the only way to get a zone's offset out of
+ * `Intl` without a tz database of our own.
+ */
+function zoneOffsetMs(instant: Date, timezone: string): number {
+  let parts: Intl.DateTimeFormatPart[];
+  try {
+    parts = new Intl.DateTimeFormat("en-US", {
+      timeZone: timezone,
+      calendar: "gregory",
+      // `hourCycle` rather than `hour12: false`, which leaves the 24-vs-00
+      // choice at midnight to the locale.
+      hourCycle: "h23",
+      year: "numeric",
+      month: "2-digit",
+      day: "2-digit",
+      hour: "2-digit",
+      minute: "2-digit",
+      second: "2-digit",
+    }).formatToParts(instant);
+  } catch {
+    // Unknown IANA identifier — same fallback as civil-date.ts: behave as the
+    // host zone rather than throwing at the caller.
+    return -instant.getTimezoneOffset() * 60_000;
+  }
+
+  const at = (type: Intl.DateTimeFormatPartTypes) =>
+    Number.parseInt(parts.find((p) => p.type === type)?.value ?? "0", 10);
+
+  const asIfUTC = Date.UTC(
+    at("year"),
+    at("month") - 1,
+    at("day"),
+    at("hour"),
+    at("minute"),
+    at("second"),
+  );
+  return asIfUTC - instant.getTime();
+}
+
+/**
+ * The instant at which `HH:mm` on the civil day `YYYY-MM-DD` occurs in
+ * `timezone`. Returns null for a malformed date or time.
+ *
+ * Two passes on purpose: the first guess uses the offset in force at the
+ * UTC-reading of the wall clock, which is the WRONG side of a DST transition
+ * for times near the changeover. Re-reading the offset at the corrected instant
+ * settles it. (For the ambiguous hour a fall-back repeats, this picks one of
+ * the two — there is no right answer, only a consistent one.)
+ */
+export function zonedWallClockInstant(
+  civilDate: string,
+  time: string,
+  timezone: string,
+): Date | null {
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(civilDate)) return null;
+  if (!/^\d{2}:\d{2}$/.test(time)) return null;
+
+  const asUTC = new Date(`${civilDate}T${time}:00Z`);
+  if (Number.isNaN(asUTC.getTime())) return null;
+
+  const firstPass = new Date(asUTC.getTime() - zoneOffsetMs(asUTC, timezone));
+  return new Date(asUTC.getTime() - zoneOffsetMs(firstPass, timezone));
+}


### PR DESCRIPTION
Arregla `mdb1/gc-fitness#748` y `mdb1/gc-fitness#747`.

## #748 — el mismo evento, contado dos veces

No era un bug de render. Una acción del coach se graba **dos veces a propósito**, por dos mecanismos que no se conocen entre sí:

- la server action agrega un evento a mano en `coach_activity` (para que My Activity lea una fila por acción en vez de escanear miles de docs de ocurrencia),
- y el trigger `onAuditableWrite` captura cada escritura subyacente en `audit_log`.

Monitoring mergea las cuatro fuentes y **no había ningún dedupe cruzado**: los tres colapsos que ya existían (`groupRecurringAuditEntries`, `findRecurrenceEdits`, `mergeWorkoutWriteBacks`) corren todos dentro de una sola fuente.

El puente es el eventId del coach, armado con el mismo id que trae la fila de audit: `asg:${seriesId}`, `exr:${exerciseId}`, `hab:${habitId}`. `tpl:` no tiene gemelo (`workout_templates` no está en `MONITORED_COLLECTIONS`).

**Sobrevive la fila de audit**, porque dice estrictamente más: sabe el día de la semana (`todas las semanas (sáb)`, no sólo `semanal`), trae el badge ×N y el link al template, y distingue un cambio de recurrencia de una asignación nueva — el log del coach republica el mismo "Workout asignado" para las dos. Eso es lo que hacía que las filas 5 y 6 de la captura se leyeran como acciones distintas siendo el mismo hecho.

Tres guardas, sin las cuales el arreglo miente en vez de sólo molestar:

| Caso | Qué pasa |
|---|---|
| Ninguna fila de audit matchea (trigger no desplegado, colección no monitoreada, cupo de 400) | queda la del coach — perder un evento es peor que mostrarlo dos veces |
| Renovación automática del horizonte sobre una serie vieja | ventana de 10 min: "se extendió sola" ≠ "asignó un workout" |
| Cliente pendiente (sin uid) | no se pliega: el email del evento de coach es lo único que lo nombra |

## #747 — las fechas en UTC

La fila de la captura ("Aug 04, 09:04 PM" para algo hecho a las 18:04 en Buenos Aires) tenía dos mitades: las tres rutas de cliente caían a `?? "UTC"` cuando el doc del cliente no tiene `timezone` (alguien que todavía no abrió la app — justo el "cliente pendiente convertido en usuario activo" de la captura), y `ClientRecentLogsFeed` formateaba con locale `undefined`, que es el del runtime: por eso una UI en español imprimía "Aug".

El ticket pide chequear **todo** lo que muestre fecha, así que va el barrido:

- **Checklist** (el peor): `parseDueAt` hacía `new Date(\`\${date}T\${time}:00\`)` — un string sin offset, que JS resuelve en la zona del host (UTC en Vercel). El coach escribía 18:00, se guardaba 18:00Z y lo leía como 15:00. El bucketing *ya* trabajaba en su zona, o sea que el instante guardado era el que estaba fuera de lugar. Nuevo `zoned-instant.ts` (wall clock + IANA → instante, dos pasadas por DST); `parseRecurrenceEnd` y `toCivilDate` van por la misma zona, y la zona se pasa por prop a la lista, al diálogo y al agrupado por día civil.
- **Roster**: "Joined" sin `timeZone` — quien se sumó 21:30 en Buenos Aires figuraba con la fecha del día siguiente hasta que hidrataba.
- **coach-less-users** (tabla y detalle): `iso.slice(0, 10)` es estable **y** equivocado — los primeros 10 chars de un instante ISO son su día UTC.
- **qa-tools**, **app-config**: `toLocaleString` sin `timeZone`.
- **Notas de cliente**, **hábito nuevo**, **preload de cliente pendiente**: `new Date().toISOString().slice(0, 10)` fechaba a mañana desde las 21:00.
- **progress-photo-actions**: el comentario de `civilDateFromIso` prometía "the trainer's local timezone" desde siempre; la llamada nunca pasó una.
- **Alertas de workout próximo**: la clave de "ya avisé hoy" rotaba a medianoche UTC.
- **workout-log-detail-view**: la zona ya era explícita, el locale no.

### Queda afuera, a propósito

- `advanceDueDate` calcula el día de la semana de una recurrencia sobre el instante (o sea en UTC). Pre-existente, ortogonal, y sólo se nota para horarios de trasnoche.
- Los reminders viejos siguen guardados con el wall clock leído en UTC. No hay migración: las fechas nuevas salen bien y las viejas siguen mostrando lo que mostraban.

## Compuertas

- `npx jest`: **93 suites / 1069 tests en verde** (eran 1048 — +21).
- `next build`: compila.
- Sin cambios en `firestore.rules`, iOS ni Android.

Los tests nuevos cubren las dos mitades de #748 (las claves por colección y op, y las tres guardas), el round-trip de wall clock con DST, y la fila exacta de la captura de #747.