### PR TITLE
Monitoring con hábitos + quick filters (#762), el coach del cliente (#754), y bajas por el coach (#753)

### DIFF
--- a/backoffice/messages/en.json
+++ b/backoffice/messages/en.json
@@ -614,6 +614,18 @@
         "saving": "Saving…",
         "savedToast": "Client identity updated.",
         "saveFailedToast": "Could not save client identity."
+      },
+      "unlink": {
+        "title": "Unlink client",
+        "body": "Remove this person from your roster. Their account, history and assigned programme stay untouched — they just stop being your client.",
+        "cta": "Unlink",
+        "confirmTitle": "Unlink {name}?",
+        "confirmBody": "They will drop off your roster and you will no longer see their progress or be able to message them. Their account, history and assigned content stay intact, and the chat comes back if you add them again later. Note: if they had premium through you, they lose it.",
+        "confirmCta": "Yes, unlink",
+        "cancel": "Cancel",
+        "pending": "Unlinking…",
+        "doneToast": "{name} is no longer your client.",
+        "errorToast": "Could not unlink the client."
       }
     }
   },

--- a/backoffice/messages/es.json
+++ b/backoffice/messages/es.json
@@ -614,6 +614,18 @@
         "saving": "Guardando…",
         "savedToast": "Identidad del cliente actualizada.",
         "saveFailedToast": "No pudimos guardar la identidad del cliente."
+      },
+      "unlink": {
+        "title": "Desvincular cliente",
+        "body": "Sacá a esta persona de tu lista. Conserva su cuenta, su historial y las rutinas que ya le diste, pero deja de ser tu cliente.",
+        "cta": "Desvincular",
+        "confirmTitle": "¿Desvincular a {name}?",
+        "confirmBody": "Va a dejar de aparecer en tu lista y no vas a poder verle el progreso ni escribirle. Su cuenta, su historial y el contenido que le asignaste quedan intactos, y el chat vuelve si más adelante la volvés a agregar. Ojo: si tenía premium por ser tu cliente, lo pierde.",
+        "confirmCta": "Sí, desvincular",
+        "cancel": "Cancelar",
+        "pending": "Desvinculando…",
+        "doneToast": "{name} ya no es tu cliente.",
+        "errorToast": "No se pudo desvincular al cliente."
       }
     }
   },

--- a/backoffice/src/app/gc-fitness/admin/audit/page.tsx
+++ b/backoffice/src/app/gc-fitness/admin/audit/page.tsx
@@ -45,8 +45,14 @@ export const generateMetadata = () => sectionMetadata("adminPanel");
 
 export const dynamic = "force-dynamic";
 
-const CATEGORY_OPTIONS: Array<"all" | FeedCategory> = [
-  "all",
+/**
+ * #762 — the quick-filter checkboxes, in the order they render. `other` is
+ * deliberately absent: it is the classifier's fallback for a collection this
+ * reader does not know yet, so there is nothing an operator would go looking
+ * for under that name. It is unfilterable-by-checkbox and therefore always
+ * shown, which is the safe direction (a new event kind stays visible).
+ */
+const CATEGORY_OPTIONS: FeedCategory[] = [
   "workout",
   "schedule",
   "routine",
@@ -64,10 +70,17 @@ const SOURCE_OPTIONS: Array<{ value: "all" | FeedSource; label: string }> = [
   { value: "coach_activity", label: "Acciones de coach" },
   { value: "admin_operations", label: "Operaciones de admin" },
   { value: "progress_photos", label: "Fotos de progreso" },
+  { value: "habit_logs", label: "Hábitos marcados" },
 ];
 
 function str(value: string | string[] | undefined): string {
   return typeof value === "string" ? value : "";
+}
+
+/** Repeated `?cat=` params — one per checked box. */
+function strList(value: string | string[] | undefined): string[] {
+  if (Array.isArray(value)) return value;
+  return typeof value === "string" && value.length > 0 ? [value] : [];
 }
 
 export default async function AuditPage({
@@ -91,10 +104,14 @@ export default async function AuditPage({
     const v = str(sp.source);
     return SOURCE_OPTIONS.some((o) => o.value === v) ? (v as "all" | FeedSource) : "all";
   })();
-  const category = (() => {
-    const v = str(sp.category);
-    return (CATEGORY_OPTIONS as string[]).includes(v) ? (v as "all" | FeedCategory) : "all";
-  })();
+  // Checked boxes. An empty set = "todos" (an untouched form and an
+  // everything-unchecked form are indistinguishable over the wire — HTML omits
+  // unchecked boxes — so both mean no filter).
+  const selectedCategories = strList(sp.cat).filter((v): v is FeedCategory =>
+    (CATEGORY_OPTIONS as string[]).includes(v),
+  );
+  const allCategoriesSelected =
+    selectedCategories.length === 0 || selectedCategories.length === CATEGORY_OPTIONS.length;
   const actorQuery = str(sp.actor).trim();
   const clientQuery = str(sp.client).trim();
   const fromISO = str(sp.from).trim();
@@ -106,7 +123,10 @@ export default async function AuditPage({
   try {
     events = await listActivityFeed({
       source,
-      category,
+      // All boxes checked ⇒ no filter at all, so `other` (which has no box —
+      // see CATEGORY_OPTIONS) keeps showing instead of being filtered out by
+      // an all-checked form submit.
+      categories: allCategoriesSelected ? [] : selectedCategories,
       actorQuery,
       clientQuery,
       fromISO,
@@ -131,7 +151,9 @@ export default async function AuditPage({
     const params = new URLSearchParams();
     params.set("tab", target);
     if (source !== "all") params.set("source", source);
-    if (category !== "all") params.set("category", category);
+    if (!allCategoriesSelected) {
+      for (const c of selectedCategories) params.append("cat", c);
+    }
     if (actorQuery) params.set("actor", actorQuery);
     if (clientQuery) params.set("client", clientQuery);
     if (fromISO) params.set("from", fromISO);
@@ -178,20 +200,33 @@ export default async function AuditPage({
             className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3"
           >
             <input type="hidden" name="tab" value={tab} />
-            <label className="flex flex-col gap-1 text-xs font-medium text-muted-foreground">
-              Tipo de evento
-              <select
-                name="category"
-                defaultValue={category}
-                className="h-9 rounded-md border border-input bg-background px-3 text-sm text-foreground"
-              >
+
+            {/* #762 — quick filters: todos marcados por defecto, destildar
+                para sacar un tipo de evento del feed. */}
+            <fieldset className="flex flex-col gap-2 sm:col-span-2 lg:col-span-3">
+              <legend className="text-xs font-medium text-muted-foreground">
+                Tipo de evento
+              </legend>
+              <div className="flex flex-wrap gap-x-4 gap-y-2">
                 {CATEGORY_OPTIONS.map((value) => (
-                  <option key={value} value={value}>
-                    {value === "all" ? "Todos los tipos" : CATEGORY_LABEL[value]}
-                  </option>
+                  <label
+                    key={value}
+                    className="flex items-center gap-2 text-sm text-foreground"
+                  >
+                    <input
+                      type="checkbox"
+                      name="cat"
+                      value={value}
+                      defaultChecked={
+                        allCategoriesSelected || selectedCategories.includes(value)
+                      }
+                      className="h-4 w-4 rounded border-input"
+                    />
+                    {CATEGORY_LABEL[value]}
+                  </label>
                 ))}
-              </select>
-            </label>
+              </div>
+            </fieldset>
 
             <label className="flex flex-col gap-1 text-xs font-medium text-muted-foreground">
               Fuente

--- a/backoffice/src/app/gc-fitness/admin/coaches/[uid]/clients/[clientId]/page.tsx
+++ b/backoffice/src/app/gc-fitness/admin/coaches/[uid]/clients/[clientId]/page.tsx
@@ -40,7 +40,7 @@ import {
 } from "@/components/ui/table";
 import { Button } from "@/components/ui/button";
 import { PageHeader } from "@/components/gc-fitness/page-header";
-import { ArrowLeft } from "lucide-react";
+import { ArrowLeft, UserRound } from "lucide-react";
 
 import { ClientRecentLogsFeed } from "@/app/gc-fitness/clients/[id]/_components/ClientRecentLogsFeed";
 import { ProgressPhotosGridClient } from "@/app/gc-fitness/clients/[id]/_components/ProgressPhotosGridClient";
@@ -85,10 +85,26 @@ export default async function AdminCoachClientPage({
   }
 
   const clientName = logs.clients[0]?.name ?? clientId;
-  const clientSnap = await gcFitnessFirestore()
-    .collection(FirestoreCollections.users)
-    .doc(clientId)
-    .get();
+  const usersCol = gcFitnessFirestore().collection(FirestoreCollections.users);
+  // #754 — "en el perfil de un client con coach falta ver quién es su coach".
+  // The route is already nested under the coach, but the page named them
+  // nowhere: the only pointer was a generic "Back to coach" button, so an
+  // operator landing here from a search or from Monitoring could not tell WHO
+  // the coach was without editing the URL. Point read, fail-soft — a missing
+  // coach doc degrades to the uid, never to a 404 on the client's profile.
+  const [clientSnap, coachSnap] = await Promise.all([
+    usersCol.doc(clientId).get(),
+    usersCol
+      .doc(uid)
+      .get()
+      .catch(() => null),
+  ]);
+  const coachName =
+    (typeof coachSnap?.get("displayName") === "string" && coachSnap.get("displayName")) ||
+    (typeof coachSnap?.get("email") === "string" && coachSnap.get("email")) ||
+    uid;
+  const coachEmail =
+    typeof coachSnap?.get("email") === "string" ? (coachSnap.get("email") as string) : null;
   const storedTimezone = clientSnap.get("timezone");
   // #747 — falls back to the ADMIN's own zone, never UTC. See the note in
   // `clients/[id]/page.tsx`.
@@ -116,7 +132,26 @@ export default async function AdminCoachClientPage({
           </span>
         }
         subtitle={`Client UID: ${clientId}`}
+        actions={
+          <Button asChild variant="outline" size="sm" className="rounded-full">
+            <Link href={`/gc-fitness/admin/coaches/${uid}`}>
+              <UserRound className="h-4 w-4" />
+              Ver coach
+            </Link>
+          </Button>
+        }
       />
+
+      <p className="-mt-2 text-sm text-muted-foreground">
+        Coach:{" "}
+        <Link
+          href={`/gc-fitness/admin/coaches/${uid}`}
+          className="font-medium text-foreground underline-offset-4 hover:underline"
+        >
+          {coachName}
+        </Link>
+        {coachEmail && coachEmail !== coachName ? ` · ${coachEmail}` : null}
+      </p>
 
       <Card>
         <CardHeader className="pb-3">

--- a/backoffice/src/app/gc-fitness/clients/[id]/_components/RemovePendingClientButton.tsx
+++ b/backoffice/src/app/gc-fitness/clients/[id]/_components/RemovePendingClientButton.tsx
@@ -1,0 +1,105 @@
+// RemovePendingClientButton.tsx — issue #753, deleting a PENDING client.
+//
+// The pending view is the one place a coach can undo a mistyped invite: until
+// the person signs in there is no account, only a `/user_mirror/{email}`
+// placeholder plus whatever was pre-loaded against that email. Both go.
+//
+// Copy is hardcoded Spanish to match the surrounding PendingClientView, which
+// is not translated either (the whole "Pendiente de ingreso" card is Spanish).
+// Mixing a translated button into an untranslated card would read worse than
+// either choice on its own.
+
+"use client";
+
+import { useState, useTransition } from "react";
+import { useRouter } from "next/navigation";
+import { Trash2 } from "lucide-react";
+import { toast } from "sonner";
+
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+import { Button } from "@/components/ui/button";
+import { removePendingClient } from "@/lib/gc-fitness/user-actions";
+
+export function RemovePendingClientButton({ email }: { email: string }) {
+  const router = useRouter();
+  const [open, setOpen] = useState(false);
+  const [pending, startTransition] = useTransition();
+
+  const confirm = () => {
+    startTransition(async () => {
+      try {
+        await removePendingClient({ email });
+        toast.success(`${email} ya no está en tu lista de clientes.`);
+        setOpen(false);
+        // The mirror is gone, so this route 404s on the next render.
+        router.replace("/gc-fitness/clients");
+        router.refresh();
+      } catch (err) {
+        toast.error(
+          err instanceof Error && err.message !== "Forbidden"
+            ? err.message
+            : "No se pudo eliminar el cliente pendiente.",
+        );
+      }
+    });
+  };
+
+  return (
+    <section className="rounded-[1.25rem] border border-destructive/30 bg-card p-5 shadow-sm">
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <div className="min-w-0">
+          <h2 className="font-medium">Eliminar cliente pendiente</h2>
+          <p className="text-sm text-muted-foreground">
+            Saca la invitación de tu lista y borra los workouts y hábitos que le
+            hayas pre-cargado. No hay ninguna cuenta que eliminar: esta persona
+            todavía no ingresó.
+          </p>
+        </div>
+        <Button
+          variant="outline"
+          className="rounded-full border-destructive/40 text-destructive hover:bg-destructive/10 hover:text-destructive"
+          onClick={() => setOpen(true)}
+        >
+          <Trash2 className="size-4" />
+          Eliminar
+        </Button>
+      </div>
+
+      <AlertDialog open={open} onOpenChange={(next) => !pending && setOpen(next)}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>¿Eliminar a {email}?</AlertDialogTitle>
+            <AlertDialogDescription>
+              Se borra la invitación y todo el contenido pre-cargado para esta
+              persona. Si más adelante ingresa a la app, ya no va a quedar
+              vinculada a vos: para volver a tenerla como cliente vas a tener
+              que invitarla de nuevo.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel disabled={pending}>Cancelar</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={(e) => {
+                e.preventDefault();
+                confirm();
+              }}
+              disabled={pending}
+              className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+            >
+              {pending ? "Eliminando…" : "Eliminar cliente pendiente"}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </section>
+  );
+}

--- a/backoffice/src/app/gc-fitness/clients/[id]/_components/UnlinkClientButton.tsx
+++ b/backoffice/src/app/gc-fitness/clients/[id]/_components/UnlinkClientButton.tsx
@@ -1,0 +1,101 @@
+// UnlinkClientButton.tsx — issue #753, "des-linkear" an active client.
+//
+// A destructive-but-recoverable action, so it gets the full confirm treatment:
+// the button never fires the mutation directly, the dialog spells out what
+// SURVIVES (the account, the history, the program) and what does not (the
+// roster link, the chat thread's place in this coach's inbox, the coached
+// premium entitlement), and the confirm stays disabled while the action runs.
+//
+// On success we leave the page — the client is no longer this coach's, so
+// /gc-fitness/clients/{id} would 404 on the very next render (its ownership
+// gate is `coachId === trainer.uid`). `router.replace` + `refresh` rather than
+// `push`, so Back doesn't land on that 404.
+
+"use client";
+
+import { useState, useTransition } from "react";
+import { useRouter } from "next/navigation";
+import { useTranslations } from "next-intl";
+import { Unlink } from "lucide-react";
+import { toast } from "sonner";
+
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+import { Button } from "@/components/ui/button";
+import { unlinkClient } from "@/lib/gc-fitness/user-actions";
+
+export function UnlinkClientButton({
+  clientId,
+  clientName,
+}: {
+  clientId: string;
+  clientName: string;
+}) {
+  const t = useTranslations("clients.detail.unlink");
+  const router = useRouter();
+  const [open, setOpen] = useState(false);
+  const [pending, startTransition] = useTransition();
+
+  const confirm = () => {
+    startTransition(async () => {
+      try {
+        await unlinkClient({ clientId });
+        toast.success(t("doneToast", { name: clientName }));
+        setOpen(false);
+        router.replace("/gc-fitness/clients");
+        router.refresh();
+      } catch (err) {
+        toast.error(err instanceof Error ? err.message : t("errorToast"));
+      }
+    });
+  };
+
+  return (
+    <section className="rounded-[1.25rem] border border-destructive/30 bg-card p-5 shadow-sm">
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <div className="min-w-0">
+          <h2 className="font-medium">{t("title")}</h2>
+          <p className="text-sm text-muted-foreground">{t("body")}</p>
+        </div>
+        <Button
+          variant="outline"
+          className="rounded-full border-destructive/40 text-destructive hover:bg-destructive/10 hover:text-destructive"
+          onClick={() => setOpen(true)}
+        >
+          <Unlink className="size-4" />
+          {t("cta")}
+        </Button>
+      </div>
+
+      <AlertDialog open={open} onOpenChange={(next) => !pending && setOpen(next)}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>{t("confirmTitle", { name: clientName })}</AlertDialogTitle>
+            <AlertDialogDescription>{t("confirmBody")}</AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel disabled={pending}>{t("cancel")}</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={(e) => {
+                e.preventDefault();
+                confirm();
+              }}
+              disabled={pending}
+              className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+            >
+              {pending ? t("pending") : t("confirmCta")}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </section>
+  );
+}

--- a/backoffice/src/app/gc-fitness/clients/[id]/page.tsx
+++ b/backoffice/src/app/gc-fitness/clients/[id]/page.tsx
@@ -56,6 +56,8 @@ import {
   progressPhotosFulfillment,
 } from "@/lib/gc-fitness/client-request-fulfillment";
 import { PendingClientPreload } from "./_components/PendingClientPreload";
+import { RemovePendingClientButton } from "./_components/RemovePendingClientButton";
+import { UnlinkClientButton } from "./_components/UnlinkClientButton";
 import { ClientSummaryCard } from "./_components/ClientSummaryCard";
 import { ClientCalendarPeek } from "./_components/ClientCalendarPeek";
 import { sectionMetadata } from "@/lib/gc-fitness/page-metadata";
@@ -268,6 +270,11 @@ export default async function ClientDetailPage({
           <ClientRecentLogsWidget clientId={id} timezone={timezone} />
         </Suspense>
       </div>
+
+      {/* #753 — last on the page on purpose: it is the only control here that
+          removes the client from the roster, and nothing above it should be
+          reachable by an accidental tap on the way to it. */}
+      <UnlinkClientButton clientId={id} clientName={displayName} />
     </div>
   );
 }
@@ -377,6 +384,9 @@ function PendingClientView({
           workout_assignments + habits with pendingEmail set. On first
           sign-in, convertMirrorToCanonical migrates clientId atomically. */}
       <PendingClientPreload normalizedEmail={normalizedEmail} />
+
+      {/* #753 — undo a mistyped invite without asking an operator. */}
+      <RemovePendingClientButton email={normalizedEmail} />
 
       <p className="text-xs text-muted-foreground">
         Cuando <strong>{email}</strong> inicie sesión con Google por primera

--- a/backoffice/src/lib/app-version.ts
+++ b/backoffice/src/lib/app-version.ts
@@ -1,1 +1,1 @@
-export const BACKOFFICE_VERSION = "2.335";
+export const BACKOFFICE_VERSION = "2.336";

--- a/backoffice/src/lib/app-version.ts
+++ b/backoffice/src/lib/app-version.ts
@@ -1,1 +1,1 @@
-export const BACKOFFICE_VERSION = "2.334";
+export const BACKOFFICE_VERSION = "2.335";

--- a/backoffice/src/lib/app-version.ts
+++ b/backoffice/src/lib/app-version.ts
@@ -1,1 +1,1 @@
-export const BACKOFFICE_VERSION = "2.333";
+export const BACKOFFICE_VERSION = "2.334";

--- a/backoffice/src/lib/gc-fitness/__tests__/activity-feed-actions.test.ts
+++ b/backoffice/src/lib/gc-fitness/__tests__/activity-feed-actions.test.ts
@@ -281,6 +281,26 @@ describe("assignments, habits and accounts", () => {
     const events = await listActivityFeed({ category: "habit" });
     expect(events.map((e) => e.id)).toEqual(["audit_log:a-habit"]);
   });
+
+  // #762 — the quick-filter checkboxes. Multi-select, and an EMPTY set means
+  // "no filter" (an untouched form and an all-unchecked form arrive identically
+  // over the wire, since HTML omits unchecked boxes).
+  it("filters by a set of categories, and an empty set filters nothing", async () => {
+    const two = await listActivityFeed({ categories: ["habit", "account"] });
+    expect(two.map((e) => e.id)).toEqual(["audit_log:a-habit", "audit_log:a-user"]);
+
+    const none = await listActivityFeed({ categories: [] });
+    expect(none.length).toBeGreaterThan(two.length);
+  });
+
+  // #762 — each monitored collection gets its own audit window on top of the
+  // global one, so a high-volume writer cannot starve the rest off the page.
+  // The windows overlap by construction; a doc must still render ONCE.
+  it("does not duplicate an audit row across the per-collection windows", async () => {
+    const events = await listActivityFeed({ includeLowSignal: true });
+    const ids = events.map((e) => e.id);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
 });
 
 describe("other sources", () => {
@@ -373,6 +393,82 @@ describe("other sources", () => {
     expect(event.category).toBe("account");
     // The stored title repeats the person the client chip already names.
     expect(event.subject).toBeNull();
+  });
+
+  // #762 — "faltan hábitos". Ticking a habit writes to `habit_logs`, which no
+  // audit trigger watches, so the single most frequent CLIENT action in the app
+  // reached this feed through no source at all.
+  describe("habit check-ins", () => {
+    beforeEach(() => {
+      docsByCollection.habits = new Map<string, Record<string, unknown>>([
+        ["hab-1", { name: { en: "Water intake", es: "Tomar agua" } }],
+      ]);
+      queryGet.habit_logs = async () => ({
+        docs: [
+          doc("hab-1_2026-07-21", {
+            habitId: "hab-1",
+            clientId: "client1",
+            civilDate: "2026-07-21",
+            value: true,
+            deleted: false,
+            createdAt: ts("2026-07-21T12:00:00.000Z"),
+          }),
+        ],
+      });
+    });
+
+    it("names the habit and links to the client", async () => {
+      const [event] = await listActivityFeed({ source: "habit_logs" });
+      expect(event.title).toBe("Marcó un hábito");
+      // Point-read hydration: the tick doc carries only the habit id.
+      expect(event.subject).toBe("Tomar agua");
+      expect(event.actor?.name).toBe("Client One");
+      expect(event.href).toBe("/gc-fitness/admin/coaches/coach1/clients/client1");
+      // Same civil day as the write → no redundant "día …" chip.
+      expect(event.meta).toEqual([]);
+    });
+
+    it("says so when the tick is back-dated to another day", async () => {
+      queryGet.habit_logs = async () => ({
+        docs: [
+          doc("hab-1_2026-07-19", {
+            habitId: "hab-1",
+            clientId: "client1",
+            civilDate: "2026-07-19",
+            value: true,
+            createdAt: ts("2026-07-21T12:00:00.000Z"),
+          }),
+        ],
+      });
+      const [event] = await listActivityFeed({ source: "habit_logs" });
+      expect(event.meta).toEqual(["día 2026-07-19"]);
+    });
+
+    // Unticking is the client changing their mind, not a baja — it must not
+    // land in the Eliminaciones tab next to deleted accounts and workout series.
+    it("reads an untick as its own event and keeps it out of Eliminaciones", async () => {
+      queryGet.habit_logs = async () => ({
+        docs: [
+          doc("hab-1_2026-07-21", {
+            habitId: "hab-1",
+            clientId: "client1",
+            civilDate: "2026-07-21",
+            value: true,
+            deleted: true,
+            createdAt: ts("2026-07-21T12:00:00.000Z"),
+          }),
+        ],
+      });
+      const [event] = await listActivityFeed({ source: "habit_logs" });
+      expect(event.title).toBe("Desmarcó un hábito");
+      expect(event.isDeletion).toBe(false);
+      expect(await listActivityFeed({ deletionsOnly: true, source: "habit_logs" })).toEqual([]);
+    });
+
+    it("is reachable from the Hábitos quick filter", async () => {
+      const events = await listActivityFeed({ categories: ["habit"] });
+      expect(events.map((e) => e.id)).toContain("habit_logs:hab-1_2026-07-21");
+    });
   });
 
   it("collapses a photo check-in set into one event that links to the gallery", async () => {

--- a/backoffice/src/lib/gc-fitness/activity-feed-actions.ts
+++ b/backoffice/src/lib/gc-fitness/activity-feed-actions.ts
@@ -18,6 +18,10 @@
 //   • `progress_photos`  — read directly, because photo uploads are NOT one of
 //                          the trigger-monitored collections and the ticket
 //                          explicitly asks for "user cargó fotos".
+//   • `habit_logs`       — #762. Same reason as the photos: ticking a habit
+//                          writes to `habit_logs`, which no audit trigger
+//                          watches, so the single most frequent CLIENT action in
+//                          the app was invisible here ("faltan hábitos").
 //
 // The readability work lives in the PURE `activity-feed-model.ts`
 // (classification, Spanish copy, recurrence/frequency labels, the
@@ -61,7 +65,8 @@ export type FeedSource =
   | "audit_log"
   | "coach_activity"
   | "admin_operations"
-  | "progress_photos";
+  | "progress_photos"
+  | "habit_logs";
 
 export interface FeedPerson {
   uid: string | null;
@@ -110,6 +115,16 @@ export interface ActivityFeedEvent {
 export interface ActivityFeedFilters {
   source?: "all" | FeedSource;
   category?: "all" | FeedCategory;
+  /**
+   * #762 — the quick-filter checkboxes ("todos marcados por defecto"). A row
+   * survives when its category is in the set. `undefined` (or an empty array)
+   * means NO category filter, which is what an untouched form sends: HTML
+   * omits unchecked boxes, so "everything checked" and "nothing checked" arrive
+   * identically and the only sane reading of both is "show everything".
+   * Composes with the single-value `category` above, which the pre-#762 links
+   * still use.
+   */
+  categories?: FeedCategory[];
   actorQuery?: string | null;
   clientQuery?: string | null;
   fromISO?: string | null;
@@ -122,6 +137,40 @@ export interface ActivityFeedFilters {
 }
 
 const PER_SOURCE_CAP = 400;
+/**
+ * #762 — per-COLLECTION cap for the `audit_log` fan-out below.
+ *
+ * The trail is written by one trigger per monitored collection into a single
+ * collection, and the write rates are nowhere near each other: a measurement of
+ * the live project found 337 `workout_assignments` rows, 45 `users`, 15
+ * `workout_logs` and **3** `habits` inside one 24-hour window (a recurring
+ * series materializes one doc per occurrence, and the 90-day self-routine
+ * horizon renews itself in bursts). A single `orderBy(occurredAt).limit(400)`
+ * therefore spans about a day and is ~85% assignment writes, so anything
+ * low-volume — habits above all — falls off the end and is simply absent from
+ * the feed. That is the "faltan hábitos" report, and it also makes a category
+ * filter useless: filtering a starved window still shows nothing.
+ *
+ * So each monitored collection additionally gets its own small window, merged
+ * and deduped with the global one. Every one of these is fail-soft: the
+ * `collection ASC, occurredAt DESC` composite index they need is declared in
+ * `gc-fitness/firestore.indexes.json`, and until it is deployed these queries
+ * just fail and the feed degrades to exactly the pre-#762 global window.
+ */
+const PER_COLLECTION_CAP = 120;
+/**
+ * The collections `onAuditableWrite` captures (functions/src/audit — its
+ * `MONITORED_COLLECTIONS`). Only used to aim the per-collection queries above;
+ * an entry that no longer exists costs one empty query, and a NEW monitored
+ * collection missing from this list still arrives through the global window.
+ */
+const AUDITED_COLLECTIONS = [
+  "habits",
+  "exercises",
+  "workout_logs",
+  "users",
+  "workout_assignments",
+] as const;
 const DEFAULT_LIMIT = 150;
 const MAX_LIMIT = 400;
 /**
@@ -172,12 +221,14 @@ async function rangedQuery(
   from: Date | null,
   to: Date | null,
   label: string,
+  options: { limit?: number; equals?: { field: string; value: unknown } } = {},
 ): Promise<FirebaseFirestore.QuerySnapshot | null> {
   let q = db.collection(collection).orderBy(timeField, "desc") as FirebaseFirestore.Query;
+  if (options.equals) q = q.where(options.equals.field, "==", options.equals.value);
   if (from) q = q.where(timeField, ">=", Timestamp.fromDate(from));
   if (to) q = q.where(timeField, "<=", Timestamp.fromDate(to));
   return q
-    .limit(PER_SOURCE_CAP)
+    .limit(options.limit ?? PER_SOURCE_CAP)
     .get()
     .catch((err) => {
       console.warn(`[gc-fitness/feed] ${label} query failed`, err);
@@ -190,16 +241,38 @@ async function fetchAuditRecords(
   from: Date | null,
   to: Date | null,
 ): Promise<AuditRecord[]> {
-  const snap = await rangedQuery(
-    db,
-    FirestoreCollections.auditLog,
-    "occurredAt",
-    from,
-    to,
-    "audit_log",
-  );
-  if (!snap) return [];
-  return snap.docs.map((doc) => {
+  // One global window plus one per monitored collection, so a high-volume
+  // writer cannot starve the rest out of the page (see PER_COLLECTION_CAP).
+  const snaps = await Promise.all([
+    rangedQuery(db, FirestoreCollections.auditLog, "occurredAt", from, to, "audit_log"),
+    ...AUDITED_COLLECTIONS.map((name) =>
+      rangedQuery(db, FirestoreCollections.auditLog, "occurredAt", from, to, `audit_log/${name}`, {
+        limit: PER_COLLECTION_CAP,
+        equals: { field: "collection", value: name },
+      }),
+    ),
+  ]);
+
+  // The windows overlap by construction — the same doc comes back from the
+  // global query and from its collection's query. First one wins; they are the
+  // same document.
+  const seen = new Set<string>();
+  const docs: FirebaseFirestore.QueryDocumentSnapshot[] = [];
+  for (const snap of snaps) {
+    if (!snap) continue;
+    for (const doc of snap.docs) {
+      if (seen.has(doc.id)) continue;
+      seen.add(doc.id);
+      docs.push(doc);
+    }
+  }
+
+  // Re-sort: the concatenation above is per-query-newest-first, not globally
+  // so. `groupRecurringAuditEntries` collapses ADJACENT sibling writes and
+  // `findRecurrenceEdits` pairs a delete with the create next to it, so both
+  // read order as meaning — an unsorted list silently stops collapsing.
+  return docs
+    .map((doc) => {
     const d = doc.data() as Record<string, unknown>;
     const changedFields = Array.isArray(d.changedFields)
       ? (d.changedFields as unknown[]).filter((f): f is string => typeof f === "string")
@@ -220,7 +293,8 @@ async function fetchAuditRecords(
       clientId: typeof d.clientId === "string" ? d.clientId : null,
       occurredAtISO: toIso(d.occurredAt) ?? toIso(d.eventTime),
     } satisfies AuditRecord;
-  });
+    })
+    .sort((a, b) => (b.occurredAtISO ?? "").localeCompare(a.occurredAtISO ?? ""));
 }
 
 /** Namespaces the coach eventId inside the feed's global id space. */
@@ -348,6 +422,52 @@ async function fetchPhotoUploads(
       setId: typeof d.setId === "string" ? d.setId : null,
       angle: typeof d.angle === "string" ? d.angle : null,
       occurredAtISO: toIso(d.createdAt) ?? toIso(d.takenAt),
+    };
+  });
+}
+
+/**
+ * #762 — a habit tick. `habit_logs` is one doc per (habit, civil day), written
+ * by the client's app and re-written (`deleted: true`) when they untick, so the
+ * doc id is stable and the newest write wins.
+ */
+interface RawHabitCheckIn {
+  id: string;
+  habitId: string | null;
+  clientId: string | null;
+  civilDate: string | null;
+  unticked: boolean;
+  occurredAtISO: string | null;
+}
+
+async function fetchHabitCheckIns(
+  db: Firestore,
+  from: Date | null,
+  to: Date | null,
+): Promise<RawHabitCheckIn[]> {
+  // Ordered/ranged on `createdAt`, NOT on `civilDate`: the feed is a timeline of
+  // when things HAPPENED, and a back-dated tick ("marqué el hábito de ayer")
+  // carries an older civil day than the moment it was written. `updatedAt` would
+  // be the truer instant for an untick, but only `createdAt` is guaranteed on
+  // every doc — the untick's own timestamp is surfaced in the row's meta instead.
+  const snap = await rangedQuery(
+    db,
+    FirestoreCollections.habitLogs,
+    "createdAt",
+    from,
+    to,
+    "habit_logs",
+  );
+  if (!snap) return [];
+  return snap.docs.map((doc) => {
+    const d = doc.data() as Record<string, unknown>;
+    return {
+      id: `habit_logs:${doc.id}`,
+      habitId: typeof d.habitId === "string" ? d.habitId : null,
+      clientId: typeof d.clientId === "string" ? d.clientId : null,
+      civilDate: typeof d.civilDate === "string" ? d.civilDate : null,
+      unticked: d.deleted === true || d.value === false,
+      occurredAtISO: toIso(d.createdAt) ?? toIso(d.loggedAt),
     };
   });
 }
@@ -668,11 +788,12 @@ async function collectFeed(
   to: Date | null,
 ): Promise<ActivityFeedEvent[]> {
   const db = gcFitnessFirestore();
-  const [auditRaw, coachRaw, adminRaw, photoRaw] = await Promise.all([
+  const [auditRaw, coachRaw, adminRaw, photoRaw, habitCheckInRaw] = await Promise.all([
     fetchAuditRecords(db, from, to),
     fetchCoachEvents(db, from, to),
     fetchAdminOperations(db, from, to),
     fetchPhotoUploads(db, from, to),
+    fetchHabitCheckIns(db, from, to),
   ]);
 
   // Collapse recurring-series writes (one coach edit → one doc per occurrence).
@@ -724,6 +845,9 @@ async function collectFeed(
   }
   for (const p of photoRaw) {
     if (p.clientId) uids.add(p.clientId);
+  }
+  for (const h of habitCheckInRaw) {
+    if (h.clientId) uids.add(h.clientId);
   }
 
   // Identities are needed HERE (hrefs + the actor/client filters). Entity names
@@ -846,6 +970,39 @@ async function collectFeed(
     });
   }
 
+  for (const h of habitCheckInRaw) {
+    events.push({
+      id: h.id,
+      source: "habit_logs",
+      category: "habit",
+      significance: "key",
+      action: h.unticked ? "update" : "create",
+      occurredAtISO: h.occurredAtISO,
+      title: h.unticked ? "Desmarcó un hábito" : "Marcó un hábito",
+      subject: null,
+      // The tick doc carries only the habit id, so the name is a point read —
+      // the same bounded, post-filter hydration the elided `templateSnapshot`
+      // rows use. A habit that was hard-deleted since simply renders unnamed.
+      subjectRef: h.habitId ? { collection: "habits", id: h.habitId } : null,
+      // Only when the tick is NOT for the day it was written: a back-dated
+      // check-in is the interesting case, and on the normal one the civil date
+      // just repeats the day header the row already sits under.
+      meta:
+        h.civilDate && h.civilDate !== (h.occurredAtISO ?? "").slice(0, 10)
+          ? [`día ${h.civilDate}`]
+          : [],
+      actor: person(h.clientId, "client", users),
+      client: null,
+      href: h.clientId ? userHref(h.clientId, users) : null,
+      // An untick is the client changing their mind, not data being removed —
+      // keeping it out of the Eliminaciones tab, which is about bajas.
+      isDeletion: false,
+      kind: "habit_log",
+      clientUid: h.clientId,
+      correlation: null,
+    });
+  }
+
   events.sort((a, b) => (b.occurredAtISO ?? "").localeCompare(a.occurredAtISO ?? ""));
 
   // #748 — the same coach action reaches the feed through two independent
@@ -870,6 +1027,9 @@ function applyFilters(
 ): ActivityFeedEvent[] {
   const source = filters.source && filters.source !== "all" ? filters.source : null;
   const category = filters.category && filters.category !== "all" ? filters.category : null;
+  // Empty / absent = no filter (see ActivityFeedFilters.categories).
+  const categories =
+    filters.categories && filters.categories.length > 0 ? new Set(filters.categories) : null;
   const actorQuery = (filters.actorQuery ?? "").trim().toLowerCase();
   const clientQuery = (filters.clientQuery ?? "").trim().toLowerCase();
 
@@ -878,6 +1038,7 @@ function applyFilters(
     if (filters.deletionsOnly && !e.isDeletion) return false;
     if (source && e.source !== source) return false;
     if (category && e.category !== category) return false;
+    if (categories && !categories.has(e.category)) return false;
     if (actorQuery) {
       const hay =
         `${e.actor?.uid ?? ""} ${e.actor?.name ?? ""} ${e.actor?.email ?? ""}`.toLowerCase();

--- a/backoffice/src/lib/gc-fitness/user-actions.ts
+++ b/backoffice/src/lib/gc-fitness/user-actions.ts
@@ -62,6 +62,7 @@ import {
 import { getCurrentTrainer } from "./auth-helpers";
 import {
   clientAddedEvent,
+  markCoachActivityDeleted,
   recordCoachActivityEvent,
 } from "./coach-activity-log";
 import {
@@ -763,4 +764,161 @@ export async function getCurrentTrainerProfile(): Promise<{
         : null,
     chatQuickReplies: data.chatQuickReplies ?? [],
   };
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Issue #753 — a coach removing someone from their own roster
+//
+// Both operations already existed, but ONLY as admin god-mode tools in
+// `admin-actions.ts` (`removePendingClientForCoach` / `unlinkClientFromCoach`),
+// which means a coach who mistyped an invite email or whose client stopped
+// training had to ask an operator. These are the coach-scoped twins: same wire
+// effect, but the coach uid comes from `getCurrentTrainer()` instead of being a
+// caller-supplied argument, so a coach can only ever act on their own roster.
+//
+// Neither deletes a person. `unlinkClient` clears the link and leaves the
+// account (and its history) intact — the destructive
+// `deleteClientCascade` stays admin-only on purpose.
+// ─────────────────────────────────────────────────────────────────────────────
+
+const removePendingClientSchema = z.object({
+  email: z.string().trim().toLowerCase().email().transform(normalizeMirrorEmail),
+});
+
+/**
+ * Delete a PENDING client — the `/user_mirror/{email}` placeholder a coach
+ * created with `provisionClient` for someone who has never signed in.
+ *
+ * Also drops the content pre-loaded against that email. This is not tidiness:
+ * `convertMirrorToCanonical` claims pre-loaded docs by `pendingEmail` on first
+ * sign-in, so an orphaned assignment/habit would silently attach itself to the
+ * person later — even if by then they belong to a DIFFERENT coach. Both queries
+ * are scoped to `trainerId == me`, so a second coach's pre-loads for the same
+ * email are never touched.
+ *
+ * Idempotent: removing an already-removed pending client is a no-op success,
+ * which keeps a double-submit from turning into an error the coach has to read.
+ */
+export async function removePendingClient(input: unknown): Promise<{ ok: true }> {
+  const session = await getCurrentTrainer();
+  const parsed = removePendingClientSchema.parse(input);
+  const db = gcFitnessFirestore();
+
+  const mirrorRef = db
+    .collection(FirestoreCollections.userMirror)
+    .doc(parsed.email);
+  const mirrorSnap = await mirrorRef.get();
+  if (!mirrorSnap.exists) {
+    revalidateTag("gc-fitness-roster", "max");
+    return { ok: true };
+  }
+  if (mirrorSnap.get("coachId") !== session.uid) {
+    throw new Error("Forbidden");
+  }
+
+  const [assignments, habits] = await Promise.all([
+    db
+      .collection(FirestoreCollections.workoutAssignments)
+      .where("trainerId", "==", session.uid)
+      .where("pendingEmail", "==", parsed.email)
+      .get(),
+    db
+      .collection(FirestoreCollections.habits)
+      .where("trainerId", "==", session.uid)
+      .where("pendingEmail", "==", parsed.email)
+      .get(),
+  ]);
+
+  const batch = db.batch();
+  for (const doc of [...assignments.docs, ...habits.docs]) batch.delete(doc.ref);
+  batch.delete(mirrorRef);
+  await batch.commit();
+
+  // The roster row came from `clientAddedEvent`, keyed by (coach, email) — mark
+  // that same event deleted so My Activity reads "Quitó un cliente" instead of
+  // still advertising an add that has been undone. Best-effort by contract.
+  await markCoachActivityDeleted(db, `client:${session.uid}:${parsed.email}`);
+  revalidateTag("gc-fitness-roster", "max");
+  return { ok: true };
+}
+
+const unlinkClientSchema = z.object({
+  clientId: z.string().trim().min(6).max(128),
+});
+
+/**
+ * Detach an ACTIVE client from the calling coach — "des-linkear", the inverse
+ * of `provisionClient`. The person keeps their account, their history and the
+ * program they were given; they simply become coach-less (self-serve) and drop
+ * off this coach's roster.
+ *
+ * Mirrors `unlinkClientFromCoach` in `admin-actions.ts` field for field: clear
+ * the link + the denormalized coach fields, clear `coachId` on the 1:1 chat doc
+ * (which removes the thread from the ex-coach's inbox query and fails
+ * `isChatParticipant` for them WITHOUT destroying the client's history — a later
+ * re-link restores it), and resync the custom claim. The claim write is
+ * fail-soft on purpose: the Firestore doc is the source of truth and the claim
+ * catches up on the client's next token refresh.
+ *
+ * Side effect worth knowing before confirming: a coached user is entitled to
+ * premium through their coach, so unlinking drops them to their own tier.
+ */
+export async function unlinkClient(input: unknown): Promise<{ ok: true }> {
+  const session = await getCurrentTrainer();
+  const parsed = unlinkClientSchema.parse(input);
+  const db = gcFitnessFirestore();
+
+  const clientRef = db.collection(FirestoreCollections.users).doc(parsed.clientId);
+  const clientSnap = await clientRef.get();
+  // Same shape as every other coach-scoped gate here: an unowned or missing
+  // client is indistinguishable from the caller's point of view.
+  if (!clientSnap.exists || clientSnap.get("coachId") !== session.uid) {
+    throw new Error("Forbidden");
+  }
+  const clientEmail =
+    typeof clientSnap.get("email") === "string" ? (clientSnap.get("email") as string) : null;
+
+  const chatRef = db.collection(FirestoreCollections.chats).doc(parsed.clientId);
+  const chatSnap = await chatRef.get();
+
+  const batch = db.batch();
+  batch.update(clientRef, {
+    coachId: FieldValue.delete(),
+    coachDisplayName: FieldValue.delete(),
+    coachPhotoURL: FieldValue.delete(),
+    coachBio: FieldValue.delete(),
+    // The "auto-assigned, needs triage" marker is meaningless with no coach.
+    autoAssignedCoach: FieldValue.delete(),
+    updatedAt: FieldValue.serverTimestamp(),
+  });
+  if (chatSnap.exists) {
+    batch.update(chatRef, {
+      coachId: FieldValue.delete(),
+      updatedAt: FieldValue.serverTimestamp(),
+    });
+  }
+  await batch.commit();
+
+  try {
+    const authUser = await gcFitnessAuth().getUser(parsed.clientId);
+    const { coachId: _dropped, ...rest } = (authUser.customClaims ?? {}) as Record<
+      string,
+      unknown
+    >;
+    await gcFitnessAuth().setCustomUserClaims(parsed.clientId, {
+      ...rest,
+      role: "client",
+    });
+  } catch {
+    // fail-soft — see the doc comment.
+  }
+
+  if (clientEmail) {
+    await markCoachActivityDeleted(
+      db,
+      `client:${session.uid}:${normalizeMirrorEmail(clientEmail)}`,
+    );
+  }
+  revalidateTag("gc-fitness-roster", "max");
+  return { ok: true };
 }


### PR DESCRIPTION
Cierra mdb1/gc-fitness#762, mdb1/gc-fitness#754 y mdb1/gc-fitness#753.

## #762 — "Monitoring: faltan hábitos"

Eran **dos causas independientes**; arreglar una sola dejaba el ticket a medias.

**1. Los ticks de hábito no entraban por ninguna fuente.** Marcar un hábito escribe en `habit_logs`, que **no está en `MONITORED_COLLECTIONS`**, así que no hay fila de `audit_log` que lo cuente — y el feed leía cuatro fuentes de las cuales ninguna era esa. Medido contra prod: **44 ticks en 7 días** (6–11 por día), invisibles. Ahora es una quinta fuente leída directo, el mismo tratamiento que ya tenía `progress_photos` y por la misma razón.

```
Marcó un hábito · Tomar agua
Desmarcó un hábito · Movilidad!
Marcó un hábito · Bb · día 2026-08-04        ← tick con fecha atrasada
```

- El nombre sale de un **point read bounded** a `habits/{habitId}` (el doc del tick sólo trae el id), por la hidratación que corre DESPUÉS de filtrar.
- Ordena por `createdAt`, no por `civilDate`: el feed es *cuándo pasaron* las cosas. Un tick atrasado imprime `día …`; cuando coincide no, para no repetir el encabezado del día.
- **Destildar no es una eliminación** — es el cliente cambiando de opinión, y no entra en la pestaña Eliminaciones.

**2. La ventana de `audit_log` la copaban las asignaciones.** Es una sola colección escrita por un trigger por cada colección monitoreada, y los ritmos no se parecen. En **24 h de prod**:

| colección | filas |
|---|---|
| `workout_assignments` | 337 |
| `users` | 45 |
| `workout_logs` | 15 |
| `habits` | **3** |

Una sola query `limit(400)` tapa ~24 h y es ~85% asignaciones, así que todo lo de bajo volumen se cae del final. Eso también volvía inútil cualquier filtro por tipo: filtrar una ventana hambreada sigue sin mostrar nada. Ahora cada colección monitoreada tiene su propia ventana además de la global, deduplicadas por id y **re-ordenadas** (`groupRecurringAuditEntries` y `findRecurrenceEdits` leen el orden como significado — una lista desordenada deja de colapsar en silencio).

> ⚠️ Necesita el índice compuesto `audit_log (collection ASC, occurredAt DESC)`, que vive en `gc-fitness/firestore.indexes.json` → **otro repo, otro PR**. Verificado contra prod que hoy la query falla con `FAILED_PRECONDITION` y cada una es fail-soft: **este PR es seguro de mergear antes que el índice**, simplemente no rinde del todo hasta que esté.

**Quick filters**: el `<select>` de "Tipo de evento" pasa a una fila de checkboxes con todo marcado por defecto (`?cat=` repetido). Conjunto vacío = sin filtro, porque HTML no manda los destildados y un form intacto llega igual que uno con todo destildado. Con todo tildado se manda la lista vacía en vez de las nueve, para que los eventos `other` no desaparezcan al mandar el form sin tocar nada.

## #754 — quién es el coach del cliente

`/gc-fitness/admin/coaches/{uid}/clients/{clientId}` no nombraba al coach en ningún lado: el único puntero era un "Back to coach" genérico. Ahora el header trae `Coach: <nombre> · <email>` linkeado más un botón "Ver coach". Point read fail-soft: sin doc de coach degrada al uid, nunca a un 404 del perfil del cliente.

## #753 — el coach puede sacarse clientes de encima

Las dos operaciones ya existían, pero **sólo como admin god-mode**. Gemelas con alcance de coach en `user-actions.ts`, con el uid saliendo de `getCurrentTrainer()` en vez de ser un argumento:

- **`removePendingClient({ email })`** — borra `/user_mirror/{email}` **y el contenido pre-cargado contra ese mail**. Esto último no es prolijidad: `convertMirrorToCanonical` reclama los docs por `pendingEmail` en el primer ingreso, así que una asignación huérfana se le pegaría a la persona más adelante *aunque para entonces sea cliente de otro coach*. Scopeado a `trainerId == me`. Idempotente.
- **`unlinkClient({ clientId })`** — espejo campo por campo de `unlinkClientFromCoach`: limpia el link + los denormalizados, limpia `coachId` en el chat (lo saca del inbox del ex-coach **sin** destruir el historial — si lo vuelve a agregar, vuelve) y resincroniza el custom claim fail-soft.

Ninguna borra a una persona: `deleteClientCascade` sigue siendo sólo de admin, a propósito. Las dos piden confirmación en un `AlertDialog` que dice qué sobrevive y qué no —incluido que desvincular le hace perder el premium que tenía por ser cliente— y quedan al final de la página para que nada de arriba se alcance con un tap accidental camino al botón.

## Gates

- `npx jest` en `backoffice`: **93 suites / 1075 tests verdes** (8 tests nuevos).
- `npx tsc --noEmit` y `npm run build`: limpios.
- Verificado contra prod (read-only): los ticks hidratan nombre y cliente bien, los atrasados producen el chip `día …`, y la query por colección falla hoy con `FAILED_PRECONDITION` — el camino fail-soft es real, no teórico.
- Versión: 2.333 → **2.336** (+1 por commit).

Notas de diseño largas en `.planning/quick/260805-762-754-753-monitoring-habits-coach-actions/SUMMARY.md`.