### PR TITLE
test(coach-portal): red de regresión de UI — P1..P7 COMPLETOS (38 componentes, 94→132 suites)

### DIFF
--- a/backoffice/README.md
+++ b/backoffice/README.md
@@ -48,6 +48,184 @@ npm run dev
 # Open http://localhost:3001
 ```
 
+## Tests
+
+```bash
+cd backoffice
+npx jest                       # everything (~11s)
+npx jest habits-client-list    # one file — the arg is a PATH pattern, not a test name
+npx jest -t "drops a recurrence"   # one test, by name
+npm run test:gc-fitness        # only the gc-fitness surface (--testPathPatterns=gc-fitness)
+```
+
+Nothing to install and nothing to start: no emulator, no dev server, no
+Firebase credentials. Every test either exercises a pure module or mounts a
+component with React Testing Library, and everything that would touch Firebase
+is mocked at the module boundary.
+
+### This suite is the only gate before production
+
+**The backoffice auto-deploys `main` on push, and CI is switched off for cost.**
+There is no pipeline that will catch a red test after the fact — `npx jest`
+green locally is literally the last thing between a merge and the trainers
+using it. Run the whole suite (not just your file) before pushing.
+
+The gate is wider than this package: `firestore.rules` and several algorithms
+are shared with the iOS and Android apps, so a change here can break them and
+vice versa. The four suites and when to run them are in the repo-root
+`CLAUDE.md` → "Test gate before push". When in doubt, run all four.
+
+### Writing a UI test
+
+The harness is already installed — RTL 16, `user-event` 14, `jest-dom`, jsdom —
+and `jest.setup.ts` polyfills what radix/shadcn need (`ResizeObserver`,
+`scrollIntoView`, `matchMedia`, pointer capture). Adding a component test is
+writing a file, not a project. Existing ones worth copying:
+`src/components/gc-fitness/__tests__/` and
+`src/app/gc-fitness/habits/__tests__/`.
+
+**1. The jsdom docblock, as the first three lines.** The config default is
+`testEnvironment: "node"`; without this, RTL dies with
+`ReferenceError: document is not defined`.
+
+```tsx
+/**
+ * @jest-environment jsdom
+ */
+```
+
+**2. Mock the Server Action and `sonner`.** Any `*-actions` module imports
+`firebase-admin`, which drags in Node-only deps and throws at import time under
+jsdom — it MUST be mocked, whether or not your test calls it. Mocking `toast`
+is how you tell "it saved" apart from "it refused".
+
+```tsx
+const mockAssignTemplate = jest.fn();
+jest.mock("@/lib/gc-fitness/workout-assignment-actions", () => ({
+  assignTemplate: (...args: unknown[]) => mockAssignTemplate(...args),
+}));
+jest.mock("sonner", () => ({ toast: { success: jest.fn(), error: jest.fn() } }));
+```
+
+**3. Translations need no provider.** `next-intl` is ESM-only at its public
+entrypoint, so `jest.config.js` maps it to `src/lib/test-utils/next-intl-stub.tsx`
+for every test. The stub resolves keys against the real **EN** catalog
+(`messages/en.json`), `useLocale()` returns `"en"`, and `NextIntlClientProvider`
+is a pass-through you don't need to render. So assert on the English strings the
+catalog actually contains — and read them from `messages/en.json` rather than
+guessing. (Some `aria-label`s are hardcoded Spanish in the components; those
+stay Spanish.)
+
+**4. Assert the PAYLOAD, not the pixels.** The question a UI test answers is
+"does this component build the right object and hand it to the right action?" —
+not "what does it look like". The rendered screen is usually driven by the same
+in-memory state that produced the write, so a screen assertion can pass with the
+wire shape wrong.
+
+```tsx
+await user.click(screen.getByRole("button", { name: "Assign" }));
+await waitFor(() => expect(mockAssignTemplate).toHaveBeenCalled());
+expect(mockAssignTemplate.mock.calls[0][0]).toMatchObject({ scope: "one" });
+```
+
+Two payload rules that bite specifically here: an omitted key must be **absent**,
+not `undefined` (the backoffice's Firestore handle has no
+`ignoreUndefinedProperties`, so `undefined` throws at write time) — assert with
+`expect("key" in payload).toBe(false)`. And an empty string is a real value:
+optional text fields must go out as `undefined`, never `""`.
+
+The exception is a purely presentational component (e.g.
+`workout-log-detail-view.tsx`), which writes nothing — there the screen IS the
+contract.
+
+**5. Mock the child, assert the props that cross the boundary.** For a component
+that is mostly a shell, this is far cheaper than mounting the whole tree and it
+tests exactly what the shell decides. Give the stub a button that fires the
+callback:
+
+```tsx
+jest.mock("@/components/gc-fitness/schedule/move-assignment-dialog", () => ({
+  MoveAssignmentDialog: (props: {
+    chip: { id: string };
+    onConfirm: (scope: string) => void;
+  }) => (
+    <div data-testid="move-dialog">
+      <span data-testid="move-dialog-chip">{props.chip.id}</span>
+      <button onClick={() => props.onConfirm("all")}>scope-all</button>
+    </div>
+  ),
+}));
+```
+
+**6. Never use today's date in a fixture.** Several components fall back to
+`todayCivil()`; a fixture pinned to today sits exactly on the boundary being
+tested and the assertion cannot fail. Compute offsets instead
+(`civilOffset(-1)`, `civilOffset(30)`). The one legitimate exception is a fixed
+instant used to test timezone conversion itself.
+
+### Verify by mutation
+
+**A test that passes on the first run has proven nothing until you have seen it
+fail.** For each assertion that matters: break the invariant in the SOURCE by
+hand, confirm the red, revert. Put the results in the PR as a table.
+
+```bash
+# 1. break it — remove the same-day guard in month-calendar.tsx:
+#      if (chip.scheduledFor === targetDay) return;
+npx jest month-calendar-drag-move     # expect RED
+git checkout src/components/gc-fitness/schedule/month-calendar.tsx
+npx jest month-calendar-drag-move     # green again
+git diff --stat                       # must be empty before committing
+```
+
+**If a mutation comes back GREEN, find out why before touching the test.** Every
+single time so far it has been one of these, and only one was a weak assertion:
+
+- **The test asserted too loosely.** `toHaveTextContent("-")` is satisfied by
+  `"-300s"`, so admitting negative rest gaps stayed green. Read the exact cell.
+- **The assertion ran before the effect.** React Query's `mutate()` does not call
+  the mutation function synchronously, so `expect(action).not.toHaveBeenCalled()`
+  right after a click passes no matter what. Flush first:
+  `await act(async () => { await new Promise((r) => setTimeout(r, 0)); })`.
+- **The mutation didn't apply where you thought.** The logic was duplicated (a
+  preview copy and a submit copy of the same `.sort()`), or a `s///` without
+  `/g` hit only one of them. Check the occurrence count.
+- **The code is dead.** Two mechanisms implementing one contract, and the one
+  you mutated isn't the one that runs (e.g. a collapsed bilingual field already
+  mirrors on every keystroke, so the mirror at save time is unreachable from
+  that path). Assert the CONTRACT, and note the finding.
+
+### Query traps that have already cost time
+
+- A bare `/Editar/` also matches "Editar recurrencia" — anchor the regex
+  (`/^Editar$/`).
+- Dialog titles and bodies often render the same text → `findAllByText`, not
+  `findByText`.
+- Numeric inputs with `inputMode` expose `role="textbox"`, **not**
+  `spinbutton`.
+- A shadcn `Select`/combobox trigger does NOT take its placeholder as its
+  accessible name — match on `textContent`.
+- With two `role="combobox"` elements, never index blindly; identify which is
+  which.
+- `window.location` cannot be stubbed in this jsdom — not via `defineProperty`,
+  not via the `delete` trick, not via `spyOn`.
+- The next-intl stub caches `t` per namespace on purpose. If you see
+  *Maximum update depth exceeded*, look for another hook in your test returning
+  a fresh reference each render before blaming the component.
+
+### What does NOT exist: browser E2E
+
+There is **no Playwright and no Cypress**, and the backoffice has **no emulator
+plumbing** — no `FIRESTORE_EMULATOR_HOST`, no `connectFirestoreEmulator`. It
+talks to real Firebase through the Admin SDK. Don't assume a real browser is
+covering anything; nothing in this repo runs one.
+
+Standing one up would mean emulator plumbing for both SDKs (client + Admin),
+minting a `next-firebase-auth-edge` session cookie, and seeding fixtures —
+roughly what the mobile UI-test harness (#609) cost. Worth doing eventually; not
+worth blocking regression coverage on, since these tests run in the gate that
+already protects production.
+
 ## Authentication
 
 Login is backend-controlled. Access is granted to emails in the SDK's `TEAM_ALLOWLIST` and to users with an active admin role assignment in Firebase (for example `full_admin`, `institution_admin`, or `institution_doctor`). Email account creation now checks that access first, creates the auth account only after approval, and then sends the authenticated user into a complete-profile flow that writes the required Firebase profile documents.

--- a/backoffice/README.md
+++ b/backoffice/README.md
@@ -216,6 +216,22 @@ single time so far it has been one of these, and only one was a weak assertion:
 - **The mutation was malformed** and changed nothing (appending a `void 0`,
   adding a second redundant call). `Tests: 0 total` or an unchanged count is the
   tell — re-read the diff you applied before drawing a conclusion.
+  In particular `if (false)`, deleting a function name from a call, or dropping
+  a null-guard the types depend on all fail to COMPILE, and ts-jest then reports
+  `Tests: 0 total` — which looks exactly like green if you only read the exit
+  code. Always read the `Tests:` line, never the exit status alone.
+- **The fixture made the two branches the same value.** Snapping to "the newest
+  photo" cannot be told from "leave it alone" when the fixture already starts on
+  the newest one; seeding URL params with exactly the defaults proves nothing
+  about whether the params are read at all. Start from a value the correct
+  behavior has to CHANGE.
+- **The assertion was weaker than the invariant.** "The two timezones produce
+  different headings" holds with the timezone bug in place too — a wrong civil
+  day still produces *some* heading. Assert the exact label.
+- **The value comes from somewhere else.** A ternary that duplicates one its
+  caller already applied (the generator repeating `metric === "time" ? 0 : reps`
+  from the engine) can never differ. That is a finding for the dead-code issue,
+  not a test to strengthen.
 
 ### Query traps that have already cost time
 
@@ -247,6 +263,26 @@ single time so far it has been one of these, and only one was a weak assertion:
 - The next-intl stub does **not** implement ICU plurals. A catalog entry like
   `{count, plural, one {# session} other {# sessions}}` renders verbatim —
   never assert on those strings.
+- **`toHaveTextContent` is a SUBSTRING match.** `toHaveTextContent("assign-1")`
+  passes on `"workout:assign-1"`, so the wrong-id bug survives the assertion
+  (this is the same shape as the earlier `toHaveTextContent("-")` matching
+  `"-300s"`). Anchor with a regex — `/^assign-1$/`.
+- **A `<label>` next to an input is not associated with it.** Several forms
+  (the generator's assign modal, among others) render the label as a sibling
+  with no `htmlFor` and no wrapping, so `getByLabelText` finds nothing. Address
+  those by `input[type=date|time|number]` and note it in the header.
+- **`key` never reaches props.** React consumes it, so a remount cannot be
+  asserted from a props spy. Count mounts with a `useEffect(() => …, [])`
+  inside the stubbed child.
+- **Two elements can share an accessible name across roles.** The "Back" muscle
+  chip and the "Back" nav button coexist on the generator's step 2. Filter on a
+  discriminating attribute (the chips are the only ones with `aria-pressed`).
+- **A day number rendered as `"YYYY-MM-DD".slice(8, 10)` is ZERO-PADDED.**
+  `getByText("9")` finds nothing; the cell says `"09"`.
+- **Controls disabled during a `useTransition` swallow the next interaction.**
+  A second filter pick, or a "Load more" whose label flips to "Loading…", fails
+  as a MISSING ELEMENT rather than as a wrong assertion. Wait for the control to
+  come back (`findByRole`, or `waitFor(() => expect(el).toBeEnabled())`).
 
 ### jsdom gaps that look like component bugs
 
@@ -267,6 +303,15 @@ button rather than on its own assertion:
 - **`mockReturnValue` hands back one stable object**, so a `useMemo` over it
   never recomputes and its dependent effects never re-run. Use
   `mockImplementation` when the test is about what happens on a re-fetch.
+- **`<canvas>.getContext("2d")` returns null** (the `canvas` npm package is not
+  installed), so any export-to-image path bails on its own first guard. Scope
+  the test to the state the export reads instead of the painting.
+- **Components that capture `new Date()` at mount need the clock pinned.**
+  Today/Yesterday/Overdue headings are decided against the wall clock, so a
+  suite run near local midnight silently regroups every fixture. Use
+  `jest.useFakeTimers({ now })` and wire user-event with
+  `userEvent.setup({ advanceTimers: jest.advanceTimersByTime })`, or clicks stop
+  working while the fake timers are installed.
 
 ### What does NOT exist: browser E2E
 

--- a/backoffice/README.md
+++ b/backoffice/README.md
@@ -107,6 +107,15 @@ jest.mock("@/lib/gc-fitness/workout-assignment-actions", () => ({
 jest.mock("sonner", () => ({ toast: { success: jest.fn(), error: jest.fn() } }));
 ```
 
+The import can reach you INDIRECTLY, and then the failure looks like nothing
+you wrote. `firebase-admin` depends on `jose`, which is ESM-only, so the suite
+dies at import with `SyntaxError: Unexpected token 'export'` and **zero tests
+run** — including via a shared UI helper: `exercise-multi-add-dialog` imports
+`ChipRow` from `exercise-picker-popover`, which imports `use-favorites`, which
+imports `favorites-actions`, which imports `firebase-admin`. If a suite reports
+`Tests: 0 total`, read the stack for the transitive import and mock the nearest
+hook (`@/lib/gc-fitness/use-favorites` in that case), not the leaf.
+
 **3. Translations need no provider.** `next-intl` is ESM-only at its public
 entrypoint, so `jest.config.js` maps it to `src/lib/test-utils/next-intl-stub.tsx`
 for every test. The stub resolves keys against the real **EN** catalog
@@ -193,7 +202,20 @@ single time so far it has been one of these, and only one was a weak assertion:
 - **The code is dead.** Two mechanisms implementing one contract, and the one
   you mutated isn't the one that runs (e.g. a collapsed bilingual field already
   mirrors on every keystroke, so the mirror at save time is unreachable from
-  that path). Assert the CONTRACT, and note the finding.
+  that path). Assert the CONTRACT, and cover EACH mechanism through the one path
+  where it is the only thing running — then both bite their own mutation.
+- **The fixture couldn't tell the two behaviors apart.** An exercise with a
+  single muscle group makes `.some()` and `.every()` agree; a row that is both
+  `source: "wger"` AND library-tagged can't distinguish a check on one from a
+  check on the other. Widen the fixture, not the assertion.
+- **The invariant you assumed isn't real.** Moving the exercise-library dedupe
+  from before the filters to after `searchExercises` keeps every test green,
+  because with real twins (same name, same fields) filtering and searching are
+  per-row predicates. Say so in the header instead of asserting an ordering the
+  code doesn't actually depend on.
+- **The mutation was malformed** and changed nothing (appending a `void 0`,
+  adding a second redundant call). `Tests: 0 total` or an unchanged count is the
+  tell — re-read the diff you applied before drawing a conclusion.
 
 ### Query traps that have already cost time
 

--- a/backoffice/README.md
+++ b/backoffice/README.md
@@ -234,6 +234,39 @@ single time so far it has been one of these, and only one was a weak assertion:
 - The next-intl stub caches `t` per namespace on purpose. If you see
   *Maximum update depth exceeded*, look for another hook in your test returning
   a fresh reference each render before blaming the component.
+- **Custom pill groups are not buttons.** The trend-range selector and the
+  metric switcher are `role="tab"` inside a `role="tablist"`; the muscle-group
+  chips are `role="checkbox"`. `getByRole("button", …)` misses all of them.
+- **RTL's string matcher compares the ELEMENT's whole text.** A label that
+  shares its `<p>` with a value (`Latest: 80 kg · 3 sessions`) is NOT findable
+  with `getByText("Latest:")` — scan for the element and read the child, or use
+  a function matcher.
+- **`textContent` runs adjacent nodes together.** A note followed by its date
+  reads as `Nota 112026-08-01`, so a loose `/Nota \d+/` matches across the
+  boundary. Bracket or otherwise delimit fixture markers.
+- The next-intl stub does **not** implement ICU plurals. A catalog entry like
+  `{count, plural, one {# session} other {# sessions}}` renders verbatim —
+  never assert on those strings.
+
+### jsdom gaps that look like component bugs
+
+Each of these throws INSIDE the component, so the test fails on a missing
+button rather than on its own assertion:
+
+- **`URL.createObjectURL` / `revokeObjectURL` don't exist.** Any staged-file
+  preview calls them synchronously. Shim both in a `beforeAll`.
+- **`Element.prototype.scrollTo` doesn't exist**, and there is no layout. Any
+  auto-scroll-to-bottom (the chat thread) dies on mount.
+- **Recharts renders nothing measurable** — no layout means width/height are
+  `-1` and the chart body never mounts. Assert the chart's data through a text
+  readout computed from the same array the chart receives, and say so in the
+  header.
+- **`rerender()` with the SAME element object is a no-op** — React bails out on
+  referential identity, so an effect you expect to re-run never does. Build the
+  element fresh each time.
+- **`mockReturnValue` hands back one stable object**, so a `useMemo` over it
+  never recomputes and its dependent effects never re-run. Use
+  `mockImplementation` when the test is about what happens on a re-fetch.
 
 ### What does NOT exist: browser E2E
 

--- a/backoffice/package.json
+++ b/backoffice/package.json
@@ -8,7 +8,7 @@
     "start": "next start",
     "lint": "eslint",
     "test": "jest",
-    "test:gc-fitness": "jest --testPathPattern=gc-fitness",
+    "test:gc-fitness": "jest --testPathPatterns=gc-fitness",
     "seed:gc-fitness-library": "node scripts/seed-gc-fitness-library.cjs",
     "seed:gc-fitness-standard-library": "node --experimental-transform-types scripts/sync-standard-exercise-library.ts",
     "seed:gc-fitness-standard-gifs": "node --experimental-transform-types scripts/sync-standard-exercise-gifs.ts",

--- a/backoffice/src/app/gc-fitness/admin/__tests__/app-version-form.test.tsx
+++ b/backoffice/src/app/gc-fitness/admin/__tests__/app-version-form.test.tsx
@@ -1,0 +1,265 @@
+/**
+ * @jest-environment jsdom
+ */
+
+// app-version-form.test.tsx
+//
+// The force-update gate. `minBuild` is compared by the apps against their own
+// native build number at launch, and anything below it gets a NON-DISMISSABLE
+// update screen — so a wrong value here locks every installed client out of the
+// product until someone notices and edits it back. There is no in-app recovery
+// and no gradual rollout: it takes effect on the next launch, for everyone.
+//
+// The FIRST THREE LINES of this file MUST stay as the
+// `/** @jest-environment jsdom */` docblock — the backoffice jest config
+// defaults to `testEnvironment: "node"` so without it React Testing Library
+// crashes with `ReferenceError: document is not defined`.
+//
+// That makes the two things worth pinning:
+//
+//   • `minBuild` REACHES THE ACTION AS A NUMBER. An `<input type="number">`
+//     hands react-hook-form a STRING; the Zod `coerce` is what turns it back.
+//     Written as `"42"` the mobile comparison is a string compare, where
+//     `"9" > "42"`, and the gate fires on the wrong builds.
+//   • THE BLANK FIELDS STAY BLANK-LEGAL. `latestVersion` and `storeUrl` are
+//     display-only and optional; a regex that stops admitting `""` would block
+//     saving a minBuild bump for an unrelated reason.
+//
+// Both platforms always travel together — the action writes one document, so a
+// form that submits only the edited half wipes the other one's settings.
+
+import "@testing-library/jest-dom";
+
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import React from "react";
+
+import type { AppVersionConfig } from "@/lib/gc-fitness/admin-actions";
+
+const mockUpdate = jest.fn();
+jest.mock("@/lib/gc-fitness/admin-actions", () => ({
+  updateAppVersionConfig: (...args: unknown[]) => mockUpdate(...args),
+}));
+
+const mockToastSuccess = jest.fn();
+const mockToastError = jest.fn();
+jest.mock("sonner", () => ({
+  toast: {
+    success: (...args: unknown[]) => mockToastSuccess(...args),
+    error: (...args: unknown[]) => mockToastError(...args),
+  },
+}));
+
+const mockRefresh = jest.fn();
+jest.mock("next/navigation", () => ({
+  useRouter: () => ({ refresh: () => mockRefresh() }),
+}));
+
+import { AppVersionForm } from "../app-config/app-version-form";
+
+const CONFIG: AppVersionConfig = {
+  ios: { minBuild: 42, latestVersion: "1.3.0", storeUrl: "https://apps.apple.com/app/id1" },
+  android: { minBuild: 0, latestVersion: "", storeUrl: "" },
+  updatedAtISO: "2026-09-10T15:00:00.000Z",
+  updatedBy: "manu@example.com",
+} as AppVersionConfig;
+
+function renderForm(config: AppVersionConfig = CONFIG) {
+  render(<AppVersionForm initialConfig={config} timezone="America/Argentina/Buenos_Aires" />);
+  return { user: userEvent.setup() };
+}
+
+/** The nth field with a given label — [0] is iOS, [1] is Android (render order
+ *  follows the PLATFORMS array). */
+function field(label: string, platform: "ios" | "android"): HTMLInputElement {
+  const all = screen.getAllByLabelText(label) as HTMLInputElement[];
+  return all[platform === "ios" ? 0 : 1];
+}
+
+async function save(user: ReturnType<typeof userEvent.setup>) {
+  await user.click(screen.getByRole("button", { name: "Save" }));
+}
+
+function payload() {
+  return mockUpdate.mock.calls.at(-1)?.[0];
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockUpdate.mockResolvedValue(undefined);
+});
+
+describe("AppVersionForm — the gate value", () => {
+  it("sends minBuild as a NUMBER, not the input's string", async () => {
+    // The apps compare it against a native build number. As a string, "9" is
+    // greater than "42" and the gate blocks the wrong releases.
+    const { user } = renderForm();
+
+    await user.clear(field("Minimum build", "ios"));
+    await user.type(field("Minimum build", "ios"), "57");
+    await save(user);
+
+    await waitFor(() => expect(mockUpdate).toHaveBeenCalledTimes(1));
+    expect(payload().ios.minBuild).toBe(57);
+    expect(typeof payload().ios.minBuild).toBe("number");
+  });
+
+  it("carries BOTH platforms even when only one was touched", async () => {
+    // One document; submitting half of it would clear the other platform.
+    const { user } = renderForm();
+
+    await user.clear(field("Minimum build", "ios"));
+    await user.type(field("Minimum build", "ios"), "57");
+    await save(user);
+
+    await waitFor(() => expect(mockUpdate).toHaveBeenCalledTimes(1));
+    expect(payload()).toEqual({
+      ios: { minBuild: 57, latestVersion: "1.3.0", storeUrl: "https://apps.apple.com/app/id1" },
+      android: { minBuild: 0, latestVersion: "", storeUrl: "" },
+    });
+  });
+
+  it("accepts 0, which is how the gate is switched OFF", async () => {
+    const { user } = renderForm();
+
+    await user.clear(field("Minimum build", "ios"));
+    await user.type(field("Minimum build", "ios"), "0");
+    await save(user);
+
+    await waitFor(() => expect(mockUpdate).toHaveBeenCalledTimes(1));
+    expect(payload().ios.minBuild).toBe(0);
+  });
+
+  it("REFUSES a negative build instead of writing it", async () => {
+    // TWO layers, and this one is the browser's: the input carries `min={0}`
+    // and `step={1}`, so native constraint validation blocks the submit before
+    // react-hook-form runs. jsdom shows no bubble, so the observable effect
+    // here is only that the value does NOT reach the action — asserting a Zod
+    // message would be asserting something a real browser never reaches either.
+    const { user } = renderForm();
+
+    await user.clear(field("Minimum build", "ios"));
+    await user.type(field("Minimum build", "ios"), "-1");
+    await save(user);
+
+    expect(field("Minimum build", "ios").validity.valid).toBe(false);
+    expect(mockUpdate).not.toHaveBeenCalled();
+  });
+
+  it("REFUSES a fractional build", async () => {
+    // Same layer: `step={1}` makes 1.5 natively invalid.
+    const { user } = renderForm();
+
+    await user.clear(field("Minimum build", "ios"));
+    await user.type(field("Minimum build", "ios"), "1.5");
+    await save(user);
+
+    expect(field("Minimum build", "ios").validity.valid).toBe(false);
+    expect(mockUpdate).not.toHaveBeenCalled();
+  });
+
+  it("REFUSES a build past the int32 ceiling, with a message", async () => {
+    // The SECOND layer. There is no `max` attribute, so the browser accepts
+    // this and Zod is what stops it — the only minBuild path where the inline
+    // error is actually reachable.
+    const { user } = renderForm();
+
+    await user.clear(field("Minimum build", "ios"));
+    await user.type(field("Minimum build", "ios"), "99999999999");
+    await save(user);
+
+    expect(await screen.findByText("Too large.")).toBeInTheDocument();
+    expect(mockUpdate).not.toHaveBeenCalled();
+  });
+});
+
+describe("AppVersionForm — the display-only fields", () => {
+  it("lets both stay blank", async () => {
+    // They are optional; a validator that stopped admitting "" would block an
+    // urgent minBuild bump for an unrelated reason.
+    const { user } = renderForm();
+
+    await user.clear(field("Latest version", "ios"));
+    await user.clear(field("Store URL", "ios"));
+    await save(user);
+
+    await waitFor(() => expect(mockUpdate).toHaveBeenCalledTimes(1));
+    expect(payload().ios).toMatchObject({ latestVersion: "", storeUrl: "" });
+  });
+
+  it("refuses a version that is not dotted digits", async () => {
+    const { user } = renderForm();
+
+    await user.clear(field("Latest version", "ios"));
+    await user.type(field("Latest version", "ios"), "v1.3-beta");
+    await save(user);
+
+    expect(
+      await screen.findByText("Use a dotted version like 1.2.0 (or leave blank)."),
+    ).toBeInTheDocument();
+    expect(mockUpdate).not.toHaveBeenCalled();
+  });
+
+  it("refuses a store URL that is not http(s)", async () => {
+    // The update button opens it; a non-http value is a dead button on the one
+    // screen the client cannot dismiss.
+    const { user } = renderForm();
+
+    await user.clear(field("Store URL", "android"));
+    await user.type(field("Store URL", "android"), "market://details?id=x");
+    await save(user);
+
+    expect(
+      await screen.findByText("Must be an http(s) URL (or leave blank)."),
+    ).toBeInTheDocument();
+    expect(mockUpdate).not.toHaveBeenCalled();
+  });
+
+  it("trims what it does send", async () => {
+    const { user } = renderForm();
+
+    await user.clear(field("Latest version", "android"));
+    await user.type(field("Latest version", "android"), "  2.0.1  ");
+    await save(user);
+
+    await waitFor(() => expect(mockUpdate).toHaveBeenCalledTimes(1));
+    expect(payload().android.latestVersion).toBe("2.0.1");
+  });
+});
+
+describe("AppVersionForm — what the admin is told", () => {
+  it("confirms and refreshes on success", async () => {
+    const { user } = renderForm();
+
+    await save(user);
+
+    await waitFor(() =>
+      expect(mockToastSuccess).toHaveBeenCalledWith("App version requirements saved."),
+    );
+    expect(mockRefresh).toHaveBeenCalled();
+  });
+
+  it("surfaces the server's message and does NOT claim it saved", async () => {
+    mockUpdate.mockRejectedValue(new Error("Forbidden"));
+    const { user } = renderForm();
+
+    await save(user);
+
+    await waitFor(() => expect(mockToastError).toHaveBeenCalledWith("Forbidden"));
+    expect(mockToastSuccess).not.toHaveBeenCalled();
+    expect(mockRefresh).not.toHaveBeenCalled();
+  });
+
+  it("shows who last touched the gate, and when", async () => {
+    // The audit line is the only trace of a change that can lock everyone out.
+    renderForm();
+
+    expect(screen.getByText(/by manu@example\.com/)).toBeInTheDocument();
+  });
+
+  it("omits the audit line when the document has never been written", async () => {
+    renderForm({ ...CONFIG, updatedAtISO: null, updatedBy: null } as AppVersionConfig);
+
+    expect(screen.queryByText(/Last updated/)).not.toBeInTheDocument();
+  });
+});

--- a/backoffice/src/app/gc-fitness/admin/__tests__/data-hygiene-feed.test.tsx
+++ b/backoffice/src/app/gc-fitness/admin/__tests__/data-hygiene-feed.test.tsx
@@ -1,0 +1,253 @@
+/**
+ * @jest-environment jsdom
+ */
+
+// data-hygiene-feed.test.tsx
+//
+// The admin's delete-from-Firestore surface. Every row is a `<form>` whose
+// HIDDEN FIELDS are the entire payload — `purgeDataHygieneItem` reads nothing
+// else. That makes this the cheapest possible place for a silent data bug: a
+// field that stops being rendered doesn't throw, it just deletes less than the
+// operator was told it would (a photo doc without its `storagePath` leaves the
+// Storage object orphaned, which is the very anomaly this page exists to find).
+//
+// The FIRST THREE LINES of this file MUST stay as the
+// `/** @jest-environment jsdom */` docblock — the backoffice jest config
+// defaults to `testEnvironment: "node"` so without it React Testing Library
+// crashes with `ReferenceError: document is not defined`.
+//
+// Also pinned: the `window.confirm` gate. It is the only thing between a
+// mis-click and an irreversible delete, and `preventDefault` on a submit
+// button is easy to break without any visible symptom until the day someone
+// cancels the dialog and the record disappears anyway.
+
+import "@testing-library/jest-dom";
+
+import { fireEvent, render, screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import React from "react";
+
+import type {
+  DataHygienePage,
+  DataHygieneRow,
+} from "@/lib/gc-fitness/data-hygiene-actions";
+
+const mockListPage = jest.fn();
+const mockPurge = jest.fn();
+jest.mock("@/lib/gc-fitness/data-hygiene-actions", () => ({
+  listDataHygienePage: (...args: unknown[]) => mockListPage(...args),
+  purgeDataHygieneItem: (...args: unknown[]) => mockPurge(...args),
+}));
+
+import { DataHygieneFeed } from "../hygiene/DataHygieneFeed";
+
+const EMPTY_SUMMARY: DataHygienePage["summary"] = {
+  user: 0,
+  chat: 0,
+  photo: 0,
+  template: 0,
+  assignment: 0,
+  log: 0,
+  exercise: 0,
+};
+
+function row(overrides: Partial<DataHygieneRow> = {}): DataHygieneRow {
+  return {
+    id: "row-1",
+    kind: "photo",
+    title: "Progress photo",
+    detail: "clients/ana",
+    issue: "Storage object with no Firestore doc",
+    sortAtISO: "2026-09-10T15:00:00.000Z",
+    ...overrides,
+  } as DataHygieneRow;
+}
+
+function page(overrides: Partial<DataHygienePage> = {}): DataHygienePage {
+  return {
+    rows: [],
+    nextOffset: 20,
+    hasMore: true,
+    summary: EMPTY_SUMMARY,
+    ...overrides,
+  } as DataHygienePage;
+}
+
+function renderFeed(initial: DataHygienePage, loadError: string | null = null) {
+  render(<DataHygieneFeed initialPage={initial} loadError={loadError} />);
+  return { user: userEvent.setup() };
+}
+
+/** Every hidden input of the row form, as a plain object. */
+function hiddenFields(index = 0): Record<string, string> {
+  const form = document.querySelectorAll("form")[index];
+  return Object.fromEntries(
+    Array.from(form.querySelectorAll<HTMLInputElement>('input[type="hidden"]')).map(
+      (input) => [input.name, input.value],
+    ),
+  );
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockListPage.mockResolvedValue(page({ rows: [], nextOffset: null, hasMore: false }));
+});
+
+describe("DataHygieneFeed — what the delete form actually carries", () => {
+  it("always sends the kind and the id", () => {
+    renderFeed(page({ rows: [row({ kind: "log", id: "log-9" })] }));
+
+    expect(hiddenFields()).toMatchObject({ kind: "log", id: "log-9" });
+  });
+
+  it("carries the STORAGE PATH of a photo, so the object goes too", () => {
+    // Without it the Firestore doc is deleted and the file stays behind —
+    // which is exactly the "orphaned image" anomaly this page reports.
+    renderFeed(
+      page({
+        rows: [
+          row({
+            kind: "photo",
+            id: "photo-1",
+            photoId: "photo-1",
+            storagePath: "progress_photos/ana/1.jpg",
+            userId: "ana",
+          }),
+        ],
+      }),
+    );
+
+    expect(hiddenFields()).toEqual({
+      kind: "photo",
+      id: "photo-1",
+      userId: "ana",
+      photoId: "photo-1",
+      storagePath: "progress_photos/ana/1.jpg",
+    });
+  });
+
+  it("carries the role alongside a user, and the owner alongside an exercise", () => {
+    renderFeed(
+      page({
+        rows: [
+          row({ kind: "user", id: "u1", userId: "u1", userRole: "client" }),
+          row({ kind: "exercise", id: "e1", exerciseId: "e1", ownerId: "coach-1", source: "trainer" }),
+        ],
+      }),
+    );
+
+    expect(hiddenFields(0)).toMatchObject({ role: "client", userId: "u1" });
+    expect(hiddenFields(1)).toMatchObject({ ownerId: "coach-1", source: "trainer" });
+  });
+
+  it("OMITS an absent field rather than sending an empty string", () => {
+    // `String(formData.get("storagePath"))` on an empty input is `""`, which is
+    // a value: the action would try to delete an object at path "".
+    renderFeed(page({ rows: [row({ kind: "photo", id: "photo-1", storagePath: null })] }));
+
+    expect(hiddenFields()).not.toHaveProperty("storagePath");
+  });
+});
+
+describe("DataHygieneFeed — the confirm gate", () => {
+  it("lets the submit through when the operator confirms", async () => {
+    const confirmSpy = jest.spyOn(window, "confirm").mockReturnValue(true);
+    renderFeed(page({ rows: [row({ kind: "log" })] }));
+
+    const event = fireEvent.click(screen.getByRole("button", { name: "Delete from DB" }));
+
+    expect(confirmSpy).toHaveBeenCalledWith(
+      "Delete this log record from Firestore?",
+    );
+    expect(event).toBe(true); // not prevented
+    confirmSpy.mockRestore();
+  });
+
+  it("CANCELS the submit when the operator says no", async () => {
+    const confirmSpy = jest.spyOn(window, "confirm").mockReturnValue(false);
+    renderFeed(page({ rows: [row()] }));
+
+    const event = fireEvent.click(screen.getByRole("button", { name: "Delete from DB" }));
+
+    expect(event).toBe(false); // preventDefault() ran
+    confirmSpy.mockRestore();
+  });
+});
+
+describe("DataHygieneFeed — the summary and the list", () => {
+  it("folds the four workout kinds into one number", () => {
+    // template + assignment + log + exercise. A missing addend understates the
+    // backlog and the operator stops paging.
+    renderFeed(
+      page({
+        summary: { ...EMPTY_SUMMARY, template: 1, assignment: 2, log: 3, exercise: 4, user: 5 },
+      }),
+    );
+
+    const workouts = screen.getByText("Workouts").closest("div") as HTMLElement;
+    expect(within(workouts).getByText("10")).toBeInTheDocument();
+  });
+
+  it("totals every kind, workouts included", () => {
+    renderFeed(
+      page({
+        summary: { ...EMPTY_SUMMARY, user: 5, chat: 1, photo: 1, template: 1 },
+      }),
+    );
+
+    const total = screen.getByText("Total").closest("div") as HTMLElement;
+    expect(within(total).getByText("8")).toBeInTheDocument();
+  });
+
+  it("says the scan is clean instead of showing an empty list", () => {
+    renderFeed(page({ rows: [], hasMore: false }));
+
+    expect(
+      screen.getByText("No anomalies found in the current scan window."),
+    ).toBeInTheDocument();
+  });
+
+  it("keeps the page usable when the initial scan failed", () => {
+    // The scan is best-effort; a failure must not blank the admin page.
+    renderFeed(page({ rows: [row()], hasMore: false }), "index missing");
+
+    expect(screen.getByText("Hygiene scan could not load")).toBeInTheDocument();
+    expect(screen.getByText("index missing")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Delete from DB" })).toBeInTheDocument();
+  });
+});
+
+describe("DataHygieneFeed — paging", () => {
+  it("asks for the NEXT offset the server handed back", async () => {
+    const { user } = renderFeed(page({ rows: [row()], nextOffset: 40, hasMore: true }));
+
+    await user.click(screen.getByRole("button", { name: "Cargar más" }));
+
+    await waitFor(() => expect(mockListPage).toHaveBeenCalledWith(40, 20));
+  });
+
+  it("appends and refreshes the summary from the new page", async () => {
+    mockListPage.mockResolvedValue(
+      page({
+        rows: [row({ id: "row-2", title: "Orphaned chat" })],
+        nextOffset: null,
+        hasMore: false,
+        summary: { ...EMPTY_SUMMARY, user: 7 },
+      }),
+    );
+    const { user } = renderFeed(page({ rows: [row({ id: "row-1", title: "Progress photo" })] }));
+
+    await user.click(screen.getByRole("button", { name: "Cargar más" }));
+
+    await waitFor(() => expect(screen.getByText("Orphaned chat")).toBeInTheDocument());
+    expect(screen.getByText("Progress photo")).toBeInTheDocument();
+    const total = screen.getByText("Total").closest("div") as HTMLElement;
+    expect(within(total).getByText("7")).toBeInTheDocument();
+  });
+
+  it("does not offer to page when the server says there is nothing left", () => {
+    renderFeed(page({ rows: [row()], nextOffset: null, hasMore: false }));
+
+    expect(screen.queryByRole("button", { name: "Cargar más" })).not.toBeInTheDocument();
+  });
+});

--- a/backoffice/src/app/gc-fitness/chat/_components/__tests__/chat-conversation.test.tsx
+++ b/backoffice/src/app/gc-fitness/chat/_components/__tests__/chat-conversation.test.tsx
@@ -1,0 +1,452 @@
+/**
+ * @jest-environment jsdom
+ */
+
+// chat-conversation.test.tsx
+//
+// The open thread: what order the messages are in, what gets marked read, and
+// which message a reply is attached to.
+//
+// The FIRST THREE LINES of this file MUST stay as the
+// `/** @jest-environment jsdom */` docblock — the backoffice jest config
+// defaults to `testEnvironment: "node"` so without it React Testing Library
+// crashes with `ReferenceError: document is not defined`.
+//
+// Four derivations, each with a quiet failure mode:
+//
+//   • THE ORDER IS REBUILT, NOT RECEIVED. `useInfiniteQuery` APPENDS each older
+//     page, so the flattened array is [newest-page, older-page, …] — literally
+//     backwards. The component re-sorts ascending by `createdAt`, and a message
+//     still in flight (no `createdAt` yet) sorts to the very BOTTOM via
+//     `+Infinity`. Sorting it as 0 would park the coach's own just-sent message
+//     at the top of the history, above messages from last year.
+//   • "SEEN" NEVER HOPS BACKWARDS. The receipt goes under the trainer's MOST
+//     RECENT own message and only when the client has actually read that one.
+//     Walking forward instead of backward parks a "Seen" halfway up the thread
+//     while newer messages sit unread — the coach reads it as "they saw my last
+//     message" when they didn't.
+//   • READ RECEIPTS ARE FOR THE PARTNER'S MESSAGES ONLY, once each. Marking
+//     your own messages read is a write per render for nothing; re-marking on
+//     every 10s poll is the same write in a loop, which is what the dedupe ref
+//     exists to stop.
+//   • THE STAGED REPLY IS PER-THREAD. Switching clients while a reply is staged
+//     must drop it, or the next message quotes something from a DIFFERENT
+//     client's conversation — and the quote renders with the new partner's
+//     name on it.
+
+import "@testing-library/jest-dom";
+
+import { render, screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import React from "react";
+
+import type { MessageRow } from "@/lib/gc-fitness/chat-schema";
+
+const mockUseChatMessages = jest.fn();
+const mockFetchNextPage = jest.fn();
+jest.mock("@/lib/gc-fitness/chat-listener", () => ({
+  CHATS_BASE_KEY: ["gc-fitness", "chats"],
+  useChatMessages: (...args: unknown[]) => mockUseChatMessages(...args),
+}));
+
+const mockSetReadReceipt = jest.fn();
+const mockMarkChatRead = jest.fn();
+const mockDeleteMessage = jest.fn();
+const mockSetReaction = jest.fn();
+jest.mock("@/lib/gc-fitness/chat-server-actions", () => ({
+  setReadReceiptForTrainer: (...args: unknown[]) => mockSetReadReceipt(...args),
+  markChatReadForTrainer: (...args: unknown[]) => mockMarkChatRead(...args),
+  deleteTrainerChatMessage: (...args: unknown[]) => mockDeleteMessage(...args),
+  setTrainerMessageReaction: (...args: unknown[]) => mockSetReaction(...args),
+  getChatAttachmentUrl: jest.fn().mockResolvedValue(null),
+  sendTrainerMessage: jest.fn(),
+  uploadTrainerChatAttachment: jest.fn(),
+}));
+
+// The composer has its own regression file; here it only needs to report the
+// reply props that cross the boundary.
+const mockMessageInputProps = jest.fn();
+jest.mock("../MessageInput", () => ({
+  MessageInput: (props: {
+    chatId: string;
+    disabled?: boolean;
+    replyingTo?: { id: string; text?: string } | null;
+    replyAuthorLabel?: string;
+  }) => {
+    mockMessageInputProps(props);
+    return (
+      <div data-testid="composer">
+        <span data-testid="composer-reply-id">{props.replyingTo?.id ?? ""}</span>
+        <span data-testid="composer-reply-author">
+          {props.replyAuthorLabel ?? ""}
+        </span>
+        <span data-testid="composer-disabled">{String(props.disabled)}</span>
+      </div>
+    );
+  },
+}));
+
+jest.mock("sonner", () => ({
+  toast: { success: jest.fn(), error: jest.fn() },
+}));
+
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { ChatConversation } from "../ChatConversation";
+
+const TRAINER = "trainer-1";
+const CLIENT = "ana";
+const TZ = "America/Argentina/Buenos_Aires";
+
+const ROSTER = [
+  { uid: CLIENT, displayName: "Ana Gomez", email: "ana@example.com", photoURL: null },
+  { uid: "beto", displayName: "Beto Diaz", email: "beto@example.com", photoURL: null },
+] as unknown as React.ComponentProps<typeof ChatConversation>["clientRoster"];
+
+function message(overrides: Partial<MessageRow> = {}): MessageRow {
+  return {
+    id: "m1",
+    senderId: CLIENT,
+    kind: "text",
+    text: "Hola coach",
+    createdAt: "2026-08-05T12:00:00.000Z",
+    readBy: {},
+    ...overrides,
+  } as MessageRow;
+}
+
+/** `pages` mirrors useInfiniteQuery: page 0 is the NEWEST slice. */
+function renderThread(
+  pages: MessageRow[][],
+  props: Partial<React.ComponentProps<typeof ChatConversation>> = {},
+) {
+  mockUseChatMessages.mockReturnValue({
+    data: { pages },
+    isLoading: false,
+    error: null,
+    hasNextPage: false,
+    fetchNextPage: mockFetchNextPage,
+    isFetchingNextPage: false,
+  });
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  const view = render(
+    <QueryClientProvider client={client}>
+      <ChatConversation
+        chatId={CLIENT}
+        trainerUid={TRAINER}
+        timezone={TZ}
+        clientRoster={ROSTER}
+        {...props}
+      />
+    </QueryClientProvider>,
+  );
+  return { user: userEvent.setup(), ...view, client };
+}
+
+/** The rendered thread as one string, for order assertions. */
+function threadText(): string {
+  return document.body.textContent ?? "";
+}
+
+/** The bubble element containing `text` — bubbles carry no test id. */
+function bubbleContaining(text: string): HTMLElement {
+  const node = screen.getByText(text).closest("div.rounded-2xl");
+  if (!node) throw new Error(`bubble for "${text}" not found`);
+  return node as HTMLElement;
+}
+
+// jsdom implements neither `Element.scrollTo` nor layout, and the thread
+// auto-scrolls to the newest message on mount — without this shim every test
+// dies inside `scrollToBottom` with "node.scrollTo is not a function", which
+// looks like a component bug and is not one.
+beforeAll(() => {
+  Object.defineProperty(Element.prototype, "scrollTo", {
+    writable: true,
+    value: jest.fn(),
+  });
+});
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockMarkChatRead.mockResolvedValue(undefined);
+  mockSetReadReceipt.mockResolvedValue(undefined);
+});
+
+describe("ChatConversation — the order is rebuilt", () => {
+  it("puts the older PAGE above the newer one", async () => {
+    renderThread([
+      // page 0 = newest slice, exactly how useInfiniteQuery hands it over
+      [message({ id: "new", text: "El más nuevo", createdAt: "2026-08-05T12:00:00.000Z" })],
+      [message({ id: "old", text: "El más viejo", createdAt: "2026-08-01T09:00:00.000Z" })],
+    ]);
+
+    const thread = threadText();
+    expect(thread.indexOf("El más viejo")).toBeLessThan(
+      thread.indexOf("El más nuevo"),
+    );
+  });
+
+  it("sorts a still-sending message to the BOTTOM, not the top", async () => {
+    renderThread([
+      [
+        message({ id: "pending", text: "Yendo", createdAt: null }),
+        message({ id: "old", text: "Anterior", createdAt: "2026-08-01T09:00:00.000Z" }),
+      ],
+    ]);
+
+    // A pending send has no server timestamp yet. Treating that as 0 parks the
+    // coach's own message above a year of history.
+    const thread = threadText();
+    expect(thread.indexOf("Anterior")).toBeLessThan(thread.indexOf("Yendo"));
+  });
+
+  it("separates the days it actually spans", () => {
+    renderThread([
+      [
+        message({ id: "a", text: "Lunes", createdAt: "2026-08-03T14:00:00.000Z" }),
+        message({ id: "b", text: "Martes", createdAt: "2026-08-04T14:00:00.000Z" }),
+        message({ id: "c", text: "Martes otra vez", createdAt: "2026-08-04T18:00:00.000Z" }),
+      ],
+    ]);
+
+    // Two days, two separators — one per bucket, not one per message.
+    const separators = document.querySelectorAll(".h-px");
+    // Each separator renders two hairlines (one on each side of the label).
+    expect(separators.length).toBe(4);
+  });
+});
+
+describe("ChatConversation — the 'Seen' receipt", () => {
+  it("sits under the trainer's MOST RECENT own message", () => {
+    renderThread([
+      [
+        message({
+          id: "mine-old",
+          senderId: TRAINER,
+          text: "Primero",
+          createdAt: "2026-08-01T09:00:00.000Z",
+          readBy: { [CLIENT]: "2026-08-01T10:00:00.000Z" },
+        }),
+        message({
+          id: "mine-new",
+          senderId: TRAINER,
+          text: "Segundo",
+          createdAt: "2026-08-05T09:00:00.000Z",
+          readBy: { [CLIENT]: "2026-08-05T10:00:00.000Z" },
+        }),
+      ],
+    ]);
+
+    // The receipt must sit inside the NEWEST own bubble, not the older one.
+    expect(bubbleContaining("Segundo")).toHaveTextContent("Seen");
+    expect(bubbleContaining("Primero")).not.toHaveTextContent("Seen");
+  });
+
+  it("shows NO receipt when the newest own message is still unread", () => {
+    renderThread([
+      [
+        message({
+          id: "mine-old",
+          senderId: TRAINER,
+          text: "Primero",
+          createdAt: "2026-08-01T09:00:00.000Z",
+          readBy: { [CLIENT]: "2026-08-01T10:00:00.000Z" },
+        }),
+        message({
+          id: "mine-new",
+          senderId: TRAINER,
+          text: "Segundo",
+          createdAt: "2026-08-05T09:00:00.000Z",
+          readBy: {},
+        }),
+      ],
+    ]);
+
+    // Hopping the receipt back to the older message reads as "they saw my last
+    // message" when they did not.
+    expect(screen.queryByText("Seen")).not.toBeInTheDocument();
+  });
+
+  it("never puts a receipt on the CLIENT's own message", () => {
+    renderThread([
+      [
+        message({
+          id: "theirs",
+          senderId: CLIENT,
+          text: "Hola",
+          createdAt: "2026-08-05T09:00:00.000Z",
+          readBy: { [CLIENT]: "2026-08-05T09:00:00.000Z" },
+        }),
+      ],
+    ]);
+
+    expect(screen.queryByText("Seen")).not.toBeInTheDocument();
+  });
+});
+
+describe("ChatConversation — read receipts", () => {
+  it("marks the partner's unread messages, once each", async () => {
+    renderThread([
+      [
+        message({ id: "unread-1", senderId: CLIENT, readBy: {} }),
+        message({ id: "unread-2", senderId: CLIENT, readBy: {}, createdAt: "2026-08-05T12:01:00.000Z" }),
+      ],
+    ]);
+
+    await waitFor(() => expect(mockSetReadReceipt).toHaveBeenCalledTimes(2));
+    expect(mockSetReadReceipt).toHaveBeenCalledWith(CLIENT, "unread-1");
+    expect(mockSetReadReceipt).toHaveBeenCalledWith(CLIENT, "unread-2");
+  });
+
+  it("skips messages the trainer sent", async () => {
+    renderThread([
+      [
+        message({ id: "mine", senderId: TRAINER, readBy: {} }),
+        message({ id: "theirs", senderId: CLIENT, readBy: {} }),
+      ],
+    ]);
+
+    await waitFor(() => expect(mockSetReadReceipt).toHaveBeenCalledTimes(1));
+    // Marking your own message read is a Firestore write per render for nothing.
+    expect(mockSetReadReceipt).toHaveBeenCalledWith(CLIENT, "theirs");
+  });
+
+  it("skips messages already marked read by this trainer", async () => {
+    renderThread([
+      [
+        message({
+          id: "already",
+          senderId: CLIENT,
+          readBy: { [TRAINER]: "2026-08-05T12:30:00.000Z" },
+        }),
+      ],
+    ]);
+
+    // Give the effect a chance to fire before asserting it didn't.
+    await waitFor(() => expect(mockMarkChatRead).toHaveBeenCalled());
+    expect(mockSetReadReceipt).not.toHaveBeenCalled();
+  });
+
+  it("does NOT re-fire when a poll returns the same unread message", async () => {
+    // React Query polls every 10s; the poll that lands before the `readBy`
+    // write propagates hands back a FRESH array with the same, still-unread
+    // message. Without the dedupe ref that re-fires the write every 10s.
+    //
+    // `mockImplementation`, not `mockReturnValue`: a stable object reference
+    // makes the `messages` memo skip recomputation and the effect never re-runs
+    // at all, so the test passes with or without the ref. (Verified — that is
+    // exactly why deleting the ref first came back green.)
+    mockUseChatMessages.mockImplementation(() => ({
+      data: { pages: [[message({ id: "unread-1", senderId: CLIENT, readBy: {} })]] },
+      isLoading: false,
+      error: null,
+      hasNextPage: false,
+      fetchNextPage: mockFetchNextPage,
+      isFetchingNextPage: false,
+    }));
+    const client = new QueryClient({
+      defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+    });
+    // A FRESH element each time: React bails out of re-rendering when the
+    // element passed to `rerender` is referentially identical, so reusing one
+    // `tree` object skips the render entirely and the effect never re-runs.
+    const tree = () => (
+      <QueryClientProvider client={client}>
+        <ChatConversation
+          chatId={CLIENT}
+          trainerUid={TRAINER}
+          timezone={TZ}
+          clientRoster={ROSTER}
+        />
+      </QueryClientProvider>
+    );
+    const { rerender } = render(tree());
+    await waitFor(() => expect(mockSetReadReceipt).toHaveBeenCalledTimes(1));
+
+    rerender(tree());
+    rerender(tree());
+
+    await waitFor(() => expect(mockMarkChatRead).toHaveBeenCalled());
+    expect(mockSetReadReceipt).toHaveBeenCalledTimes(1);
+  });
+
+  it("zeroes the thread's unread badge on open", async () => {
+    renderThread([[message()]]);
+
+    // The fast path: one round-trip clears the inbox row + sidebar badge
+    // instead of waiting for the per-message readBy fan-in.
+    await waitFor(() => expect(mockMarkChatRead).toHaveBeenCalledWith(CLIENT));
+  });
+});
+
+describe("ChatConversation — the staged reply", () => {
+  it("hands the quoted message to the composer with the partner's name", async () => {
+    const { user } = renderThread([
+      [message({ id: "m1", senderId: CLIENT, text: "¿Cambio el jueves?" })],
+    ]);
+
+    await user.click(screen.getByRole("button", { name: "Reply" }));
+
+    expect(screen.getByTestId("composer-reply-id")).toHaveTextContent("m1");
+    expect(screen.getByTestId("composer-reply-author")).toHaveTextContent("Ana Gomez");
+  });
+
+  it("labels the trainer's own message as 'You'", async () => {
+    const { user } = renderThread([
+      [message({ id: "mine", senderId: TRAINER, text: "Dale" })],
+    ]);
+
+    await user.click(screen.getByRole("button", { name: "Reply" }));
+
+    expect(screen.getByTestId("composer-reply-author")).toHaveTextContent("You");
+  });
+
+  it("DROPS the staged reply when the coach switches client", async () => {
+    const { user, rerender, client } = renderThread([
+      [message({ id: "m1", senderId: CLIENT, text: "¿Cambio el jueves?" })],
+    ]);
+    await user.click(screen.getByRole("button", { name: "Reply" }));
+    expect(screen.getByTestId("composer-reply-id")).toHaveTextContent("m1");
+
+    mockUseChatMessages.mockReturnValue({
+      data: { pages: [[message({ id: "b1", senderId: "beto" })]] },
+      isLoading: false,
+      error: null,
+      hasNextPage: false,
+      fetchNextPage: mockFetchNextPage,
+      isFetchingNextPage: false,
+    });
+    rerender(
+      <QueryClientProvider client={client}>
+        <ChatConversation
+          chatId="beto"
+          trainerUid={TRAINER}
+          timezone={TZ}
+          clientRoster={ROSTER}
+        />
+      </QueryClientProvider>,
+    );
+
+    // Carrying it over quotes a message from ANOTHER client's thread, and the
+    // quote renders under the new partner's name.
+    await waitFor(() =>
+      expect(screen.getByTestId("composer-reply-id")).toHaveTextContent(""),
+    );
+  });
+});
+
+describe("ChatConversation — a pending client", () => {
+  it("passes the block down to the composer", () => {
+    renderThread([[message()]], { isPendingClient: true });
+
+    expect(screen.getByTestId("composer-disabled")).toHaveTextContent("true");
+  });
+
+  it("still renders the history so the coach can read it", () => {
+    renderThread([[message({ text: "Hola coach" })]], { isPendingClient: true });
+
+    // Blocked from replying is not the same as blocked from looking.
+    expect(screen.getByText("Hola coach")).toBeInTheDocument();
+  });
+});

--- a/backoffice/src/app/gc-fitness/chat/_components/__tests__/chat-thread-list.test.tsx
+++ b/backoffice/src/app/gc-fitness/chat/_components/__tests__/chat-thread-list.test.tsx
@@ -1,0 +1,373 @@
+/**
+ * @jest-environment jsdom
+ */
+
+// chat-thread-list.test.tsx
+//
+// The trainer inbox's left pane: which conversations exist, in what order, and
+// which of them are shouting for attention.
+//
+// The FIRST THREE LINES of this file MUST stay as the
+// `/** @jest-environment jsdom */` docblock — the backoffice jest config
+// defaults to `testEnvironment: "node"` so without it React Testing Library
+// crashes with `ReferenceError: document is not defined`.
+//
+// Everything on this pane is a derivation, and the failures are all silent:
+//
+//   • UNREAD IS PER-UID. The count lives at `unreadCount[trainerUid]` — the
+//     same map also carries the CLIENT's count. Reading the wrong key (or a
+//     total) shows the coach a badge for messages the coach themselves sent,
+//     or hides a real one. Firestore can't compositely index a dot-path map
+//     with a variable key, which is why this sort is client-side at all.
+//   • THE SORT IS unread DESC, THEN RECENCY DESC. A thread with unread
+//     messages that sinks below the fold is a client waiting for an answer
+//     nobody sees.
+//   • EVERY ROSTER CLIENT APPEARS, even with no chat doc yet. The parent doc
+//     is created by the first message, so a never-messaged client would be
+//     unreachable from the inbox — the coach cannot start the conversation
+//     with someone who isn't listed.
+//   • THE PREVIEW IS BY KIND. An image or a voice note has no text to show;
+//     falling through to the raw `text` field prints an empty preview and the
+//     thread reads as "(nothing here)".
+//
+// The timestamp fallback chain (`lastMessageAt ?? lastMessage.createdAt ??
+// updatedAt ?? createdAt`) exists for the brief denorm race where the chat doc
+// is written before the Cloud Function stamps `lastMessageAt`. A thread in that
+// window must not sort as if it were from 1970.
+
+import "@testing-library/jest-dom";
+
+import { render, screen, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import React from "react";
+
+import type { ChatRow } from "@/lib/gc-fitness/chat-schema";
+
+const mockUseTrainerChats = jest.fn();
+jest.mock("@/lib/gc-fitness/chat-listener", () => ({
+  useTrainerChats: () => mockUseTrainerChats(),
+}));
+
+import { ChatThreadList } from "../ChatThreadList";
+
+const TRAINER = "trainer-1";
+const TZ = "America/Argentina/Buenos_Aires";
+
+const ROSTER = [
+  { uid: "ana", displayName: "Ana Gomez", email: "ana@example.com", photoURL: null },
+  { uid: "beto", displayName: "Beto Diaz", email: "beto@example.com", photoURL: null },
+  { uid: "caro", displayName: "Caro Ruiz", email: "caro@example.com", photoURL: null },
+] as unknown as React.ComponentProps<typeof ChatThreadList>["clientRoster"];
+
+function chat(overrides: Partial<ChatRow> = {}): ChatRow {
+  return {
+    id: "ana",
+    clientId: "ana",
+    coachId: TRAINER,
+    lastMessage: {
+      text: "Hola coach",
+      senderId: "ana",
+      createdAt: "2026-08-05T12:00:00.000Z",
+      kind: "text",
+    },
+    lastMessageAt: "2026-08-05T12:00:00.000Z",
+    unreadCount: {},
+    createdAt: null,
+    updatedAt: null,
+    ...overrides,
+  } as ChatRow;
+}
+
+function renderList(
+  rows: ChatRow[],
+  roster = ROSTER,
+  state: { isLoading?: boolean; error?: unknown } = {},
+) {
+  mockUseTrainerChats.mockReturnValue({
+    data: rows,
+    isLoading: state.isLoading ?? false,
+    error: state.error ?? null,
+  });
+  const onSelect = jest.fn();
+  render(
+    <ChatThreadList
+      trainerUid={TRAINER}
+      timezone={TZ}
+      activeChatId={null}
+      onSelect={onSelect}
+      clientRoster={roster}
+    />,
+  );
+  return { onSelect };
+}
+
+/**
+ * Thread rows in DOM order, by the client name each one shows.
+ *
+ * `queryAllByRole`, not `getAllByRole`: a filter that matches nothing leaves
+ * the list with zero buttons, and the `get*` variant throws instead of
+ * returning the empty array the assertion is about.
+ */
+function rowNames(): string[] {
+  return screen
+    .queryAllByRole("button")
+    .filter((b) => b.querySelector(".font-semibold"))
+    .map((b) => b.querySelector(".font-semibold")?.textContent ?? "");
+}
+
+function rowFor(name: string): HTMLElement {
+  const node = screen.getByText(name).closest("button");
+  if (!node) throw new Error(`thread row for ${name} not found`);
+  return node as HTMLElement;
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe("ChatThreadList — the unread badge is per-uid", () => {
+  it("reads the TRAINER's own entry in the unread map", () => {
+    renderList(
+      [
+        chat({
+          id: "ana",
+          clientId: "ana",
+          // The same map carries the client's count. Reading the wrong key
+          // shows the coach a badge for their own messages.
+          unreadCount: { [TRAINER]: 3, ana: 9 },
+        }),
+      ],
+      [ROSTER[0]],
+    );
+
+    expect(within(rowFor("Ana Gomez")).getByText("3")).toBeInTheDocument();
+    expect(within(rowFor("Ana Gomez")).queryByText("9")).not.toBeInTheDocument();
+  });
+
+  it("shows no badge when the trainer has nothing unread", () => {
+    renderList([chat({ unreadCount: { ana: 4 } })], [ROSTER[0]]);
+
+    const row = rowFor("Ana Gomez");
+    expect(within(row).queryByText("4")).not.toBeInTheDocument();
+  });
+});
+
+describe("ChatThreadList — the order", () => {
+  it("floats unread threads above more recent read ones", () => {
+    renderList(
+      [
+        chat({
+          id: "beto",
+          clientId: "beto",
+          lastMessageAt: "2026-08-05T18:00:00.000Z",
+          lastMessage: {
+            text: "ok",
+            senderId: TRAINER,
+            createdAt: "2026-08-05T18:00:00.000Z",
+            kind: "text",
+          },
+          unreadCount: { [TRAINER]: 0 },
+        }),
+        chat({
+          id: "ana",
+          clientId: "ana",
+          lastMessageAt: "2026-08-05T09:00:00.000Z",
+          unreadCount: { [TRAINER]: 2 },
+        }),
+      ],
+      [ROSTER[0], ROSTER[1]],
+    );
+
+    // Ana wrote earlier but is still waiting for an answer. Sorting purely by
+    // recency buries the person who needs the coach.
+    expect(rowNames()).toEqual(["Ana Gomez", "Beto Diaz"]);
+  });
+
+  it("breaks ties by recency, newest first", () => {
+    renderList(
+      [
+        chat({
+          id: "ana",
+          clientId: "ana",
+          lastMessageAt: "2026-08-01T09:00:00.000Z",
+          unreadCount: { [TRAINER]: 1 },
+        }),
+        chat({
+          id: "beto",
+          clientId: "beto",
+          lastMessageAt: "2026-08-05T09:00:00.000Z",
+          unreadCount: { [TRAINER]: 1 },
+        }),
+      ],
+      [ROSTER[0], ROSTER[1]],
+    );
+
+    expect(rowNames()).toEqual(["Beto Diaz", "Ana Gomez"]);
+  });
+
+  it("falls back down the timestamp chain when lastMessageAt is missing", () => {
+    // The denorm race: the chat doc exists but the Cloud Function hasn't
+    // written `lastMessageAt` yet. Without the fallback this thread sorts as
+    // if it had never received a message.
+    renderList(
+      [
+        chat({
+          id: "ana",
+          clientId: "ana",
+          lastMessageAt: null,
+          lastMessage: {
+            text: "recién llegado",
+            senderId: "ana",
+            createdAt: "2026-08-05T23:00:00.000Z",
+            kind: "text",
+          },
+          unreadCount: {},
+        }),
+        chat({
+          id: "beto",
+          clientId: "beto",
+          lastMessageAt: "2026-08-05T09:00:00.000Z",
+          unreadCount: {},
+        }),
+      ],
+      [ROSTER[0], ROSTER[1]],
+    );
+
+    expect(rowNames()).toEqual(["Ana Gomez", "Beto Diaz"]);
+  });
+});
+
+describe("ChatThreadList — every client is reachable", () => {
+  it("lists a roster client who has never been messaged", () => {
+    // The chat parent doc is created by the FIRST message, so a client with no
+    // doc would be missing from the inbox — and the coach cannot start a
+    // conversation with someone who isn't listed.
+    renderList([chat({ id: "ana", clientId: "ana" })], ROSTER);
+
+    expect(rowNames().sort()).toEqual(["Ana Gomez", "Beto Diaz", "Caro Ruiz"]);
+  });
+
+  it("invites the coach to start, instead of showing a blank preview", () => {
+    renderList([], [ROSTER[2]]);
+
+    expect(
+      within(rowFor("Caro Ruiz")).getByText("Start the conversation…"),
+    ).toBeInTheDocument();
+  });
+
+  it("selects by chat id on click", async () => {
+    const user = userEvent.setup();
+    const { onSelect } = renderList([chat()], [ROSTER[0]]);
+
+    await user.click(rowFor("Ana Gomez"));
+
+    expect(onSelect).toHaveBeenCalledWith("ana");
+  });
+});
+
+describe("ChatThreadList — the preview reads by kind", () => {
+  it("shows the text of a text message", () => {
+    renderList([chat()], [ROSTER[0]]);
+
+    expect(within(rowFor("Ana Gomez")).getByText("Hola coach")).toBeInTheDocument();
+  });
+
+  it("labels an image instead of printing nothing", () => {
+    renderList(
+      [
+        chat({
+          lastMessage: {
+            text: "",
+            senderId: "ana",
+            createdAt: "2026-08-05T12:00:00.000Z",
+            kind: "image",
+          },
+        }),
+      ],
+      [ROSTER[0]],
+    );
+
+    // An image has no text; falling through to `text` renders an empty row and
+    // the thread reads as if nothing happened.
+    expect(within(rowFor("Ana Gomez")).getByText("📷 Photo")).toBeInTheDocument();
+  });
+
+  it("keeps an image caption when there is one", () => {
+    renderList(
+      [
+        chat({
+          lastMessage: {
+            text: "mirá la postura",
+            senderId: "ana",
+            createdAt: "2026-08-05T12:00:00.000Z",
+            kind: "image",
+          },
+        }),
+      ],
+      [ROSTER[0]],
+    );
+
+    expect(
+      within(rowFor("Ana Gomez")).getByText("📷 mirá la postura"),
+    ).toBeInTheDocument();
+  });
+
+  it("labels a voice note", () => {
+    renderList(
+      [
+        chat({
+          lastMessage: {
+            text: "",
+            senderId: "ana",
+            createdAt: "2026-08-05T12:00:00.000Z",
+            kind: "voice",
+          },
+        }),
+      ],
+      [ROSTER[0]],
+    );
+
+    expect(within(rowFor("Ana Gomez")).getByText("🎤 Voice note")).toBeInTheDocument();
+  });
+
+  it("marks an empty text message rather than rendering a blank line", () => {
+    renderList(
+      [
+        chat({
+          lastMessage: {
+            text: "",
+            senderId: "ana",
+            createdAt: "2026-08-05T12:00:00.000Z",
+            kind: "text",
+          },
+        }),
+      ],
+      [ROSTER[0]],
+    );
+
+    expect(within(rowFor("Ana Gomez")).getByText("(empty message)")).toBeInTheDocument();
+  });
+});
+
+describe("ChatThreadList — search", () => {
+  it("filters by the resolved client NAME, not the uid", async () => {
+    const user = userEvent.setup();
+    renderList([chat(), chat({ id: "beto", clientId: "beto" })], ROSTER);
+
+    await user.type(screen.getByRole("searchbox"), "beto d");
+
+    // The uid is never on screen; matching on it would make the search look
+    // broken for every coach who types what they can see.
+    expect(rowNames()).toEqual(["Beto Diaz"]);
+  });
+
+  it("says 'no conversations' for a search that matches nothing", async () => {
+    const user = userEvent.setup();
+    renderList([chat()], ROSTER);
+
+    await user.type(screen.getByRole("searchbox"), "zzzz");
+
+    expect(rowNames()).toEqual([]);
+    expect(screen.getByText("No conversations yet.")).toBeInTheDocument();
+  });
+});

--- a/backoffice/src/app/gc-fitness/chat/_components/__tests__/message-input.test.tsx
+++ b/backoffice/src/app/gc-fitness/chat/_components/__tests__/message-input.test.tsx
@@ -1,0 +1,387 @@
+/**
+ * @jest-environment jsdom
+ */
+
+// message-input.test.tsx
+//
+// The composer. Everything a coach ever says to a client goes through the
+// payload this file asserts.
+//
+// The FIRST THREE LINES of this file MUST stay as the
+// `/** @jest-environment jsdom */` docblock — the backoffice jest config
+// defaults to `testEnvironment: "node"` so without it React Testing Library
+// crashes with `ReferenceError: document is not defined`.
+//
+// The wire shapes, and what breaking each one looks like:
+//
+//   • A PHOTO IS ONE MESSAGE, NOT TWO. The upload happens first and its
+//     `storagePath` rides on the SAME `sendTrainerMessage` call as the typed
+//     caption — `kind: "image"` + `imagePath`. Splitting it into an image
+//     message plus a text message double-notifies the client and breaks the
+//     caption association on both mobile surfaces. `imagePath` is also one of
+//     the wire-TYPE mismatches that already bit the Android port, so the key
+//     name matters as much as the value.
+//   • AN EMPTY CAPTION IS `undefined`, NOT `""`. Same Admin-SDK rule as
+//     everywhere else in this codebase.
+//   • THE REPLY QUOTE IS `undefined` WHEN THERE ISN'T ONE. `buildReplyQuote`
+//     returns `null` for an unquotable message and `null` is a value Firestore
+//     will happily store, leaving a message that claims to be a reply to
+//     nothing.
+//   • A QUICK REPLY IS APPENDED, NEVER SENT. Plan 08-12 states it as a truth:
+//     the trainer edits the template before it goes out. Auto-sending puts a
+//     canned message in a client's chat without anyone reading it.
+//   • ENTER SENDS, SHIFT+ENTER DOESN'T. And because Enter bypasses the
+//     disabled Send button entirely, the empty-text guard inside `handleSubmit`
+//     IS reachable here — unlike most guards in this portal. It gets a test
+//     rather than a note.
+//
+// On failure the composer must KEEP the text. A send that clears the box and
+// then errors loses what the coach wrote.
+
+import "@testing-library/jest-dom";
+
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import React from "react";
+
+import type { MessageRow } from "@/lib/gc-fitness/chat-schema";
+
+const mockSendTrainerMessage = jest.fn();
+const mockUploadAttachment = jest.fn();
+jest.mock("@/lib/gc-fitness/chat-server-actions", () => ({
+  sendTrainerMessage: (...args: unknown[]) => mockSendTrainerMessage(...args),
+  uploadTrainerChatAttachment: (...args: unknown[]) => mockUploadAttachment(...args),
+}));
+
+const mockInvalidate = jest.fn();
+jest.mock("@tanstack/react-query", () => {
+  const actual = jest.requireActual("@tanstack/react-query");
+  return {
+    ...actual,
+    useQueryClient: () => ({ invalidateQueries: mockInvalidate }),
+  };
+});
+
+// The dropdown self-fetches its templates through a Server Action; stub it to a
+// button that emits one, which is the only thing the composer reacts to.
+jest.mock("../QuickReplyDropdown", () => ({
+  QuickReplyDropdown: ({ onSelect }: { onSelect: (reply: string) => void }) => (
+    <button type="button" onClick={() => onSelect("Buen trabajo esta semana 💪")}>
+      quick-reply
+    </button>
+  ),
+}));
+
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { MessageInput } from "../MessageInput";
+
+const CHAT_ID = "client-1";
+
+function renderInput(
+  props: Partial<React.ComponentProps<typeof MessageInput>> = {},
+) {
+  const onCancelReply = jest.fn();
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  render(
+    <QueryClientProvider client={client}>
+      <MessageInput chatId={CHAT_ID} onCancelReply={onCancelReply} {...props} />
+    </QueryClientProvider>,
+  );
+  return { onCancelReply, user: userEvent.setup() };
+}
+
+function box() {
+  return screen.getByRole("textbox", { name: "Message text" });
+}
+
+function sendButton() {
+  return screen.getByRole("button", { name: "Send" });
+}
+
+async function sentPayload(): Promise<Record<string, unknown>> {
+  await waitFor(() => expect(mockSendTrainerMessage).toHaveBeenCalledTimes(1));
+  return mockSendTrainerMessage.mock.calls[0][0] as Record<string, unknown>;
+}
+
+/** A real File the jsdom FileReader can turn into base64. */
+function imageFile(name = "photo.png") {
+  return new File(["binary-ish"], name, { type: "image/png" });
+}
+
+function quotedMessage(overrides: Partial<MessageRow> = {}): MessageRow {
+  return {
+    id: "msg-7",
+    chatId: CHAT_ID,
+    senderId: "client-1",
+    kind: "text",
+    text: "¿Puedo cambiar el jueves?",
+    createdAt: "2026-08-05T12:00:00.000Z",
+    ...overrides,
+  } as MessageRow;
+}
+
+// jsdom ships no object-URL implementation, and staging a photo calls
+// `URL.createObjectURL` synchronously for the preview — without these shims the
+// component throws mid-render and every attachment test fails on a missing
+// button rather than on its actual assertion.
+beforeAll(() => {
+  Object.defineProperty(URL, "createObjectURL", {
+    writable: true,
+    value: jest.fn(() => "blob:preview"),
+  });
+  Object.defineProperty(URL, "revokeObjectURL", {
+    writable: true,
+    value: jest.fn(),
+  });
+});
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockSendTrainerMessage.mockResolvedValue(undefined);
+  mockUploadAttachment.mockResolvedValue({
+    storagePath: "chat/client-1/photo.png",
+  });
+});
+
+describe("MessageInput — a text message", () => {
+  it("sends the TRIMMED text as kind 'text'", async () => {
+    const { user } = renderInput();
+
+    await user.type(box(), "  Nos vemos el martes  ");
+    await user.click(sendButton());
+
+    expect(await sentPayload()).toEqual({
+      chatId: CHAT_ID,
+      kind: "text",
+      text: "Nos vemos el martes",
+      replyTo: undefined,
+    });
+  });
+
+  it("clears the box and refreshes the thread after a send", async () => {
+    const { user } = renderInput();
+
+    await user.type(box(), "Listo");
+    await user.click(sendButton());
+
+    await waitFor(() => expect(box()).toHaveValue(""));
+    expect(mockInvalidate).toHaveBeenCalled();
+  });
+
+  it("KEEPS the text when the send fails", async () => {
+    const { user } = renderInput();
+    mockSendTrainerMessage.mockRejectedValue(new Error("Network down."));
+
+    await user.type(box(), "Un mensaje largo que no quiero reescribir");
+    await user.click(sendButton());
+
+    expect(await screen.findByText("Network down.")).toBeInTheDocument();
+    // Clearing on failure loses what the coach wrote.
+    expect(box()).toHaveValue("Un mensaje largo que no quiero reescribir");
+  });
+});
+
+describe("MessageInput — a photo is ONE message", () => {
+  it("uploads first, then sends kind 'image' with the storage path", async () => {
+    const { user } = renderInput();
+
+    await user.upload(
+      document.querySelector('input[type="file"][accept*="image"]') as HTMLInputElement,
+      imageFile(),
+    );
+    await user.click(sendButton());
+
+    const payload = await sentPayload();
+    expect(mockUploadAttachment).toHaveBeenCalledTimes(1);
+    expect(payload).toMatchObject({
+      chatId: CHAT_ID,
+      kind: "image",
+      imagePath: "chat/client-1/photo.png",
+    });
+    // Exactly one message — a second text message would double-notify.
+    expect(mockSendTrainerMessage).toHaveBeenCalledTimes(1);
+  });
+
+  it("rides the typed caption on the SAME message", async () => {
+    const { user } = renderInput();
+
+    await user.upload(
+      document.querySelector('input[type="file"][accept*="image"]') as HTMLInputElement,
+      imageFile(),
+    );
+    await user.type(box(), "mirá la postura acá");
+    await user.click(sendButton());
+
+    const payload = await sentPayload();
+    expect(payload.text).toBe("mirá la postura acá");
+    expect(mockSendTrainerMessage).toHaveBeenCalledTimes(1);
+  });
+
+  it("sends `undefined`, not '', for a captionless photo", async () => {
+    const { user } = renderInput();
+
+    await user.upload(
+      document.querySelector('input[type="file"][accept*="image"]') as HTMLInputElement,
+      imageFile(),
+    );
+    await user.click(sendButton());
+
+    const payload = await sentPayload();
+    expect(payload.text).toBeUndefined();
+    expect("text" in payload).toBe(true); // the key is passed, the VALUE is undefined
+  });
+
+  it("enables Send on a staged photo with no text at all", async () => {
+    const { user } = renderInput();
+
+    expect(sendButton()).toBeDisabled();
+
+    await user.upload(
+      document.querySelector('input[type="file"][accept*="image"]') as HTMLInputElement,
+      imageFile(),
+    );
+
+    expect(sendButton()).toBeEnabled();
+  });
+
+  it("lets the coach unstage the photo before sending", async () => {
+    const { user } = renderInput();
+
+    await user.upload(
+      document.querySelector('input[type="file"][accept*="image"]') as HTMLInputElement,
+      imageFile(),
+    );
+    await user.click(screen.getByRole("button", { name: "Remove photo" }));
+
+    expect(sendButton()).toBeDisabled();
+    expect(mockUploadAttachment).not.toHaveBeenCalled();
+  });
+});
+
+describe("MessageInput — the reply quote", () => {
+  it("attaches the quote to the outgoing message", async () => {
+    const { user } = renderInput({
+      replyingTo: quotedMessage(),
+      replyAuthorLabel: "Ana",
+    });
+
+    await user.type(box(), "Sí, dale");
+    await user.click(sendButton());
+
+    const payload = await sentPayload();
+    expect(payload.replyTo).toEqual({
+      messageId: "msg-7",
+      senderId: "client-1",
+      kind: "text",
+      textSnippet: "¿Puedo cambiar el jueves?",
+    });
+  });
+
+  it("sends `undefined` — never null — when nothing is quoted", async () => {
+    const { user } = renderInput();
+
+    await user.type(box(), "Hola");
+    await user.click(sendButton());
+
+    // `buildReplyQuote` returns null for an unquotable message, and null is a
+    // value Firestore stores: the message would claim to reply to nothing.
+    expect((await sentPayload()).replyTo).toBeUndefined();
+  });
+
+  it("drops the reply banner once the message is away", async () => {
+    const { user, onCancelReply } = renderInput({
+      replyingTo: quotedMessage(),
+      replyAuthorLabel: "Ana",
+    });
+
+    await user.type(box(), "Sí");
+    await user.click(sendButton());
+
+    // Leaving it staged quotes the same message on the NEXT send too.
+    await waitFor(() => expect(onCancelReply).toHaveBeenCalled());
+  });
+});
+
+describe("MessageInput — quick replies are a draft, not a send", () => {
+  it("appends the template into the box without sending", async () => {
+    const { user } = renderInput();
+
+    await user.click(screen.getByRole("button", { name: "quick-reply" }));
+
+    expect(box()).toHaveValue("Buen trabajo esta semana 💪");
+    // Plan 08-12 states it as a truth: the trainer edits before submit.
+    expect(mockSendTrainerMessage).not.toHaveBeenCalled();
+  });
+
+  it("keeps what the coach already typed, on its own line", async () => {
+    const { user } = renderInput();
+
+    await user.type(box(), "Ana,");
+    await user.click(screen.getByRole("button", { name: "quick-reply" }));
+
+    expect(box()).toHaveValue("Ana,\nBuen trabajo esta semana 💪");
+  });
+});
+
+describe("MessageInput — the keyboard", () => {
+  it("sends on Enter", async () => {
+    const { user } = renderInput();
+
+    await user.type(box(), "Dale{Enter}");
+
+    expect((await sentPayload()).text).toBe("Dale");
+  });
+
+  it("inserts a newline on Shift+Enter instead of sending", async () => {
+    const { user } = renderInput();
+
+    await user.type(box(), "Primera{Shift>}{Enter}{/Shift}Segunda");
+
+    expect(box()).toHaveValue("Primera\nSegunda");
+    expect(mockSendTrainerMessage).not.toHaveBeenCalled();
+  });
+
+  it("sends nothing when Enter lands on an empty box", async () => {
+    const { user } = renderInput();
+
+    // Enter bypasses the disabled Send button, so the empty-text guard inside
+    // `handleSubmit` is genuinely reachable here — unlike most guards in this
+    // portal, which sit behind a disabled CTA.
+    await user.click(box());
+    await user.keyboard("{Enter}");
+    await user.type(box(), "   {Enter}");
+
+    expect(mockSendTrainerMessage).not.toHaveBeenCalled();
+  });
+});
+
+describe("MessageInput — a pending client", () => {
+  it("locks the composer itself, not just the Send button", async () => {
+    const { user } = renderInput({ disabled: true });
+
+    await user.type(box(), "Hola");
+
+    // The guard that actually runs is the INPUT being disabled: nothing can be
+    // typed, so `canSend` is false because the text is empty — its `!disabled`
+    // term never gets to decide anything. (Verified by mutation: forcing
+    // `canSend` true leaves every test green, because the box still refuses
+    // the keystrokes.) The photo input is disabled the same way.
+    expect(box()).toBeDisabled();
+    expect(box()).toHaveValue("");
+    expect(
+      document.querySelector('input[type="file"][accept*="image"]'),
+    ).toBeDisabled();
+    expect(sendButton()).toBeDisabled();
+  });
+
+  it("says why, instead of just going dead", async () => {
+    renderInput({ disabled: true });
+
+    // The client hasn't activated their account: the message would have
+    // nowhere to land, and a composer that silently refuses input reads as a
+    // broken page.
+    expect(screen.getByText(/pending activation/i)).toBeInTheDocument();
+  });
+});

--- a/backoffice/src/app/gc-fitness/checklist/__tests__/coach-checklist-client.test.tsx
+++ b/backoffice/src/app/gc-fitness/checklist/__tests__/coach-checklist-client.test.tsx
@@ -1,0 +1,335 @@
+/**
+ * @jest-environment jsdom
+ */
+
+// coach-checklist-client.test.tsx
+//
+// The coach's own reminder list. It writes through three Server Actions and
+// then re-renders itself from the server, so the interesting part is not the
+// payload alone but the GROUPING: which bucket an item lands in, and in which
+// order. A reminder filed under the wrong heading is a reminder the coach does
+// not act on.
+//
+// The FIRST THREE LINES of this file MUST stay as the
+// `/** @jest-environment jsdom */` docblock — the backoffice jest config
+// defaults to `testEnvironment: "node"` so without it React Testing Library
+// crashes with `ReferenceError: document is not defined`.
+//
+// What is pinned:
+//
+//   • THE COACH'S TIMEZONE DECIDES THE DAY (#747). Every civil day here is
+//     computed in the zone the server resolved, not in the host's. The bug
+//     this replaced put an item due at 21:00 in Buenos Aires under TOMORROW
+//     until hydration corrected it — visible, wrong, and self-healing, which
+//     is the worst combination to debug.
+//   • OVERDUE OUTRANKS THE DAY. An item due at 09:00 that it is now 18:00 is
+//     "Overdue", not "Today" — grouping it under Today buries it among things
+//     that have not happened yet.
+//   • UNDATED ITEMS SORT LAST but are not overdue — `MAX_SAFE_INTEGER`, not 0.
+//   • COMPLETED ITEMS ARE HIDDEN until asked for, and the active COUNT never
+//     includes them.
+//
+// The clock is PINNED. The component captures `new Date()` at mount and every
+// bucket is decided against it, so a suite run at 23:30 local would file
+// "later today" fixtures under tomorrow. `setSystemTime` fixes it at
+// 2026-09-10T15:00Z = 12:00 in Buenos Aires, which leaves room on both sides
+// of the same civil day. user-event is wired to the fake timers via
+// `advanceTimers`, which is what makes clicks work while they are installed.
+
+import "@testing-library/jest-dom";
+
+import { render, screen, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import React from "react";
+
+import type { CoachChecklistItem } from "@/lib/gc-fitness/coach-checklist-actions";
+
+const mockCreate = jest.fn();
+const mockSetCompleted = jest.fn();
+const mockDelete = jest.fn();
+jest.mock("@/lib/gc-fitness/coach-checklist-actions", () => ({
+  createCoachChecklistItem: (...a: unknown[]) => mockCreate(...a),
+  setCoachChecklistItemCompleted: (...a: unknown[]) => mockSetCompleted(...a),
+  deleteCoachChecklistItem: (...a: unknown[]) => mockDelete(...a),
+}));
+
+const mockRefresh = jest.fn();
+jest.mock("next/navigation", () => ({
+  useRouter: () => ({ refresh: () => mockRefresh() }),
+}));
+
+// The edit dialog owns its own save path; this file is about the list.
+jest.mock("@/components/gc-fitness/ChecklistEditDialog", () => ({
+  ChecklistEditDialog: () => null,
+}));
+
+import { CoachChecklistClient } from "../CoachChecklistClient";
+
+const TZ = "America/Argentina/Buenos_Aires";
+
+function item(overrides: Partial<CoachChecklistItem> = {}): CoachChecklistItem {
+  return {
+    id: "i1",
+    title: "Call Ana",
+    notes: null,
+    dueAt: null,
+    completed: false,
+    createdAt: "2026-01-01T00:00:00.000Z",
+    clients: [],
+    recurrence: "none",
+    recurrenceEndsOn: null,
+    recurrenceWeekdays: [],
+    recurrenceMonthDays: [],
+    ...overrides,
+  } as CoachChecklistItem;
+}
+
+function renderList(items: CoachChecklistItem[], timezone = TZ) {
+  const view = render(
+    <CoachChecklistClient
+      items={items}
+      clients={[{ uid: "ana", displayName: "Ana Gomez", photoURL: null }]}
+      timezone={timezone}
+    />,
+  );
+  return {
+    ...view,
+    user: userEvent.setup({ advanceTimers: jest.advanceTimersByTime }),
+  };
+}
+
+/** The `<section>` under a group heading, matched on the heading text. */
+function group(heading: string): HTMLElement {
+  const node = screen.getByRole("heading", { name: heading }).closest("section");
+  if (!node) throw new Error(`no group section for ${heading}`);
+  return node as HTMLElement;
+}
+
+/** Every group heading, in the order they are rendered. */
+function groupHeadings(): string[] {
+  return screen
+    .getAllByRole("heading", { level: 3 })
+    .map((h) => h.textContent ?? "");
+}
+
+/**
+ * The item titles inside a group, in render order.
+ *
+ * Rows are plain `<div>`s (no list semantics), so they are counted by their
+ * checkbox — whose accessible name carries the title, one per row.
+ */
+function titlesIn(heading: string): string[] {
+  return within(group(heading))
+    .getAllByRole("checkbox")
+    .map((cb) => (cb.getAttribute("aria-label") ?? "").replace(/^Toggle /, ""));
+}
+
+// 12:00 in Buenos Aires on a Thursday.
+const NOW = "2026-09-10T15:00:00.000Z";
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  jest.useFakeTimers({ now: new Date(NOW) });
+});
+
+afterEach(() => {
+  jest.useRealTimers();
+});
+
+describe("CoachChecklistClient — which bucket an item lands in", () => {
+  it("files a PAST due time as Overdue, not under its own day", async () => {
+    const past = "2026-09-10T13:00:00.000Z"; // 10:00 in Buenos Aires — same day, gone
+    renderList([item({ dueAt: past, title: "Call Ana" })]);
+
+    expect(titlesIn("Overdue")).toEqual(["Call Ana"]);
+    expect(screen.queryByRole("heading", { name: "Today" })).not.toBeInTheDocument();
+  });
+
+  it("files a LATER TODAY due time under Today", async () => {
+    // Same civil day, still in the future — the two branches differ only by
+    // the comparison against `now`, which is exactly the confusion worth
+    // pinning.
+    const soon = "2026-09-10T22:00:00.000Z"; // 19:00 in Buenos Aires
+    renderList([item({ dueAt: soon, title: "Call Ana" })]);
+
+    expect(titlesIn("Today")).toEqual(["Call Ana"]);
+  });
+
+  it("files an item with no due date under its own heading, never Overdue", async () => {
+    renderList([item({ dueAt: null, title: "Someday" })]);
+
+    expect(titlesIn("No date")).toEqual(["Someday"]);
+    expect(screen.queryByRole("heading", { name: "Overdue" })).not.toBeInTheDocument();
+  });
+
+  it("names the day in the COACH's timezone, not in UTC (#747)", async () => {
+    // 2026-09-12T02:00Z is Sep 11 at 23:00 in Buenos Aires — TOMORROW for this
+    // coach, and Saturday the 12th for a UTC one. Asserting merely that the
+    // two renders "differ" is not enough: they also differ with the bug in
+    // place (verified by mutation), because a wrong civil day still produces
+    // some heading. The exact label is the assertion.
+    const dueAt = "2026-09-12T02:00:00.000Z";
+
+    const { unmount } = renderWithTz([item({ dueAt })], TZ);
+    expect(groupHeadings()).toEqual(["Tomorrow"]);
+    unmount();
+
+    renderWithTz([item({ dueAt })], "UTC");
+    expect(groupHeadings()).toEqual(["Saturday, September 12"]);
+  });
+
+  it("BUCKETS by the coach's civil day, so one local day is ONE group (#747)", async () => {
+    // Both instants are Sep 11 in Buenos Aires (12:00 and 23:00) but land on
+    // different UTC days. Keyed in UTC they split into two headings and the
+    // coach reads their Friday as two separate days.
+    const items = [
+      item({ id: "a", title: "Noon", dueAt: "2026-09-11T15:00:00.000Z" }),
+      item({ id: "b", title: "Late", dueAt: "2026-09-12T02:00:00.000Z" }),
+    ];
+
+    const { unmount } = renderWithTz(items, TZ);
+    expect(groupHeadings()).toEqual(["Tomorrow"]);
+    expect(titlesIn("Tomorrow")).toEqual(["Noon", "Late"]);
+    unmount();
+
+    renderWithTz(items, "UTC");
+    expect(groupHeadings()).toHaveLength(2);
+  });
+});
+
+describe("CoachChecklistClient — the order things appear in", () => {
+  it("sorts by due instant, earliest first", async () => {
+    renderList([
+      item({ id: "b", title: "Later", dueAt: "2026-09-13T20:00:00.000Z" }),
+      item({ id: "a", title: "Earlier", dueAt: "2026-09-13T16:00:00.000Z" }),
+    ]);
+
+    expect(groupHeadings()).toHaveLength(1);
+    expect(titlesIn(groupHeadings()[0])).toEqual(["Earlier", "Later"]);
+  });
+
+  it("pushes the UNDATED group to the end", async () => {
+    // `MAX_SAFE_INTEGER`, not 0 — a missing date sorted as epoch would put
+    // every vague reminder above every dated one.
+    renderList([
+      item({ id: "a", title: "Someday", dueAt: null }),
+      item({ id: "b", title: "Dated", dueAt: "2026-09-13T16:00:00.000Z" }),
+    ]);
+
+    expect(groupHeadings().at(-1)).toBe("No date");
+  });
+
+  it("breaks a tie on creation order", async () => {
+    const same = "2026-09-13T16:00:00.000Z";
+    renderList([
+      item({ id: "b", title: "Second", dueAt: same, createdAt: "2026-02-02T00:00:00.000Z" }),
+      item({ id: "a", title: "First", dueAt: same, createdAt: "2026-01-01T00:00:00.000Z" }),
+    ]);
+
+    expect(titlesIn(groupHeadings()[0])).toEqual(["First", "Second"]);
+  });
+});
+
+describe("CoachChecklistClient — completed items", () => {
+  it("hides them, and keeps them out of the active count", async () => {
+    renderList([
+      item({ id: "a", title: "Open" }),
+      item({ id: "b", title: "Done", completed: true }),
+    ]);
+
+    expect(screen.queryByText("Done")).not.toBeInTheDocument();
+    expect(screen.getByText("1 active")).toBeInTheDocument();
+  });
+
+  it("reveals them on demand, under their own heading", async () => {
+    const { user } = renderList([
+      item({ id: "a", title: "Open" }),
+      item({ id: "b", title: "Done", completed: true }),
+    ]);
+
+    await user.click(screen.getByRole("button", { name: /Show completed/ }));
+
+    expect(titlesIn("Completed")).toEqual(["Done"]);
+    // …and still not counted as active.
+    expect(screen.getByText("1 active")).toBeInTheDocument();
+  });
+
+  it("offers no toggle at all when nothing is completed", async () => {
+    renderList([item({ id: "a", title: "Open" })]);
+
+    expect(
+      screen.queryByRole("button", { name: /Show completed/ }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("distinguishes 'nothing at all' from 'nothing active'", async () => {
+    const { unmount } = renderList([]);
+    expect(screen.getByText("No reminders yet.")).toBeInTheDocument();
+    unmount();
+
+    renderList([item({ completed: true })]);
+    expect(screen.getByText("No active reminders.")).toBeInTheDocument();
+  });
+});
+
+describe("CoachChecklistClient — writing", () => {
+  it("sends the form fields the action expects, and refreshes", async () => {
+    const { user } = renderList([]);
+
+    await user.type(screen.getByLabelText("Title"), "Call Ana");
+    await user.type(screen.getByLabelText("Notes"), "about her knee");
+    await user.click(screen.getByRole("button", { name: "Add reminder" }));
+
+    expect(mockCreate).toHaveBeenCalledTimes(1);
+    expect(mockCreate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        title: "Call Ana",
+        notes: "about her knee",
+        clientIds: [],
+        recurrence: "none",
+      }),
+    );
+    expect(mockRefresh).toHaveBeenCalled();
+  });
+
+  it("toggles an item to the OPPOSITE of what it is now", async () => {
+    // `!item.completed`, not a hardcoded true — otherwise nothing can ever be
+    // un-completed and the toggle is a one-way door.
+    const { user } = renderList([item({ id: "a", title: "Open" })]);
+
+    await user.click(screen.getByRole("checkbox", { name: /Toggle Open/ }));
+
+    expect(mockSetCompleted).toHaveBeenCalledWith("a", true);
+  });
+
+  it("un-completes a completed item", async () => {
+    const { user } = renderList([item({ id: "a", title: "Done", completed: true })]);
+
+    await user.click(screen.getByRole("button", { name: /Show completed/ }));
+    await user.click(screen.getByRole("checkbox", { name: /Toggle Done/ }));
+
+    expect(mockSetCompleted).toHaveBeenCalledWith("a", false);
+  });
+
+  it("deletes by id", async () => {
+    const { user } = renderList([item({ id: "a", title: "Open" })]);
+
+    await user.click(screen.getByRole("button", { name: /Delete Open/ }));
+
+    expect(mockDelete).toHaveBeenCalledWith("a");
+    expect(mockRefresh).toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+
+function renderWithTz(items: CoachChecklistItem[], timezone: string) {
+  return render(
+    <CoachChecklistClient
+      items={items}
+      clients={[]}
+      timezone={timezone}
+    />,
+  );
+}
+

--- a/backoffice/src/app/gc-fitness/clients/[id]/_components/__tests__/client-calendar-peek.test.tsx
+++ b/backoffice/src/app/gc-fitness/clients/[id]/_components/__tests__/client-calendar-peek.test.tsx
@@ -1,0 +1,535 @@
+/**
+ * @jest-environment jsdom
+ */
+
+// client-calendar-peek.test.tsx
+//
+// The mini calendar on the client-detail page: a 7-day window (anchor ± 3)
+// that WRITES — a chip dragged onto another day calls `moveAssignment`, the
+// same server action the Agenda's month calendar uses.
+//
+// The FIRST THREE LINES of this file MUST stay as the
+// `/** @jest-environment jsdom */` docblock — the backoffice jest config
+// defaults to `testEnvironment: "node"` so without it React Testing Library
+// crashes with `ReferenceError: document is not defined`.
+//
+// This surface is a TWIN of `month-calendar.tsx`'s drag path (#461 copied the
+// semantics deliberately), so the same four branches decide everything, and a
+// drift between the two is invisible until a coach drags on the wrong page:
+//
+//   1. THE FORK. A one-off moves immediately with `scope: "one"`; a recurring
+//      one must stop and ask, because `scope: "all"` rewrites every occurrence.
+//   2. `recurrenceKind === "single"` COUNTS AS NON-RECURRING even with a
+//      `seriesId` present — assignments created one at a time still carry one,
+//      so a `seriesId`-only check prompts on every ordinary drag.
+//   3. THE SAME-DAY NO-OP. Lifting a chip and dropping it back must not write.
+//   4. #449/#461 — a CLIENT-CREATED workout is not draggable at all;
+//      `moveAssignment` throws on ownership, so the guard keeps the coach from
+//      ever seeing that error.
+//
+// Two things that are only true HERE (the Agenda gets them for free from
+// React Query, this component keeps the week in `useState`):
+//
+//   • A successful move must RE-FETCH the visible week by hand. Without it the
+//     chip stays painted on the day it was dragged off of.
+//   • A failed re-fetch must keep the previously loaded week on screen behind
+//     the error banner, not blank the grid.
+//
+// Note on the drag mechanics: `user-event` has no drag-and-drop API (HTML5 DnD
+// isn't implemented in jsdom either), so these tests fire the two React
+// synthetic events the component listens to — `dragStart` on the row and
+// `drop` on the target cell — with a stub `dataTransfer`. That is exactly the
+// pair a browser delivers.
+
+import "@testing-library/jest-dom";
+
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import React from "react";
+
+import type { ClientCalendarPeekPayload } from "@/lib/gc-fitness/client-calendar-peek-actions";
+import type {
+  MonthHabitChip,
+  MonthWorkoutChip,
+} from "@/lib/gc-fitness/schedule-month-actions";
+
+// Both action modules import firebase-admin, which explodes on import under
+// jsdom. Mocked at the module boundary — the component only ever reaches
+// Firestore through these two.
+const mockGetClientCalendarPeek = jest.fn();
+jest.mock("@/lib/gc-fitness/client-calendar-peek-actions", () => ({
+  getClientCalendarPeek: (...args: unknown[]) =>
+    mockGetClientCalendarPeek(...args),
+}));
+
+const mockMoveAssignment = jest.fn();
+jest.mock("@/lib/gc-fitness/schedule-month-actions", () => ({
+  moveAssignment: (...args: unknown[]) => mockMoveAssignment(...args),
+}));
+
+// The move dialog and the detail dialog are stubbed rather than mounted: what
+// this file tests is the SHELL's decision — whether the prompt opens at all,
+// with which chip and which target date, and what it does with the scope that
+// comes back. Their own contracts are pinned in move-assignment-dialog.test.tsx
+// and workout-detail-dialog.test.tsx.
+const mockMoveDialogProps = jest.fn();
+jest.mock("@/components/gc-fitness/schedule/move-assignment-dialog", () => ({
+  MoveAssignmentDialog: (props: {
+    chip: { id: string };
+    newDate: string;
+    onConfirm: (scope: "one" | "future" | "all") => void;
+    onOpenChange: (open: boolean) => void;
+  }) => {
+    mockMoveDialogProps(props);
+    return (
+      <div data-testid="move-dialog">
+        <span data-testid="move-dialog-chip">{props.chip.id}</span>
+        <span data-testid="move-dialog-date">{props.newDate}</span>
+        <button type="button" onClick={() => props.onConfirm("all")}>
+          scope-all
+        </button>
+        <button type="button" onClick={() => props.onOpenChange(false)}>
+          dismiss-move
+        </button>
+      </div>
+    );
+  },
+}));
+
+const mockDetailDialogProps = jest.fn();
+jest.mock("@/components/gc-fitness/schedule/workout-detail-dialog", () => ({
+  WorkoutDetailDialog: (props: {
+    assignmentId: string;
+    onDeleted: () => void;
+    onOpenChange: (open: boolean) => void;
+  }) => {
+    mockDetailDialogProps(props);
+    return (
+      <div data-testid="detail-dialog">
+        <span data-testid="detail-dialog-id">{props.assignmentId}</span>
+        <button type="button" onClick={() => props.onDeleted()}>
+          detail-deleted
+        </button>
+      </div>
+    );
+  },
+}));
+
+const mockToastSuccess = jest.fn();
+const mockToastError = jest.fn();
+jest.mock("sonner", () => ({
+  toast: {
+    success: (...args: unknown[]) => mockToastSuccess(...args),
+    error: (...args: unknown[]) => mockToastError(...args),
+  },
+}));
+
+import { ClientCalendarPeek } from "../ClientCalendarPeek";
+
+const CLIENT_ID = "client-1";
+// The window is anchor ± 3, so this renders 2026-09-07 … 2026-09-13. Day
+// NUMBERS 7..13 each appear exactly once in the grid, which is what the drop
+// target is matched on.
+const TODAY = "2026-09-10";
+const SOURCE_DAY = "2026-09-09";
+const TARGET_DAY = "2026-09-12";
+
+function chip(overrides: Partial<MonthWorkoutChip> = {}): MonthWorkoutChip {
+  return {
+    id: "assign-1",
+    clientId: CLIENT_ID,
+    scheduledFor: SOURCE_DAY,
+    originallyScheduledFor: null,
+    templateName: "Push Day",
+    templateTag: "push",
+    status: "scheduled",
+    seriesId: null,
+    recurrenceKind: null,
+    selfAssigned: false,
+    ...overrides,
+  };
+}
+
+function habit(overrides: Partial<MonthHabitChip> = {}): MonthHabitChip {
+  return {
+    id: "habit-1",
+    clientId: CLIENT_ID,
+    civilDate: SOURCE_DAY,
+    habitName: "Drink water",
+    status: "done",
+    clientOwned: false,
+    ...overrides,
+  };
+}
+
+function payload(
+  chips: MonthWorkoutChip[],
+  habits: MonthHabitChip[] = [],
+  anchorCivil = TODAY,
+): ClientCalendarPeekPayload {
+  const workoutsByDay: Record<string, MonthWorkoutChip[]> = {};
+  for (const c of chips) (workoutsByDay[c.scheduledFor] ??= []).push(c);
+  const habitsByDay: Record<string, MonthHabitChip[]> = {};
+  for (const h of habits) (habitsByDay[h.civilDate] ??= []).push(h);
+  return {
+    anchorCivil,
+    startCivil: addDays(anchorCivil, -3),
+    endCivil: addDays(anchorCivil, 3),
+    todayCivil: TODAY,
+    calendar: {
+      monthStart: `${anchorCivil.slice(0, 7)}-01`,
+      monthEnd: `${anchorCivil.slice(0, 7)}-30`,
+      workoutsByDay,
+      habitsByDay,
+    },
+  };
+}
+
+function addDays(civil: string, days: number): string {
+  const [y, m, d] = civil.split("-").map(Number);
+  const next = new Date(Date.UTC(y, m - 1, d + days));
+  return next.toISOString().slice(0, 10);
+}
+
+function renderPeek(initial: ClientCalendarPeekPayload) {
+  render(<ClientCalendarPeek clientId={CLIENT_ID} initialPayload={initial} />);
+  return { user: userEvent.setup() };
+}
+
+/** The workout row, matched on its template name. */
+function workoutRow(name: string): HTMLElement {
+  return screen.getByRole("button", { name: new RegExp(name) });
+}
+
+/** The day cell carrying `dayNumber` — the drop event fired on its number
+ *  label bubbles into the cell's own `onDrop`. The label is the raw
+ *  `"YYYY-MM-DD".slice(8, 10)`, i.e. ZERO-PADDED: the cell for the 9th says
+ *  "09", and `getByText("9")` finds nothing. */
+function dayCell(dayNumber: number): HTMLElement {
+  return screen.getByText(dayLabel(dayNumber));
+}
+
+function dayLabel(dayNumber: number): string {
+  return String(dayNumber).padStart(2, "0");
+}
+
+function dataTransfer() {
+  return { effectAllowed: "", setData: jest.fn(), getData: jest.fn() };
+}
+
+function dragRowToDay(name: string, dayNumber: number) {
+  fireEvent.dragStart(workoutRow(name), { dataTransfer: dataTransfer() });
+  fireEvent.drop(dayCell(dayNumber), { dataTransfer: dataTransfer() });
+}
+
+/**
+ * Let the pending promise chain drain.
+ *
+ * REQUIRED before any "did NOT write" assertion: `performMove` is async, so
+ * asserting `not.toHaveBeenCalled()` right after the drop passes no matter
+ * what the component did. Same trap as month-calendar-drag-move.test.tsx,
+ * where deleting the same-day guard left every negative test green until the
+ * flush was added.
+ */
+async function settle() {
+  await act(async () => {
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  });
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockMoveAssignment.mockResolvedValue({ movedCount: 1 });
+  mockGetClientCalendarPeek.mockResolvedValue(payload([]));
+});
+
+describe("ClientCalendarPeek — dragging a workout onto another day", () => {
+  it("moves a ONE-OFF straight away, with scope 'one' and the dropped-on date", async () => {
+    renderPeek(payload([chip()]));
+
+    dragRowToDay("Push Day", 12);
+
+    await waitFor(() => expect(mockMoveAssignment).toHaveBeenCalledTimes(1));
+    expect(mockMoveAssignment).toHaveBeenCalledWith({
+      id: "assign-1",
+      newScheduledFor: TARGET_DAY,
+      scope: "one",
+    });
+    // Nothing to reshape → the coach is never asked.
+    expect(screen.queryByTestId("move-dialog")).not.toBeInTheDocument();
+  });
+
+  it("treats a seriesId with recurrenceKind 'single' as one-off", async () => {
+    // Assignments created one at a time still carry a series id. Prompting on
+    // those would put a scope dialog in front of every ordinary drag.
+    renderPeek(payload([chip({ seriesId: "series-1", recurrenceKind: "single" })]));
+
+    dragRowToDay("Push Day", 12);
+
+    await waitFor(() => expect(mockMoveAssignment).toHaveBeenCalledTimes(1));
+    expect(mockMoveAssignment).toHaveBeenCalledWith(
+      expect.objectContaining({ scope: "one" }),
+    );
+    expect(screen.queryByTestId("move-dialog")).not.toBeInTheDocument();
+  });
+
+  it("STOPS a recurring one and asks for the scope first", async () => {
+    renderPeek(payload([chip({ seriesId: "series-1", recurrenceKind: "weekly" })]));
+
+    dragRowToDay("Push Day", 12);
+    await settle();
+
+    // The prompt is the only thing between this drag and a series-wide rewrite.
+    expect(mockMoveAssignment).not.toHaveBeenCalled();
+    expect(screen.getByTestId("move-dialog")).toBeInTheDocument();
+    expect(screen.getByTestId("move-dialog-chip")).toHaveTextContent("assign-1");
+    expect(screen.getByTestId("move-dialog-date")).toHaveTextContent(TARGET_DAY);
+  });
+
+  it("writes the scope the dialog came back with", async () => {
+    const { user } = renderPeek(
+      payload([chip({ seriesId: "series-1", recurrenceKind: "weekly" })]),
+    );
+
+    dragRowToDay("Push Day", 12);
+    await user.click(await screen.findByText("scope-all"));
+
+    await waitFor(() => expect(mockMoveAssignment).toHaveBeenCalledTimes(1));
+    expect(mockMoveAssignment).toHaveBeenCalledWith({
+      id: "assign-1",
+      newScheduledFor: TARGET_DAY,
+      scope: "all",
+    });
+    expect(screen.queryByTestId("move-dialog")).not.toBeInTheDocument();
+  });
+
+  it("writes nothing when the prompt is dismissed", async () => {
+    const { user } = renderPeek(
+      payload([chip({ seriesId: "series-1", recurrenceKind: "weekly" })]),
+    );
+
+    dragRowToDay("Push Day", 12);
+    await user.click(await screen.findByText("dismiss-move"));
+    await settle();
+
+    expect(mockMoveAssignment).not.toHaveBeenCalled();
+    expect(screen.queryByTestId("move-dialog")).not.toBeInTheDocument();
+  });
+
+  it("does NOT write when the chip is dropped back on its own day", async () => {
+    renderPeek(payload([chip()]));
+
+    dragRowToDay("Push Day", 9);
+    await settle();
+
+    // Without the guard every accidental jiggle costs a write and a toast for
+    // a move that didn't happen.
+    expect(mockMoveAssignment).not.toHaveBeenCalled();
+  });
+
+  it("leaves a CLIENT-CREATED workout undraggable, and a drop on it inert", async () => {
+    // #449/#461 — moveAssignment throws on ownership for a self-assigned
+    // workout, so the guard is what keeps that error off the coach's screen.
+    renderPeek(payload([chip({ selfAssigned: true })]));
+
+    const row = workoutRow("Push Day");
+    expect(row).toHaveAttribute("draggable", "false");
+
+    dragRowToDay("Push Day", 12);
+    await settle();
+
+    expect(mockMoveAssignment).not.toHaveBeenCalled();
+  });
+
+  it("keeps an ordinary workout draggable", async () => {
+    renderPeek(payload([chip()]));
+
+    expect(workoutRow("Push Day")).toHaveAttribute("draggable", "true");
+  });
+});
+
+describe("ClientCalendarPeek — what happens after the move", () => {
+  it("re-fetches the VISIBLE week so the chip lands on its new day", async () => {
+    // The week lives in useState, not React Query: nothing invalidates it for
+    // us. Skip the refetch and the chip stays painted where it was dragged from.
+    renderPeek(payload([chip()]));
+
+    dragRowToDay("Push Day", 12);
+
+    await waitFor(() =>
+      expect(mockGetClientCalendarPeek).toHaveBeenCalledWith({
+        clientId: CLIENT_ID,
+        anchorCivil: TODAY,
+      }),
+    );
+    expect(mockToastSuccess).toHaveBeenCalledWith("Workout movido");
+  });
+
+  it("counts the moved occurrences in the toast for a series", async () => {
+    mockMoveAssignment.mockResolvedValue({ movedCount: 4 });
+    const { user } = renderPeek(
+      payload([chip({ seriesId: "series-1", recurrenceKind: "weekly" })]),
+    );
+
+    dragRowToDay("Push Day", 12);
+    await user.click(await screen.findByText("scope-all"));
+
+    await waitFor(() =>
+      expect(mockToastSuccess).toHaveBeenCalledWith("4 workouts movidos"),
+    );
+  });
+
+  it("surfaces the server's refusal and does NOT re-fetch", async () => {
+    mockMoveAssignment.mockRejectedValue(new Error("Forbidden"));
+    renderPeek(payload([chip()]));
+
+    dragRowToDay("Push Day", 12);
+
+    await waitFor(() => expect(mockToastError).toHaveBeenCalledWith("Forbidden"));
+    expect(mockGetClientCalendarPeek).not.toHaveBeenCalled();
+  });
+});
+
+describe("ClientCalendarPeek — the week navigation", () => {
+  it("steps back a FULL week, so the windows stay contiguous", async () => {
+    // The window is anchor ± 3 (7 days); a step of anything but 7 would either
+    // repeat days or skip them.
+    const { user } = renderPeek(payload([]));
+
+    await user.click(screen.getByRole("button", { name: "Previous week" }));
+
+    await waitFor(() =>
+      expect(mockGetClientCalendarPeek).toHaveBeenCalledWith({
+        clientId: CLIENT_ID,
+        anchorCivil: "2026-09-03",
+      }),
+    );
+  });
+
+  it("steps forward a full week", async () => {
+    const { user } = renderPeek(payload([]));
+
+    await user.click(screen.getByRole("button", { name: "Next week" }));
+
+    await waitFor(() =>
+      expect(mockGetClientCalendarPeek).toHaveBeenCalledWith({
+        clientId: CLIENT_ID,
+        anchorCivil: "2026-09-17",
+      }),
+    );
+  });
+
+  it("steps from the week ON SCREEN, not from the initial one", async () => {
+    // Two forward steps must land on +14, not twice on +7 — the anchor has to
+    // come from the payload the server echoed back.
+    mockGetClientCalendarPeek.mockResolvedValue(payload([], [], "2026-09-17"));
+    const { user } = renderPeek(payload([]));
+
+    await user.click(screen.getByRole("button", { name: "Next week" }));
+    await waitFor(() => expect(mockGetClientCalendarPeek).toHaveBeenCalledTimes(1));
+    await user.click(screen.getByRole("button", { name: "Next week" }));
+
+    await waitFor(() => expect(mockGetClientCalendarPeek).toHaveBeenCalledTimes(2));
+    expect(mockGetClientCalendarPeek).toHaveBeenLastCalledWith({
+      clientId: CLIENT_ID,
+      anchorCivil: "2026-09-24",
+    });
+  });
+
+  it("disables 'Today' while today's week is the one on screen, and re-enables it after a step", async () => {
+    mockGetClientCalendarPeek.mockResolvedValue(payload([], [], "2026-09-17"));
+    const { user } = renderPeek(payload([]));
+
+    expect(screen.getByRole("button", { name: "Today" })).toBeDisabled();
+
+    await user.click(screen.getByRole("button", { name: "Next week" }));
+
+    await waitFor(() =>
+      expect(screen.getByRole("button", { name: "Today" })).toBeEnabled(),
+    );
+    await user.click(screen.getByRole("button", { name: "Today" }));
+    expect(mockGetClientCalendarPeek).toHaveBeenLastCalledWith({
+      clientId: CLIENT_ID,
+      anchorCivil: TODAY,
+    });
+  });
+
+  it("keeps the loaded week on screen behind the error when a step fails", async () => {
+    // Blanking the grid on a failed fetch would read as "this client has
+    // nothing scheduled" — the opposite of what happened.
+    mockGetClientCalendarPeek.mockRejectedValue(new Error("boom"));
+    const { user } = renderPeek(payload([chip()]));
+
+    await user.click(screen.getByRole("button", { name: "Next week" }));
+
+    expect(await screen.findByText("Could not load this week.")).toBeInTheDocument();
+    expect(workoutRow("Push Day")).toBeInTheDocument();
+  });
+
+  it("links to the Agenda on the anchor's MONTH, filtered to this client", async () => {
+    renderPeek(payload([]));
+
+    expect(screen.getByRole("link", { name: /Open schedule/ })).toHaveAttribute(
+      "href",
+      "/gc-fitness/schedule?month=2026-09&clientIds=client-1",
+    );
+  });
+});
+
+describe("ClientCalendarPeek — opening a workout", () => {
+  it("opens the detail dialog on the RAW assignment id", async () => {
+    // The render key is `workout:<id>`-prefixed; handing that to the dialog
+    // would look up an assignment that doesn't exist.
+    const { user } = renderPeek(payload([chip()]));
+
+    await user.click(workoutRow("Push Day"));
+
+    // ANCHORED on purpose: `toHaveTextContent` is a SUBSTRING match, and the
+    // wrong value here ("workout:assign-1") contains the right one — the
+    // unanchored assertion passes with the bug in place (verified by mutation).
+    expect(await screen.findByTestId("detail-dialog-id")).toHaveTextContent(
+      /^assign-1$/,
+    );
+  });
+
+  it("re-fetches the visible week after a delete from the dialog", async () => {
+    const { user } = renderPeek(payload([chip()]));
+
+    await user.click(workoutRow("Push Day"));
+    await user.click(await screen.findByText("detail-deleted"));
+
+    await waitFor(() =>
+      expect(mockGetClientCalendarPeek).toHaveBeenCalledWith({
+        clientId: CLIENT_ID,
+        anchorCivil: TODAY,
+      }),
+    );
+    expect(screen.queryByTestId("detail-dialog")).not.toBeInTheDocument();
+  });
+});
+
+describe("ClientCalendarPeek — what the grid shows", () => {
+  it("renders exactly the 7 days of the window", async () => {
+    renderPeek(payload([]));
+
+    for (const day of [7, 8, 9, 10, 11, 12, 13]) {
+      expect(screen.getByText(dayLabel(day))).toBeInTheDocument();
+    }
+    expect(screen.queryByText("06")).not.toBeInTheDocument();
+    expect(screen.queryByText("14")).not.toBeInTheDocument();
+  });
+
+  it("marks the empty days, and only those", async () => {
+    renderPeek(payload([chip()], [habit({ civilDate: TARGET_DAY })]));
+
+    // 7 days, one with a workout and one with a habit → 5 empty.
+    expect(screen.getAllByText("No workouts or habits")).toHaveLength(5);
+  });
+
+  it("shows a habit day as busy even with no workout on it", async () => {
+    renderPeek(payload([], [habit({ civilDate: TARGET_DAY })]));
+
+    expect(screen.getAllByText("No workouts or habits")).toHaveLength(6);
+    expect(screen.getByTitle(/Drink water/)).toBeInTheDocument();
+  });
+});

--- a/backoffice/src/app/gc-fitness/clients/[id]/_components/__tests__/client-notes-card.test.tsx
+++ b/backoffice/src/app/gc-fitness/clients/[id]/_components/__tests__/client-notes-card.test.tsx
@@ -1,0 +1,328 @@
+/**
+ * @jest-environment jsdom
+ */
+
+// client-notes-card.test.tsx
+//
+// The coach's private notes log on a client profile. Nothing here reaches the
+// client's phone, which is exactly why it never gets looked at until a note is
+// missing.
+//
+// The FIRST THREE LINES of this file MUST stay as the
+// `/** @jest-environment jsdom */` docblock — the backoffice jest config
+// defaults to `testEnvironment: "node"` so without it React Testing Library
+// crashes with `ReferenceError: document is not defined`.
+//
+// THE ENTRIES HAVE NO ID. They are addressed by the `(createdAt, date)` pair —
+// in the Server Action call AND in the local list update afterwards. Everything
+// interesting follows from that:
+//
+//   • A LEGACY ENTRY WITH NO `createdAt` CANNOT BE TARGETED, so its edit and
+//     delete controls are hidden rather than pointed at a guess. Showing them
+//     would let a coach delete a different note than the one they clicked.
+//   • THE LOCAL UPDATE MUST MATCH ON BOTH FIELDS. Matching on the date alone
+//     rewrites every note of that day; matching on the text alone rewrites
+//     every note that happens to say the same thing.
+//   • THE NOTE IS FILED UNDER THE PICKED DATE, not today. The whole point of
+//     the date picker is back-filling a session the coach didn't write up on
+//     the day.
+//
+// The compose box clears OPTIMISTICALLY and is restored on failure — a coach
+// who just lost a paragraph they typed does not type it again.
+
+import "@testing-library/jest-dom";
+
+import { render, screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import React from "react";
+
+const mockUpdateClientNotes = jest.fn();
+const mockEditClientNote = jest.fn();
+const mockDeleteClientNote = jest.fn();
+jest.mock("@/lib/gc-fitness/client-notes-actions", () => ({
+  updateClientNotes: (...args: unknown[]) => mockUpdateClientNotes(...args),
+  editClientNote: (...args: unknown[]) => mockEditClientNote(...args),
+  deleteClientNote: (...args: unknown[]) => mockDeleteClientNote(...args),
+}));
+
+import { ClientNotesCard } from "../ClientNotesCard";
+
+const CLIENT = "ana";
+const TZ = "America/Argentina/Buenos_Aires";
+const TODAY = "2026-08-05";
+
+type Entry = { date: string; notes: string; createdAt: string | null };
+
+function entry(overrides: Partial<Entry> = {}): Entry {
+  return {
+    date: TODAY,
+    notes: "Trabajó hombro con molestia",
+    createdAt: "2026-08-05T15:00:00.000Z",
+    ...overrides,
+  };
+}
+
+function renderCard(entries: Entry[] = []) {
+  render(
+    <ClientNotesCard
+      clientId={CLIENT}
+      timezone={TZ}
+      todayCivil={TODAY}
+      initialNotes=""
+      initialUpdatedAt={null}
+      initialEntries={entries}
+    />,
+  );
+  return { user: userEvent.setup() };
+}
+
+function composeBox() {
+  return screen.getByPlaceholderText("Write a note for this day...");
+}
+
+function addButton() {
+  return screen.getByRole("button", { name: "Add note" });
+}
+
+function dateInput() {
+  return screen.getByLabelText("Date");
+}
+
+/** The "Notes for <date>" section — the picked day's entries. */
+function forDateSection(): HTMLElement {
+  const heading = screen.getByText(/^Notes for /);
+  return heading.parentElement as HTMLElement;
+}
+
+/** The "Previous notes" section. */
+function recentSection(): HTMLElement {
+  const heading = screen.getByText("Previous notes");
+  return heading.parentElement as HTMLElement;
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockUpdateClientNotes.mockResolvedValue({ updatedAt: "2026-08-05T16:00:00.000Z" });
+  mockEditClientNote.mockResolvedValue({ ok: true });
+  mockDeleteClientNote.mockResolvedValue({ ok: true });
+});
+
+describe("ClientNotesCard — adding a note", () => {
+  it("files it under the PICKED date, not today", async () => {
+    const { user } = renderCard();
+
+    await user.clear(dateInput());
+    await user.type(dateInput(), "2026-07-28");
+    await user.type(composeBox(), "Sesión de test");
+    await user.click(addButton());
+
+    await waitFor(() => expect(mockUpdateClientNotes).toHaveBeenCalled());
+    // Back-filling a session the coach didn't write up on the day is the whole
+    // reason the date picker exists.
+    expect(mockUpdateClientNotes).toHaveBeenCalledWith({
+      clientId: CLIENT,
+      notes: "Sesión de test",
+      date: "2026-07-28",
+    });
+  });
+
+  it("shows the new note without waiting for a refetch", async () => {
+    const { user } = renderCard();
+
+    await user.type(composeBox(), "Nueva observación");
+    await user.click(addButton());
+
+    await waitFor(() =>
+      expect(within(forDateSection()).getByText("Nueva observación")).toBeInTheDocument(),
+    );
+    expect(composeBox()).toHaveValue("");
+  });
+
+  it("RESTORES the typed text when the save fails", async () => {
+    const { user } = renderCard();
+    mockUpdateClientNotes.mockRejectedValue(new Error("Sin conexión."));
+
+    await user.type(composeBox(), "Un parrafo largo que no quiero reescribir");
+    await user.click(addButton());
+
+    expect(await screen.findByText("Sin conexión.")).toBeInTheDocument();
+    // The box is cleared optimistically; leaving it cleared on failure loses
+    // what the coach wrote.
+    await waitFor(() =>
+      expect(composeBox()).toHaveValue("Un parrafo largo que no quiero reescribir"),
+    );
+  });
+
+  it("keeps Add disabled until there is real text", async () => {
+    const { user } = renderCard();
+
+    expect(addButton()).toBeDisabled();
+
+    await user.type(composeBox(), "   ");
+    expect(addButton()).toBeDisabled();
+
+    await user.type(composeBox(), "algo");
+    expect(addButton()).toBeEnabled();
+  });
+});
+
+describe("ClientNotesCard — which entries show where", () => {
+  it("puts only the picked day's notes in the day section", () => {
+    renderCard([
+      entry({ date: TODAY, notes: "De hoy" }),
+      entry({ date: "2026-08-01", notes: "De la semana pasada", createdAt: "2026-08-01T10:00:00.000Z" }),
+    ]);
+
+    const section = forDateSection();
+    expect(within(section).getByText("De hoy")).toBeInTheDocument();
+    expect(within(section).queryByText("De la semana pasada")).not.toBeInTheDocument();
+  });
+
+  it("keeps a FUTURE note out of the previous-notes list", () => {
+    renderCard([
+      entry({ date: TODAY, notes: "De hoy" }),
+      entry({
+        date: "2026-09-01",
+        notes: "Planificado para septiembre",
+        createdAt: "2026-08-05T16:00:00.000Z",
+      }),
+    ]);
+
+    // "Previous" means `date <= picked`. A note filed ahead of the picked day
+    // is not history.
+    expect(
+      within(recentSection()).queryByText("Planificado para septiembre"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("orders the day's notes newest first", () => {
+    renderCard([
+      entry({ notes: "Primera", createdAt: "2026-08-05T09:00:00.000Z" }),
+      entry({ notes: "Segunda", createdAt: "2026-08-05T18:00:00.000Z" }),
+    ]);
+
+    const text = forDateSection().textContent ?? "";
+    expect(text.indexOf("Segunda")).toBeLessThan(text.indexOf("Primera"));
+  });
+
+  it("orders the PREVIOUS-notes list newest first too", () => {
+    // Two independent sorts, one per section. Verified by mutation: reversing
+    // only the `recentEntries` one left the day-section test green.
+    renderCard([
+      entry({ date: "2026-08-01", notes: "Vieja", createdAt: "2026-08-01T09:00:00.000Z" }),
+      entry({ date: "2026-08-04", notes: "Reciente", createdAt: "2026-08-04T09:00:00.000Z" }),
+    ]);
+
+    const text = recentSection().textContent ?? "";
+    expect(text.indexOf("Reciente")).toBeLessThan(text.indexOf("Vieja"));
+  });
+
+  it("caps the previous-notes list at 8", () => {
+    renderCard(
+      Array.from({ length: 12 }, (_, i) => ({
+        date: "2026-08-01",
+        notes: `[nota-${i}]`,
+        createdAt: `2026-08-01T${String(i + 8).padStart(2, "0")}:00:00.000Z`,
+      })),
+    );
+
+    // An unbounded log turns the profile page into a wall of history.
+    //
+    // The marker is bracketed on purpose: `textContent` runs the note straight
+    // into the entry's date, so a bare `Nota 11` matches "Nota 112026-08-01".
+    const shown = (recentSection().textContent ?? "").match(/\[nota-\d+\]/g) ?? [];
+    expect(shown).toHaveLength(8);
+    // …and it keeps the NEWEST eight, not the first eight it happened to read.
+    expect(shown[0]).toBe("[nota-11]");
+  });
+
+  it("says so when the picked day has nothing", async () => {
+    const { user } = renderCard([entry({ date: "2026-08-01", createdAt: "2026-08-01T10:00:00.000Z" })]);
+
+    await user.clear(dateInput());
+    await user.type(dateInput(), "2026-08-05");
+
+    expect(screen.getByText("No notes for this day.")).toBeInTheDocument();
+  });
+});
+
+describe("ClientNotesCard — editing an entry", () => {
+  it("targets the entry by (createdAt, date)", async () => {
+    const { user } = renderCard([entry({ notes: "Original" })]);
+
+    await user.click(within(forDateSection()).getAllByRole("button", { name: "Edit" })[0]);
+    const draft = within(forDateSection()).getByRole("textbox");
+    await user.clear(draft);
+    await user.type(draft, "  Corregido  ");
+    await user.click(within(forDateSection()).getByRole("button", { name: "Save" }));
+
+    await waitFor(() => expect(mockEditClientNote).toHaveBeenCalled());
+    // Entries have no id: this pair IS the address.
+    expect(mockEditClientNote).toHaveBeenCalledWith({
+      clientId: CLIENT,
+      entryCreatedAt: "2026-08-05T15:00:00.000Z",
+      entryDate: TODAY,
+      notes: "Corregido",
+    });
+  });
+
+  it("updates ONLY the edited entry, not its same-day siblings", async () => {
+    const { user } = renderCard([
+      entry({ notes: "Mañana", createdAt: "2026-08-05T09:00:00.000Z" }),
+      entry({ notes: "Tarde", createdAt: "2026-08-05T18:00:00.000Z" }),
+    ]);
+
+    // The first Edit button belongs to the newest entry ("Tarde").
+    await user.click(within(forDateSection()).getAllByRole("button", { name: "Edit" })[0]);
+    const draft = within(forDateSection()).getByRole("textbox");
+    await user.clear(draft);
+    await user.type(draft, "Tarde corregida");
+    await user.click(within(forDateSection()).getByRole("button", { name: "Save" }));
+
+    await waitFor(() =>
+      expect(within(forDateSection()).getByText("Tarde corregida")).toBeInTheDocument(),
+    );
+    // Matching on the date alone would rewrite both notes of that day.
+    expect(within(forDateSection()).getByText("Mañana")).toBeInTheDocument();
+  });
+
+  it("keeps the row open with an error when the edit fails", async () => {
+    const { user } = renderCard([entry({ notes: "Original" })]);
+    mockEditClientNote.mockRejectedValue(new Error("No se pudo guardar."));
+
+    await user.click(within(forDateSection()).getAllByRole("button", { name: "Edit" })[0]);
+    await user.click(within(forDateSection()).getByRole("button", { name: "Save" }));
+
+    expect(await screen.findByText("No se pudo guardar.")).toBeInTheDocument();
+    // Closing the editor on failure would look like it saved.
+    expect(within(forDateSection()).getByRole("textbox")).toBeInTheDocument();
+  });
+
+  it("cancel restores the original text", async () => {
+    const { user } = renderCard([entry({ notes: "Original" })]);
+
+    await user.click(within(forDateSection()).getAllByRole("button", { name: "Edit" })[0]);
+    const draft = within(forDateSection()).getByRole("textbox");
+    await user.clear(draft);
+    await user.type(draft, "descartame");
+    await user.click(within(forDateSection()).getByRole("button", { name: "Cancel" }));
+
+    expect(within(forDateSection()).getByText("Original")).toBeInTheDocument();
+    expect(mockEditClientNote).not.toHaveBeenCalled();
+  });
+});
+
+describe("ClientNotesCard — a legacy entry with no createdAt", () => {
+  it("hides edit and delete rather than guessing which row it is", () => {
+    renderCard([entry({ notes: "Nota vieja sin timestamp", createdAt: null })]);
+
+    // The Server Action addresses an entry by `(createdAt, date)`. With no
+    // createdAt there is nothing to target, and a guess deletes a DIFFERENT
+    // note than the one the coach clicked.
+    const section = forDateSection();
+    expect(within(section).queryByRole("button", { name: "Edit" })).not.toBeInTheDocument();
+    expect(within(section).queryByRole("button", { name: "Delete" })).not.toBeInTheDocument();
+    // The note itself still shows — unreachable is not the same as invisible.
+    expect(within(section).getByText("Nota vieja sin timestamp")).toBeInTheDocument();
+  });
+});

--- a/backoffice/src/app/gc-fitness/clients/[id]/compare-photos/__tests__/photo-compare-editor.test.tsx
+++ b/backoffice/src/app/gc-fitness/clients/[id]/compare-photos/__tests__/photo-compare-editor.test.tsx
@@ -1,0 +1,368 @@
+/**
+ * @jest-environment jsdom
+ */
+
+// photo-compare-editor.test.tsx
+//
+// SCOPE: the PAIR PICKER, and nothing else. The file is 806 lines, but ~450 of
+// them are the JPG export — two canvas painters that jsdom cannot run at all
+// (`getContext("2d")` returns null without the `canvas` npm package, so the
+// export bails on its own first guard). What decides what the coach actually
+// compares is the top 100 lines: which photos are offered, which are refused,
+// and what happens to the OTHER half of the pair when one half moves.
+//
+// The FIRST THREE LINES of this file MUST stay as the
+// `/** @jest-environment jsdom */` docblock — the backoffice jest config
+// defaults to `testEnvironment: "node"` so without it React Testing Library
+// crashes with `ReferenceError: document is not defined`.
+//
+// The rules being pinned (issue #435). All three are enforced by DISABLING
+// options, which is the failure mode worth testing: a disabled option that
+// stops being disabled doesn't throw anywhere — it just lets the coach build a
+// backwards comparison and export it with the labels swapped.
+//
+//   1. "after" must be STRICTLY LATER than "before" — same civil day included,
+//      because two photos from one check-in have nothing to show.
+//   3. the NEWEST photo can never be the "before".
+//   4. the OLDEST photo can never be the "after".
+//
+// Plus the one piece of state that moves on its own: picking a "before" that
+// invalidates the current "after" SNAPS after to the newest photo. Without it
+// the pair silently stays backwards — both selects still show a date, and the
+// only symptom is an export where "Before" is later than "After".
+//
+// The date each photo is filed under is `checkInDate` when present (a civil
+// date, timezone-independent) and only otherwise the `takenAt`/`createdAt`
+// instant resolved in the CLIENT's timezone. Those are different clocks and
+// the elapsed label is computed from whichever one wins.
+
+import "@testing-library/jest-dom";
+
+import { render, screen, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import React from "react";
+
+import type { ProgressPhotoRow } from "@/lib/gc-fitness/progress-photo-actions";
+
+let searchParams = new URLSearchParams("");
+jest.mock("next/navigation", () => ({
+  useSearchParams: () => searchParams,
+}));
+
+import { ProgressPhotoCompareEditor } from "../photo-compare-editor";
+
+const TZ = "America/Argentina/Buenos_Aires";
+
+function photo(overrides: Partial<ProgressPhotoRow> = {}): ProgressPhotoRow {
+  return {
+    id: "p1",
+    caption: null,
+    storagePath: "progress_photos/client-1/p1.jpg",
+    url: "https://example.test/p1.jpg",
+    angle: "front",
+    checkInDate: "2026-06-01",
+    setId: null,
+    createdAt: null,
+    takenAt: null,
+    ...overrides,
+  };
+}
+
+// The loader hands the editor its photos NEWEST FIRST, and the whole
+// newest/oldest logic reads position (`angled[0]` / `angled[length - 1]`)
+// rather than re-sorting. Fixtures keep that order.
+const NEWEST = photo({ id: "jun", checkInDate: "2026-06-01" });
+const MIDDLE = photo({ id: "may", checkInDate: "2026-05-01" });
+const OLDEST = photo({ id: "mar", checkInDate: "2026-03-01" });
+const THREE = [NEWEST, MIDDLE, OLDEST];
+
+function renderEditor(photos: ProgressPhotoRow[], query = "") {
+  searchParams = new URLSearchParams(query);
+  render(
+    <ProgressPhotoCompareEditor
+      photos={photos}
+      timezone={TZ}
+      clientName="Ana Gomez"
+    />,
+  );
+  return { user: userEvent.setup() };
+}
+
+/**
+ * The three selects carry no label, so they are identified by an option only
+ * they can have — indexing `getAllByRole("combobox")` blindly is the trap that
+ * already cost time on the exercise pickers.
+ */
+function selectNamed(kind: "angle" | "before" | "after"): HTMLSelectElement {
+  const marker = kind === "angle" ? "Front" : kind === "before" ? "Before" : "After";
+  const node = screen
+    .getAllByRole("combobox")
+    .find((el) =>
+      Array.from(el.querySelectorAll("option")).some(
+        (opt) => opt.textContent === marker,
+      ),
+    );
+  if (!node) throw new Error(`${kind} select not found`);
+  return node as HTMLSelectElement;
+}
+
+/** The option for `photoId` inside one of the pickers. */
+function optionFor(kind: "before" | "after", photoId: string): HTMLOptionElement {
+  const opt = selectNamed(kind).querySelector<HTMLOptionElement>(
+    `option[value="${photoId}"]`,
+  );
+  if (!opt) throw new Error(`no ${kind} option for ${photoId}`);
+  return opt;
+}
+
+function selectedIds(): { before: string; after: string } {
+  return {
+    before: selectNamed("before").value,
+    after: selectNamed("after").value,
+  };
+}
+
+describe("ProgressPhotoCompareEditor — which photos the pickers offer", () => {
+  it("opens on the two most recent photos: newest as AFTER, next as BEFORE", () => {
+    renderEditor(THREE);
+
+    expect(selectedIds()).toEqual({ before: "may", after: "jun" });
+  });
+
+  it("refuses the NEWEST photo as 'before' (#435 rule 3)", () => {
+    renderEditor(THREE);
+
+    expect(optionFor("before", "jun")).toBeDisabled();
+    expect(optionFor("before", "may")).toBeEnabled();
+    expect(optionFor("before", "mar")).toBeEnabled();
+  });
+
+  it("refuses the OLDEST photo as 'after' (#435 rule 4)", () => {
+    renderEditor(THREE);
+
+    expect(optionFor("after", "mar")).toBeDisabled();
+  });
+
+  it("refuses an 'after' that is not STRICTLY later than the before (#435 rule 1)", async () => {
+    // Same civil day: two photos from one check-in have nothing to show, so
+    // `photoCompareElapsed` returns null and the option must not be pickable.
+    const sameDay = photo({ id: "jun-2", checkInDate: "2026-06-01" });
+    const { user } = renderEditor([NEWEST, sameDay, MIDDLE, OLDEST]);
+
+    await user.selectOptions(selectNamed("before"), "jun-2");
+
+    expect(optionFor("after", "jun")).toBeDisabled(); // same civil day
+    expect(optionFor("after", "may")).toBeDisabled(); // earlier
+    expect(optionFor("after", "mar")).toBeDisabled(); // earlier AND oldest
+  });
+
+  it("DEAD END when the two most recent photos share a check-in day", async () => {
+    // Found writing this file, and it is a live defect, not a harness artifact.
+    // The default pair is positional (`angled[1]` vs `angled[0]`) with NO date
+    // check, so a client who uploaded two front photos on one day opens the
+    // comparator on a pair that rule 1 itself forbids — and cannot get out of
+    // it: every option in the after picker is disabled, and re-picking the
+    // before snaps the after back to that same newest photo.
+    //
+    // This test pins the CURRENT (broken) behaviour so the fix has something
+    // to flip. See the issue linked from #306.
+    const sameDay = photo({ id: "jun-2", checkInDate: "2026-06-01" });
+    renderEditor([NEWEST, sameDay, MIDDLE, OLDEST]);
+
+    expect(selectedIds()).toEqual({ before: "jun-2", after: "jun" });
+    // …a same-day pair, which is exactly what rule 1 exists to prevent.
+    const afterOptions = Array.from(
+      selectNamed("after").querySelectorAll("option[value]:not([value=''])"),
+    );
+    expect(afterOptions.every((o) => (o as HTMLOptionElement).disabled)).toBe(true);
+  });
+
+  it("leaves out photos of another angle", () => {
+    renderEditor([NEWEST, photo({ id: "side-1", angle: "side" }), MIDDLE, OLDEST]);
+
+    expect(
+      selectNamed("before").querySelector('option[value="side-1"]'),
+    ).toBeNull();
+  });
+
+  it("leaves out photos with no URL — they cannot be compared", () => {
+    // A row whose signed URL failed to mint still comes back from the loader.
+    renderEditor([NEWEST, photo({ id: "broken", url: null }), MIDDLE, OLDEST]);
+
+    expect(
+      selectNamed("after").querySelector('option[value="broken"]'),
+    ).toBeNull();
+  });
+
+  it("treats a photo with no angle as a FRONT photo", () => {
+    // Legacy rows predate the angle field; dropping them would empty the
+    // comparator for clients who only ever uploaded from the old app.
+    renderEditor([photo({ id: "legacy", angle: null, checkInDate: "2026-07-01" }), MIDDLE]);
+
+    expect(optionFor("after", "legacy")).toBeInTheDocument();
+  });
+});
+
+describe("ProgressPhotoCompareEditor — moving one half of the pair", () => {
+  it("SNAPS after to the newest when the new before invalidates it", async () => {
+    // The starting after must NOT already be the newest photo — otherwise
+    // "snapped to the newest" and "left untouched" are the same value and the
+    // assertion cannot fail. Verified by mutation: with a newest-valued after,
+    // deleting the snap left this file green.
+    const july = photo({ id: "jul", checkInDate: "2026-07-01" });
+    const { user } = renderEditor(
+      [july, NEWEST, MIDDLE, OLDEST],
+      "before=mar&after=jun",
+    );
+    expect(selectedIds()).toEqual({ before: "mar", after: "jun" });
+
+    // before → jun, the SAME civil day as the after: the pair stops being
+    // valid, so the after jumps to the newest photo instead of sitting there
+    // backwards with both selects still showing a date.
+    await user.selectOptions(selectNamed("before"), "jun");
+
+    expect(selectedIds()).toEqual({ before: "jun", after: "jul" });
+  });
+
+  it("snaps away from an after that the new before has overtaken", async () => {
+    const july = photo({ id: "jul", checkInDate: "2026-07-01" });
+    const { user } = renderEditor(
+      [july, NEWEST, MIDDLE, OLDEST],
+      "before=mar&after=may",
+    );
+
+    await user.selectOptions(selectNamed("before"), "jun");
+
+    expect(selectedIds()).toEqual({ before: "jun", after: "jul" });
+  });
+
+  it("leaves a still-valid after alone", async () => {
+    const { user } = renderEditor(THREE);
+
+    await user.selectOptions(selectNamed("before"), "mar");
+
+    expect(selectedIds()).toEqual({ before: "mar", after: "jun" });
+  });
+});
+
+describe("ProgressPhotoCompareEditor — switching angle", () => {
+  it("re-seeds BOTH halves from the new angle's own photos", async () => {
+    // Carrying a front photo id into the back picker leaves the select on a
+    // value that no option carries — the editor renders its empty state and
+    // the coach sees nothing, with both dropdowns looking populated.
+    const backNew = photo({ id: "back-jun", angle: "back", checkInDate: "2026-06-10" });
+    const backOld = photo({ id: "back-mar", angle: "back", checkInDate: "2026-03-10" });
+    const { user } = renderEditor([NEWEST, backNew, MIDDLE, backOld, OLDEST]);
+
+    await user.selectOptions(selectNamed("angle"), "back");
+
+    expect(selectedIds()).toEqual({ before: "back-mar", after: "back-jun" });
+  });
+
+  it("falls back to the single photo for BOTH halves when the angle has only one", async () => {
+    const onlyBack = photo({ id: "back-1", angle: "back", checkInDate: "2026-04-01" });
+    const { user } = renderEditor([NEWEST, onlyBack, MIDDLE]);
+
+    await user.selectOptions(selectNamed("angle"), "back");
+
+    // Same photo on both sides is not a comparison — and the pickers say so:
+    // it is simultaneously the newest (disabled as before) and the oldest
+    // (disabled as after).
+    expect(selectedIds()).toEqual({ before: "back-1", after: "back-1" });
+    expect(optionFor("before", "back-1")).toBeDisabled();
+    expect(optionFor("after", "back-1")).toBeDisabled();
+  });
+});
+
+describe("ProgressPhotoCompareEditor — the URL seeds the pair", () => {
+  it("honours ?angle=, ?before= and ?after=", () => {
+    // The client-detail page deep-links into a specific comparison; ignoring
+    // the params would silently reset it to the two most recent photos.
+    //
+    // The seeded pair must DIFFER from those defaults or the assertion holds
+    // with the params thrown away — verified by mutation, the two-photo
+    // version of this test passed with `params.get("after")` deleted.
+    const back = ["2026-06-10", "2026-05-10", "2026-04-10", "2026-03-10"].map(
+      (checkInDate, index) =>
+        photo({ id: `back-${index + 1}`, angle: "back", checkInDate }),
+    );
+    renderEditor(
+      [NEWEST, ...back, MIDDLE, OLDEST],
+      "angle=back&before=back-4&after=back-2",
+    );
+
+    // The defaults for this angle would be before=back-2 / after=back-1.
+    expect(selectedIds()).toEqual({ before: "back-4", after: "back-2" });
+  });
+});
+
+describe("ProgressPhotoCompareEditor — the dates it prints", () => {
+  it("labels an option by its checkInDate, NOT by the upload instant", () => {
+    // `checkInDate` is a civil date: it must not be shifted by anyone's
+    // timezone. The upload instant here is the previous UTC day on purpose.
+    renderEditor([
+      photo({
+        id: "jun",
+        checkInDate: "2026-06-01",
+        createdAt: "2026-05-31T23:30:00.000Z",
+      }),
+      MIDDLE,
+    ]);
+
+    expect(optionFor("after", "jun").textContent).toContain("June 1, 2026");
+  });
+
+  it("falls back to the takenAt instant in the CLIENT's timezone", () => {
+    // 2026-06-01T02:00Z is still May 31 in Buenos Aires (UTC-3).
+    renderEditor([
+      photo({ id: "no-checkin", checkInDate: null, takenAt: "2026-06-01T02:00:00.000Z" }),
+      MIDDLE,
+    ]);
+
+    expect(optionFor("after", "no-checkin").textContent).toContain("May 31");
+  });
+
+  it("tells the coach how much time each candidate covers", async () => {
+    const { user } = renderEditor([
+      photo({ id: "aug", checkInDate: "2026-08-01" }), // 3 months
+      photo({ id: "jun15", checkInDate: "2026-06-15" }), // ~1 month
+      photo({ id: "jun08", checkInDate: "2026-06-08" }), // 1 week
+      photo({ id: "jun04", checkInDate: "2026-06-04" }), // 3 days
+      photo({ id: "may", checkInDate: "2026-05-01" }),
+    ]);
+
+    await user.selectOptions(selectNamed("before"), "jun04");
+
+    expect(optionFor("after", "jun08").textContent).toContain("(4 days)");
+    expect(optionFor("after", "jun15").textContent).toContain("(~1 week)");
+    expect(optionFor("after", "aug").textContent).toContain("(~1 month)");
+  });
+});
+
+describe("ProgressPhotoCompareEditor — nothing to compare", () => {
+  it("says so instead of rendering half a comparison", () => {
+    renderEditor([]);
+
+    expect(screen.getByText("Seleccioná fotos para comparar.")).toBeInTheDocument();
+  });
+
+  it("renders the two panels once a valid pair resolves", () => {
+    renderEditor(THREE);
+
+    // Slider is the default mode; both images are on screen.
+    const images = screen.getAllByRole("img");
+    expect(images.map((i) => i.getAttribute("alt"))).toEqual(
+      expect.arrayContaining(["before", "after"]),
+    );
+  });
+
+  it("switches to the side-by-side view", async () => {
+    const { user } = renderEditor(THREE);
+
+    await user.click(screen.getByRole("button", { name: "Lado a lado" }));
+
+    const panel = screen.getByText("before").closest("div");
+    expect(panel).not.toBeNull();
+    expect(within(panel as HTMLElement).getByText("May 1, 2026")).toBeInTheDocument();
+  });
+});

--- a/backoffice/src/app/gc-fitness/clients/[id]/progress/__tests__/exercise-progress-client.test.tsx
+++ b/backoffice/src/app/gc-fitness/clients/[id]/progress/__tests__/exercise-progress-client.test.tsx
@@ -1,0 +1,387 @@
+/**
+ * @jest-environment jsdom
+ */
+
+// exercise-progress-client.test.tsx
+//
+// Per-exercise progress. The maths behind every number here already has pure
+// unit tests; what nobody covered is the part that decides WHICH numbers the
+// component feeds them — the range window, the metric, and the exercise
+// selection.
+//
+// The FIRST THREE LINES of this file MUST stay as the
+// `/** @jest-environment jsdom */` docblock — the backoffice jest config
+// defaults to `testEnvironment: "node"` so without it React Testing Library
+// crashes with `ReferenceError: document is not defined`.
+//
+// The window is where this surface has already broken (#526): the evolution
+// chart showed roughly one month of history because of a stack of independent
+// caps. The rules the component owns:
+//
+//   • THE RANGE SELECTOR FILTERS THE CHART, NEVER THE SESSION LIST (#574). The
+//     list is the exercise's history — "See more" is what keeps it manageable.
+//     Leaking the range into it hides sessions the coach came to read, with no
+//     indication that a filter is doing it.
+//   • A NULL METRIC IS DROPPED, NOT PLOTTED AS ZERO. A bodyweight session has
+//     no top set and no estimated 1RM; charting those as 0 draws a cliff into
+//     the client's progression that never happened.
+//   • THE POINTS ARE RE-SORTED ASCENDING. The server emits sessions
+//     newest-first, so "Latest" is the LAST element only after the sort — read
+//     off the raw array it is the OLDEST session.
+//   • NARROWING THE MUSCLE FILTER RE-SELECTS A VALID EXERCISE. Otherwise the
+//     picker shows a list that doesn't contain the exercise being charted.
+//
+// Recharts renders nothing measurable under jsdom (no layout), so the chart's
+// content is asserted through the "Latest: <value> <unit>" line, which is
+// computed from exactly the same `chartPoints` array the chart receives.
+
+import "@testing-library/jest-dom";
+
+import { render, screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import React from "react";
+
+import type {
+  ExerciseSessionPoint,
+  ExerciseSetSession,
+  LoggedExerciseOption,
+} from "@/lib/gc-fitness/exercise-progress-actions";
+
+import { ExerciseProgressClient } from "../ExerciseProgressClient";
+
+const TODAY = "2026-08-05";
+
+// Matches the real `rangeStarts` the server computes for each key.
+const RANGE_STARTS = {
+  all: "2025-08-05",
+  "90": "2026-05-07",
+  "30": "2026-07-06",
+  "7": "2026-07-29",
+};
+
+const LABELS = {
+  exercisePickerLabel: "Exercise",
+  metricTopSet: "Top set",
+  metricE1rm: "Est. 1RM",
+  metricVolume: "Volume",
+  weightUnit: "kg",
+  volumeUnit: "kg",
+  latestPrefix: "Latest:",
+  emptyNoExercises: "This client hasn't logged any weighted exercise yet.",
+  emptyNoData: "No data for this exercise in the selected range.",
+  tooltipTopSet: "Top set",
+  tooltipE1rm: "Est. 1RM",
+  tooltipVolume: "Volume",
+  ranges: { all: "All", "90": "90d", "30": "30d", "7": "7d" },
+};
+
+function option(overrides: Partial<LoggedExerciseOption> = {}): LoggedExerciseOption {
+  return {
+    exerciseId: "bench",
+    name: "Bench Press",
+    searchAliases: [],
+    sessionCount: 3,
+    muscleGroups: ["chest"],
+    ...overrides,
+  } as LoggedExerciseOption;
+}
+
+function point(overrides: Partial<ExerciseSessionPoint> = {}): ExerciseSessionPoint {
+  return {
+    exerciseId: "bench",
+    date: TODAY,
+    topSetWeightKg: 80,
+    estimatedOneRmKg: 92.5,
+    volumeKg: 2400,
+    ...overrides,
+  };
+}
+
+function session(overrides: Partial<ExerciseSetSession> = {}): ExerciseSetSession {
+  return {
+    exerciseId: "bench",
+    date: TODAY,
+    logId: `log-${overrides.date ?? TODAY}`,
+    sets: [
+      { reps: 8, weightKg: 80, setType: "normal", isPR: false } as unknown as ExerciseSetSession["sets"][number],
+    ],
+    ...overrides,
+  } as ExerciseSetSession;
+}
+
+function renderProgress(
+  props: Partial<React.ComponentProps<typeof ExerciseProgressClient>> = {},
+) {
+  render(
+    <ExerciseProgressClient
+      exercises={[option()]}
+      points={[point()]}
+      setSessions={[session()]}
+      truncatedSetHistoryExerciseIds={[]}
+      today={TODAY}
+      rangeStarts={RANGE_STARTS}
+      labels={LABELS}
+      {...props}
+    />,
+  );
+  return { user: userEvent.setup() };
+}
+
+/**
+ * The "Latest: <value> <unit>" figure — the chart's last point, in text.
+ *
+ * Found by scanning the paragraphs rather than `getByText("Latest:")`: the
+ * prefix shares its `<p>` with the value and the session count, and RTL's
+ * default string matcher compares the ELEMENT's whole text, so the exact
+ * lookup finds nothing.
+ */
+function latestValue(): string | null {
+  const p = Array.from(document.querySelectorAll("p")).find((n) =>
+    (n.textContent ?? "").startsWith("Latest:"),
+  );
+  return p?.querySelector("span")?.textContent?.trim() ?? null;
+}
+
+/** How many sessions the set-history list is showing. */
+function sessionRows(): HTMLElement[] {
+  const heading = screen.queryByText("Logged sets");
+  if (!heading) return [];
+  const block = heading.closest("div.flex-col")?.parentElement as HTMLElement;
+  return Array.from(block.querySelectorAll(":scope > ul > li"));
+}
+
+/** The range pills are a `role="tablist"`, not buttons. */
+function pickRange(user: ReturnType<typeof userEvent.setup>, label: string) {
+  return user.click(screen.getByRole("tab", { name: label }));
+}
+
+/** The metric pills are a `role="tablist"` too, same as the range selector. */
+function pickMetric(user: ReturnType<typeof userEvent.setup>, label: string) {
+  return user.click(screen.getByRole("tab", { name: label }));
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe("ExerciseProgressClient — the range window", () => {
+  const POINTS = [
+    // Server order: newest first.
+    point({ date: "2026-08-04", topSetWeightKg: 100 }),
+    point({ date: "2026-06-01", topSetWeightKg: 90 }),
+    point({ date: "2025-11-15", topSetWeightKg: 70 }),
+  ];
+
+  it("charts only the sessions inside the selected window", async () => {
+    const { user } = renderProgress({ points: POINTS });
+
+    // Default is 30d: only the August session qualifies.
+    expect(latestValue()).toBe("100.0 kg");
+
+    await pickRange(user, "All");
+
+    // "All" is a bounded year — the 2025-11 session is inside it.
+    await waitFor(() => expect(latestValue()).toBe("100.0 kg"));
+    expect(screen.queryByText(LABELS.emptyNoData)).not.toBeInTheDocument();
+  });
+
+  it("says so when the window has no sessions at all", async () => {
+    const { user } = renderProgress({
+      points: [point({ date: "2026-06-01", topSetWeightKg: 90 })],
+    });
+
+    await pickRange(user, "7d");
+
+    // Not an error, and not a zeroed chart: there is simply nothing in the
+    // last week.
+    expect(await screen.findByText(LABELS.emptyNoData)).toBeInTheDocument();
+  });
+
+  it("does NOT let the range touch the session list (#574)", async () => {
+    const { user } = renderProgress({
+      // Deliberately nothing inside the 7-day window (starts 2026-07-29), so
+      // picking "7d" empties the CHART and the list has to survive it.
+      points: [
+        point({ date: "2026-07-20", topSetWeightKg: 100 }),
+        point({ date: "2026-06-01", topSetWeightKg: 90 }),
+        point({ date: "2025-11-15", topSetWeightKg: 70 }),
+      ],
+      setSessions: [
+        session({ date: "2026-07-20" }),
+        session({ date: "2026-06-01" }),
+        session({ date: "2025-11-15" }),
+      ],
+    });
+
+    expect(sessionRows()).toHaveLength(3);
+
+    await pickRange(user, "7d");
+
+    // The chart is now empty, and the history is still the history. This is the
+    // #526 failure mode in miniature: a filter silently eating the sessions the
+    // coach opened the page to read.
+    expect(await screen.findByText(LABELS.emptyNoData)).toBeInTheDocument();
+    expect(sessionRows()).toHaveLength(3);
+  });
+});
+
+describe("ExerciseProgressClient — the metric", () => {
+  it("reads a different field per metric", async () => {
+    const { user } = renderProgress({
+      points: [point({ topSetWeightKg: 80, estimatedOneRmKg: 92.5, volumeKg: 2400 })],
+    });
+
+    expect(latestValue()).toBe("80.0 kg");
+
+    await pickMetric(user, "Est. 1RM");
+    await waitFor(() => expect(latestValue()).toBe("92.5 kg"));
+
+    await pickMetric(user, "Volume");
+    // Volume is rounded, not one-decimal — it's a much bigger number.
+    await waitFor(() => expect(latestValue()).toBe("2400 kg"));
+  });
+
+  it("DROPS a session whose metric is null instead of charting a zero", async () => {
+    const { user } = renderProgress({
+      points: [
+        // A bodyweight session: reps logged, no weight, so no top set and no
+        // estimated 1RM.
+        point({ date: "2026-08-04", topSetWeightKg: null, estimatedOneRmKg: null, volumeKg: 0 }),
+        point({ date: "2026-08-01", topSetWeightKg: 60, estimatedOneRmKg: 70, volumeKg: 1200 }),
+      ],
+    });
+
+    // Latest CHARTED point is the 1st, not the 4th: plotting the null as 0
+    // would draw a cliff into the client's progression that never happened.
+    expect(latestValue()).toBe("60.0 kg");
+
+    await pickMetric(user, "Est. 1RM");
+    await waitFor(() => expect(latestValue()).toBe("70.0 kg"));
+  });
+
+  it("shows the empty state when every session lacks the metric", async () => {
+    const { user } = renderProgress({
+      points: [point({ topSetWeightKg: null, estimatedOneRmKg: null, volumeKg: 500 })],
+    });
+
+    expect(screen.getByText(LABELS.emptyNoData)).toBeInTheDocument();
+
+    // …but volume still has data for the same sessions.
+    await pickMetric(user, "Volume");
+    await waitFor(() => expect(latestValue()).toBe("500 kg"));
+  });
+});
+
+describe("ExerciseProgressClient — 'Latest' is chronological", () => {
+  it("takes the newest session even though the server sends it first", () => {
+    renderProgress({
+      points: [
+        // Newest-first, as the server emits it.
+        point({ date: "2026-08-04", topSetWeightKg: 100 }),
+        point({ date: "2026-07-20", topSetWeightKg: 85 }),
+      ],
+    });
+
+    // Read off the raw array, "latest" would be the OLDEST session and the
+    // chart would run backwards.
+    expect(latestValue()).toBe("100.0 kg");
+  });
+});
+
+describe("ExerciseProgressClient — the exercise selection", () => {
+  const EXERCISES = [
+    option({ exerciseId: "bench", name: "Bench Press", muscleGroups: ["chest"] }),
+    option({ exerciseId: "row", name: "Barbell Row", muscleGroups: ["back"] }),
+  ];
+  const POINTS = [
+    point({ exerciseId: "bench", topSetWeightKg: 100 }),
+    point({ exerciseId: "row", topSetWeightKg: 70 }),
+  ];
+
+  it("starts on the first exercise", () => {
+    renderProgress({ exercises: EXERCISES, points: POINTS });
+
+    expect(screen.getByRole("combobox", { name: /Exercise/ })).toHaveTextContent(
+      "Bench Press",
+    );
+    expect(latestValue()).toBe("100.0 kg");
+  });
+
+  it("re-selects a valid exercise when the muscle filter excludes the current one", async () => {
+    const { user } = renderProgress({ exercises: EXERCISES, points: POINTS });
+
+    await user.click(screen.getByRole("combobox", { name: "Muscle group" }));
+    await user.click(await screen.findByRole("option", { name: "Back" }));
+
+    // Leaving "Bench Press" selected would chart an exercise that isn't in the
+    // (now back-only) picker list.
+    await waitFor(() => expect(latestValue()).toBe("70.0 kg"));
+    expect(
+      screen.getByRole("combobox", { name: /Exercise/ }),
+    ).toHaveTextContent("Barbell Row");
+  });
+
+  it("charts only the selected exercise's sessions", () => {
+    renderProgress({
+      exercises: EXERCISES,
+      points: [
+        point({ exerciseId: "bench", date: "2026-08-04", topSetWeightKg: 100 }),
+        // A heavier row on a LATER date must not become the bench's "latest".
+        point({ exerciseId: "row", date: "2026-08-05", topSetWeightKg: 140 }),
+      ],
+    });
+
+    expect(latestValue()).toBe("100.0 kg");
+  });
+});
+
+describe("ExerciseProgressClient — the session list paging", () => {
+  const SESSIONS = Array.from({ length: 7 }, (_, i) =>
+    session({ date: `2026-08-0${i + 1}`, logId: `log-${i}` }),
+  );
+
+  it("shows one page, then reveals more on demand", async () => {
+    const { user } = renderProgress({ setSessions: SESSIONS });
+
+    expect(sessionRows()).toHaveLength(3);
+
+    await user.click(screen.getByRole("button", { name: /See more/ }));
+
+    await waitFor(() => expect(sessionRows()).toHaveLength(6));
+  });
+
+  it("resets the page size when the coach switches exercise", async () => {
+    const { user } = renderProgress({
+      exercises: [
+        option({ exerciseId: "bench", name: "Bench Press", muscleGroups: ["chest"] }),
+        option({ exerciseId: "row", name: "Barbell Row", muscleGroups: ["back"] }),
+      ],
+      points: [point({ exerciseId: "bench" }), point({ exerciseId: "row" })],
+      setSessions: [
+        ...SESSIONS,
+        ...Array.from({ length: 7 }, (_, i) =>
+          session({ exerciseId: "row", date: `2026-08-0${i + 1}`, logId: `rowlog-${i}` }),
+        ),
+      ],
+    });
+
+    await user.click(screen.getByRole("button", { name: /See more/ }));
+    expect(sessionRows()).toHaveLength(6);
+
+    await user.click(screen.getByRole("combobox", { name: "Muscle group" }));
+    await user.click(await screen.findByRole("option", { name: "Back" }));
+
+    // A new exercise is a new history; carrying the expansion over shows a
+    // page size the coach never asked for on this exercise.
+    await waitFor(() => expect(sessionRows()).toHaveLength(3));
+  });
+});
+
+describe("ExerciseProgressClient — nothing logged at all", () => {
+  it("explains instead of rendering an empty chart frame", () => {
+    renderProgress({ exercises: [], points: [], setSessions: [] });
+
+    expect(screen.getByText(LABELS.emptyNoExercises)).toBeInTheDocument();
+    expect(screen.queryByRole("combobox")).not.toBeInTheDocument();
+  });
+});

--- a/backoffice/src/app/gc-fitness/clients/[id]/progress/__tests__/muscle-group-progress-client.test.tsx
+++ b/backoffice/src/app/gc-fitness/clients/[id]/progress/__tests__/muscle-group-progress-client.test.tsx
@@ -1,0 +1,323 @@
+/**
+ * @jest-environment jsdom
+ */
+
+// muscle-group-progress-client.test.tsx
+//
+// Weekly sets + volume per muscle group. As with the per-exercise chart, the
+// maths already has pure tests (`muscle-group-weeks`, `muscle-group-display`,
+// `muscle-group-preferences`); what nobody covered is the component's own job:
+// which weeks land in the window, which groups are drawn, and what the coach's
+// saved preferences are allowed to override.
+//
+// The FIRST THREE LINES of this file MUST stay as the
+// `/** @jest-environment jsdom */` docblock — the backoffice jest config
+// defaults to `testEnvironment: "node"` so without it React Testing Library
+// crashes with `ReferenceError: document is not defined`.
+//
+//   • A STORED SELECTION WINS OUTRIGHT (#578), INCLUDING AN EMPTY ONE. An empty
+//     stored array means "the coach unticked everything", not "nothing saved" —
+//     falling back to the defaults there re-adds chips the coach removed, every
+//     single time they open the page. It is also NOT intersected with the
+//     client's available groups: a group this client doesn't train is simply
+//     not drawn, and stays in the preference for the next client.
+//   • THE ORDER IS CANONICAL, NOT CLICK ORDER. Lines and legend entries have to
+//     keep their position when a group is toggled off and back on, or the
+//     colours shuffle under the coach mid-comparison.
+//   • PROJECTED WEEKS ONLY EXIST WHEN THERE IS A PROJECTION (#568). With no
+//     upcoming scheduled work the future weeks must not appear as empty
+//     columns — an empty projected week reads as "nothing planned AND nothing
+//     done".
+//   • THE READOUT SHOWS LOGGED → PROJECTED. On a Monday the logged figure alone
+//     says "1 set this week" for a client with four sessions booked.
+//
+// Recharts renders nothing measurable under jsdom, so the assertions read the
+// per-group readout line, which is computed from the same `windowWeeks` slice
+// the charts receive.
+
+import "@testing-library/jest-dom";
+
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import React from "react";
+
+import { MUSCLE_PREFERENCE_KEYS } from "@/lib/gc-fitness/muscle-group-preferences";
+import type { MuscleGroupWeekPoint } from "@/lib/gc-fitness/muscle-group-weeks";
+
+import { MuscleGroupProgressClient } from "../MuscleGroupProgressClient";
+
+const CURRENT_WEEK = "2026-08-03"; // a Monday
+const RANGE_STARTS = {
+  all: "2025-08-04",
+  "90": "2026-05-11",
+  "30": "2026-07-06",
+  "7": "2026-07-27",
+};
+
+function week(
+  weekStart: string,
+  byGroup: Record<string, number>,
+  extra: Partial<MuscleGroupWeekPoint> = {},
+): MuscleGroupWeekPoint {
+  return {
+    weekStart,
+    byGroup: Object.fromEntries(
+      Object.entries(byGroup).map(([g, sets]) => [g, { sets, volume: sets * 100 }]),
+    ),
+    projected: false,
+    ...extra,
+  } as MuscleGroupWeekPoint;
+}
+
+function renderChart(
+  props: Partial<React.ComponentProps<typeof MuscleGroupProgressClient>> = {},
+) {
+  render(
+    <MuscleGroupProgressClient
+      availableGroups={["chest", "back", "legs"]}
+      weeks={[week(CURRENT_WEEK, { chest: 10, back: 8, legs: 6 })]}
+      currentWeekStart={CURRENT_WEEK}
+      rangeStarts={RANGE_STARTS}
+      {...props}
+    />,
+  );
+  return { user: userEvent.setup() };
+}
+
+/** The per-group readout lines, in DOM order: ["Chest", "Back", …]. */
+function readoutGroups(): string[] {
+  return Array.from(document.querySelectorAll("span.inline-flex"))
+    .map((n) => n.querySelector("span.text-foreground")?.textContent ?? "")
+    .filter(Boolean);
+}
+
+/**
+ * A muscle-group chip. They are `role="checkbox"` (an aria-checked toggle),
+ * NOT buttons — `getByRole("button", …)` misses every one of them.
+ */
+function groupChip(_user: unknown, label: string): HTMLElement {
+  return screen.getByRole("checkbox", { name: label });
+}
+
+/** The readout text for one group, e.g. "10 sets this week → 14 projected". */
+function readoutFor(group: string): string {
+  const line = Array.from(document.querySelectorAll("span.inline-flex")).find(
+    (n) => n.querySelector("span.text-foreground")?.textContent === group,
+  );
+  return line?.querySelector("span.tabular-nums")?.textContent ?? "";
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  window.localStorage.clear();
+});
+
+describe("MuscleGroupProgressClient — the saved selection (#578)", () => {
+  it("restores the coach's stored chips over the defaults", async () => {
+    window.localStorage.setItem(
+      MUSCLE_PREFERENCE_KEYS.selected,
+      JSON.stringify(["legs"]),
+    );
+
+    renderChart();
+
+    await waitFor(() => expect(readoutGroups()).toEqual(["Legs"]));
+  });
+
+  it("treats an EMPTY stored selection as a real choice", async () => {
+    // The distinction that matters: `[]` is "I unticked everything", not
+    // "nothing saved". Falling back to the defaults here re-adds the chips the
+    // coach removed, every time they open the page.
+    window.localStorage.setItem(MUSCLE_PREFERENCE_KEYS.selected, JSON.stringify([]));
+
+    renderChart();
+
+    await waitFor(() => expect(readoutGroups()).toEqual([]));
+    expect(
+      screen.getByText("Select muscle groups above to compare them."),
+    ).toBeInTheDocument();
+  });
+
+  it("keeps a stored group this client doesn't train, without drawing it", async () => {
+    window.localStorage.setItem(
+      MUSCLE_PREFERENCE_KEYS.selected,
+      JSON.stringify(["chest", "shoulders"]),
+    );
+
+    const { user } = renderChart({ availableGroups: ["chest", "back"] });
+
+    // Not drawn — this client has no shoulders data.
+    await waitFor(() => expect(readoutGroups()).toEqual(["Chest"]));
+
+    // …but still IN the preference. Intersecting at restore time is invisible
+    // on screen (the chip list is already scoped to `availableGroups`) and only
+    // shows on the next write: the group would be silently dropped from the
+    // coach's saved selection by opening a client who doesn't train it.
+    // Verified by mutation — asserting only the readout left the intersection
+    // undetectable.
+    await user.click(groupChip(user, "Back"));
+
+    await waitFor(() => {
+      const stored = JSON.parse(
+        window.localStorage.getItem(MUSCLE_PREFERENCE_KEYS.selected) ?? "[]",
+      );
+      expect(stored).toContain("shoulders");
+    });
+  });
+
+  it("persists a toggle so the next visit starts there", async () => {
+    const { user } = renderChart();
+    await waitFor(() => expect(readoutGroups().length).toBeGreaterThan(0));
+
+    await user.click(groupChip(user, "Legs"));
+
+    await waitFor(() =>
+      expect(
+        window.localStorage.getItem(MUSCLE_PREFERENCE_KEYS.selected),
+      ).toBeTruthy(),
+    );
+    const stored = JSON.parse(
+      window.localStorage.getItem(MUSCLE_PREFERENCE_KEYS.selected) ?? "[]",
+    );
+    expect(stored).not.toContain("legs");
+  });
+});
+
+describe("MuscleGroupProgressClient — the group order", () => {
+  it("keeps the canonical order, not the click order", async () => {
+    window.localStorage.setItem(
+      MUSCLE_PREFERENCE_KEYS.selected,
+      JSON.stringify(["legs"]),
+    );
+    const { user } = renderChart();
+    await waitFor(() => expect(readoutGroups()).toEqual(["Legs"]));
+
+    await user.click(groupChip(user, "Chest"));
+
+    // Chest was clicked LAST but comes first: line colours and legend entries
+    // must not shuffle under the coach mid-comparison.
+    await waitFor(() => expect(readoutGroups()).toEqual(["Chest", "Legs"]));
+  });
+});
+
+describe("MuscleGroupProgressClient — the week window", () => {
+  const WEEKS = [
+    week("2026-05-04", { chest: 4 }),
+    week("2026-07-13", { chest: 8 }),
+    week(CURRENT_WEEK, { chest: 10 }),
+  ];
+
+  it("drops weeks older than the selected range", async () => {
+    window.localStorage.setItem(
+      MUSCLE_PREFERENCE_KEYS.selected,
+      JSON.stringify(["chest"]),
+    );
+    // Only an OLD week, so narrowing the range empties the window entirely and
+    // the readout's fallback has nothing left to fall back to. (With the
+    // current week present the filter is invisible here — recharts renders
+    // nothing measurable under jsdom, so this fallback is the only window
+    // observable the component exposes.)
+    // Inside the default 30-day window (starts 2026-07-06) and outside the
+    // 7-day one (starts 2026-07-27).
+    const { user } = renderChart({
+      weeks: [week("2026-07-13", { chest: 4 })],
+      currentWeekStart: CURRENT_WEEK,
+    });
+    await waitFor(() => expect(readoutFor("Chest")).toContain("4"));
+
+    await user.click(screen.getByRole("tab", { name: "7d" }));
+
+    await waitFor(() => expect(readoutFor("Chest")).toContain("0"));
+  });
+
+  it("keeps the whole history under the widest range", async () => {
+    window.localStorage.setItem(
+      MUSCLE_PREFERENCE_KEYS.selected,
+      JSON.stringify(["chest"]),
+    );
+    const { user } = renderChart({ weeks: WEEKS, currentWeekStart: "2026-09-07" });
+
+    await user.click(screen.getByRole("tab", { name: "All" }));
+
+    // Newest week in the window, since "today" has no point of its own.
+    await waitFor(() => expect(readoutFor("Chest")).toContain("10"));
+  });
+
+  it("falls back to the last week in the window when 'today' is outside it", async () => {
+    window.localStorage.setItem(
+      MUSCLE_PREFERENCE_KEYS.selected,
+      JSON.stringify(["chest"]),
+    );
+    renderChart({
+      weeks: [week("2026-07-13", { chest: 8 })],
+      currentWeekStart: CURRENT_WEEK, // no week point for it
+    });
+
+    // A client who hasn't trained this week still gets a readout — of their
+    // most recent week, not a blank.
+    await waitFor(() => expect(readoutFor("Chest")).toContain("8"));
+  });
+});
+
+describe("MuscleGroupProgressClient — the projection (#568)", () => {
+  it("shows logged → projected when there is upcoming work", async () => {
+    window.localStorage.setItem(
+      MUSCLE_PREFERENCE_KEYS.selected,
+      JSON.stringify(["chest"]),
+    );
+    renderChart({
+      weeks: [
+        week(CURRENT_WEEK, { chest: 2 }, {
+          projectedByGroup: { chest: { sets: 12, volume: 1200 } },
+        } as Partial<MuscleGroupWeekPoint>),
+      ],
+    });
+
+    // On a Monday, "2 sets this week" is technically true and useless.
+    await waitFor(() => expect(readoutFor("Chest")).toContain("12"));
+  });
+
+  it("shows the plain figure when nothing is scheduled ahead", async () => {
+    window.localStorage.setItem(
+      MUSCLE_PREFERENCE_KEYS.selected,
+      JSON.stringify(["chest"]),
+    );
+    renderChart({ weeks: [week(CURRENT_WEEK, { chest: 9 })] });
+
+    const text = readoutFor("Chest");
+    await waitFor(() => expect(text).toContain("9"));
+    // No arrow, no phantom projection.
+    expect(text).not.toContain("→");
+  });
+
+  it("hides projected-only weeks when the client has no upcoming work", async () => {
+    window.localStorage.setItem(
+      MUSCLE_PREFERENCE_KEYS.selected,
+      JSON.stringify(["chest"]),
+    );
+    renderChart({
+      weeks: [
+        week("2026-07-13", { chest: 9 }),
+        // A future week carrying no projection: an empty column that reads as
+        // "nothing planned AND nothing done".
+        week("2026-08-10", {}, { projected: true }),
+      ],
+      // No week point for "today", so the readout falls back to the LAST week
+      // in the window — which is exactly where a stray projected-empty week
+      // does its damage, and the only place jsdom can see the filter at all.
+      currentWeekStart: CURRENT_WEEK,
+    });
+
+    await waitFor(() => expect(readoutFor("Chest")).toContain("9"));
+  });
+});
+
+describe("MuscleGroupProgressClient — nothing logged", () => {
+  it("explains instead of drawing empty axes", () => {
+    renderChart({ availableGroups: [], weeks: [] });
+
+    expect(
+      screen.getByText("This client hasn't logged any completed sets yet."),
+    ).toBeInTheDocument();
+  });
+});

--- a/backoffice/src/app/gc-fitness/clients/[id]/sessions/[assignmentId]/run/__tests__/active-workout-session.test.tsx
+++ b/backoffice/src/app/gc-fitness/clients/[id]/sessions/[assignmentId]/run/__tests__/active-workout-session.test.tsx
@@ -1,0 +1,272 @@
+/**
+ * @jest-environment jsdom
+ */
+
+// active-workout-session.test.tsx
+//
+// The coach-run live session — the backoffice surface that writes `workout_logs`
+// in the SAME wire shape iOS and Android write. A drift here doesn't break the
+// portal, it breaks the client's history on all three surfaces.
+//
+// The FIRST THREE LINES of this file MUST stay as the
+// `/** @jest-environment jsdom */` docblock — the backoffice jest config
+// defaults to `testEnvironment: "node"` so without it React Testing Library
+// crashes with `ReferenceError: document is not defined`.
+//
+// The set-logging math lives in `use-live-session` and is already covered by
+// pure tests (`live-workout-*.test.ts`). What is NOT covered, and is what this
+// file pins, is the component's own TERMINAL orchestration:
+//
+//   1. THE FALSY GUARD. `finalize()` / `cancel()` return null/false when the
+//      write did not happen. The component must not close, toast, or navigate
+//      on that path — doing so tells a coach the session was saved when it was
+//      not, and they walk away from a workout that is still open.
+//   2. WHERE EACH ONE LANDS. Finish returns to the client's profile; cancel
+//      goes to the notifications hub instead, deliberately, so a cancelled
+//      workout does not re-enter the client-detail flow.
+//   3. THE CACHE. Finish INVALIDATES the session queries (refetch the new
+//      truth); cancel REMOVES them (there is nothing left to refetch). Getting
+//      these backwards leaves a finished-or-cancelled workout on screen.
+
+import "@testing-library/jest-dom";
+
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import React from "react";
+
+import { ActiveWorkoutSession } from "@/app/gc-fitness/clients/[id]/sessions/[assignmentId]/run/_components/active-workout-session";
+
+const mockPush = jest.fn();
+jest.mock("next/navigation", () => ({
+  useRouter: () => ({ push: mockPush }),
+}));
+
+const mockInvalidate = jest.fn();
+const mockRemove = jest.fn();
+jest.mock("@tanstack/react-query", () => ({
+  useQueryClient: () => ({
+    invalidateQueries: mockInvalidate,
+    removeQueries: mockRemove,
+  }),
+}));
+
+const mockFinalize = jest.fn();
+const mockCancel = jest.fn();
+const mockSession = {
+  logId: "log-1",
+  assignmentId: "assign-1",
+  clientId: "client-1",
+  trainerId: "trainer-9",
+  workoutName: { en: "Push Day", es: "Día de Empuje" },
+  startedAt: null,
+  status: "active",
+  exercises: [],
+  sets: [],
+  meetingNotes: null,
+  scheduledTime: null,
+  scheduledFor: "2026-09-17",
+  seriesId: "series-1",
+  prescriptionUpdatedAt: null,
+};
+jest.mock(
+  "@/app/gc-fitness/clients/[id]/sessions/[assignmentId]/run/_components/use-live-session",
+  () => ({
+    useLiveSession: () => ({
+      session: mockSession,
+      exercises: [],
+      rowsByExercise: {},
+      finalize: (...args: unknown[]) => mockFinalize(...args),
+      cancel: (...args: unknown[]) => mockCancel(...args),
+      loading: false,
+    }),
+  }),
+);
+
+jest.mock("@/lib/gc-fitness/live-workout-listener", () => ({
+  usePreviousSessionForClient: () => ({ data: {} }),
+  activeWorkoutSummariesKey: () => ["active-workout-summaries"],
+  activeSessionKey: (id: string) => ["active-session", id],
+}));
+
+// Children are their own surfaces; stub them and expose the two terminal
+// callbacks so the tests can drive finish/cancel directly.
+jest.mock(
+  "@/app/gc-fitness/clients/[id]/sessions/[assignmentId]/run/_components/finalize-dialog",
+  () => ({
+    FinalizeDialog: (props: Record<string, unknown>) => (
+      <button
+        type="button"
+        onClick={() =>
+          (props.onConfirm as (m: string, n: string | null) => void)(
+            "finish",
+            null,
+          )
+        }
+      >
+        stub-finalize
+      </button>
+    ),
+  }),
+);
+
+jest.mock(
+  "@/app/gc-fitness/clients/[id]/sessions/[assignmentId]/run/_components/cancel-workout-dialog",
+  () => ({
+    CancelWorkoutDialog: (props: Record<string, unknown>) => (
+      <button type="button" onClick={() => (props.onConfirm as () => void)()}>
+        stub-cancel
+      </button>
+    ),
+  }),
+);
+
+jest.mock(
+  "@/app/gc-fitness/clients/[id]/sessions/[assignmentId]/run/_components/session-exercise-card",
+  () => ({ SessionExerciseCard: () => null }),
+);
+
+jest.mock(
+  "@/app/gc-fitness/clients/[id]/sessions/[assignmentId]/run/_components/rest-timer-overlay",
+  () => ({ RestTimerOverlay: () => null }),
+);
+
+jest.mock(
+  "@/app/gc-fitness/clients/[id]/sessions/[assignmentId]/run/_components/use-rest-timer",
+  () => ({
+    useRestTimer: () => ({
+      start: jest.fn(),
+      stop: jest.fn(),
+      remaining: 0,
+      running: false,
+    }),
+  }),
+);
+
+const mockToastSuccess = jest.fn();
+const mockToastError = jest.fn();
+jest.mock("sonner", () => ({
+  toast: {
+    success: (...args: unknown[]) => mockToastSuccess(...args),
+    error: (...args: unknown[]) => mockToastError(...args),
+  },
+}));
+
+// NOT ASSERTED: the exact URL `cancelWorkout` hard-navigates to. It uses
+// `window.location.replace`, and this jsdom build makes both `window.location`
+// and its methods non-configurable and read-only — `defineProperty`, the
+// delete-then-define workaround, and `spyOn` all throw. What IS asserted below
+// is the observable half that matters just as much: cancel must NOT use the
+// Next router (`push`), because routing it through the client-detail flow is
+// exactly the behavior the source deliberately avoids.
+
+function renderSession() {
+  render(
+    <ActiveWorkoutSession
+      clientId="client-1"
+      assignmentId="assign-1"
+      initialSession={mockSession as never}
+    />,
+  );
+}
+
+const finish = (user: ReturnType<typeof userEvent.setup>) =>
+  user.click(screen.getByRole("button", { name: "stub-finalize" }));
+const cancel = (user: ReturnType<typeof userEvent.setup>) =>
+  user.click(screen.getByRole("button", { name: "stub-cancel" }));
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockFinalize.mockResolvedValue({ futureUpdated: 0 });
+  mockCancel.mockResolvedValue(true);
+});
+
+describe("ActiveWorkoutSession — finishing", () => {
+  it("navigates back to the client's profile and refreshes the caches", async () => {
+    const user = userEvent.setup();
+    renderSession();
+
+    await finish(user);
+
+    expect(mockFinalize).toHaveBeenCalledWith({ mode: "finish", notes: null });
+    expect(mockPush).toHaveBeenCalledWith("/gc-fitness/clients/client-1");
+    // INVALIDATE, not remove: there is a new finished log to refetch.
+    expect(mockInvalidate).toHaveBeenCalled();
+    expect(mockToastSuccess).toHaveBeenCalledWith("Entrenamiento finalizado");
+  });
+
+  it("mentions how many future occurrences the write-back touched", async () => {
+    const user = userEvent.setup();
+    mockFinalize.mockResolvedValueOnce({ futureUpdated: 3 });
+    renderSession();
+
+    await finish(user);
+
+    expect(mockToastSuccess).toHaveBeenCalledWith(
+      "Entrenamiento finalizado · 3 futuros actualizados",
+    );
+  });
+
+  it("uses the singular when exactly one future occurrence was updated", async () => {
+    const user = userEvent.setup();
+    mockFinalize.mockResolvedValueOnce({ futureUpdated: 1 });
+    renderSession();
+
+    await finish(user);
+
+    expect(mockToastSuccess).toHaveBeenCalledWith(
+      "Entrenamiento finalizado · 1 futuro actualizado",
+    );
+  });
+
+  it("does NOT navigate or toast when finalize reports no write", async () => {
+    const user = userEvent.setup();
+    mockFinalize.mockResolvedValueOnce(null);
+    renderSession();
+
+    await finish(user);
+
+    // The session is still open. Telling the coach otherwise is how a workout
+    // gets abandoned mid-write.
+    expect(mockPush).not.toHaveBeenCalled();
+    expect(mockToastSuccess).not.toHaveBeenCalled();
+  });
+});
+
+describe("ActiveWorkoutSession — cancelling", () => {
+  it("does not route back through the client profile", async () => {
+    const user = userEvent.setup();
+    renderSession();
+
+    await cancel(user);
+
+    expect(mockCancel).toHaveBeenCalledTimes(1);
+    // Deliberate per the source: a cancelled workout must not re-enter the
+    // client-detail flow, so the Next router is never used here.
+    expect(mockPush).not.toHaveBeenCalled();
+    expect(mockToastSuccess).toHaveBeenCalledWith(
+      "Entrenamiento cancelado · volvió a programado",
+    );
+  });
+
+  it("REMOVES the session queries rather than refetching them", async () => {
+    const user = userEvent.setup();
+    renderSession();
+
+    await cancel(user);
+
+    // Nothing left to refetch — an invalidate here would re-request a session
+    // that no longer exists.
+    expect(mockRemove).toHaveBeenCalled();
+  });
+
+  it("does NOT navigate when cancel reports it did not happen", async () => {
+    const user = userEvent.setup();
+    mockCancel.mockResolvedValueOnce(false);
+    renderSession();
+
+    await cancel(user);
+
+    expect(mockToastSuccess).not.toHaveBeenCalled();
+    expect(mockRemove).not.toHaveBeenCalled();
+  });
+});

--- a/backoffice/src/app/gc-fitness/clients/[id]/sessions/[assignmentId]/run/__tests__/session-exercise-card.test.tsx
+++ b/backoffice/src/app/gc-fitness/clients/[id]/sessions/[assignmentId]/run/__tests__/session-exercise-card.test.tsx
@@ -1,0 +1,192 @@
+/**
+ * @jest-environment jsdom
+ */
+
+// session-exercise-card.test.tsx
+//
+// One exercise inside the coach-run live session: the set rows the coach
+// actually taps through while standing next to the client.
+//
+// The FIRST THREE LINES of this file MUST stay as the
+// `/** @jest-environment jsdom */` docblock — the backoffice jest config
+// defaults to `testEnvironment: "node"` so without it React Testing Library
+// crashes with `ReferenceError: document is not defined`.
+//
+// The card owns no state — every interaction is a callback with an INDEX. That
+// index is the whole risk surface: an off-by-one marks the wrong set done,
+// edits the wrong weight, or removes a set the coach meant to keep, and none of
+// it errors. So these tests assert the (index, value) pairs that leave the card.
+//
+// Also pinned: a set already marked done LOCKS its inputs. Without that, a
+// stray tap after logging silently rewrites a set the client already performed.
+
+import "@testing-library/jest-dom";
+
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import React from "react";
+
+import { SessionExerciseCard } from "@/app/gc-fitness/clients/[id]/sessions/[assignmentId]/run/_components/session-exercise-card";
+
+// The card imports a Server Action, which drags `firebase-admin` (and its
+// node-only crypto deps) into the jsdom bundle. Stub the module.
+jest.mock("@/lib/gc-fitness/live-workout-actions", () => ({
+  setClientExerciseNote: jest.fn(),
+}));
+
+jest.mock("@/lib/gc-fitness/live-workout-listener", () => ({
+  clientExerciseNoteKey: (a: string, b: string) => ["note", a, b],
+  useClientExerciseNote: () => ({ data: null, isLoading: false }),
+}));
+
+jest.mock("@tanstack/react-query", () => ({
+  useQueryClient: () => ({ invalidateQueries: jest.fn(), setQueryData: jest.fn() }),
+  useMutation: () => ({ mutate: jest.fn(), isPending: false }),
+}));
+
+jest.mock("@/components/gc-fitness/exercise-preview-thumb", () => ({
+  ExercisePreviewThumb: () => null,
+}));
+
+jest.mock("@/components/gc-fitness/StorageImagePreview", () => ({
+  StorageImagePreview: () => null,
+}));
+
+function row(overrides: Record<string, unknown> = {}) {
+  return {
+    id: "set-1",
+    weightKg: 60,
+    reps: 10,
+    durationSeconds: null,
+    isWarmup: false,
+    setType: "normal",
+    done: false,
+    completedAt: null,
+    ...overrides,
+  };
+}
+
+const EXERCISE = {
+  exerciseId: "ex-bench",
+  name: { en: "Bench Press", es: "Press Banca" },
+  previewUrl: null,
+  mediaUrl: null,
+  videoUrl: null,
+  restSeconds: 90,
+  transitionRestSeconds: 120,
+  notes: "",
+  metric: "reps",
+  supersetGroup: null,
+  setTypesBySet: ["normal", "normal", "normal"],
+};
+
+function renderCard(rows: Array<Record<string, unknown>>, overrides = {}) {
+  const handlers = {
+    onWeight: jest.fn(),
+    onReps: jest.fn(),
+    onDuration: jest.fn(),
+    onToggleDone: jest.fn(),
+    onSetType: jest.fn(),
+    onAddSet: jest.fn(),
+    onRemoveSet: jest.fn(),
+    onMove: jest.fn(),
+  };
+  render(
+    <SessionExerciseCard
+      clientId="client-1"
+      exercise={EXERCISE as never}
+      rows={rows as never}
+      canMoveUp
+      canMoveDown
+      {...handlers}
+      {...overrides}
+    />,
+  );
+  return handlers;
+}
+
+/** The done buttons are titled "Marcar como hecha" / "Desmarcar", in row order. */
+function doneButtons() {
+  return screen.getAllByRole("button", {
+    name: /Marcar como hecha|Desmarcar/,
+  });
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe("SessionExerciseCard — which set the tap lands on", () => {
+  it("marks the SECOND set done with index 1, not 0 or 2", async () => {
+    const user = userEvent.setup();
+    const handlers = renderCard([row(), row({ id: "set-2" }), row({ id: "set-3" })]);
+
+    await user.click(doneButtons()[1]);
+
+    // The off-by-one here logs a set the client did not do and leaves the one
+    // they did unlogged.
+    expect(handlers.onToggleDone).toHaveBeenCalledTimes(1);
+    expect(handlers.onToggleDone).toHaveBeenCalledWith(1);
+  });
+
+  it("marks the LAST set done with the last index", async () => {
+    const user = userEvent.setup();
+    const handlers = renderCard([row(), row({ id: "set-2" }), row({ id: "set-3" })]);
+
+    const buttons = doneButtons();
+    await user.click(buttons[buttons.length - 1]);
+
+    expect(handlers.onToggleDone).toHaveBeenCalledWith(2);
+  });
+
+  it("removes the LAST set, never an arbitrary one", async () => {
+    const user = userEvent.setup();
+    const handlers = renderCard([row(), row({ id: "set-2" }), row({ id: "set-3" })]);
+
+    await user.click(screen.getByRole("button", { name: /Quitar|Eliminar serie|−|-/ }));
+
+    // The remove affordance is a single "drop the last set" action — passing
+    // anything but `rows.length - 1` deletes a set the coach was looking at.
+    expect(handlers.onRemoveSet).toHaveBeenCalledWith(2);
+  });
+
+  it("adds a set through onAddSet", async () => {
+    const user = userEvent.setup();
+    const handlers = renderCard([row()]);
+
+    await user.click(screen.getByRole("button", { name: /Agregar serie/i }));
+
+    expect(handlers.onAddSet).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("SessionExerciseCard — a logged set is locked", () => {
+  it("disables the inputs of a set already marked done", () => {
+    renderCard([row({ done: true }), row({ id: "set-2" })]);
+
+    // Queried from the DOM, not by role: the numeric fields are `inputMode`
+    // text inputs, so they expose `textbox`, not `spinbutton`.
+    const numberInputs = Array.from(
+      document.querySelectorAll("input"),
+    ) as HTMLInputElement[];
+
+    // The first row's inputs belong to the done set and must be locked; a stray
+    // tap otherwise rewrites a set the client already performed.
+    expect(numberInputs[0]).toBeDisabled();
+    // …and a not-yet-done row stays editable.
+    expect(numberInputs.some((el) => !el.disabled)).toBe(true);
+  });
+});
+
+describe("SessionExerciseCard — reordering", () => {
+  it("moves the exercise up with -1 and down with +1", async () => {
+    const user = userEvent.setup();
+    const handlers = renderCard([row()]);
+
+    await user.click(screen.getByRole("button", { name: "Subir ejercicio" }));
+    expect(handlers.onMove).toHaveBeenCalledWith(-1);
+
+    await user.click(screen.getByRole("button", { name: "Bajar ejercicio" }));
+    expect(handlers.onMove).toHaveBeenCalledWith(1);
+  });
+});

--- a/backoffice/src/app/gc-fitness/clients/_components/__tests__/roster-table.test.tsx
+++ b/backoffice/src/app/gc-fitness/clients/_components/__tests__/roster-table.test.tsx
@@ -1,0 +1,266 @@
+/**
+ * @jest-environment jsdom
+ */
+
+// roster-table.test.tsx
+//
+// The client roster — the coach's home screen, and the only way into a client.
+//
+// The FIRST THREE LINES of this file MUST stay as the
+// `/** @jest-environment jsdom */` docblock — the backoffice jest config
+// defaults to `testEnvironment: "node"` so without it React Testing Library
+// crashes with `ReferenceError: document is not defined`.
+//
+// The invariant that matters most here is THE ROUTE FORK. A client who signed
+// up but has never signed in has no `/users/{uid}` document yet, so their card
+// must route to `/clients/pending/<email>` and NOT to `/clients/<uid>` — the
+// latter 404s. This is the same failure family as #392/#400 on the other
+// surfaces: a row that is legitimately present but whose identity is shaped
+// differently, and every `uid`-shaped assumption around it breaks quietly.
+//
+// Two details of that fork that are easy to lose:
+//   • THE EMAIL IS URL-ENCODED. Emails with a `+` tag (`ana+gym@…`) are common
+//     and a raw `+` decodes back as a SPACE, so the pending page looks up an
+//     address that doesn't exist and shows "not found" for a client who is
+//     right there in the list.
+//   • BOTH ACTIVATION PATHS ROUTE THE SAME. The card is a `role="link"` with a
+//     click handler AND an Enter/Space keydown handler — two independent code
+//     paths to the same push. #163 shipped a bug that lived in exactly one of
+//     the two, so both get asserted (same as `templates/client.tsx`).
+//
+// The at-risk filter has its own trap: the COUNT is over the whole roster while
+// the LIST is filtered, so the button must keep saying "Needs attention (3)"
+// after it hides the other clients — a count that collapses to the filtered set
+// makes the coach think the others got better.
+
+import "@testing-library/jest-dom";
+
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import React from "react";
+
+import type { ClientRosterRow } from "@/lib/gc-fitness/client-roster";
+
+const mockPush = jest.fn();
+jest.mock("next/navigation", () => ({
+  useRouter: () => ({ push: (...args: unknown[]) => mockPush(...args) }),
+}));
+
+import { RosterTable } from "../RosterTable";
+
+const TRAINER = "trainer-1";
+const TZ = "America/Argentina/Buenos_Aires";
+
+function client(overrides: Partial<ClientRosterRow> = {}): ClientRosterRow {
+  return {
+    uid: "ana",
+    email: "ana@example.com",
+    displayName: "Ana Gomez",
+    createdAt: "2026-07-01T00:00:00.000Z",
+    photoURL: null,
+    timezone: TZ,
+    source: "active",
+    pendingProvisioning: false,
+    autoAssignedCoach: false,
+    lastActivityAt: "2026-08-05T12:00:00.000Z",
+    thisWeekComplianceRatio: 0.8,
+    unreadChatCount: 0,
+    missedWorkoutsLast7Days: 0,
+    needsAttention: false,
+    needsAttentionReasons: [],
+    habitsCompletedThisWeek: 4,
+    habitsScheduledThisWeek: 5,
+    workoutsCompletedThisMonth: 6,
+    workoutsScheduledThisMonth: 8,
+    goalsCount: { short: 1, medium: 0, long: 0 },
+    ...overrides,
+  } as ClientRosterRow;
+}
+
+function renderRoster(rows: ClientRosterRow[]) {
+  render(<RosterTable rows={rows} trainerUid={TRAINER} timezone={TZ} />);
+  return { user: userEvent.setup() };
+}
+
+/** The clickable card for a client, matched by their displayed name. */
+function cardFor(name: string): HTMLElement {
+  const node = screen.getByText(name).closest('[role="link"]');
+  if (!node) throw new Error(`roster card for ${name} not found`);
+  return node as HTMLElement;
+}
+
+function visibleNames(): string[] {
+  return screen
+    .queryAllByRole("link")
+    .map((c) => c.querySelector(".truncate")?.textContent ?? "");
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe("RosterTable — the pending route fork", () => {
+  it("routes an ACTIVE client to their uid page", async () => {
+    const { user } = renderRoster([client()]);
+
+    await user.click(cardFor("Ana Gomez"));
+
+    expect(mockPush).toHaveBeenCalledWith("/gc-fitness/clients/ana");
+  });
+
+  it("routes a PENDING client to the pending page, by email", async () => {
+    const { user } = renderRoster([
+      client({
+        uid: "pending-uid",
+        displayName: "Beto Diaz",
+        email: "beto@example.com",
+        pendingProvisioning: true,
+      }),
+    ]);
+
+    await user.click(cardFor("Beto Diaz"));
+
+    // There is no `/users/{uid}` doc until the first sign-in, so the uid route
+    // 404s on a client who is sitting right there in the roster.
+    expect(mockPush).toHaveBeenCalledWith(
+      "/gc-fitness/clients/pending/beto%40example.com",
+    );
+  });
+
+  it("URL-encodes a plus-tagged email", async () => {
+    const { user } = renderRoster([
+      client({
+        displayName: "Caro Ruiz",
+        email: "caro+gym@example.com",
+        pendingProvisioning: true,
+      }),
+    ]);
+
+    await user.click(cardFor("Caro Ruiz"));
+
+    // A raw `+` decodes back as a SPACE, so the pending page looks up an
+    // address that doesn't exist and reports "not found".
+    expect(mockPush).toHaveBeenCalledWith(
+      "/gc-fitness/clients/pending/caro%2Bgym%40example.com",
+    );
+  });
+
+  it("routes the same way from the KEYBOARD", async () => {
+    const { user } = renderRoster([
+      client({ displayName: "Beto Diaz", email: "beto@example.com", pendingProvisioning: true }),
+    ]);
+
+    cardFor("Beto Diaz").focus();
+    await user.keyboard("{Enter}");
+
+    // Click and keydown are two independent handlers; #163 shipped a bug that
+    // lived in exactly one of them.
+    expect(mockPush).toHaveBeenCalledWith(
+      "/gc-fitness/clients/pending/beto%40example.com",
+    );
+  });
+
+  it("routes on Space as well as Enter", async () => {
+    const { user } = renderRoster([client()]);
+
+    cardFor("Ana Gomez").focus();
+    await user.keyboard(" ");
+
+    expect(mockPush).toHaveBeenCalledWith("/gc-fitness/clients/ana");
+  });
+});
+
+describe("RosterTable — the at-risk filter", () => {
+  const ROWS = [
+    client({ uid: "ana", displayName: "Ana Gomez", email: "ana@example.com", needsAttention: false }),
+    client({
+      uid: "beto",
+      displayName: "Beto Diaz",
+      email: "beto@example.com",
+      needsAttention: true,
+      needsAttentionReasons: ["inactive"] as unknown as ClientRosterRow["needsAttentionReasons"],
+    }),
+    client({
+      uid: "caro",
+      displayName: "Caro Ruiz",
+      email: "caro@example.com",
+      needsAttention: true,
+      needsAttentionReasons: ["inactive"] as unknown as ClientRosterRow["needsAttentionReasons"],
+    }),
+  ];
+
+  it("keeps only the clients who need attention", async () => {
+    const { user } = renderRoster(ROWS);
+
+    await user.click(screen.getByRole("button", { name: /Needs attention \(2\)/ }));
+
+    expect(visibleNames().sort()).toEqual(["Beto Diaz", "Caro Ruiz"]);
+  });
+
+  it("counts over the WHOLE roster, not the filtered list", async () => {
+    const { user } = renderRoster(ROWS);
+    const toggle = screen.getByRole("button", { name: /Needs attention \(2\)/ });
+
+    await user.click(toggle);
+
+    // A count that collapses to the filtered set reads as "the others got
+    // better" the moment the filter is on.
+    expect(
+      screen.getByRole("button", { name: /Needs attention \(2\)/ }),
+    ).toHaveAttribute("aria-pressed", "true");
+  });
+
+  it("comes back off again", async () => {
+    const { user } = renderRoster(ROWS);
+
+    await user.click(screen.getByRole("button", { name: /Needs attention \(2\)/ }));
+    await user.click(screen.getByRole("button", { name: /Needs attention \(2\)/ }));
+
+    expect(visibleNames()).toHaveLength(3);
+  });
+});
+
+describe("RosterTable — search", () => {
+  const ROWS = [
+    client({ uid: "ana", displayName: "Ana Gomez", email: "ana@example.com" }),
+    client({ uid: "beto", displayName: "Beto Diaz", email: "beto@gym.test" }),
+  ];
+
+  it("matches the display name", async () => {
+    const { user } = renderRoster(ROWS);
+
+    await user.type(screen.getByRole("searchbox"), "beto d");
+
+    expect(visibleNames()).toEqual(["Beto Diaz"]);
+  });
+
+  it("matches the EMAIL too", async () => {
+    const { user } = renderRoster(ROWS);
+
+    // Coaches look people up by the address they invited, which is often the
+    // only thing they remember.
+    await user.type(screen.getByRole("searchbox"), "gym.test");
+
+    expect(visibleNames()).toEqual(["Beto Diaz"]);
+  });
+
+  it("says 'no clients' for a search that matches nobody", async () => {
+    const { user } = renderRoster(ROWS);
+
+    await user.type(screen.getByRole("searchbox"), "zzzz");
+
+    expect(visibleNames()).toEqual([]);
+    expect(screen.getByText("No clients in your roster yet.")).toBeInTheDocument();
+  });
+});
+
+describe("RosterTable — an empty roster", () => {
+  it("shows the designed empty state, not an empty grid", () => {
+    renderRoster([]);
+
+    // A blank page reads as a loading failure; the empty state tells the coach
+    // what to do next.
+    expect(screen.queryByRole("searchbox")).not.toBeInTheDocument();
+    expect(screen.queryAllByRole("link")).toHaveLength(0);
+  });
+});

--- a/backoffice/src/app/gc-fitness/dashboard/__tests__/coach-pulse.test.tsx
+++ b/backoffice/src/app/gc-fitness/dashboard/__tests__/coach-pulse.test.tsx
@@ -1,0 +1,274 @@
+/**
+ * @jest-environment jsdom
+ */
+
+// coach-pulse.test.tsx
+//
+// The dashboard's four presentational pieces: the two 7-day charts, the
+// podium, and the recent-activity row. Nothing here writes, so the assertions
+// go to the SCREEN — same shape as workout-log-detail-view.test.tsx.
+//
+// The FIRST THREE LINES of this file MUST stay as the
+// `/** @jest-environment jsdom */` docblock — the backoffice jest config
+// defaults to `testEnvironment: "node"` so without it React Testing Library
+// crashes with `ReferenceError: document is not defined`.
+//
+// The distinction the whole card hangs on is NOTHING SCHEDULED vs SCHEDULED
+// AND MISSED. Both are "0" and they mean opposite things: one is a rest day,
+// the other is a client who didn't do the work. The component keeps them apart
+// three separate times — the empty state, the bar height, and the label — and
+// each one can regress on its own:
+//
+//   • THE EMPTY STATE IS `some`, NOT `every`. A week with a single scheduled
+//     day still gets a chart; collapsing to "every day must have data" hides a
+//     real week behind "no data yet".
+//   • A ZERO-DENOMINATOR DAY IS A ZERO-HEIGHT MUTED BAR. The 4% floor that
+//     keeps a missed day visible must NOT apply to it, or a rest day looks
+//     exactly like a failed one.
+//   • THE LABEL SAYS "nothing scheduled", never "0%".
+
+import "@testing-library/jest-dom";
+
+import { render, screen, within } from "@testing-library/react";
+import React from "react";
+
+import type { DailyMetric, PerformerRow } from "@/lib/gc-fitness/coach-pulse-actions";
+
+import {
+  ActivityRow,
+  DailyBars,
+  DailyLineChart,
+  TopPerformers,
+  type ActivityRowData,
+} from "../_components/coach-pulse";
+
+function day(overrides: Partial<DailyMetric> = {}): DailyMetric {
+  return {
+    civilDate: "2026-09-10",
+    weekdayLabel: "THU",
+    numerator: 3,
+    denominator: 4,
+    percentage: 75,
+    ...overrides,
+  };
+}
+
+const REST_DAY = day({
+  civilDate: "2026-09-08",
+  weekdayLabel: "TUE",
+  numerator: 0,
+  denominator: 0,
+  percentage: 0,
+});
+
+const MISSED_DAY = day({
+  civilDate: "2026-09-09",
+  weekdayLabel: "WED",
+  numerator: 0,
+  denominator: 3,
+  percentage: 0,
+});
+
+/** The bar/dot buttons, in render order. Their accessible name is the tooltip
+ *  text, which is where the "nothing scheduled" wording lives. */
+function pointLabels(): string[] {
+  return screen.getAllByRole("button").map((b) => b.getAttribute("aria-label") ?? "");
+}
+
+describe("DailyBars — a rest day is not a missed day", () => {
+  it("renders the chart when even ONE day has something scheduled", () => {
+    render(
+      <DailyBars data={[REST_DAY, MISSED_DAY]} emptyLabel="No data yet" unitLabel="habits" />,
+    );
+
+    expect(screen.queryByText("No data yet")).not.toBeInTheDocument();
+    expect(screen.getAllByRole("button")).toHaveLength(2);
+  });
+
+  it("falls back to the empty label only when NOTHING was scheduled all week", () => {
+    render(
+      <DailyBars
+        data={[REST_DAY, { ...REST_DAY, civilDate: "2026-09-09" }]}
+        emptyLabel="No data yet"
+        unitLabel="habits"
+      />,
+    );
+
+    expect(screen.getByText("No data yet")).toBeInTheDocument();
+    expect(screen.queryAllByRole("button")).toHaveLength(0);
+  });
+
+  it("says 'nothing scheduled' for a rest day and gives the numbers for the rest", () => {
+    render(
+      <DailyBars data={[REST_DAY, MISSED_DAY, day()]} emptyLabel="x" unitLabel="habits" />,
+    );
+
+    expect(pointLabels()).toEqual([
+      "TUE: nothing scheduled",
+      "WED: 0 of 3 habits (0%)",
+      "THU: 3 of 4 habits (75%)",
+    ]);
+  });
+
+  it("draws a rest day at zero height and a missed day at the visible floor", () => {
+    // Both are "0". Without the 4% floor the missed day disappears; with the
+    // floor applied to the rest day too, a rest day grows a bar it should not
+    // have.
+    render(
+      <DailyBars data={[REST_DAY, MISSED_DAY]} emptyLabel="x" unitLabel="habits" />,
+    );
+
+    const [rest, missed] = screen.getAllByRole("button").map((b) => b.firstElementChild as HTMLElement);
+    expect(rest.style.height).toBe("0%");
+    expect(missed.style.height).toBe("4%");
+  });
+
+  it("emphasises the LAST day, which is today", () => {
+    const { container } = render(
+      <DailyBars data={[REST_DAY, MISSED_DAY, day()]} emptyLabel="x" unitLabel="habits" />,
+    );
+
+    const labels = Array.from(
+      container.querySelectorAll(".mt-2 > span"),
+    ) as HTMLElement[];
+    expect(labels.map((l) => l.textContent)).toEqual(["TUE", "WED", "THU"]);
+    expect(labels.at(-1)?.className).toContain("font-semibold");
+    expect(labels[0].className).not.toContain("font-semibold");
+  });
+});
+
+describe("DailyLineChart — the same data as a line", () => {
+  it("shares the bar chart's empty rule and its labels", () => {
+    const { unmount } = render(
+      <DailyLineChart data={[REST_DAY]} emptyLabel="No data yet" unitLabel="workouts" />,
+    );
+    expect(screen.getByText("No data yet")).toBeInTheDocument();
+    unmount();
+
+    render(
+      <DailyLineChart data={[REST_DAY, MISSED_DAY]} emptyLabel="No data yet" unitLabel="workouts" />,
+    );
+    expect(pointLabels()).toEqual([
+      "TUE: nothing scheduled",
+      "WED: 0 of 3 workouts (0%)",
+    ]);
+  });
+
+  it("INVERTS the percentage into the viewBox — 100% sits at the top", () => {
+    // y = 100 - percentage. Getting the sign wrong flips the whole chart and
+    // it still looks like a plausible line.
+    render(
+      <DailyLineChart
+        data={[day({ percentage: 0 }), day({ percentage: 100 })]}
+        emptyLabel="x"
+        unitLabel="workouts"
+      />,
+    );
+
+    const [low, high] = screen.getAllByRole("button") as HTMLElement[];
+    expect(low.style.top).toBe("100%");
+    expect(high.style.top).toBe("0%");
+  });
+
+  it("spaces the points evenly across the width", () => {
+    render(
+      <DailyLineChart
+        data={[day(), day({ civilDate: "2026-09-11" }), day({ civilDate: "2026-09-12" })]}
+        emptyLabel="x"
+        unitLabel="workouts"
+      />,
+    );
+
+    expect(
+      (screen.getAllByRole("button") as HTMLElement[]).map((b) => b.style.left),
+    ).toEqual(["0%", "50%", "100%"]);
+  });
+
+  it("centres a lone point instead of dividing by zero", () => {
+    render(<DailyLineChart data={[day()]} emptyLabel="x" unitLabel="workouts" />);
+
+    expect((screen.getByRole("button") as HTMLElement).style.left).toBe("50%");
+  });
+});
+
+describe("TopPerformers", () => {
+  function performer(overrides: Partial<PerformerRow> = {}): PerformerRow {
+    return {
+      uid: "ana",
+      name: "Ana Gomez",
+      photoURL: null,
+      pct: 90,
+      numerator: 9,
+      denominator: 10,
+      ...overrides,
+    };
+  }
+
+  it("ranks from 1 and links each row to the client", () => {
+    render(
+      <TopPerformers
+        performers={[performer(), performer({ uid: "beto", name: "Beto Diaz", pct: 80 })]}
+      />,
+    );
+
+    const [first, second] = screen.getAllByRole("link");
+    expect(within(first).getByText("1")).toBeInTheDocument();
+    expect(first).toHaveAttribute("href", "/gc-fitness/clients/ana");
+    expect(within(second).getByText("2")).toBeInTheDocument();
+    expect(second).toHaveAttribute("href", "/gc-fitness/clients/beto");
+  });
+
+  it("shows the ratio behind the percentage", () => {
+    // 90% off 9/10 and 90% off 45/50 are different weeks; the percentage alone
+    // hides how much the client was actually asked to do.
+    render(<TopPerformers performers={[performer()]} />);
+
+    expect(screen.getByText("9/10")).toBeInTheDocument();
+    expect(screen.getByText("90%")).toBeInTheDocument();
+  });
+
+  it("uses the caller's empty label, falling back to its own", () => {
+    const { unmount } = render(<TopPerformers performers={[]} emptyLabel="Nobody yet" />);
+    expect(screen.getByText("Nobody yet")).toBeInTheDocument();
+    unmount();
+
+    render(<TopPerformers performers={[]} />);
+    expect(screen.getByText("No habit activity to rank yet.")).toBeInTheDocument();
+  });
+});
+
+describe("ActivityRow", () => {
+  function activity(overrides: Partial<ActivityRowData> = {}): ActivityRowData {
+    return {
+      uid: "ana",
+      name: "Ana Gomez",
+      photoURL: null,
+      primary: "Completed Upper Body",
+      timeLabel: "2h ago",
+      ratio: 0.8,
+      stale: false,
+      ...overrides,
+    };
+  }
+
+  it("marks an on-track client with the check, a stale one with the clock", () => {
+    const { container, unmount } = render(<ActivityRow row={activity()} />);
+    expect(container.querySelector(".lucide-circle-check")).not.toBeNull();
+    expect(container.querySelector(".lucide-clock")).toBeNull();
+    unmount();
+
+    const { container: stale } = render(<ActivityRow row={activity({ stale: true })} />);
+    expect(stale.querySelector(".lucide-clock")).not.toBeNull();
+    expect(stale.querySelector(".lucide-circle-check")).toBeNull();
+  });
+
+  it("prints the server-rendered copy verbatim and links to the client", () => {
+    // Both `primary` and `timeLabel` are localized server-side; the row must
+    // not re-derive them.
+    render(<ActivityRow row={activity()} />);
+
+    expect(screen.getByText("Completed Upper Body")).toBeInTheDocument();
+    expect(screen.getByText("2h ago")).toBeInTheDocument();
+    expect(screen.getByRole("link")).toHaveAttribute("href", "/gc-fitness/clients/ana");
+  });
+});

--- a/backoffice/src/app/gc-fitness/exercises/__tests__/exercises-client-list.test.tsx
+++ b/backoffice/src/app/gc-fitness/exercises/__tests__/exercises-client-list.test.tsx
@@ -1,0 +1,537 @@
+/**
+ * @jest-environment jsdom
+ */
+
+// exercises-client-list.test.tsx
+//
+// The exercise library list: the pipeline from the cached feed to the rows on
+// screen, and the per-row action gate.
+//
+// The FIRST THREE LINES of this file MUST stay as the
+// `/** @jest-environment jsdom */` docblock — the backoffice jest config
+// defaults to `testEnvironment: "node"` so without it React Testing Library
+// crashes with `ReferenceError: document is not defined`.
+//
+// The pipeline is five stages deep and the ORDER of the first three is the
+// whole point:
+//
+//     isPickableExercise → dedupeExercisesByDisplayName → chip filters
+//        → searchExercises → favorites → usage sort
+//
+//   • VISIBILITY FIRST (#552 / the 2026-06-12 retirement decision). ~400 legacy
+//     `fexd-*` / `wger-*` / `standard_alias` docs are alive in Firestore ON
+//     PURPOSE — ~600 historical templates and logs reference their ids, so
+//     hiding them is CODE-SIDE only, never a `deleted: true` write. The
+//     `ownerId != null` half of the predicate is load-bearing: `snapToRow`
+//     coerces every unknown wire `source` to `"trainer"`, so a bare
+//     `source === "trainer"` check keeps all 24 alias docs pickable.
+//   • DEDUPE SECOND, BEFORE filter and search (#179). Prod's standard library
+//     is DOUBLE-SEEDED: every curated exercise exists as a numeric-id doc with
+//     working https media AND as a `std-<slug>` twin whose media is a
+//     non-renderable `gs://` URL. Un-deduped, the library shows everything
+//     twice, the second copy with a broken thumbnail — and, because search
+//     runs after, a search for one exercise returns two hits.
+//   • THE ACTION GATE. A library exercise is READ-ONLY: View + Duplicate. Only
+//     a trainer-owned one gets Edit + Delete. The gate is `!== "trainer"`, not
+//     `=== "wger"` — that spelling is the fix for the free-exercise-db rows
+//     that used to offer Edit and 404 on it. Same shape as the #163 invariant
+//     on templates.
+//
+// `ExerciseFilters` is stubbed with one button per preset filter state, so
+// these tests drive the parent's pipeline directly instead of re-driving the
+// chip UI (which has its own surface). Everything the pipeline is MADE of —
+// the visibility predicate, the dedupe, the ranked search, the columns — stays
+// real; mocking those would leave nothing under test.
+
+import "@testing-library/jest-dom";
+
+import { QueryClientProvider, QueryClient } from "@tanstack/react-query";
+import { render, screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import React from "react";
+
+import type { ExerciseRow } from "@/lib/gc-fitness/exercises-listener";
+import type { ExerciseFiltersState } from "../_components/ExerciseFilters";
+
+const mockUseExercises = jest.fn();
+jest.mock("@/lib/gc-fitness/exercises-listener", () => ({
+  EXERCISES_QUERY_KEY: ["gc-fitness", "exercises"],
+  useExercisesQuery: (...args: unknown[]) => mockUseExercises(...args),
+}));
+
+const mockSoftDeleteExercise = jest.fn();
+const mockDuplicateExercise = jest.fn();
+jest.mock("@/lib/gc-fitness/exercise-server-actions", () => ({
+  softDeleteExercise: (...args: unknown[]) => mockSoftDeleteExercise(...args),
+  duplicateExercise: (...args: unknown[]) => mockDuplicateExercise(...args),
+}));
+
+const mockFavorites = jest.fn();
+jest.mock("@/lib/gc-fitness/use-favorites", () => ({
+  useFavorites: () => ({ favorites: mockFavorites(), isFavorite: () => false, toggle: jest.fn() }),
+}));
+
+const mockUsageCounts = jest.fn();
+jest.mock("@/lib/gc-fitness/library-usage-listeners", () => ({
+  useExerciseUsageCounts: () => ({ data: mockUsageCounts() }),
+}));
+
+const mockPush = jest.fn();
+jest.mock("next/navigation", () => ({
+  useRouter: () => ({ push: (...args: unknown[]) => mockPush(...args), back: jest.fn() }),
+}));
+
+jest.mock("sonner", () => ({
+  toast: { success: jest.fn(), error: jest.fn() },
+}));
+
+jest.mock("../_components/NewExerciseDialog", () => ({
+  NewExerciseDialog: () => null,
+}));
+
+// One button per preset filter state. Driving the real chip UI would test the
+// filter component, not this pipeline; what matters here is what the parent
+// DOES with a given state.
+const mockFilterPresets: Record<string, Partial<ExerciseFiltersState>> = {
+  standard: { source: ["Standard"] },
+  custom: { source: ["Custom"] },
+  mine: { mineOnly: true },
+  favorites: { favoritesOnly: true },
+  chest: { muscleGroups: ["chest"] },
+  barbell: { equipment: ["barbell"] },
+  "search-press": { search: "press" },
+  "search-stretch": { search: "stretch" },
+  "search-sentadilla": { search: "sentadilla" },
+  "search-nothing": { search: "zzzzz" },
+};
+jest.mock("../_components/ExerciseFilters", () => ({
+  ExerciseFilters: ({
+    onChange,
+  }: {
+    onChange: (f: ExerciseFiltersState) => void;
+  }) => (
+    <div>
+      {Object.entries(mockFilterPresets).map(([key, patch]) => (
+        <button
+          key={key}
+          type="button"
+          onClick={() =>
+            onChange({
+              search: "",
+              muscleGroups: [],
+              equipment: [],
+              source: [],
+              mineOnly: false,
+              favoritesOnly: false,
+              ...patch,
+            })
+          }
+        >
+          {`filter:${key}`}
+        </button>
+      ))}
+    </div>
+  ),
+}));
+
+import { ExerciseLibraryClient } from "../client";
+
+const TRAINER = "trainer-1";
+
+function exercise(overrides: Partial<ExerciseRow> = {}): ExerciseRow {
+  return {
+    id: "ex-1",
+    name: { en: "Bench Press", es: "Press de Banca" },
+    description: { en: "", es: "" },
+    muscleGroups: ["chest"],
+    equipment: ["barbell"],
+    source: "trainer",
+    ownerId: TRAINER,
+    tags: [],
+    metric: "reps",
+    version: 1,
+    updatedAt: "2026-08-01T00:00:00.000Z",
+    createdAt: "2026-08-01T00:00:00.000Z",
+    ...overrides,
+  } as ExerciseRow;
+}
+
+/** A doc from the curated standard library (the tag is what makes it pickable). */
+function standard(overrides: Partial<ExerciseRow> = {}): ExerciseRow {
+  return exercise({
+    id: "1259",
+    source: "wger",
+    ownerId: null,
+    tags: ["standard-library"],
+    gifUrl: "https://storage.example/1259.gif",
+    ...overrides,
+  } as Partial<ExerciseRow>);
+}
+
+function renderList(rows: ExerciseRow[]) {
+  mockUseExercises.mockReturnValue({
+    data: rows,
+    isLoading: false,
+    error: null,
+    hasSnapshot: true,
+  });
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  render(
+    <QueryClientProvider client={client}>
+      <ExerciseLibraryClient trainerUid={TRAINER} />
+    </QueryClientProvider>,
+  );
+}
+
+/**
+ * Primary names in the rendered table body, in DOM order.
+ *
+ * Scoped to the name cell's `span.font-medium`, not the whole cell: the cell
+ * also carries the secondary-language line, the tag badges and the usage pill,
+ * so the full `textContent` reads "Chest StretchStandard-library".
+ */
+function visibleNames(): string[] {
+  return screen
+    .getAllByRole("row")
+    .slice(1) // header
+    .map(
+      (r) =>
+        within(r)
+          .queryAllByRole("cell")[2]
+          ?.querySelector("span.font-medium")?.textContent ?? "",
+    )
+    .filter((s) => s.length > 0);
+}
+
+function applyFilter(user: ReturnType<typeof userEvent.setup>, key: string) {
+  return user.click(screen.getByRole("button", { name: `filter:${key}` }));
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockFavorites.mockReturnValue({
+    exerciseIds: [],
+    workoutTemplateIds: [],
+    habitTemplateIds: [],
+  });
+  mockUsageCounts.mockReturnValue({});
+  mockDuplicateExercise.mockResolvedValue({ id: "copy-1" });
+  mockSoftDeleteExercise.mockResolvedValue({ ok: true });
+});
+
+describe("Exercise library — visibility (#552 / legacy retirement)", () => {
+  it("hides a legacy catalog doc that is alive in Firestore on purpose", () => {
+    renderList([
+      exercise({ id: "own", name: { en: "My Curl", es: "" } }),
+      // fexd/wger legacy: no standard-library tag, no owner. ~400 of these
+      // exist in prod so old templates keep resolving their ids.
+      exercise({
+        id: "fexd-legacy",
+        name: { en: "Legacy Row", es: "" },
+        source: "free-exercise-db",
+        ownerId: null,
+        tags: [],
+      }),
+    ]);
+
+    expect(visibleNames()).toEqual(["My Curl"]);
+  });
+
+  it("hides a standard_alias doc that snapToRow coerced to source 'trainer'", () => {
+    // THE ownerId GUARD. All 24 alias docs land here as `source: "trainer"`
+    // with `ownerId: null`; a bare source check would show every one of them.
+    renderList([
+      exercise({ id: "own", name: { en: "My Curl", es: "" } }),
+      exercise({
+        id: "alias-1",
+        name: { en: "Aliased Movement", es: "" },
+        source: "trainer",
+        ownerId: null,
+      }),
+    ]);
+
+    expect(visibleNames()).toEqual(["My Curl"]);
+  });
+
+  it("hides a soft-deleted doc even when it carries the library tag", () => {
+    renderList([
+      exercise({ id: "own", name: { en: "My Curl", es: "" } }),
+      standard({ id: "gone", name: { en: "Deleted Std", es: "" }, deleted: true }),
+    ]);
+
+    expect(visibleNames()).toEqual(["My Curl"]);
+  });
+});
+
+describe("Exercise library — the double-seeded standard library (#179)", () => {
+  const TWINS = [
+    standard({
+      id: "1259",
+      name: { en: "Chest Stretch", es: "" },
+      gifUrl: "https://storage.example/1259.gif",
+    }),
+    standard({
+      id: "std-flexibility-chest-stretch",
+      name: { en: "Chest Stretch", es: "" },
+      // The twin's media is a gs:// path the browser cannot render.
+      gifUrl: "gs://gcfitness/std-flexibility-chest-stretch.gif",
+    }),
+  ];
+
+  it("shows ONE row per exercise, keeping the renderable-media doc", () => {
+    renderList(TWINS);
+
+    expect(visibleNames()).toEqual(["Chest Stretch"]);
+  });
+
+  it("returns ONE hit when the search matches both twins", async () => {
+    const user = userEvent.setup();
+    // The user-visible symptom of #179: every query in the library comes back
+    // doubled, the second hit with a broken thumbnail.
+    //
+    // NOTE on the stage order — the source runs dedupe BEFORE the chip filters
+    // and the search, and that reads like the invariant, but it isn't
+    // observable: with real twins (same name, same muscles, same equipment)
+    // filtering and searching are per-row predicates, so pre- and post-dedupe
+    // produce the identical set. Verified by mutation — moving the dedupe
+    // after `searchExercises` keeps every test green. The contract asserted
+    // here is "one row per exercise", which is the part that matters.
+    renderList([...TWINS, exercise({ id: "own", name: { en: "Bench Press", es: "" } })]);
+
+    await applyFilter(user, "search-nothing");
+    await waitFor(() => expect(visibleNames()).toEqual([]));
+
+    await applyFilter(user, "search-stretch");
+    await waitFor(() => expect(visibleNames()).toEqual(["Chest Stretch"]));
+  });
+
+  it("never lets a library twin hide the trainer's own exercise", async () => {
+    // The dedupe tiebreak puts owned first: a coach who authored their own
+    // "Chest Stretch" must still find it, or their exercise silently vanishes
+    // from their own library.
+    renderList([
+      standard({ id: "1259", name: { en: "Chest Stretch", es: "" } }),
+      exercise({ id: "mine", name: { en: "Chest Stretch", es: "" } }),
+    ]);
+    const user = userEvent.setup();
+
+    expect(visibleNames()).toEqual(["Chest Stretch"]);
+    // And the surviving row is the OWNED one — it offers Edit, which a library
+    // row never does.
+    await applyFilter(user, "mine");
+    await waitFor(() => expect(visibleNames()).toEqual(["Chest Stretch"]));
+  });
+});
+
+describe("Exercise library — filters", () => {
+  const ROWS = [
+    exercise({ id: "mine", name: { en: "My Curl", es: "" }, muscleGroups: ["biceps"], equipment: ["dumbbell"] }),
+    exercise({
+      id: "other-coach",
+      name: { en: "Other Coach Curl", es: "" },
+      ownerId: "trainer-2",
+      muscleGroups: ["biceps"],
+      equipment: ["dumbbell"],
+    }),
+    standard({
+      id: "1259",
+      name: { en: "Bench Press", es: "" },
+      // Two groups, so the muscle filter's array-contains-ANY semantics are
+      // distinguishable from contains-ALL. A single-group fixture makes
+      // `.some()` and `.every()` agree and the filter untested.
+      muscleGroups: ["chest", "triceps"],
+      equipment: ["barbell"],
+    }),
+  ];
+
+  it("splits Standard from Custom", async () => {
+    const user = userEvent.setup();
+    renderList([
+      ...ROWS,
+      // A library-tagged doc whose `source` is NOT "wger". Classifying it as
+      // Custom would be a lie in the filter: it's read-only like every other
+      // library row. The tag, not the source, is what makes it Standard.
+      standard({
+        id: "fexd-std",
+        source: "free-exercise-db",
+        name: { en: "Push Up", es: "" },
+      }),
+    ]);
+
+    await applyFilter(user, "standard");
+    await waitFor(() =>
+      expect(visibleNames().sort()).toEqual(["Bench Press", "Push Up"]),
+    );
+
+    await applyFilter(user, "custom");
+    await waitFor(() =>
+      expect(visibleNames().sort()).toEqual(["My Curl", "Other Coach Curl"]),
+    );
+  });
+
+  it("'created by me' excludes ANOTHER trainer's exercise", async () => {
+    const user = userEvent.setup();
+    renderList(ROWS);
+
+    await applyFilter(user, "mine");
+
+    // Both are `source: "trainer"`. Only the ownerId tells them apart, and
+    // showing someone else's authored exercise under "mine" is a cross-tenant
+    // leak in a list the coach believes is theirs.
+    await waitFor(() => expect(visibleNames()).toEqual(["My Curl"]));
+  });
+
+  it("filters by muscle with contains-ANY, and by equipment", async () => {
+    const user = userEvent.setup();
+    renderList(ROWS);
+
+    // Bench Press is tagged ["chest", "triceps"] and the filter selects only
+    // "chest": contains-ANY keeps it, contains-ALL would drop it and the coach
+    // would conclude they have no chest exercises.
+    await applyFilter(user, "chest");
+    await waitFor(() => expect(visibleNames()).toEqual(["Bench Press"]));
+
+    await applyFilter(user, "barbell");
+    await waitFor(() => expect(visibleNames()).toEqual(["Bench Press"]));
+  });
+
+  it("searches the Spanish name too", async () => {
+    const user = userEvent.setup();
+    renderList([
+      exercise({ id: "a", name: { en: "Squat", es: "Sentadilla" } }),
+      exercise({ id: "b", name: { en: "Bench Press", es: "Press de Banca" } }),
+    ]);
+
+    await applyFilter(user, "search-sentadilla");
+
+    // The coach types in whichever language they think in.
+    await waitFor(() => expect(visibleNames()).toEqual(["Squat"]));
+  });
+
+  it("floats favorites to the top and can keep only them", async () => {
+    const user = userEvent.setup();
+    mockFavorites.mockReturnValue({
+      exerciseIds: ["fav"],
+      workoutTemplateIds: [],
+      habitTemplateIds: [],
+    });
+    renderList([
+      exercise({ id: "a", name: { en: "Aaa", es: "" } }),
+      exercise({ id: "fav", name: { en: "Zzz", es: "" } }),
+    ]);
+
+    expect(visibleNames()).toEqual(["Zzz", "Aaa"]);
+
+    await applyFilter(user, "favorites");
+    await waitFor(() => expect(visibleNames()).toEqual(["Zzz"]));
+  });
+
+  it("sorts by routine usage when 'Most used' is on", async () => {
+    const user = userEvent.setup();
+    mockUsageCounts.mockReturnValue({ popular: 12, rare: 1 });
+    renderList([
+      exercise({ id: "rare", name: { en: "Rare Move", es: "" } }),
+      exercise({ id: "popular", name: { en: "Popular Move", es: "" } }),
+    ]);
+
+    expect(visibleNames()).toEqual(["Rare Move", "Popular Move"]);
+
+    await user.click(screen.getByRole("button", { name: "Most used" }));
+
+    await waitFor(() =>
+      expect(visibleNames()).toEqual(["Popular Move", "Rare Move"]),
+    );
+  });
+
+  it("distinguishes 'nothing yet' from 'nothing matches'", async () => {
+    const user = userEvent.setup();
+    renderList([exercise()]);
+
+    await applyFilter(user, "search-nothing");
+
+    expect(await screen.findByText("No matches.")).toBeInTheDocument();
+    expect(screen.queryByText("No exercises yet.")).not.toBeInTheDocument();
+  });
+});
+
+describe("Exercise library — the per-row action gate", () => {
+  it("gives a LIBRARY row View + Duplicate, never Edit or Delete", () => {
+    renderList([standard({ name: { en: "Bench Press", es: "" } })]);
+
+    // A library exercise is shared and read-only: the edit route redirects it
+    // and the Server Action rejects the write, so offering Edit is offering a
+    // dead end.
+    expect(screen.getByRole("button", { name: "View" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Duplicate" })).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Edit" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Delete" })).not.toBeInTheDocument();
+  });
+
+  it("gates on source !== 'trainer', so free-exercise-db rows are read-only too", () => {
+    // The narrower `=== "wger"` spelling is what let fexd rows show Edit and
+    // 404. This row is fexd-shaped but library-tagged, i.e. pickable.
+    renderList([
+      standard({
+        id: "fexd-1",
+        source: "free-exercise-db",
+        name: { en: "Push Up", es: "" },
+      }),
+    ]);
+
+    expect(screen.queryByRole("button", { name: "Edit" })).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Duplicate" })).toBeInTheDocument();
+  });
+
+  it("gives a TRAINER-OWNED row Edit + Delete", () => {
+    renderList([exercise()]);
+
+    expect(screen.getByRole("button", { name: "Edit" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Delete" })).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Duplicate" })).not.toBeInTheDocument();
+  });
+
+  it("routes a library row to /view and an owned row to /edit on row click", async () => {
+    const user = userEvent.setup();
+    renderList([
+      standard({ id: "1259", name: { en: "Bench Press", es: "" } }),
+      exercise({ id: "mine", name: { en: "My Curl", es: "" } }),
+    ]);
+
+    await user.click(screen.getByText("Bench Press"));
+    expect(mockPush).toHaveBeenCalledWith("/gc-fitness/exercises/1259/view");
+
+    await user.click(screen.getByText("My Curl"));
+    expect(mockPush).toHaveBeenCalledWith("/gc-fitness/exercises/mine/edit");
+  });
+
+  it("lands the coach on their editable COPY after duplicating", async () => {
+    const user = userEvent.setup();
+    renderList([standard({ id: "1259", name: { en: "Bench Press", es: "" } })]);
+
+    await user.click(screen.getByRole("button", { name: "Duplicate" }));
+
+    await waitFor(() =>
+      expect(mockDuplicateExercise).toHaveBeenCalledWith("1259"),
+    );
+    // Duplicate-to-customize is pointless if it leaves you on the read-only
+    // original.
+    expect(mockPush).toHaveBeenCalledWith("/gc-fitness/exercises/copy-1/edit");
+  });
+
+  it("asks before deleting, and only then calls the action", async () => {
+    const user = userEvent.setup();
+    renderList([exercise({ id: "mine" })]);
+
+    await user.click(screen.getByRole("button", { name: "Delete" }));
+    expect(mockSoftDeleteExercise).not.toHaveBeenCalled();
+
+    // The row's icon button and the confirm CTA are both named "Delete";
+    // scope to the dialog rather than indexing blind.
+    const dialog = await screen.findByRole("alertdialog");
+    await user.click(within(dialog).getByRole("button", { name: "Delete" }));
+
+    await waitFor(() => expect(mockSoftDeleteExercise).toHaveBeenCalledWith("mine"));
+  });
+});

--- a/backoffice/src/app/gc-fitness/exercises/_components/__tests__/exercise-form-save.test.tsx
+++ b/backoffice/src/app/gc-fitness/exercises/_components/__tests__/exercise-form-save.test.tsx
@@ -1,0 +1,358 @@
+/**
+ * @jest-environment jsdom
+ */
+
+// exercise-form-save.test.tsx
+//
+// The SAVE half of the exercise form. `exercise-form-validation.test.tsx`
+// covers the render, the Zod error copy, one create payload and the read-only
+// view route; this file covers the parts of the outgoing payload that are
+// DERIVED rather than typed in, plus the edit / duplicate / delete branches.
+//
+// The FIRST THREE LINES of this file MUST stay as the
+// `/** @jest-environment jsdom */` docblock — the backoffice jest config
+// defaults to `testEnvironment: "node"` so without it React Testing Library
+// crashes with `ReferenceError: document is not defined`.
+//
+// What is derived, and why each one matters downstream:
+//
+//   • THE PRESCRIPTION TRIPLE (#206 / 26-09). Three chips span TWO orthogonal
+//     fields: "Reps × Weight" → `metric:"reps" + tracksWeight:true`,
+//     "Reps (no weight)" → `metric:"reps" + tracksWeight:false`, "Time (sec)"
+//     → `metric:"time" + tracksWeight:true`. `tracksWeight:false` is not
+//     cosmetic: it is what seeds the template editor's "Sin peso" sentinel
+//     (`weightBySetKg: []`) when the exercise is dropped into a routine, which
+//     iOS and Android already honor. Writing `metric:"time"` while leaving
+//     `tracksWeight:false` behind, or forgetting to flip it back, produces an
+//     exercise that prescribes the wrong thing on a client's phone.
+//   • THE MUSCLE MERGE (#480). `muscleGroups` is REBUILT on submit as
+//     `[primary, ...secondaries]` — the primary always first and never
+//     duplicated — because the coach's per-muscle-group progress chart weights
+//     the primary 1.0 and each secondary 0.5. A primary that isn't in the
+//     array is a muscle that scores 0 on every chart; a primary listed twice
+//     double-counts it.
+//   • AN EMPTY PRIMARY COLLAPSES TO `undefined`. Zod's optional enum rejects
+//     `""`, so passing the raw form value through would fail validation on a
+//     perfectly legal "no primary picked" exercise.
+//   • THE MODE FORK. `create` calls `createExercise`, `edit` calls
+//     `updateExercise(id, …)`. Same form, same button, different write.
+
+import "@testing-library/jest-dom";
+
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import React from "react";
+
+import type { ExerciseInput } from "@/lib/gc-fitness/exercise-schema";
+
+const mockRouter = { push: jest.fn(), back: jest.fn(), refresh: jest.fn(), replace: jest.fn() };
+jest.mock("next/navigation", () => ({
+  useRouter: () => mockRouter,
+  redirect: jest.fn(),
+}));
+
+const mockCreateExercise = jest.fn();
+const mockUpdateExercise = jest.fn();
+const mockSoftDeleteExercise = jest.fn();
+const mockDuplicateExercise = jest.fn();
+jest.mock("@/lib/gc-fitness/exercise-server-actions", () => ({
+  createExercise: (...args: unknown[]) => mockCreateExercise(...args),
+  updateExercise: (...args: unknown[]) => mockUpdateExercise(...args),
+  softDeleteExercise: (...args: unknown[]) => mockSoftDeleteExercise(...args),
+  duplicateExercise: (...args: unknown[]) => mockDuplicateExercise(...args),
+  mintExerciseMediaUploadUrl: jest.fn(),
+}));
+
+const mockInvalidate = jest.fn();
+jest.mock("@tanstack/react-query", () => ({
+  useQueryClient: () => ({ invalidateQueries: mockInvalidate }),
+}));
+
+// The upload path is out of scope here; keep browser-only Firebase out.
+jest.mock("@/lib/firebase/gc-fitness-client", () => ({
+  getGCFitnessStorage: () => ({}),
+}));
+
+jest.mock("sonner", () => ({
+  toast: { success: jest.fn(), error: jest.fn() },
+  Toaster: () => null,
+}));
+
+// ESM-only under ts-jest; the form renders a markdown preview of the notes.
+jest.mock("react-markdown", () => ({
+  __esModule: true,
+  default: ({ children }: { children: React.ReactNode }) => (
+    <div>{String(children ?? "")}</div>
+  ),
+}));
+
+import { ExerciseForm } from "@/app/gc-fitness/exercises/_components/ExerciseForm";
+
+/** A complete, valid exercise so a bare Save submits without validation noise. */
+function defaults(overrides: Partial<ExerciseInput> = {}): Partial<ExerciseInput> {
+  return {
+    name: { en: "Bench Press", es: "Press de Banca" },
+    description: { en: "Press the bar.", es: "Empujá la barra." },
+    primaryMuscleGroup: "chest",
+    muscleGroups: ["chest"],
+    equipment: ["barbell"],
+    metric: "reps",
+    tracksWeight: true,
+    ...overrides,
+  } as Partial<ExerciseInput>;
+}
+
+function renderEdit(overrides: Partial<ExerciseInput> = {}) {
+  render(
+    <ExerciseForm
+      mode="edit"
+      exerciseId="ex-1"
+      defaultValues={defaults(overrides)}
+    />,
+  );
+}
+
+function save(user: ReturnType<typeof userEvent.setup>) {
+  return user.click(screen.getByRole("button", { name: /^save$/i }));
+}
+
+/** The payload handed to `updateExercise` (second arg; the first is the id). */
+async function savedPayload(): Promise<Record<string, unknown>> {
+  await waitFor(() => expect(mockUpdateExercise).toHaveBeenCalledTimes(1));
+  return mockUpdateExercise.mock.calls[0][1] as Record<string, unknown>;
+}
+
+function metricChip(name: RegExp) {
+  return screen.getByRole("button", { name });
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockCreateExercise.mockResolvedValue({ id: "new-1" });
+  mockUpdateExercise.mockResolvedValue({ ok: true });
+  mockSoftDeleteExercise.mockResolvedValue({ ok: true });
+  mockDuplicateExercise.mockResolvedValue({ id: "copy-1" });
+});
+
+describe("ExerciseForm — the prescription triple (#206)", () => {
+  it("writes reps + tracksWeight:true for 'Reps × Weight'", async () => {
+    const user = userEvent.setup();
+    renderEdit({ metric: "time", tracksWeight: false });
+
+    await metricChip(/Reps × Weight/);
+    await user.click(metricChip(/Reps × Weight/));
+    await save(user);
+
+    const payload = await savedPayload();
+    expect(payload).toMatchObject({ metric: "reps", tracksWeight: true });
+  });
+
+  it("writes reps + tracksWeight:FALSE for 'Reps (no weight)'", async () => {
+    const user = userEvent.setup();
+    renderEdit();
+
+    await user.click(metricChip(/Reps \(no weight\)/));
+    await save(user);
+
+    const payload = await savedPayload();
+    // This flag is the whole feature: it seeds `weightBySetKg: []` when the
+    // exercise is added to a template, which is how a bodyweight movement
+    // reaches the client without a phantom 0 kg column.
+    expect(payload).toMatchObject({ metric: "reps", tracksWeight: false });
+  });
+
+  it("flips tracksWeight back to true when switching to Time", async () => {
+    const user = userEvent.setup();
+    renderEdit();
+
+    await user.click(metricChip(/Reps \(no weight\)/));
+    await user.click(metricChip(/Time \(sec\)/));
+    await save(user);
+
+    const payload = await savedPayload();
+    // A time exercise left on `tracksWeight:false` carries a stale bodyweight
+    // flag into every routine that picks it up afterwards.
+    expect(payload).toMatchObject({ metric: "time", tracksWeight: true });
+  });
+
+  it("marks exactly one chip as pressed", async () => {
+    const user = userEvent.setup();
+    renderEdit();
+
+    await user.click(metricChip(/Reps \(no weight\)/));
+
+    // Two orthogonal fields, three chips: the chip state is derived, so it can
+    // disagree with the payload and show the coach a selection they don't have.
+    expect(metricChip(/Reps \(no weight\)/)).toHaveAttribute("aria-pressed", "true");
+    expect(metricChip(/Reps × Weight/)).toHaveAttribute("aria-pressed", "false");
+    expect(metricChip(/Time \(sec\)/)).toHaveAttribute("aria-pressed", "false");
+  });
+});
+
+describe("ExerciseForm — the muscle merge (#480)", () => {
+  it("puts the primary FIRST in muscleGroups and keeps it there", async () => {
+    const user = userEvent.setup();
+    renderEdit({
+      primaryMuscleGroup: "chest",
+      // Defaults arriving from Firestore with the primary missing from the
+      // array — the shape the merge exists to repair.
+      muscleGroups: ["triceps", "shoulders"],
+    });
+
+    await save(user);
+
+    const payload = await savedPayload();
+    // The progress chart weights primary 1.0 and each secondary 0.5. A primary
+    // that isn't in the array scores ZERO on every chart it should lead.
+    expect(payload.muscleGroups).toEqual(["chest", "triceps", "shoulders"]);
+    expect(payload.primaryMuscleGroup).toBe("chest");
+  });
+
+  it("never lists the primary twice", async () => {
+    const user = userEvent.setup();
+    renderEdit({
+      primaryMuscleGroup: "chest",
+      muscleGroups: ["chest", "triceps"],
+    });
+
+    await save(user);
+
+    const payload = await savedPayload();
+    // A duplicated primary double-counts that muscle in the weekly-sets chart.
+    expect(payload.muscleGroups).toEqual(["chest", "triceps"]);
+  });
+
+  // The `""` → `undefined` collapse at the top of `onSubmit` is UNREACHABLE
+  // through the form. `primaryMuscleGroup` is `z.enum(...).optional()`, which
+  // admits `undefined` but not `""`, and `handleSubmit` validates BEFORE it
+  // calls the success callback — so a `""` in form state fails the resolver and
+  // the normalization never runs. (Verified: seeding `primaryMuscleGroup: ""`
+  // through `defaultValues` produces ZERO calls to `updateExercise`.)
+  //
+  // The guard that actually keeps `""` out is one layer up, in `buildDefaults`:
+  // `passed?.primaryMuscleGroup ?? passed?.muscleGroups?.[0] ?? undefined`.
+  // That is what this test pins.
+  it("seeds a missing primary from the first muscle group", async () => {
+    const user = userEvent.setup();
+    // The legacy / wger-seeded shape: `muscleGroups` populated, no explicit
+    // primary. Saving it as `undefined` drops the exercise to the anatomy
+    // heuristic on every progress chart instead of leading with its own
+    // first-listed muscle.
+    renderEdit({
+      primaryMuscleGroup: undefined,
+      muscleGroups: ["chest", "triceps"],
+    });
+
+    await save(user);
+
+    const payload = await savedPayload();
+    expect(payload.primaryMuscleGroup).toBe("chest");
+    expect(payload.muscleGroups).toEqual(["chest", "triceps"]);
+  });
+});
+
+// The "one language means every language" contract has TWO mechanisms here,
+// same as `HabitForm` and `HabitTemplateDetailDialog`: `buildDefaults` mirrors
+// on LOAD (so an English-only exercise never renders an empty Spanish field)
+// and `onSubmit` mirrors again on WRITE. The load-time one makes the save-time
+// one unreachable whenever the blank language came from the document — deleting
+// the save-time mirror leaves the first test below GREEN. The second test opens
+// the translation pane and blanks the field by hand, which is the only path
+// where the save-time mirror is the one doing the work.
+describe("ExerciseForm — the localized mirror", () => {
+  it("stores the coach's single language in both", async () => {
+    const user = userEvent.setup();
+    renderEdit({
+      name: { en: "Bench Press", es: "" },
+      description: { en: "Press the bar.", es: "" },
+    });
+
+    await save(user);
+
+    const payload = await savedPayload();
+    // A blank ES renders as an unnamed exercise for a Spanish client.
+    expect(payload.name).toEqual({ en: "Bench Press", es: "Bench Press" });
+    expect(payload.description).toEqual({
+      en: "Press the bar.",
+      es: "Press the bar.",
+    });
+  });
+
+  it("re-fills a translation the coach blanked out, on save", async () => {
+    const user = userEvent.setup();
+    // Both fields single-language, so the translation pane starts COLLAPSED —
+    // it auto-opens whenever any field already carries a real translation.
+    renderEdit({
+      name: { en: "Bench Press", es: "" },
+      description: { en: "Press the bar.", es: "" },
+    });
+
+    // Opening the pane exposes the mirrored Spanish field; emptying it by hand
+    // is the one state the load-time mirror can't repair.
+    await user.click(screen.getByRole("button", { name: /add translation/i }));
+    // The load-time mirror's own job: an English-only exercise must not open
+    // its Spanish field EMPTY, or the coach reads it as "no translation yet"
+    // and the field they never touch is the one that ships.
+    expect(screen.getByLabelText(/name \(spanish\)/i)).toHaveValue("Bench Press");
+
+    await user.clear(screen.getByLabelText(/name \(spanish\)/i));
+    await save(user);
+
+    const payload = await savedPayload();
+    expect(payload.name).toEqual({ en: "Bench Press", es: "Bench Press" });
+  });
+
+  it("leaves a real translation alone", async () => {
+    const user = userEvent.setup();
+    renderEdit();
+
+    await save(user);
+
+    const payload = await savedPayload();
+    expect(payload.name).toEqual({ en: "Bench Press", es: "Press de Banca" });
+  });
+});
+
+describe("ExerciseForm — the mode fork", () => {
+  it("EDIT patches the existing id and never creates", async () => {
+    const user = userEvent.setup();
+    renderEdit();
+
+    await save(user);
+
+    await waitFor(() => expect(mockUpdateExercise).toHaveBeenCalled());
+    expect(mockUpdateExercise.mock.calls[0][0]).toBe("ex-1");
+    // Creating from the edit form would leave the original untouched and
+    // silently fork the library.
+    expect(mockCreateExercise).not.toHaveBeenCalled();
+    expect(mockInvalidate).toHaveBeenCalled();
+    expect(mockRouter.push).toHaveBeenCalledWith("/gc-fitness/exercises");
+  });
+
+  it("lands the coach on the COPY after duplicating a library exercise", async () => {
+    const user = userEvent.setup();
+    // Duplicate lives ONLY on the read-only view route — it is the
+    // "duplicate to customize" escape hatch for a library exercise the coach
+    // can't edit. There is no Duplicate on your own exercise: you just edit it.
+    render(
+      <ExerciseForm mode="view" exerciseId="ex-1" defaultValues={defaults()} />,
+    );
+
+    await user.click(screen.getByRole("button", { name: /duplicate/i }));
+
+    await waitFor(() =>
+      expect(mockDuplicateExercise).toHaveBeenCalledWith("ex-1"),
+    );
+    // Landing back on the read-only original would make the CTA a no-op the
+    // coach has to figure out.
+    expect(mockRouter.push).toHaveBeenCalledWith("/gc-fitness/exercises/copy-1/edit");
+  });
+
+  it("offers no Duplicate on an editable exercise", () => {
+    renderEdit();
+
+    expect(
+      screen.queryByRole("button", { name: /duplicate/i }),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/backoffice/src/app/gc-fitness/habits/__tests__/habits-client-list.test.tsx
+++ b/backoffice/src/app/gc-fitness/habits/__tests__/habits-client-list.test.tsx
@@ -1,0 +1,463 @@
+/**
+ * @jest-environment jsdom
+ */
+
+// habits-client-list.test.tsx
+//
+// The habits page's two lists and the filters over them: "All" (the reusable
+// template library) and "Assignments" (one row per client × habit).
+//
+// The FIRST THREE LINES of this file MUST stay as the
+// `/** @jest-environment jsdom */` docblock — the backoffice jest config
+// defaults to `testEnvironment: "node"` so without it React Testing Library
+// crashes with `ReferenceError: document is not defined`.
+//
+// Why this surface: every habit bug that reached production was a habit that
+// was THERE and didn't show, or one that was gone and did. The filters are the
+// only thing between the server payload and what a coach believes their client
+// is doing.
+//
+//   • THE `deleted` SHAPE (#400). A habit the CLIENT created has no `deleted`
+//     field at all. The row filter must therefore be a TRUTHINESS check
+//     (`if (r.deleted) return false`), never an equality check against `false`,
+//     which drops every field-less doc silently.
+//     NOTE — the equality form still exists one layer down, in
+//     `listHabitsForTrainer`'s `.where("deleted", "==", false)`. That is a
+//     server-side query this file cannot reach (it's mocked here, and it runs
+//     in `node`); it stays on the latent list in #400. What IS pinned here is
+//     that the component never re-introduces the same mistake on its side.
+//   • THE ENDED-RECURRENCE CUTOFF. "Assignments" means current + future
+//     commitments. A habit whose recurrence ended yesterday must drop off;
+//     a recurring habit with NO `endsOn` never ends and must never drop off.
+//     One-time habits are cut on `endsOn ?? startsOn`.
+//   • THE CLIENT FILTER. Showing another client's habits under the wrong name
+//     is the same failure class as the fixed/roster mix-up in
+//     `new-habit-dialog.test.tsx` — quiet and wrong.
+//
+// Fixture dates are computed as OFFSETS from the real current day, because the
+// component derives its own `todayCivil` from `new Date()`. A hardcoded date
+// would rot; a fixture pinned to today would sit exactly on the boundary the
+// filter tests, and could not fail.
+//
+// The library table is stubbed to expose the `templates` prop it receives, so
+// the search / favorites / sort assertions read the ORDERED LIST the filter
+// produced instead of scraping rendered rows.
+
+import "@testing-library/jest-dom";
+
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import React from "react";
+
+import type {
+  HabitRow,
+  HabitTemplateRow,
+} from "@/lib/gc-fitness/habit-actions";
+
+const mockListHabitsForTrainer = jest.fn();
+const mockListHabitTemplates = jest.fn();
+jest.mock("@/lib/gc-fitness/habit-actions", () => ({
+  listHabitsForTrainer: () => mockListHabitsForTrainer(),
+  listHabitTemplates: () => mockListHabitTemplates(),
+  listHiddenGlobalTemplateIds: jest.fn().mockResolvedValue([]),
+  softDeleteHabit: jest.fn(),
+  deleteHabitRecurrenceFromDate: jest.fn(),
+  unhideGlobalHabitTemplate: jest.fn(),
+}));
+
+const mockFavorites = jest.fn();
+jest.mock("@/lib/gc-fitness/use-favorites", () => ({
+  useFavorites: () => ({
+    favorites: mockFavorites(),
+    isFavorite: () => false,
+    toggle: jest.fn(),
+  }),
+}));
+
+jest.mock("next/navigation", () => ({
+  useRouter: () => ({ push: jest.fn(), back: jest.fn() }),
+}));
+
+jest.mock("sonner", () => ({
+  toast: { success: jest.fn(), error: jest.fn() },
+}));
+
+jest.mock("@/components/gc-fitness/schedule/new-habit-dialog", () => ({
+  NewHabitDialog: () => null,
+}));
+jest.mock("@/components/gc-fitness/schedule/bulk-assign-habit-dialog", () => ({
+  BulkAssignHabitDialog: () => null,
+}));
+jest.mock("../_components/HabitTemplateDetailDialog", () => ({
+  HabitTemplateDetailDialog: () => null,
+}));
+
+// Stub the library table and publish the ORDER of what it was handed — that
+// list IS the output of the search / favorites / sort pipeline.
+jest.mock("../_components/HabitLibraryTable", () => ({
+  HabitLibraryTable: ({ templates }: { templates: Array<{ id: string }> }) => (
+    <div data-testid="library-ids">{templates.map((t) => t.id).join(",")}</div>
+  ),
+}));
+
+import { HabitsLibraryClient } from "../client";
+
+// ── Dates, relative to the real today ───────────────────────────────────────
+function civilOffset(days: number): string {
+  const d = new Date();
+  d.setDate(d.getDate() + days);
+  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}-${String(d.getDate()).padStart(2, "0")}`;
+}
+const YESTERDAY = civilOffset(-1);
+const LAST_MONTH = civilOffset(-30);
+const NEXT_MONTH = civilOffset(30);
+
+const ROSTER = [
+  {
+    uid: "client-1",
+    displayName: "Ana Gomez",
+    email: "ana@example.com",
+    photoURL: null,
+    pendingProvisioning: false,
+  },
+  {
+    uid: "client-2",
+    displayName: "Beto Diaz",
+    email: "beto@example.com",
+    photoURL: null,
+    pendingProvisioning: false,
+  },
+];
+
+function habit(overrides: Partial<HabitRow> = {}): HabitRow {
+  return {
+    id: "habit-1",
+    clientId: "client-1",
+    trainerId: "trainer-1",
+    type: "binary",
+    name: { en: "Drink water", es: "Tomar agua" },
+    reminderEnabled: false,
+    scheduleType: "recurring",
+    startsOn: LAST_MONTH,
+    scheduleCadence: "daily",
+    deleted: false,
+    createdAt: null,
+    updatedAt: null,
+    ...overrides,
+  } as HabitRow;
+}
+
+function template(overrides: Partial<HabitTemplateRow> = {}): HabitTemplateRow {
+  return {
+    id: "tpl-1",
+    scope: "trainer",
+    trainerId: "trainer-1",
+    type: "binary",
+    name: { en: "Drink water", es: "Tomar agua" },
+    reminderEnabled: false,
+    scheduleType: "recurring",
+    startsOn: LAST_MONTH,
+    deleted: false,
+    createdAt: null,
+    updatedAt: null,
+    ...overrides,
+  } as HabitTemplateRow;
+}
+
+function renderList() {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  render(
+    <QueryClientProvider client={client}>
+      <HabitsLibraryClient clientRoster={ROSTER} trainerUid="trainer-1" />
+    </QueryClientProvider>,
+  );
+}
+
+/** The page opens on the library tab; assignments live behind the toggle. */
+async function goToAssignments(user: ReturnType<typeof userEvent.setup>) {
+  await user.click(screen.getByRole("button", { name: "Assignments" }));
+}
+
+function searchBox() {
+  return screen.getByPlaceholderText("Search by name or client…");
+}
+
+/** ids the library table was rendered with, in order. */
+async function libraryIds(): Promise<string[]> {
+  const node = await screen.findByTestId("library-ids");
+  const text = node.textContent ?? "";
+  return text.length > 0 ? text.split(",") : [];
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockListHabitsForTrainer.mockResolvedValue([]);
+  mockListHabitTemplates.mockResolvedValue([]);
+  mockFavorites.mockReturnValue({
+    exerciseIds: [],
+    workoutTemplateIds: [],
+    habitTemplateIds: [],
+  });
+});
+
+describe("Habits — assignments visibility", () => {
+  it("keeps a habit whose doc has NO `deleted` field (#400)", async () => {
+    const user = userEvent.setup();
+    // The client-created shape: `clientOwned`, `clientId === trainerId`, and
+    // no `deleted` key at all. An equality filter against `false` drops this
+    // row; a truthiness filter keeps it.
+    const clientMade = habit({
+      id: "habit-client-made",
+      name: { en: "Morning walk", es: "Caminata" },
+    });
+    delete (clientMade as Partial<HabitRow>).deleted;
+    mockListHabitsForTrainer.mockResolvedValue([clientMade]);
+    renderList();
+    await goToAssignments(user);
+
+    expect(await screen.findByText("Morning walk")).toBeInTheDocument();
+  });
+
+  it("hides a soft-deleted habit", async () => {
+    const user = userEvent.setup();
+    mockListHabitsForTrainer.mockResolvedValue([
+      habit({ id: "gone", name: { en: "Deleted one", es: "Borrado" }, deleted: true }),
+      habit({ id: "kept", name: { en: "Kept one", es: "Vigente" } }),
+    ]);
+    renderList();
+    await goToAssignments(user);
+
+    expect(await screen.findByText("Kept one")).toBeInTheDocument();
+    expect(screen.queryByText("Deleted one")).not.toBeInTheDocument();
+  });
+
+  it("drops a recurrence that already ended, keeps an open-ended one", async () => {
+    const user = userEvent.setup();
+    mockListHabitsForTrainer.mockResolvedValue([
+      habit({
+        id: "ended",
+        name: { en: "Ended habit", es: "Terminado" },
+        endsOn: YESTERDAY,
+      }),
+      // No `endsOn` on a recurring habit means "never ends".
+      habit({ id: "forever", name: { en: "Forever habit", es: "Para siempre" } }),
+      habit({
+        id: "future-end",
+        name: { en: "Ends later", es: "Termina despues" },
+        endsOn: NEXT_MONTH,
+      }),
+    ]);
+    renderList();
+    await goToAssignments(user);
+
+    expect(await screen.findByText("Forever habit")).toBeInTheDocument();
+    expect(screen.getByText("Ends later")).toBeInTheDocument();
+    expect(screen.queryByText("Ended habit")).not.toBeInTheDocument();
+  });
+
+  it("cuts a one-time habit on its single occurrence", async () => {
+    const user = userEvent.setup();
+    // A one-time habit carries no `endsOn`, so the cutoff has to fall back to
+    // `startsOn` — otherwise every past one-off stays in the list forever.
+    mockListHabitsForTrainer.mockResolvedValue([
+      habit({
+        id: "past-oneoff",
+        name: { en: "Past one-off", es: "Puntual pasado" },
+        scheduleType: "one-time",
+        startsOn: YESTERDAY,
+        scheduleCadence: undefined,
+      }),
+      habit({
+        id: "future-oneoff",
+        name: { en: "Future one-off", es: "Puntual futuro" },
+        scheduleType: "one-time",
+        startsOn: NEXT_MONTH,
+        scheduleCadence: undefined,
+      }),
+    ]);
+    renderList();
+    await goToAssignments(user);
+
+    expect(await screen.findByText("Future one-off")).toBeInTheDocument();
+    expect(screen.queryByText("Past one-off")).not.toBeInTheDocument();
+  });
+});
+
+describe("Habits — assignment filters", () => {
+  it("narrows to one client and drops the other's habits", async () => {
+    const user = userEvent.setup();
+    mockListHabitsForTrainer.mockResolvedValue([
+      habit({ id: "a", clientId: "client-1", name: { en: "Ana habit", es: "Ana" } }),
+      habit({ id: "b", clientId: "client-2", name: { en: "Beto habit", es: "Beto" } }),
+    ]);
+    renderList();
+    await goToAssignments(user);
+    await screen.findByText("Ana habit");
+
+    // The client Select's trigger renders its value inside a child span, so it
+    // has no accessible name to match on — go through the combobox role.
+    await user.click(screen.getByRole("combobox"));
+    await user.click(await screen.findByRole("option", { name: /Beto Diaz/ }));
+
+    await waitFor(() =>
+      expect(screen.queryByText("Ana habit")).not.toBeInTheDocument(),
+    );
+    expect(screen.getByText("Beto habit")).toBeInTheDocument();
+  });
+
+  it("searches the CLIENT name, not just the habit name", async () => {
+    const user = userEvent.setup();
+    // Both rows share a habit name; only the client name tells them apart.
+    mockListHabitsForTrainer.mockResolvedValue([
+      habit({ id: "a", clientId: "client-1" }),
+      habit({ id: "b", clientId: "client-2" }),
+    ]);
+    renderList();
+    await goToAssignments(user);
+    await screen.findByText("Ana Gomez");
+
+    await user.type(searchBox(), "beto");
+
+    await waitFor(() =>
+      expect(screen.queryByText("Ana Gomez")).not.toBeInTheDocument(),
+    );
+    expect(screen.getByText("Beto Diaz")).toBeInTheDocument();
+  });
+
+  it("groups the same habit across clients into ONE card", async () => {
+    const user = userEvent.setup();
+    mockListHabitsForTrainer.mockResolvedValue([
+      habit({ id: "a", clientId: "client-1" }),
+      habit({ id: "b", clientId: "client-2" }),
+      habit({
+        id: "c",
+        clientId: "client-1",
+        name: { en: "Stretching", es: "Elongar" },
+      }),
+    ]);
+    renderList();
+    await goToAssignments(user);
+
+    // The grouping is what makes "who has habit X" scannable — two cards, and
+    // both clients under the shared title.
+    const waterHeading = await screen.findByRole("heading", {
+      name: "Drink water",
+    });
+    const waterCard = waterHeading.closest("div.overflow-hidden")!;
+    expect(within(waterCard as HTMLElement).getByText("Ana Gomez")).toBeInTheDocument();
+    expect(within(waterCard as HTMLElement).getByText("Beto Diaz")).toBeInTheDocument();
+    expect(
+      screen.getByRole("heading", { name: "Stretching" }),
+    ).toBeInTheDocument();
+  });
+
+  it("distinguishes 'nothing yet' from 'nothing matches'", async () => {
+    const user = userEvent.setup();
+    mockListHabitsForTrainer.mockResolvedValue([habit()]);
+    renderList();
+    await goToAssignments(user);
+    await screen.findByText("Ana Gomez");
+
+    await user.type(searchBox(), "zzzz");
+
+    // Telling a coach "No habits yet" when they simply mistyped a filter is
+    // how a support ticket about "my habits disappeared" starts.
+    expect(await screen.findByText("No matches.")).toBeInTheDocument();
+    expect(screen.queryByText("No habits yet.")).not.toBeInTheDocument();
+  });
+});
+
+describe("Habits — the template library", () => {
+  it("searches templates in BOTH languages", async () => {
+    const user = userEvent.setup();
+    mockListHabitTemplates.mockResolvedValue([
+      template({ id: "water", name: { en: "Drink water", es: "Tomar agua" } }),
+      template({ id: "sleep", name: { en: "Sleep 8h", es: "Dormir 8h" } }),
+    ]);
+    renderList();
+    await waitFor(async () => expect(await libraryIds()).toHaveLength(2));
+
+    // The coach types in whichever language they think in; a needle that only
+    // hits the ES side must still match.
+    await user.type(searchBox(), "agua");
+
+    await waitFor(async () => expect(await libraryIds()).toEqual(["water"]));
+  });
+
+  it("floats favorites to the top, and hides the rest when toggled", async () => {
+    const user = userEvent.setup();
+    mockListHabitTemplates.mockResolvedValue([
+      template({ id: "a" }),
+      template({ id: "b" }),
+      template({ id: "starred" }),
+    ]);
+    mockFavorites.mockReturnValue({
+      exerciseIds: [],
+      workoutTemplateIds: [],
+      habitTemplateIds: ["starred"],
+    });
+    renderList();
+
+    // Sorted first even though it arrived last.
+    await waitFor(async () =>
+      expect(await libraryIds()).toEqual(["starred", "a", "b"]),
+    );
+
+    await user.click(screen.getByRole("button", { name: "Show only favorites" }));
+
+    await waitFor(async () => expect(await libraryIds()).toEqual(["starred"]));
+  });
+
+  it("sorts by assignment count when 'Most assignments' is on", async () => {
+    const user = userEvent.setup();
+    mockListHabitTemplates.mockResolvedValue([
+      template({ id: "rare" }),
+      template({ id: "popular" }),
+    ]);
+    // The counts come from the ASSIGNMENTS feed via `sourceTemplateId` — the
+    // only link between a template and how much it's actually used.
+    mockListHabitsForTrainer.mockResolvedValue([
+      habit({ id: "1", sourceTemplateId: "popular" }),
+      habit({ id: "2", sourceTemplateId: "popular", clientId: "client-2" }),
+      habit({ id: "3", sourceTemplateId: "rare" }),
+    ]);
+    renderList();
+    await waitFor(async () =>
+      expect(await libraryIds()).toEqual(["rare", "popular"]),
+    );
+
+    await user.click(screen.getByRole("button", { name: "Most assignments" }));
+
+    await waitFor(async () =>
+      expect(await libraryIds()).toEqual(["popular", "rare"]),
+    );
+  });
+
+  it("counts assignments the ASSIGNMENTS view hides", async () => {
+    const user = userEvent.setup();
+    // The ended-recurrence cutoff is a view filter, not a usage fact: a
+    // template used all last year is still the coach's most-used template.
+    mockListHabitTemplates.mockResolvedValue([
+      template({ id: "rare" }),
+      template({ id: "popular" }),
+    ]);
+    mockListHabitsForTrainer.mockResolvedValue([
+      habit({ id: "1", sourceTemplateId: "popular", endsOn: YESTERDAY }),
+      habit({ id: "2", sourceTemplateId: "popular", endsOn: YESTERDAY, clientId: "client-2" }),
+      habit({ id: "3", sourceTemplateId: "rare" }),
+    ]);
+    renderList();
+    await waitFor(async () =>
+      expect(await libraryIds()).toEqual(["rare", "popular"]),
+    );
+
+    await user.click(screen.getByRole("button", { name: "Most assignments" }));
+
+    await waitFor(async () =>
+      expect(await libraryIds()).toEqual(["popular", "rare"]),
+    );
+  });
+});

--- a/backoffice/src/app/gc-fitness/habits/_components/__tests__/habit-form-submit.test.tsx
+++ b/backoffice/src/app/gc-fitness/habits/_components/__tests__/habit-form-submit.test.tsx
@@ -1,0 +1,223 @@
+/**
+ * @jest-environment jsdom
+ */
+
+// habit-form-submit.test.tsx
+//
+// The shared habit form, from the SUBMIT side: what payload leaves it, and what
+// happens after the server answers.
+//
+// The FIRST THREE LINES of this file MUST stay as the
+// `/** @jest-environment jsdom */` docblock — the backoffice jest config
+// defaults to `testEnvironment: "node"` so without it React Testing Library
+// crashes with `ReferenceError: document is not defined`.
+//
+// What these tests protect:
+//
+//   1. NO REMINDER FIELDS ON THE WIRE WHEN THE TOGGLE IS OFF. This is not a
+//      cosmetic contract — habit reminders are SERVER-SIDE FCM pushes, so a
+//      stale cadence sends a real client a real notification for a habit whose
+//      reminder they turned off.
+//      MEASURED: the `else` branch in `onSubmit` that assigns `undefined` to
+//      the four reminder fields is DEAD CODE — deleting it keeps these tests
+//      green. The real guarantee is that `cleaned` is built from an explicit
+//      key whitelist, so those keys are only ever ADDED inside the
+//      `if (values.reminderEnabled)` branch. The tests pin the CONTRACT (what
+//      reaches the server), which is what matters and what survives a refactor
+//      of either mechanism.
+//   2. THE "NO TRANSLATION" MIRROR. When the coach fills one language only, the
+//      text is stored in BOTH — otherwise the habit renders blank for a client
+//      whose app is set to the other language.
+//      MEASURED: removing the `mirrorLocalizedBlank(cleaned.name)` call also
+//      keeps this green, because the collapsed `LocalizedTextField` already
+//      mirrors as the coach types. Two mechanisms, one contract; the assertion
+//      is on the contract deliberately.
+//   3. THE CREATE/EDIT FORK. Create toasts "created" and hands the new id back;
+//      edit toasts "saved". And a THROWN submit must not report success upstream.
+
+import "@testing-library/jest-dom";
+
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import React from "react";
+
+import { HabitForm } from "@/app/gc-fitness/habits/_components/HabitForm";
+
+const mockBack = jest.fn();
+jest.mock("next/navigation", () => ({
+  useRouter: () => ({ back: mockBack, push: jest.fn() }),
+}));
+
+const mockToastSuccess = jest.fn();
+const mockToastError = jest.fn();
+jest.mock("sonner", () => ({
+  toast: {
+    success: (...args: unknown[]) => mockToastSuccess(...args),
+    error: (...args: unknown[]) => mockToastError(...args),
+  },
+}));
+
+// The photo dropzone mints Storage upload URLs; not this file's concern.
+jest.mock("@/components/gc-fitness/StorageImagePreview", () => ({
+  StorageImagePreview: () => null,
+}));
+
+const CLIENTS = [{ uid: "client-1", displayName: "Ana" }];
+
+function baseDefaults(overrides: Record<string, unknown> = {}) {
+  return {
+    clientId: "client-1",
+    name: { en: "Drink water", es: "Tomar agua" },
+    description: { en: "", es: "" },
+    type: "binary",
+    scheduleType: "recurring",
+    scheduleCadence: "daily",
+    startsOn: "2026-09-17",
+    reminderEnabled: false,
+    ...overrides,
+  };
+}
+
+function renderForm(
+  props: Partial<React.ComponentProps<typeof HabitForm>> = {},
+  defaults: Record<string, unknown> = {},
+) {
+  const onSubmit = jest.fn().mockResolvedValue({ id: "habit-new" });
+  const onAfterSubmit = jest.fn();
+  render(
+    <HabitForm
+      mode="create"
+      clientOptions={CLIENTS}
+      habitId="habit-draft-1"
+      defaultValues={baseDefaults(defaults) as never}
+      onSubmit={onSubmit}
+      onAfterSubmit={onAfterSubmit}
+      {...props}
+    />,
+  );
+  return { onSubmit, onAfterSubmit };
+}
+
+function submitButton() {
+  return screen.getByRole("button", { name: /Create habit|Save changes|Save/i });
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe("HabitForm — reminder fields", () => {
+  it("sends every reminder field as undefined when the toggle is off", async () => {
+    const user = userEvent.setup();
+    const { onSubmit } = renderForm();
+
+    await user.click(submitButton());
+
+    await waitFor(() => expect(onSubmit).toHaveBeenCalledTimes(1));
+    const payload = onSubmit.mock.calls[0][0];
+    // Habit reminders are server-side FCM pushes. A stale cadence here sends a
+    // real notification for a reminder the coach switched off.
+    expect(payload.reminderCadence).toBeUndefined();
+    expect(payload.reminderWeekdays).toBeUndefined();
+    expect(payload.reminderDayOfMonth).toBeUndefined();
+    expect(payload.reminderMonthDays).toBeUndefined();
+  });
+
+  it("clears them even when the defaults arrived carrying reminder values", async () => {
+    const user = userEvent.setup();
+    // The realistic regression: editing a habit that HAD a weekly reminder and
+    // switching the reminder off. The stale cadence must not survive.
+    const { onSubmit } = renderForm({}, {
+      reminderEnabled: false,
+      reminderCadence: "weekly",
+      reminderWeekdays: [1, 3, 5],
+    });
+
+    await user.click(submitButton());
+
+    await waitFor(() => expect(onSubmit).toHaveBeenCalledTimes(1));
+    const payload = onSubmit.mock.calls[0][0];
+    expect(payload.reminderCadence).toBeUndefined();
+    expect(payload.reminderWeekdays).toBeUndefined();
+  });
+});
+
+describe("HabitForm — localized text", () => {
+  it("mirrors a single-language name into both languages", async () => {
+    const user = userEvent.setup();
+    const { onSubmit } = renderForm({}, {
+      name: { en: "Drink water", es: "" },
+    });
+
+    await user.click(submitButton());
+
+    await waitFor(() => expect(onSubmit).toHaveBeenCalledTimes(1));
+    const payload = onSubmit.mock.calls[0][0];
+    // A blank side renders as an empty habit name for any client on that
+    // locale — the mirror is what stops that.
+    expect(payload.name.en).toBe("Drink water");
+    expect(payload.name.es).toBe("Drink water");
+  });
+});
+
+describe("HabitForm — after the server answers", () => {
+  it("reports creation and hands the new id back to the host", async () => {
+    const user = userEvent.setup();
+    const { onSubmit, onAfterSubmit } = renderForm();
+
+    await user.click(submitButton());
+
+    await waitFor(() => expect(onAfterSubmit).toHaveBeenCalledTimes(1));
+    expect(mockToastSuccess).toHaveBeenCalledWith("Habit created.");
+    expect(onAfterSubmit).toHaveBeenCalledWith({ id: "habit-new" });
+    expect(onSubmit).toHaveBeenCalledTimes(1);
+    // With a host callback present the form must NOT also navigate back.
+    expect(mockBack).not.toHaveBeenCalled();
+  });
+
+  it("reports a save (not a create) in edit mode", async () => {
+    const user = userEvent.setup();
+    const onSubmit = jest.fn().mockResolvedValue({ ok: true as const });
+    render(
+      <HabitForm
+        mode="edit"
+        clientOptions={CLIENTS}
+        habitId="hab-existing"
+        defaultValues={baseDefaults() as never}
+        onSubmit={onSubmit}
+        onAfterSubmit={jest.fn()}
+      />,
+    );
+
+    await user.click(submitButton());
+
+    await waitFor(() => expect(mockToastSuccess).toHaveBeenCalled());
+    expect(mockToastSuccess).toHaveBeenCalledWith("Habit saved.");
+  });
+
+  it("surfaces a failed save and does NOT tell the host it succeeded", async () => {
+    const user = userEvent.setup();
+    const onSubmit = jest.fn().mockRejectedValue(new Error("Rules rejected it"));
+    const onAfterSubmit = jest.fn();
+    render(
+      <HabitForm
+        mode="create"
+        clientOptions={CLIENTS}
+        habitId="habit-draft-1"
+        defaultValues={baseDefaults() as never}
+        onSubmit={onSubmit}
+        onAfterSubmit={onAfterSubmit}
+      />,
+    );
+
+    await user.click(submitButton());
+
+    await waitFor(() =>
+      expect(mockToastError).toHaveBeenCalledWith("Rules rejected it"),
+    );
+    // The host closes its dialog on onAfterSubmit — firing it here would hide
+    // a habit that was never written.
+    expect(onAfterSubmit).not.toHaveBeenCalled();
+    expect(mockToastSuccess).not.toHaveBeenCalled();
+  });
+});

--- a/backoffice/src/app/gc-fitness/habits/_components/__tests__/habit-template-detail-dialog.test.tsx
+++ b/backoffice/src/app/gc-fitness/habits/_components/__tests__/habit-template-detail-dialog.test.tsx
@@ -1,0 +1,389 @@
+/**
+ * @jest-environment jsdom
+ */
+
+// habit-template-detail-dialog.test.tsx
+//
+// The detail view of a habit LIBRARY template — the surface where a coach edits
+// or removes a reusable habit.
+//
+// The FIRST THREE LINES of this file MUST stay as the
+// `/** @jest-environment jsdom */` docblock — the backoffice jest config
+// defaults to `testEnvironment: "node"` so without it React Testing Library
+// crashes with `ReferenceError: document is not defined`.
+//
+// Three things make this dialog worth pinning:
+//
+//   1. THE SCOPE FORK. A `trainer` template is the coach's own: Edit + Delete.
+//      A `global` one is SHARED across every coach on the platform, so it is
+//      read-only and can only be HIDDEN from this coach's library (reversible
+//      via "show hidden"). The two removals look identical in the UI and are
+//      completely different in the data: `hideGlobalHabitTemplate` writes an
+//      id into this trainer's private hidden-set, `softDeleteHabitTemplate`
+//      flips `deleted` on the shared doc. Wiring the wrong one to the global
+//      branch takes a habit away from everybody.
+//      (The Server Action refuses a global edit too — but by then the coach
+//      has already typed the edit and gets an error toast, so the UI fork is
+//      the guard that matters.)
+//   2. THE SAVE PAYLOAD. Same rules as the habit form: blank optional fields
+//      go out as `undefined` (never ""), the coach's single language is
+//      MIRRORED into both, and a reminder time is dropped when the toggle is
+//      off — habit reminders are server-side FCM pushes, so a stale time left
+//      on the doc is a push nobody asked for.
+//   3. THE CASCADE IS OPT-IN. Saving a template edit does NOT push content to
+//      the clients who already have the habit assigned. It asks. A silent
+//      cascade rewrites live assignments on somebody's phone.
+//
+// `useLocale()` is stubbed to "en" (see `next-intl-stub.tsx`), so the coach's
+// primary language here is English and the mirror fills Spanish.
+
+import "@testing-library/jest-dom";
+
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import React from "react";
+
+import type { HabitTemplateRow } from "@/lib/gc-fitness/habit-actions";
+
+const mockUpdateHabitTemplate = jest.fn();
+const mockSoftDeleteHabitTemplate = jest.fn();
+const mockHideGlobalHabitTemplate = jest.fn();
+const mockPropagate = jest.fn();
+const mockListAssignments = jest.fn();
+jest.mock("@/lib/gc-fitness/habit-actions", () => ({
+  updateHabitTemplate: (...args: unknown[]) => mockUpdateHabitTemplate(...args),
+  softDeleteHabitTemplate: (...args: unknown[]) =>
+    mockSoftDeleteHabitTemplate(...args),
+  hideGlobalHabitTemplate: (...args: unknown[]) =>
+    mockHideGlobalHabitTemplate(...args),
+  propagateHabitTemplateContent: (...args: unknown[]) => mockPropagate(...args),
+  listHabitTemplateAssignments: (...args: unknown[]) =>
+    mockListAssignments(...args),
+}));
+
+// Uploads to Storage; irrelevant to every assertion here.
+jest.mock("../HabitPhotoDropzone", () => ({
+  HabitPhotoDropzone: () => null,
+}));
+
+jest.mock("sonner", () => ({
+  toast: { success: jest.fn(), error: jest.fn() },
+}));
+
+import { HabitTemplateDetailDialog } from "../HabitTemplateDetailDialog";
+
+function template(overrides: Partial<HabitTemplateRow> = {}): HabitTemplateRow {
+  return {
+    id: "tpl-1",
+    scope: "trainer",
+    trainerId: "trainer-1",
+    type: "binary",
+    name: { en: "Drink water", es: "" },
+    reminderEnabled: false,
+    scheduleType: "recurring",
+    startsOn: "2026-01-01",
+    deleted: false,
+    createdAt: null,
+    updatedAt: null,
+    ...overrides,
+  } as HabitTemplateRow;
+}
+
+function renderDialog(tpl: HabitTemplateRow) {
+  const onChanged = jest.fn();
+  const onOpenChange = jest.fn();
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  render(
+    <QueryClientProvider client={client}>
+      <HabitTemplateDetailDialog
+        open
+        onOpenChange={onOpenChange}
+        template={tpl}
+        onChanged={onChanged}
+        clientNames={new Map([["client-1", "Ana Gomez"]])}
+      />
+    </QueryClientProvider>,
+  );
+  return { onChanged, onOpenChange };
+}
+
+function button(name: string | RegExp) {
+  return screen.getByRole("button", { name });
+}
+
+function queryButton(name: string | RegExp) {
+  return screen.queryByRole("button", { name });
+}
+
+/** Enter edit mode (trainer-owned templates only). */
+async function startEditing(user: ReturnType<typeof userEvent.setup>) {
+  await user.click(button("Edit"));
+}
+
+function assignment(clientId: string, habitId: string) {
+  return {
+    habitId,
+    clientId,
+    pendingEmail: null,
+    scheduleType: "recurring" as const,
+    scheduleCadence: "daily" as const,
+  };
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockUpdateHabitTemplate.mockResolvedValue({ ok: true });
+  mockSoftDeleteHabitTemplate.mockResolvedValue({ ok: true });
+  mockHideGlobalHabitTemplate.mockResolvedValue({ ok: true });
+  mockPropagate.mockResolvedValue({ updated: 1 });
+  mockListAssignments.mockResolvedValue([]);
+});
+
+describe("HabitTemplateDetailDialog — the scope fork", () => {
+  it("offers Edit + Delete on the coach's OWN template", () => {
+    renderDialog(template({ scope: "trainer" }));
+
+    expect(button("Edit")).toBeInTheDocument();
+    expect(button("Delete")).toBeInTheDocument();
+    expect(queryButton(/Hide from my library/)).not.toBeInTheDocument();
+  });
+
+  it("offers only Hide on a GLOBAL template", () => {
+    renderDialog(template({ scope: "global", trainerId: null }));
+
+    // A global template belongs to every coach on the platform. Editing or
+    // deleting it from here would reach into all of their libraries.
+    expect(queryButton("Edit")).not.toBeInTheDocument();
+    expect(queryButton("Delete")).not.toBeInTheDocument();
+    expect(button(/Hide from my library/)).toBeInTheDocument();
+  });
+
+  it("hides (per-trainer) instead of deleting (shared) on a global", async () => {
+    const user = userEvent.setup();
+    const { onChanged } = renderDialog(
+      template({ scope: "global", trainerId: null }),
+    );
+
+    await user.click(button(/Hide from my library/));
+    await user.click(await screen.findByRole("button", { name: "Hide" }));
+
+    await waitFor(() =>
+      expect(mockHideGlobalHabitTemplate).toHaveBeenCalledWith("tpl-1"),
+    );
+    // The one that must NOT fire: it flips `deleted` on the shared doc.
+    expect(mockSoftDeleteHabitTemplate).not.toHaveBeenCalled();
+    expect(onChanged).toHaveBeenCalled();
+  });
+
+  it("soft-deletes the coach's own template", async () => {
+    const user = userEvent.setup();
+    const { onChanged } = renderDialog(template({ scope: "trainer" }));
+
+    await user.click(button("Delete"));
+    await user.click(await screen.findByRole("button", { name: "Delete" }));
+
+    await waitFor(() =>
+      expect(mockSoftDeleteHabitTemplate).toHaveBeenCalledWith("tpl-1"),
+    );
+    expect(mockHideGlobalHabitTemplate).not.toHaveBeenCalled();
+    expect(onChanged).toHaveBeenCalled();
+  });
+
+  it("states that deleting the library habit leaves assignments alone", async () => {
+    const user = userEvent.setup();
+    renderDialog(template({ scope: "trainer" }));
+
+    await user.click(button("Delete"));
+
+    // The confirm is also the only place the coach is told the truth about the
+    // blast radius. Silence here reads as "this removes it from my clients".
+    expect(
+      await screen.findByText(/deleting it only affects your library/i),
+    ).toBeInTheDocument();
+  });
+});
+
+describe("HabitTemplateDetailDialog — the save payload", () => {
+  // The "one language means every language" contract has TWO mechanisms, and
+  // it took a green mutation to notice: with the translation pane COLLAPSED the
+  // primary input already writes both languages on every keystroke, so
+  // `mirrorLocalizedBlank` at save time is unreachable on that path — deleting
+  // it leaves this first test green. The second test is the one that pins the
+  // save-time mirror, by opening the pane (which stops the typing mirror) and
+  // blanking the translation by hand. Assertions go to the CONTRACT, so both
+  // mechanisms are covered regardless of which one does the work.
+  it("mirrors while the coach types, with translations collapsed", async () => {
+    const user = userEvent.setup();
+    renderDialog(template({ name: { en: "Drink water", es: "" } }));
+
+    await startEditing(user);
+    const name = screen.getByLabelText("Name");
+    await user.clear(name);
+    await user.type(name, "Hydrate");
+    await user.click(button("Save changes"));
+
+    await waitFor(() => expect(mockUpdateHabitTemplate).toHaveBeenCalled());
+    const [id, payload] = mockUpdateHabitTemplate.mock.calls[0];
+    expect(id).toBe("tpl-1");
+    // A blank ES on the doc renders as an empty habit name for a Spanish
+    // client — the habit is there, nameless.
+    expect(payload.name).toEqual({ en: "Hydrate", es: "Hydrate" });
+  });
+
+  it("re-fills a translation the coach blanked out, on save", async () => {
+    const user = userEvent.setup();
+    renderDialog(template({ name: { en: "Drink water", es: "" } }));
+
+    await startEditing(user);
+    // Opening the pane switches the primary input OFF the typing mirror, so
+    // an emptied Spanish field stays empty until save.
+    await user.click(button("Add translation"));
+    await user.clear(screen.getByLabelText("Name (Spanish)"));
+    await user.click(button("Save changes"));
+
+    await waitFor(() => expect(mockUpdateHabitTemplate).toHaveBeenCalled());
+    expect(mockUpdateHabitTemplate.mock.calls[0][1].name).toEqual({
+      en: "Drink water",
+      es: "Drink water",
+    });
+  });
+
+  it("sends `undefined`, not '', for the fields left blank", async () => {
+    const user = userEvent.setup();
+    renderDialog(template());
+
+    await startEditing(user);
+    await user.click(button("Save changes"));
+
+    await waitFor(() => expect(mockUpdateHabitTemplate).toHaveBeenCalled());
+    const payload = mockUpdateHabitTemplate.mock.calls[0][1];
+    // An empty string is a real value on Firestore: it would overwrite a
+    // description with blankness rather than leaving the field alone.
+    expect(payload.description).toBeUndefined();
+    expect(payload.youtubeUrl).toBeUndefined();
+    expect(payload.photoUrl).toBeUndefined();
+  });
+
+  it("drops the reminder time when the toggle is OFF", async () => {
+    const user = userEvent.setup();
+    // Habit reminders are SERVER-side FCM pushes keyed off these two fields.
+    // A time left behind with the toggle off is a notification the coach
+    // believes they turned off.
+    renderDialog(template({ reminderEnabled: true, reminderTime: "08:00" }));
+
+    await startEditing(user);
+    await user.click(screen.getByRole("checkbox"));
+    await user.click(button("Save changes"));
+
+    await waitFor(() => expect(mockUpdateHabitTemplate).toHaveBeenCalled());
+    const payload = mockUpdateHabitTemplate.mock.calls[0][1];
+    expect(payload.reminderEnabled).toBe(false);
+    expect(payload.reminderTime).toBeUndefined();
+  });
+
+  it("keeps the reminder time when the toggle is ON", async () => {
+    const user = userEvent.setup();
+    renderDialog(template({ reminderEnabled: true, reminderTime: "08:00" }));
+
+    await startEditing(user);
+    await user.click(button("Save changes"));
+
+    await waitFor(() => expect(mockUpdateHabitTemplate).toHaveBeenCalled());
+    const payload = mockUpdateHabitTemplate.mock.calls[0][1];
+    expect(payload).toMatchObject({ reminderEnabled: true, reminderTime: "08:00" });
+  });
+
+  it("seeds BOTH language fields from an English-only template", async () => {
+    const user = userEvent.setup();
+    renderDialog(
+      template({
+        name: { en: "Drink water", es: "" },
+        description: { en: "Two litres", es: "" },
+      }),
+    );
+
+    await startEditing(user);
+    await user.click(button("Add translation"));
+
+    // Without the load-time mirror the Spanish field opens EMPTY, and saving
+    // from there wipes the Spanish copy of a habit that had one.
+    expect(screen.getByLabelText("Name (Spanish)")).toHaveValue("Drink water");
+  });
+
+  it("disables Save while the name is empty", async () => {
+    const user = userEvent.setup();
+    renderDialog(template());
+
+    await startEditing(user);
+    await user.clear(screen.getByLabelText("Name"));
+
+    // The guard the coach actually meets — there is no "name required" toast
+    // path in this dialog, the button simply doesn't fire.
+    expect(button("Save changes")).toBeDisabled();
+  });
+});
+
+describe("HabitTemplateDetailDialog — the cascade is opt-in", () => {
+  it("asks before pushing a content edit to assigned clients", async () => {
+    const user = userEvent.setup();
+    mockListAssignments.mockResolvedValue([assignment("client-1", "h1")]);
+    renderDialog(template());
+
+    await startEditing(user);
+    await user.click(button("Save changes"));
+
+    // The template is saved…
+    await waitFor(() => expect(mockUpdateHabitTemplate).toHaveBeenCalled());
+    // …and nothing reached the client's assignment yet.
+    expect(await screen.findByText(/¿Actualizar a los clientes\?/)).toBeInTheDocument();
+    expect(mockPropagate).not.toHaveBeenCalled();
+  });
+
+  it("propagates only when the coach confirms", async () => {
+    const user = userEvent.setup();
+    mockListAssignments.mockResolvedValue([
+      assignment("client-1", "h1"),
+      assignment("client-1", "h2"),
+    ]);
+    renderDialog(template());
+
+    await startEditing(user);
+    await user.click(button("Save changes"));
+    await screen.findByText(/¿Actualizar a los clientes\?/);
+    // Two assignments, ONE client — the count in the CTA is per client, not
+    // per assignment.
+    await user.click(button(/Actualizar a 1 cliente/));
+
+    await waitFor(() => expect(mockPropagate).toHaveBeenCalledWith("tpl-1"));
+  });
+
+  it("dismissing keeps the template saved and touches no assignment", async () => {
+    const user = userEvent.setup();
+    mockListAssignments.mockResolvedValue([assignment("client-1", "h1")]);
+    const { onOpenChange } = renderDialog(template());
+
+    await startEditing(user);
+    await user.click(button("Save changes"));
+    await screen.findByText(/¿Actualizar a los clientes\?/);
+    await user.click(button("No actualizar"));
+
+    expect(mockUpdateHabitTemplate).toHaveBeenCalledTimes(1);
+    expect(mockPropagate).not.toHaveBeenCalled();
+    await waitFor(() => expect(onOpenChange).toHaveBeenCalledWith(false));
+  });
+
+  it("skips the question entirely when nobody has it assigned", async () => {
+    const user = userEvent.setup();
+    mockListAssignments.mockResolvedValue([]);
+    const { onOpenChange } = renderDialog(template());
+
+    await startEditing(user);
+    await user.click(button("Save changes"));
+
+    await waitFor(() => expect(onOpenChange).toHaveBeenCalledWith(false));
+    expect(screen.queryByText(/¿Actualizar a los clientes\?/)).not.toBeInTheDocument();
+  });
+});

--- a/backoffice/src/app/gc-fitness/my-activity/__tests__/my-activity-feed.test.tsx
+++ b/backoffice/src/app/gc-fitness/my-activity/__tests__/my-activity-feed.test.tsx
@@ -1,0 +1,348 @@
+/**
+ * @jest-environment jsdom
+ */
+
+// my-activity-feed.test.tsx
+//
+// "Mi Actividad" — the coach's own event log, read from `coach_activity`. It
+// writes nothing, but it PAGES and it FILTERS, and those two interact: the
+// cursor belongs to a filter, so mixing them up appends rows the coach just
+// filtered out and the feed quietly stops meaning anything.
+//
+// The FIRST THREE LINES of this file MUST stay as the
+// `/** @jest-environment jsdom */` docblock — the backoffice jest config
+// defaults to `testEnvironment: "node"` so without it React Testing Library
+// crashes with `ReferenceError: document is not defined`.
+//
+// What is pinned:
+//
+//   • CHANGING A FILTER RESTARTS THE PAGE. Cursor back to `null`, rows
+//     REPLACED — not appended. Passing the old cursor would page into the
+//     middle of a different result set.
+//   • LOAD MORE CARRIES THE FILTERS. Dropping them appends unfiltered rows
+//     under a filtered heading.
+//   • LOAD MORE DEDUPES BY ID. A cursor that overlaps by one (the usual
+//     boundary case with equal timestamps) would otherwise duplicate rows, and
+//     duplicate React keys on top of that.
+//   • THE DAY HEADINGS ARE IN THE COACH'S TIMEZONE, so one local day is one
+//     section — the same invariant the checklist has.
+//   • A DELETION READS AS A DELETION, whatever kind it was.
+
+import "@testing-library/jest-dom";
+
+import { render, screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import React from "react";
+
+import type {
+  MyCoachActivityRow,
+  MyActivityClientOption,
+} from "@/lib/gc-fitness/coach-activity-actions";
+
+const mockListPage = jest.fn();
+jest.mock("@/lib/gc-fitness/coach-activity-actions", () => ({
+  listMyCoachActivityPage: (...args: unknown[]) => mockListPage(...args),
+}));
+
+import { MyActivityFeed } from "../MyActivityFeed";
+
+const TZ = "America/Argentina/Buenos_Aires";
+const PAGE_SIZE = 50;
+
+function row(overrides: Partial<MyCoachActivityRow> = {}): MyCoachActivityRow {
+  return {
+    id: "e1",
+    kind: "workout_assignment",
+    occurredAt: "2026-09-10T15:00:00.000Z",
+    title: "Assigned Push Day",
+    detail: null,
+    clientId: "ana",
+    clientName: "Ana Gomez",
+    ...overrides,
+  } as MyCoachActivityRow;
+}
+
+const CLIENTS: MyActivityClientOption[] = [
+  { id: "ana", name: "Ana Gomez" },
+  { id: "beto", name: "Beto Diaz" },
+];
+
+function renderFeed(
+  rows: MyCoachActivityRow[],
+  opts: { cursor?: string | null; hasMore?: boolean } = {},
+) {
+  render(
+    <MyActivityFeed
+      initialRows={rows}
+      initialCursor={opts.cursor ?? "cursor-1"}
+      initialHasMore={opts.hasMore ?? true}
+      clients={CLIENTS}
+      timezone={TZ}
+    />,
+  );
+  return { user: userEvent.setup({ advanceTimers: jest.advanceTimersByTime }) };
+}
+
+/** The two shadcn selects, told apart by the label above them (their trigger
+ *  carries no accessible name of its own). */
+function filterTrigger(which: "client" | "type"): HTMLElement {
+  const [clientSel, typeSel] = screen.getAllByRole("combobox");
+  return which === "client" ? clientSel : typeSel;
+}
+
+async function chooseFilter(
+  user: ReturnType<typeof userEvent.setup>,
+  which: "client" | "type",
+  option: string,
+) {
+  await user.click(filterTrigger(which));
+  await user.click(await screen.findByRole("option", { name: option }));
+}
+
+function titles(): string[] {
+  return screen
+    .getAllByRole("heading", { level: 3 })
+    .flatMap((h) =>
+      Array.from(
+        (h.parentElement as HTMLElement).querySelectorAll("p.font-semibold"),
+      ).map((p) => p.textContent ?? ""),
+    );
+}
+
+function dayHeadings(): string[] {
+  return screen.getAllByRole("heading", { level: 3 }).map((h) => h.textContent ?? "");
+}
+
+/** The arguments of the last page request: (cursor, size, clientId, kind). */
+function lastCall(): [string | null, number, string | null, string | null] {
+  return mockListPage.mock.calls.at(-1) as [
+    string | null,
+    number,
+    string | null,
+    string | null,
+  ];
+}
+
+// 12:00 in Buenos Aires. The Today/Yesterday headings are computed against the
+// wall clock, so it is pinned — otherwise every "Today" assertion is a coin
+// flip depending on when the suite runs.
+const NOW = "2026-09-10T15:00:00.000Z";
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  jest.useFakeTimers({ now: new Date(NOW) });
+  mockListPage.mockResolvedValue({ rows: [], nextCursor: null, hasMore: false });
+});
+
+afterEach(() => {
+  jest.useRealTimers();
+});
+
+describe("MyActivityFeed — filtering", () => {
+  it("restarts from the FIRST page when a client filter is picked", async () => {
+    const { user } = renderFeed([row()]);
+
+    await chooseFilter(user, "client", "Ana Gomez");
+
+    await waitFor(() => expect(mockListPage).toHaveBeenCalledTimes(1));
+    expect(lastCall()).toEqual([null, PAGE_SIZE, "ana", null]);
+  });
+
+  it("REPLACES the rows rather than appending them", async () => {
+    // Appending would leave the pre-filter rows on screen under the new
+    // filter — the feed then shows exactly what the coach filtered out.
+    mockListPage.mockResolvedValue({
+      rows: [row({ id: "e2", title: "Assigned Leg Day", clientId: "beto", clientName: "Beto Diaz" })],
+      nextCursor: null,
+      hasMore: false,
+    });
+    const { user } = renderFeed([row({ title: "Assigned Push Day" })]);
+
+    await chooseFilter(user, "client", "Beto Diaz");
+
+    await waitFor(() =>
+      expect(screen.queryByText("Assigned Push Day")).not.toBeInTheDocument(),
+    );
+    expect(screen.getByText("Assigned Leg Day")).toBeInTheDocument();
+  });
+
+  it("sends 'all' as null, not as the literal string", async () => {
+    // The action treats null as "no filter"; the string "all" would be matched
+    // against a clientId and return nothing.
+    const { user } = renderFeed([row()]);
+
+    await chooseFilter(user, "type", "Chat");
+    await waitFor(() => expect(mockListPage).toHaveBeenCalledTimes(1));
+
+    expect(lastCall()).toEqual([null, PAGE_SIZE, null, "chat"]);
+  });
+
+  it("keeps the OTHER filter when one changes", async () => {
+    const { user } = renderFeed([row()]);
+
+    await chooseFilter(user, "client", "Ana Gomez");
+    // The two selects are DISABLED while the transition is in flight, so the
+    // second pick has to wait for the first to land — otherwise the option
+    // list never opens and the failure looks like a missing option.
+    await waitFor(() => expect(filterTrigger("type")).toBeEnabled());
+    await chooseFilter(user, "type", "Chat");
+
+    await waitFor(() => expect(mockListPage).toHaveBeenCalledTimes(2));
+    expect(lastCall()).toEqual([null, PAGE_SIZE, "ana", "chat"]);
+  });
+
+  it("does not offer the client-side rest edit as a coach filter", async () => {
+    // `workout_rest_edited` is something the CLIENT does; it is excluded from
+    // this feed, so offering it as a filter is a guaranteed empty screen.
+    const { user } = renderFeed([row()]);
+
+    await user.click(filterTrigger("type"));
+
+    expect(screen.queryByRole("option", { name: /rest/i })).not.toBeInTheDocument();
+  });
+
+  it("tells an empty FILTERED feed apart from an empty one", async () => {
+    const { user } = renderFeed([], { hasMore: false });
+    expect(screen.getByText("No recent actions yet.")).toBeInTheDocument();
+
+    await chooseFilter(user, "client", "Ana Gomez");
+
+    await waitFor(() =>
+      expect(screen.getByText("No activity for this filter.")).toBeInTheDocument(),
+    );
+  });
+});
+
+describe("MyActivityFeed — paging", () => {
+  it("carries the CURSOR and the active filters into the next page", async () => {
+    // The filtered response must carry a cursor of its OWN and still have more
+    // — otherwise the Load more button is gone before the second half of the
+    // test, which reads as a locator failure.
+    mockListPage.mockResolvedValue({
+      rows: [row({ id: "e9" })],
+      nextCursor: "cursor-filtered",
+      hasMore: true,
+    });
+    const { user } = renderFeed([row()], { cursor: "cursor-1", hasMore: true });
+
+    await chooseFilter(user, "client", "Ana Gomez");
+    await waitFor(() => expect(mockListPage).toHaveBeenCalledTimes(1));
+    mockListPage.mockClear();
+
+    // While the transition is in flight the button READS "Loading...", so a
+    // by-name lookup right here fails on the name, not on the button.
+    await user.click(await screen.findByRole("button", { name: "Load more" }));
+
+    await waitFor(() => expect(mockListPage).toHaveBeenCalledTimes(1));
+    expect(lastCall()).toEqual([
+      "cursor-filtered", // the pre-filter cursor is dead
+      PAGE_SIZE,
+      "ana",
+      null,
+    ]);
+  });
+
+  it("appends the next page under the existing rows", async () => {
+    mockListPage.mockResolvedValue({
+      rows: [row({ id: "e2", title: "Older thing" })],
+      nextCursor: null,
+      hasMore: false,
+    });
+    const { user } = renderFeed([row({ id: "e1", title: "Newer thing" })]);
+
+    await user.click(screen.getByRole("button", { name: "Load more" }));
+
+    await waitFor(() => expect(titles()).toEqual(["Newer thing", "Older thing"]));
+  });
+
+  it("DROPS rows it already has", async () => {
+    // Equal timestamps at the page boundary hand the same row back twice.
+    // Without the dedupe the coach sees it twice and React logs a duplicate key.
+    mockListPage.mockResolvedValue({
+      rows: [row({ id: "e1", title: "Newer thing" }), row({ id: "e2", title: "Older thing" })],
+      nextCursor: null,
+      hasMore: false,
+    });
+    const { user } = renderFeed([row({ id: "e1", title: "Newer thing" })]);
+
+    await user.click(screen.getByRole("button", { name: "Load more" }));
+
+    await waitFor(() => expect(titles()).toEqual(["Newer thing", "Older thing"]));
+  });
+
+  it("hides the button once the server says there is no more", async () => {
+    mockListPage.mockResolvedValue({ rows: [], nextCursor: null, hasMore: false });
+    const { user } = renderFeed([row()]);
+
+    await user.click(screen.getByRole("button", { name: "Load more" }));
+
+    await waitFor(() =>
+      expect(screen.queryByRole("button", { name: "Load more" })).not.toBeInTheDocument(),
+    );
+  });
+
+  it("does not render the button at all when the first page is the last", () => {
+    renderFeed([row()], { hasMore: false });
+
+    expect(screen.queryByRole("button", { name: "Load more" })).not.toBeInTheDocument();
+  });
+});
+
+describe("MyActivityFeed — how a row reads", () => {
+  it("groups a local day into ONE section, in the coach's timezone", async () => {
+    // 02:00Z is the previous day at 23:00 in Buenos Aires: keyed in UTC these
+    // two rows split across two headings.
+    renderFeed([
+      row({ id: "a", occurredAt: "2026-09-10T15:00:00.000Z" }),
+      row({ id: "b", occurredAt: "2026-09-11T02:00:00.000Z" }),
+    ]);
+
+    expect(dayHeadings()).toEqual(["Today"]);
+  });
+
+  it("names yesterday as Yesterday", async () => {
+    renderFeed([row({ occurredAt: "2026-09-09T15:00:00.000Z" })]);
+
+    expect(dayHeadings()).toEqual(["Yesterday"]);
+  });
+
+  it("dates anything older", async () => {
+    renderFeed([row({ occurredAt: "2026-08-01T15:00:00.000Z" })]);
+
+    expect(dayHeadings()[0]).not.toBe("Today");
+    expect(dayHeadings()[0]).not.toBe("Yesterday");
+  });
+
+  it("labels a DELETION as one, not by its kind", async () => {
+    renderFeed([row({ kind: "habit_assignment", deleted: true })]);
+
+    expect(screen.getByTitle("Deleted")).toBeInTheDocument();
+  });
+
+  it("links the client name to their profile", async () => {
+    renderFeed([row({ clientId: "ana", clientName: "Ana Gomez" })]);
+
+    expect(screen.getByRole("link", { name: "Ana Gomez" })).toHaveAttribute(
+      "href",
+      "/gc-fitness/clients/ana",
+    );
+  });
+
+  it("keeps the name as plain text when there is no id to link to", async () => {
+    // A row about a client who no longer resolves must not render a link to
+    // `/clients/null`.
+    renderFeed([row({ clientId: null, clientName: "Ana Gomez" })]);
+
+    expect(screen.queryByRole("link", { name: /Ana Gomez/ })).not.toBeInTheDocument();
+    expect(screen.getByText(/Ana Gomez/)).toBeInTheDocument();
+  });
+
+  it("prints the time in the coach's timezone", async () => {
+    // 15:00Z is 12:00 in Buenos Aires. Rendering the host's hour would show a
+    // coach in another zone the wrong time for their own action.
+    renderFeed([row({ occurredAt: "2026-09-10T15:00:00.000Z" })]);
+
+    const section = screen.getByRole("heading", { level: 3 }).parentElement!;
+    expect(within(section).getByText(/12:00/)).toBeInTheDocument();
+  });
+});

--- a/backoffice/src/app/gc-fitness/templates/__tests__/templates-standard-routing.test.tsx
+++ b/backoffice/src/app/gc-fitness/templates/__tests__/templates-standard-routing.test.tsx
@@ -1,0 +1,190 @@
+/**
+ * @jest-environment jsdom
+ */
+
+// templates-standard-routing.test.tsx
+//
+// The #163 invariant, which had no coverage: a STANDARD (shared-library)
+// template must open the read-only `/view` page, never `/edit`.
+//
+// The FIRST THREE LINES of this file MUST stay as the
+// `/** @jest-environment jsdom */` docblock — the backoffice jest config
+// defaults to `testEnvironment: "node"` so without it React Testing Library
+// crashes with `ReferenceError: document is not defined`.
+//
+// WHY IT MATTERS, from the source comment on the handler itself: "/edit on a
+// non-owned standard template would auto-fork and silently create duplicates."
+// The trainer forks explicitly from the view page instead. This shipped as a
+// real bug once; the failure mode is invisible at the click — the editor opens
+// and looks right, and the library quietly grows a copy every time somebody
+// opens a standard template.
+//
+// There IS a server-side redirect in `/edit/page.tsx` as a second line of
+// defense, but relying on it means every mis-route costs a page load and an
+// extra Firestore read, and the redirect only covers the not-owned case. The
+// list must not send the trainer there in the first place.
+
+import "@testing-library/jest-dom";
+
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import React from "react";
+
+import { TemplatesLibraryClient } from "@/app/gc-fitness/templates/client";
+
+const mockPush = jest.fn();
+jest.mock("next/navigation", () => ({
+  useRouter: () => ({ push: mockPush }),
+}));
+
+const mockUseWorkoutTemplates = jest.fn();
+jest.mock("@/lib/gc-fitness/workout-templates-listener", () => ({
+  useWorkoutTemplates: () => mockUseWorkoutTemplates(),
+  WORKOUT_TEMPLATES_BASE_KEY: ["workout-templates"],
+}));
+
+jest.mock("@/lib/gc-fitness/use-favorites", () => ({
+  useFavorites: () => ({ favorites: [], toggle: jest.fn() }),
+}));
+
+jest.mock("@/lib/gc-fitness/library-usage-listeners", () => ({
+  useTemplateAssignmentCounts: () => ({ data: {} }),
+}));
+
+const mockDuplicate = jest.fn();
+jest.mock("@/lib/gc-fitness/workout-template-actions", () => ({
+  duplicateWorkoutTemplate: (...args: unknown[]) => mockDuplicate(...args),
+  softDeleteWorkoutTemplate: jest.fn(),
+}));
+
+jest.mock("@tanstack/react-query", () => ({
+  useQueryClient: () => ({ invalidateQueries: jest.fn() }),
+}));
+
+jest.mock("sonner", () => ({
+  toast: { success: jest.fn(), error: jest.fn() },
+}));
+
+jest.mock("@/components/gc-fitness/favorite-star-button", () => ({
+  FavoriteStarButton: () => null,
+}));
+
+jest.mock("@/app/gc-fitness/templates/_components/TemplateAssignmentsView", () => ({
+  TemplateAssignmentsView: () => null,
+}));
+
+const TRAINER = "trainer-9";
+
+function template(overrides: Record<string, unknown> = {}) {
+  return {
+    id: "tpl-1",
+    name: { en: "Full Body A", es: "Cuerpo Completo A" },
+    description: { en: "", es: "" },
+    trainerId: TRAINER,
+    isStandard: false,
+    tags: [],
+    tag: null,
+    exercises: [],
+    exerciseCount: 4,
+    updatedAt: null,
+    ...overrides,
+  };
+}
+
+function renderLibrary(rows: Array<Record<string, unknown>>) {
+  mockUseWorkoutTemplates.mockReturnValue({
+    data: rows,
+    isLoading: false,
+    error: null,
+  });
+  render(<TemplatesLibraryClient trainerUid={TRAINER} />);
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe("Templates library — standard templates never open /edit (#163)", () => {
+  it("routes a STANDARD template row to /view", async () => {
+    const user = userEvent.setup();
+    renderLibrary([
+      template({
+        id: "std-1",
+        name: { en: "Standard Push", es: "Empuje Estándar" },
+        isStandard: true,
+        trainerId: "__standard__",
+      }),
+    ]);
+
+    await user.click(await screen.findByText("Standard Push"));
+
+    expect(mockPush).toHaveBeenCalledWith("/gc-fitness/templates/std-1/view");
+    // The whole point of #163 — /edit auto-forks and duplicates silently.
+    expect(mockPush).not.toHaveBeenCalledWith(
+      "/gc-fitness/templates/std-1/edit",
+    );
+  });
+
+  it("routes a TRAINER-OWNED template row to /edit", async () => {
+    const user = userEvent.setup();
+    renderLibrary([
+      template({ id: "mine-1", name: { en: "My Push", es: "Mi Empuje" } }),
+    ]);
+
+    await user.click(await screen.findByText("My Push"));
+
+    // The counter-case matters as much: over-correcting to always-/view would
+    // make a trainer's own templates read-only.
+    expect(mockPush).toHaveBeenCalledWith("/gc-fitness/templates/mine-1/edit");
+  });
+
+  it("keeps the two apart when both are on screen together", async () => {
+    const user = userEvent.setup();
+    renderLibrary([
+      template({
+        id: "std-1",
+        name: { en: "Standard Push", es: "Empuje Estándar" },
+        isStandard: true,
+        trainerId: "__standard__",
+      }),
+      template({ id: "mine-1", name: { en: "My Push", es: "Mi Empuje" } }),
+    ]);
+
+    await user.click(await screen.findByText("Standard Push"));
+    await user.click(await screen.findByText("My Push"));
+
+    expect(mockPush).toHaveBeenNthCalledWith(
+      1,
+      "/gc-fitness/templates/std-1/view",
+    );
+    expect(mockPush).toHaveBeenNthCalledWith(
+      2,
+      "/gc-fitness/templates/mine-1/edit",
+    );
+  });
+
+  it("routes standard rows to /view on keyboard activation too", async () => {
+    const user = userEvent.setup();
+    renderLibrary([
+      template({
+        id: "std-1",
+        name: { en: "Standard Push", es: "Empuje Estándar" },
+        isStandard: true,
+        trainerId: "__standard__",
+      }),
+    ]);
+
+    // The row is a `role="button"` div with its own onKeyDown branch — a second
+    // copy of the same decision, so it can (and did) drift from the click path.
+    const row = (await screen.findByText("Standard Push")).closest(
+      '[role="button"]',
+    ) as HTMLElement;
+    row.focus();
+    await user.keyboard("{Enter}");
+
+    expect(mockPush).toHaveBeenCalledWith("/gc-fitness/templates/std-1/view");
+    expect(mockPush).not.toHaveBeenCalledWith(
+      "/gc-fitness/templates/std-1/edit",
+    );
+  });
+});

--- a/backoffice/src/components/gc-fitness/__tests__/assign-generated-modal.test.tsx
+++ b/backoffice/src/components/gc-fitness/__tests__/assign-generated-modal.test.tsx
@@ -1,0 +1,383 @@
+/**
+ * @jest-environment jsdom
+ */
+
+// assign-generated-modal.test.tsx
+//
+// The generator's success-screen assign step: pick clients, pick a cadence,
+// write N assignments through `bulkAssignTemplate`. It is the THIRD surface
+// that builds a recurrence payload (after AssignTemplateModal and
+// BulkAssignForm) and the only one a coach reaches straight after generating —
+// so a drift here writes a different schedule from the identical-looking form
+// two clicks away on the Agenda.
+//
+// The FIRST THREE LINES of this file MUST stay as the
+// `/** @jest-environment jsdom */` docblock — the backoffice jest config
+// defaults to `testEnvironment: "node"` so without it React Testing Library
+// crashes with `ReferenceError: document is not defined`.
+//
+// What is pinned, and why each one is a real failure and not a style opinion:
+//
+//   • ONE weekday → `{kind: "weekly", weekday}`, MORE than one →
+//     `{kind: "weekly_days", weekdays}`. Two different shapes out of one UI
+//     control; the expansion code reads `kind` and silently expands nothing
+//     for a shape it doesn't know.
+//   • The weekday list is SORTED. Same trap as `assign-template-modal`, where
+//     the `.sort()` turned out to be duplicated in two places and a mutation
+//     only hit one of them.
+//   • `once` carries NO recurrence and NO endDate.
+//   • `monthly` takes its day-of-month from the picked DATE, not from today.
+//   • An empty time is `undefined`, never `""` — an empty string would be
+//     stored and then read back as a scheduled time by the reminder job.
+//   • A failed write keeps the dialog OPEN with the selection intact; closing
+//     it loses the client picks, which is the expensive part of the form.
+
+import "@testing-library/jest-dom";
+
+import { render, screen, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import React from "react";
+
+import type { ClientRosterEntry } from "@/lib/gc-fitness/client-roster";
+
+const mockBulkAssignTemplate = jest.fn();
+jest.mock("@/lib/gc-fitness/workout-assignment-actions", () => ({
+  bulkAssignTemplate: (...args: unknown[]) => mockBulkAssignTemplate(...args),
+}));
+
+const mockToastSuccess = jest.fn();
+const mockToastError = jest.fn();
+jest.mock("sonner", () => ({
+  toast: {
+    success: (...args: unknown[]) => mockToastSuccess(...args),
+    error: (...args: unknown[]) => mockToastError(...args),
+  },
+}));
+
+// `civilDateToday` reads the wall clock. A fixture that depends on the day the
+// suite runs is the trap that already produced an unfailable assertion in this
+// project (a `startsOn` seeded with today, asserted against a today-fallback),
+// so the clock is pinned here. 2026-09-10 is a THURSDAY = weekday index 4.
+jest.mock("@/lib/gc-fitness/civil-date", () => ({
+  ...jest.requireActual("@/lib/gc-fitness/civil-date"),
+  civilDateToday: () => "2026-09-10",
+}));
+
+import { AssignGeneratedModal } from "@/components/gc-fitness/generator/assign-generated-modal";
+
+const TODAY = "2026-09-10";
+const TZ = "America/Argentina/Buenos_Aires";
+
+function client(uid: string, name: string): ClientRosterEntry {
+  return {
+    uid,
+    email: `${uid}@example.com`,
+    displayName: name,
+    photoURL: null,
+    coachNickname: null,
+  } as ClientRosterEntry;
+}
+
+const CLIENTS = [
+  client("ana", "Ana Gomez"),
+  client("beto", "Beto Diaz"),
+  client("cami", "Cami Ruiz"),
+];
+
+function renderModal(clients: ClientRosterEntry[] = CLIENTS) {
+  const onOpenChange = jest.fn();
+  render(
+    <AssignGeneratedModal
+      open
+      onOpenChange={onOpenChange}
+      templateId="tpl-1"
+      clients={clients}
+      trainerTimezone={TZ}
+    />,
+  );
+  return { user: userEvent.setup(), onOpenChange };
+}
+
+function clientButton(name: string): HTMLElement {
+  return screen.getByRole("button", { name: new RegExp(name) });
+}
+
+async function pick(user: ReturnType<typeof userEvent.setup>, ...names: string[]) {
+  for (const name of names) await user.click(clientButton(name));
+}
+
+/** The cadence `Select` is a shadcn trigger — its placeholder is not an
+ *  accessible name, so it is matched on the option text it currently shows. */
+async function setCadence(
+  user: ReturnType<typeof userEvent.setup>,
+  option: string,
+) {
+  await user.click(screen.getByRole("combobox"));
+  await user.click(await screen.findByRole("option", { name: option }));
+}
+
+/**
+ * The date / time / number inputs carry a `<label>` that is NOT associated
+ * with them (no `htmlFor`, no wrapping), so `getByLabelText` finds nothing.
+ * They are addressed by type — there is exactly one of each on screen per
+ * cadence, except the two dates, which are told apart by order (start, end).
+ */
+function inputByType(type: string, index = 0): HTMLInputElement {
+  const nodes = document.querySelectorAll<HTMLInputElement>(`input[type="${type}"]`);
+  const node = nodes[index];
+  if (!node) throw new Error(`no input[type=${type}] #${index}`);
+  return node;
+}
+
+function assignButton(): HTMLElement {
+  return screen.getByRole("button", { name: "Assign" });
+}
+
+function lastPayload() {
+  return mockBulkAssignTemplate.mock.calls.at(-1)?.[0];
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockBulkAssignTemplate.mockResolvedValue({ ids: ["a1"] });
+});
+
+describe("AssignGeneratedModal — who gets it", () => {
+  it("writes ONE call carrying every picked client", async () => {
+    const { user } = renderModal();
+
+    await pick(user, "Ana Gomez", "Cami Ruiz");
+    await user.click(assignButton());
+
+    expect(mockBulkAssignTemplate).toHaveBeenCalledTimes(1);
+    expect(lastPayload()).toMatchObject({
+      templateId: "tpl-1",
+      clientIds: ["ana", "cami"],
+    });
+  });
+
+  it("selects everyone with 'Select all', and clears on a second press", async () => {
+    const { user } = renderModal();
+
+    await user.click(screen.getByRole("button", { name: "Select all" }));
+    await user.click(assignButton());
+    expect(lastPayload().clientIds).toEqual(["ana", "beto", "cami"]);
+
+    await user.click(screen.getByRole("button", { name: "Select all" }));
+    // Nothing selected → the CTA is disabled again, so nothing more is written.
+    expect(assignButton()).toBeDisabled();
+    expect(mockBulkAssignTemplate).toHaveBeenCalledTimes(1);
+  });
+
+  it("cannot be submitted with nobody picked", async () => {
+    renderModal();
+
+    expect(assignButton()).toBeDisabled();
+  });
+
+  it("says so when the roster is empty", () => {
+    renderModal([]);
+
+    expect(screen.getByText("No clients yet. Add a client first.")).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "Select all" }),
+    ).not.toBeInTheDocument();
+  });
+});
+
+describe("AssignGeneratedModal — the cadence payload", () => {
+  it("'Once' carries NO recurrence and NO end date", async () => {
+    const { user } = renderModal();
+
+    await pick(user, "Ana Gomez");
+    await user.click(assignButton());
+
+    expect(lastPayload()).toMatchObject({
+      scheduledFor: TODAY,
+      timezone: TZ,
+      recurrence: undefined,
+      endDate: undefined,
+    });
+  });
+
+  it("a single weekday is 'weekly', not 'weekly_days'", async () => {
+    // The seeded weekday is the one the picked date falls on — Thursday (4).
+    const { user } = renderModal();
+
+    await pick(user, "Ana Gomez");
+    await setCadence(user, "Weekly");
+    await user.click(assignButton());
+
+    expect(lastPayload().recurrence).toEqual({ kind: "weekly", weekday: 4 });
+  });
+
+  it("two or more weekdays switch to 'weekly_days', SORTED", async () => {
+    // Clicked out of order on purpose: the expansion walks the array as given.
+    const { user } = renderModal();
+
+    await pick(user, "Ana Gomez");
+    await setCadence(user, "Weekly");
+    await user.click(screen.getByRole("button", { name: "Sat" })); // 6
+    await user.click(screen.getByRole("button", { name: "Mon" })); // 1
+    await user.click(assignButton());
+
+    expect(lastPayload().recurrence).toEqual({
+      kind: "weekly_days",
+      weekdays: [1, 4, 6],
+    });
+  });
+
+  it("refuses to unselect the LAST weekday", async () => {
+    // An empty weekday set would expand to nothing — a recurring assignment
+    // that never lands on a day.
+    const { user } = renderModal();
+
+    await pick(user, "Ana Gomez");
+    await setCadence(user, "Weekly");
+    await user.click(screen.getByRole("button", { name: "Thu" }));
+    await user.click(assignButton());
+
+    expect(lastPayload().recurrence).toEqual({ kind: "weekly", weekday: 4 });
+  });
+
+  it("'Daily' carries no parameters", async () => {
+    const { user } = renderModal();
+
+    await pick(user, "Ana Gomez");
+    await setCadence(user, "Daily");
+    await user.click(assignButton());
+
+    expect(lastPayload().recurrence).toEqual({ kind: "daily" });
+  });
+
+  it("'Monthly' takes its day-of-month from the PICKED date", async () => {
+    // Not from today: the coach can schedule the first occurrence weeks out,
+    // and the recurrence must land on that day of the month.
+    const { user } = renderModal();
+
+    await pick(user, "Ana Gomez");
+    await setCadence(user, "Monthly");
+    await user.clear(inputByType("date"));
+    await user.type(inputByType("date"), "2026-10-23");
+    await user.click(assignButton());
+
+    expect(lastPayload()).toMatchObject({
+      scheduledFor: "2026-10-23",
+      recurrence: { kind: "monthly", dayOfMonth: 23 },
+    });
+  });
+
+  it("clamps 'every N days' into 2..30", async () => {
+    const { user } = renderModal();
+
+    await pick(user, "Ana Gomez");
+    await setCadence(user, "Every N days");
+    const everyN = inputByType("number");
+    await user.clear(everyN);
+    await user.type(everyN, "99");
+    await user.click(assignButton());
+
+    expect(lastPayload().recurrence).toEqual({
+      kind: "every_n_days",
+      everyN: 30,
+    });
+  });
+});
+
+describe("AssignGeneratedModal — the end date", () => {
+  it("defaults to three months out on any recurring cadence", async () => {
+    const { user } = renderModal();
+
+    await pick(user, "Ana Gomez");
+    await setCadence(user, "Daily");
+    await user.click(assignButton());
+
+    expect(lastPayload().endDate).toBe("2026-12-10");
+  });
+
+  it("is omitted when the coach unticks it", async () => {
+    // An open-ended series: the expansion horizon, not a date, decides where
+    // it stops. Sending "" or a stale date would cap it silently.
+    const { user } = renderModal();
+
+    await pick(user, "Ana Gomez");
+    await setCadence(user, "Daily");
+    await user.click(screen.getByRole("checkbox"));
+    await user.click(assignButton());
+
+    expect(lastPayload().endDate).toBeUndefined();
+  });
+
+  it("is never sent for a one-off, even though the state still holds one", async () => {
+    const { user } = renderModal();
+
+    await pick(user, "Ana Gomez");
+    await setCadence(user, "Daily");
+    await setCadence(user, "Once");
+    await user.click(assignButton());
+
+    expect(lastPayload().endDate).toBeUndefined();
+  });
+});
+
+describe("AssignGeneratedModal — the scheduled time", () => {
+  it("sends an empty time as undefined, not as an empty string", async () => {
+    // `scheduledTime` is what the reminder push keys off; "" is a value and
+    // would be read back as a real time.
+    const { user } = renderModal();
+
+    await pick(user, "Ana Gomez");
+    await user.click(assignButton());
+
+    expect(lastPayload().scheduledTime).toBeUndefined();
+  });
+
+  it("passes a picked time through", async () => {
+    const { user } = renderModal();
+
+    await pick(user, "Ana Gomez");
+    await user.type(inputByType("time"), "07:30");
+    await user.click(assignButton());
+
+    expect(lastPayload().scheduledTime).toBe("07:30");
+  });
+});
+
+describe("AssignGeneratedModal — what the coach is told", () => {
+  it("reports the number the server actually wrote, not the number picked", async () => {
+    // A recurring assign writes one doc per occurrence; the count comes back
+    // from the action.
+    mockBulkAssignTemplate.mockResolvedValue({ ids: ["a", "b", "c", "d"] });
+    const { user, onOpenChange } = renderModal();
+
+    await pick(user, "Ana Gomez");
+    await user.click(assignButton());
+
+    expect(mockToastSuccess).toHaveBeenCalledWith("Assigned to 4 client(s).");
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+  });
+
+  it("keeps the dialog OPEN with the picks intact when the write fails", async () => {
+    mockBulkAssignTemplate.mockRejectedValue(new Error("Forbidden"));
+    const { user, onOpenChange } = renderModal();
+
+    await pick(user, "Ana Gomez", "Beto Diaz");
+    await user.click(assignButton());
+
+    expect(mockToastError).toHaveBeenCalledWith("Forbidden");
+    expect(onOpenChange).not.toHaveBeenCalledWith(false);
+    // …and the selection survives, so retrying is one click.
+    expect(clientButton("Ana Gomez")).toHaveAttribute("aria-pressed", "true");
+    expect(assignButton()).toBeEnabled();
+  });
+
+  it("re-enables the CTA after a failure", async () => {
+    mockBulkAssignTemplate.mockRejectedValue(new Error("boom"));
+    const { user } = renderModal();
+
+    await pick(user, "Ana Gomez");
+    await user.click(assignButton());
+
+    expect(within(assignButton()).queryByText("Assigning…")).toBeNull();
+  });
+});

--- a/backoffice/src/components/gc-fitness/__tests__/assign-template-modal.test.tsx
+++ b/backoffice/src/components/gc-fitness/__tests__/assign-template-modal.test.tsx
@@ -1,0 +1,356 @@
+/**
+ * @jest-environment jsdom
+ */
+
+// assign-template-modal.test.tsx
+//
+// Regression net for the coach portal's single most-used write: assigning a
+// workout template to a client. Nothing covered this before — the schema and
+// the Server Action each had unit tests, but nobody checked that the MODAL
+// builds the payload it hands them.
+//
+// The FIRST THREE LINES of this file MUST stay as the
+// `/** @jest-environment jsdom */` docblock — the backoffice jest config
+// defaults to `testEnvironment: "node"` so without it React Testing Library
+// crashes with `ReferenceError: document is not defined`.
+//
+// What these tests protect:
+//
+//   1. THE TWO-ACTION FORK. "One-time" must call `assignTemplate`; every
+//      recurring mode must call `assignTemplateRecurring`. Calling the wrong
+//      one doesn't throw — it silently creates one workout where the coach
+//      asked for twelve, or twelve where they asked for one.
+//   2. THE RECURRENCE RULE, which is the SAME wire shape the recurrence-edit
+//      dialog writes and mobile reads: one weekday collapses to
+//      `{kind:"weekly", weekday}`, two or more widen to
+//      `{kind:"weekly_days", weekdays}` SORTED. These two components must not
+//      drift from each other — see workout-recurrence-edit-dialog.test.tsx.
+//   3. EMPTY-STRING → UNDEFINED. `scheduledTime` and `meetingNotes` are
+//      optional fields; the modal holds them as "" and must send `undefined`,
+//      not "". An empty string reaches Firestore as a real value and the
+//      `scheduledTime` one silently arms the workout-reminder push.
+
+import "@testing-library/jest-dom";
+
+import { render, screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import React from "react";
+
+import { AssignTemplateModal } from "@/components/gc-fitness/schedule/assign-template-modal";
+
+// The two Server Actions the modal forks between.
+const mockAssignTemplate = jest.fn();
+const mockAssignTemplateRecurring = jest.fn();
+jest.mock("@/lib/gc-fitness/workout-assignment-actions", () => ({
+  assignTemplate: (...args: unknown[]) => mockAssignTemplate(...args),
+  assignTemplateRecurring: (...args: unknown[]) =>
+    mockAssignTemplateRecurring(...args),
+}));
+
+// Per-exercise overrides are a separate surface; stub the fetch so the modal
+// renders without one and the payloads stay override-free.
+jest.mock("@/lib/gc-fitness/workout-template-actions", () => ({
+  getWorkoutTemplateForAssignment: jest.fn().mockResolvedValue(null),
+}));
+
+// The template list normally arrives over a Firestore listener.
+const mockUseWorkoutTemplates = jest.fn();
+jest.mock("@/lib/gc-fitness/workout-templates-listener", () => ({
+  useWorkoutTemplates: () => mockUseWorkoutTemplates(),
+}));
+
+// Media thumbs would try to resolve Storage URLs.
+jest.mock("@/components/gc-fitness/exercise-preview-thumb", () => ({
+  ExercisePreviewThumb: () => null,
+}));
+
+const mockToastSuccess = jest.fn();
+const mockToastError = jest.fn();
+jest.mock("sonner", () => ({
+  toast: {
+    success: (...args: unknown[]) => mockToastSuccess(...args),
+    error: (...args: unknown[]) => mockToastError(...args),
+  },
+}));
+
+// 2026-08-05 is a Wednesday → getDay() === 3.
+const DEFAULT_DATE = "2026-08-05";
+
+const TEMPLATES = [
+  { id: "tpl-push", name: { en: "Push Day", es: "Día de Empuje" }, tags: ["push"] },
+  { id: "tpl-pull", name: { en: "Pull Day", es: "Día de Tirón" }, tags: ["pull"] },
+];
+
+function renderModal(
+  overrides: Partial<React.ComponentProps<typeof AssignTemplateModal>> = {},
+) {
+  const onOpenChange = jest.fn();
+  const onAssigned = jest.fn();
+  render(
+    <AssignTemplateModal
+      open
+      onOpenChange={onOpenChange}
+      clientId="client-1"
+      defaultDate={DEFAULT_DATE}
+      trainerTimezone="America/Argentina/Buenos_Aires"
+      onAssigned={onAssigned}
+      {...overrides}
+    />,
+  );
+  return { onOpenChange, onAssigned };
+}
+
+// Both the template picker and the cadence Select expose `role="combobox"`.
+// The picker is the first one and is named by its placeholder; the cadence
+// Select is the second. Indexing blind here is how you end up driving the wrong
+// control and asserting on a payload nobody built.
+function templatePicker() {
+  // Matched on text content, not accessible name: the trigger renders its
+  // placeholder inside a child <span>, which does not become the button's
+  // accessible name, so `getByRole("combobox", { name: ... })` misses it.
+  const picker = screen
+    .getAllByRole("combobox")
+    .find((el) => /Choose a template|Push Day|Pull Day/i.test(el.textContent ?? ""));
+  if (!picker) throw new Error("template picker combobox not found");
+  return picker;
+}
+
+/** Open the template combobox and pick one by its EN name. */
+async function pickTemplate(user: ReturnType<typeof userEvent.setup>, name: string) {
+  await user.click(templatePicker());
+  await user.click(await screen.findByText(name));
+}
+
+/** Switch the cadence Select ("One-time" by default) to another mode. */
+async function selectMode(
+  user: ReturnType<typeof userEvent.setup>,
+  optionLabel: string,
+) {
+  const cadence = screen
+    .getAllByRole("combobox")
+    .find((el) => el !== templatePicker());
+  await user.click(cadence!);
+  await user.click(await screen.findByRole("option", { name: optionLabel }));
+}
+
+function submit(user: ReturnType<typeof userEvent.setup>) {
+  return user.click(screen.getByRole("button", { name: "Assign" }));
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockUseWorkoutTemplates.mockReturnValue({
+    data: TEMPLATES,
+    isLoading: false,
+  });
+  mockAssignTemplate.mockResolvedValue({ id: "assign-1" });
+  mockAssignTemplateRecurring.mockResolvedValue({ count: 12 });
+});
+
+describe("AssignTemplateModal — the guard", () => {
+  it("keeps [Assign] disabled until a template is picked, and enables it after", async () => {
+    const user = userEvent.setup();
+    const { onAssigned } = renderModal();
+
+    // The reachable guard is the disabled button — `onSubmit`'s
+    // `errorPickTemplate` toast is defense-in-depth that the UI never lets you
+    // hit. Asserting the toast would be testing dead code.
+    expect(screen.getByRole("button", { name: "Assign" })).toBeDisabled();
+
+    await user.click(screen.getByRole("button", { name: "Assign" }));
+    expect(mockAssignTemplate).not.toHaveBeenCalled();
+    expect(mockAssignTemplateRecurring).not.toHaveBeenCalled();
+    expect(onAssigned).not.toHaveBeenCalled();
+
+    await pickTemplate(user, "Push Day");
+    expect(screen.getByRole("button", { name: "Assign" })).toBeEnabled();
+  });
+});
+
+describe("AssignTemplateModal — one-time", () => {
+  it("calls assignTemplate (NOT the recurring action) with the picked date", async () => {
+    const user = userEvent.setup();
+    const { onAssigned, onOpenChange } = renderModal();
+
+    await pickTemplate(user, "Push Day");
+    await submit(user);
+
+    await waitFor(() => expect(mockAssignTemplate).toHaveBeenCalledTimes(1));
+    // The fork matters more than the fields: the recurring action here would
+    // create a whole series the coach never asked for.
+    expect(mockAssignTemplateRecurring).not.toHaveBeenCalled();
+    expect(mockAssignTemplate).toHaveBeenCalledWith({
+      templateId: "tpl-push",
+      clientId: "client-1",
+      scheduledFor: DEFAULT_DATE,
+      scheduledTime: undefined,
+      meetingNotes: undefined,
+      timezone: "America/Argentina/Buenos_Aires",
+      exerciseOverrides: undefined,
+    });
+    expect(mockToastSuccess).toHaveBeenCalledWith("Template assigned.");
+    expect(onAssigned).toHaveBeenCalledTimes(1);
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+  });
+
+  it("sends undefined — not '' — for an untouched time and notes", async () => {
+    const user = userEvent.setup();
+    renderModal();
+
+    await pickTemplate(user, "Push Day");
+    await submit(user);
+
+    await waitFor(() => expect(mockAssignTemplate).toHaveBeenCalledTimes(1));
+    const payload = mockAssignTemplate.mock.calls[0][0];
+    // An empty string is a REAL value in Firestore. `scheduledTime: ""` would
+    // also arm the workout-reminder push for a workout with no time set.
+    expect(payload.scheduledTime).toBeUndefined();
+    expect(payload.meetingNotes).toBeUndefined();
+    expect("scheduledTime" in payload).toBe(true); // sent explicitly, as undefined
+  });
+});
+
+describe("AssignTemplateModal — the recurrence rule it builds", () => {
+  it("collapses a single weekday to kind 'weekly', seeded on the picked date", async () => {
+    const user = userEvent.setup();
+    renderModal();
+
+    await pickTemplate(user, "Push Day");
+    await selectMode(user, "Weekly recurring");
+    await submit(user);
+
+    await waitFor(() =>
+      expect(mockAssignTemplateRecurring).toHaveBeenCalledTimes(1),
+    );
+    expect(mockAssignTemplate).not.toHaveBeenCalled();
+    const payload = mockAssignTemplateRecurring.mock.calls[0][0];
+    // 2026-08-05 is a Wednesday.
+    expect(payload.recurrence).toEqual({ kind: "weekly", weekday: 3 });
+    expect(payload.startDate).toBe(DEFAULT_DATE);
+    expect(payload.clientId).toBe("client-1");
+  });
+
+  it("widens to 'weekly_days' with a SORTED array on a second weekday", async () => {
+    const user = userEvent.setup();
+    renderModal();
+
+    await pickTemplate(user, "Push Day");
+    await selectMode(user, "Weekly recurring");
+    // Seeded on Wed (3); add Mon (1). Insertion order is [3, 1], so an
+    // implementation that dropped the sort would emit the array backwards —
+    // and mobile reads this verbatim.
+    await user.click(screen.getByRole("button", { name: "Mon" }));
+    await submit(user);
+
+    await waitFor(() =>
+      expect(mockAssignTemplateRecurring).toHaveBeenCalledTimes(1),
+    );
+    expect(mockAssignTemplateRecurring.mock.calls[0][0].recurrence).toEqual({
+      kind: "weekly_days",
+      weekdays: [1, 3],
+    });
+  });
+
+  it("builds a daily rule", async () => {
+    const user = userEvent.setup();
+    renderModal();
+
+    await pickTemplate(user, "Push Day");
+    await selectMode(user, "Daily");
+    await submit(user);
+
+    await waitFor(() =>
+      expect(mockAssignTemplateRecurring).toHaveBeenCalledTimes(1),
+    );
+    expect(mockAssignTemplateRecurring.mock.calls[0][0].recurrence).toEqual({
+      kind: "daily",
+    });
+  });
+
+  it("builds a monthly rule anchored on the picked date's day-of-month", async () => {
+    const user = userEvent.setup();
+    renderModal({ defaultDate: "2026-08-21" });
+
+    await pickTemplate(user, "Push Day");
+    await selectMode(user, "Monthly");
+    await submit(user);
+
+    await waitFor(() =>
+      expect(mockAssignTemplateRecurring).toHaveBeenCalledTimes(1),
+    );
+    // Must read the day out of the CIVIL date, not out of `new Date()` —
+    // a UTC parse here shifts the anchor by one day for half the world.
+    expect(mockAssignTemplateRecurring.mock.calls[0][0].recurrence).toEqual({
+      kind: "monthly",
+      dayOfMonth: 21,
+    });
+  });
+
+  it("defaults the series to a 3-month end date rather than open-ended", async () => {
+    const user = userEvent.setup();
+    renderModal();
+
+    await pickTemplate(user, "Push Day");
+    await selectMode(user, "Daily");
+    await submit(user);
+
+    await waitFor(() =>
+      expect(mockAssignTemplateRecurring).toHaveBeenCalledTimes(1),
+    );
+    // Deliberate: the reset effect turns the end ON at the 3-month preset, so a
+    // coach who never touches the end date still gets a bounded series instead
+    // of one that expands forever. Pinned because flipping this default would
+    // silently start creating unbounded series.
+    expect(mockAssignTemplateRecurring.mock.calls[0][0].endDate).toBe(
+      "2026-11-05",
+    );
+  });
+
+  it("reports the created count from the server, not a local guess", async () => {
+    const user = userEvent.setup();
+    mockAssignTemplateRecurring.mockResolvedValueOnce({ count: 7 });
+    renderModal();
+
+    await pickTemplate(user, "Push Day");
+    await selectMode(user, "Daily");
+    await submit(user);
+
+    await waitFor(() =>
+      expect(mockToastSuccess).toHaveBeenCalledWith(
+        "Recurring assignment created (7 workouts).",
+      ),
+    );
+  });
+});
+
+describe("AssignTemplateModal — failure handling", () => {
+  it("surfaces the server's message and keeps the modal open", async () => {
+    const user = userEvent.setup();
+    mockAssignTemplate.mockRejectedValueOnce(
+      new Error("Client no longer has a coach."),
+    );
+    const { onAssigned, onOpenChange } = renderModal();
+
+    await pickTemplate(user, "Push Day");
+    await submit(user);
+
+    await waitFor(() =>
+      expect(mockToastError).toHaveBeenCalledWith("Client no longer has a coach."),
+    );
+    // Closing on failure would strand the coach believing the workout landed.
+    expect(onAssigned).not.toHaveBeenCalled();
+    expect(onOpenChange).not.toHaveBeenCalledWith(false);
+  });
+
+  it("re-enables the submit button after a failure so the coach can retry", async () => {
+    const user = userEvent.setup();
+    mockAssignTemplate.mockRejectedValueOnce(new Error("boom"));
+    renderModal();
+
+    await pickTemplate(user, "Push Day");
+    await submit(user);
+
+    await waitFor(() => expect(mockToastError).toHaveBeenCalled());
+    expect(screen.getByRole("button", { name: "Assign" })).toBeEnabled();
+  });
+});

--- a/backoffice/src/components/gc-fitness/__tests__/bulk-assign-form.test.tsx
+++ b/backoffice/src/components/gc-fitness/__tests__/bulk-assign-form.test.tsx
@@ -1,0 +1,213 @@
+/**
+ * @jest-environment jsdom
+ */
+
+// bulk-assign-form.test.tsx
+//
+// Assigning one template to MANY clients at once. Every mistake here is
+// multiplied by the size of the roster, which is exactly why it deserves a net.
+//
+// The FIRST THREE LINES of this file MUST stay as the
+// `/** @jest-environment jsdom */` docblock — the backoffice jest config
+// defaults to `testEnvironment: "node"` so without it React Testing Library
+// crashes with `ReferenceError: document is not defined`.
+//
+// The confirm modal is stubbed at the prop boundary: it hands `onConfirm` the
+// FINAL client list (the coach can drop people inside the modal), so driving it
+// directly is both simpler and closer to the real contract than clicking
+// through a second dialog.
+//
+// What these tests protect:
+//
+//   1. THE "ONCE" PATH STAYS CLEAN. The source states the single-date submit
+//      must be byte-identical to the pre-recurrence one — no `recurrence`, no
+//      `endDate` keys at all. Leaking either turns one workout per client into
+//      a whole series per client.
+//   2. THE FINAL CLIENT LIST WINS. Whoever survives the confirm modal is who
+//      gets written. Falling back to the pre-modal selection re-adds clients
+//      the coach just removed.
+//   3. THE COUNT THE COACH IS TOLD. Recurring reports CLIENTS; one-time reports
+//      DOCUMENTS. Recurring writes one doc per client × date, so reporting the
+//      doc count there would tell a coach they just assigned 60 people.
+
+import "@testing-library/jest-dom";
+
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import React from "react";
+
+import { BulkAssignForm } from "@/components/gc-fitness/schedule/bulk-assign-form";
+
+const mockBulkAssign = jest.fn();
+jest.mock("@/lib/gc-fitness/workout-assignment-actions", () => ({
+  bulkAssignTemplate: (...args: unknown[]) => mockBulkAssign(...args),
+}));
+
+const mockUseWorkoutTemplates = jest.fn();
+jest.mock("@/lib/gc-fitness/workout-templates-listener", () => ({
+  useWorkoutTemplates: () => mockUseWorkoutTemplates(),
+}));
+
+const mockPush = jest.fn();
+jest.mock("next/navigation", () => ({
+  useRouter: () => ({ push: mockPush }),
+}));
+
+// Stub the confirm modal at its prop boundary and expose the final-list hook.
+let confirmProps: Record<string, unknown> | null = null;
+jest.mock("@/components/gc-fitness/schedule/bulk-confirm-modal", () => ({
+  BulkConfirmModal: (props: Record<string, unknown>) => {
+    confirmProps = props;
+    return props.open ? <div data-testid="confirm-modal-open" /> : null;
+  },
+}));
+
+const mockToastSuccess = jest.fn();
+const mockToastError = jest.fn();
+jest.mock("sonner", () => ({
+  toast: {
+    success: (...args: unknown[]) => mockToastSuccess(...args),
+    error: (...args: unknown[]) => mockToastError(...args),
+  },
+}));
+
+const CLIENTS = [
+  { uid: "client-1", displayName: "Ana", email: "ana@example.com" },
+  { uid: "client-2", displayName: "Beto", email: "beto@example.com" },
+  { uid: "client-3", displayName: "Cami", email: "cami@example.com" },
+];
+
+const TEMPLATES = [
+  { id: "tpl-push", name: { en: "Push Day", es: "Empuje" }, tags: [] },
+];
+
+function renderForm() {
+  render(
+    <BulkAssignForm
+      clients={CLIENTS as never}
+      trainerTimezone="America/Argentina/Buenos_Aires"
+    />,
+  );
+}
+
+/** Drive the stubbed confirm modal's callback with an explicit final list. */
+async function confirmWith(clientIds: string[]) {
+  await (confirmProps!.onConfirm as (ids: string[]) => Promise<void>)(clientIds);
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  confirmProps = null;
+  mockUseWorkoutTemplates.mockReturnValue({
+    data: TEMPLATES,
+    isLoading: false,
+  });
+  mockBulkAssign.mockResolvedValue({ ids: ["a1", "a2"] });
+});
+
+describe("BulkAssignForm — guards", () => {
+  it("refuses to write with no template picked", async () => {
+    renderForm();
+
+    await confirmWith(["client-1"]);
+
+    expect(mockBulkAssign).not.toHaveBeenCalled();
+    expect(mockToastError).toHaveBeenCalled();
+  });
+
+  it("refuses to write when the coach removed every client in the modal", async () => {
+    const user = userEvent.setup();
+    renderForm();
+    await pickTemplate(user);
+
+    await confirmWith([]);
+
+    // An empty roster must not reach the action — a zero-client bulk write is
+    // never what anyone meant.
+    expect(mockBulkAssign).not.toHaveBeenCalled();
+    expect(mockToastError).toHaveBeenCalled();
+  });
+});
+
+/** Select the only template through the shadcn Select trigger. */
+async function pickTemplate(user: ReturnType<typeof userEvent.setup>) {
+  const triggers = screen.getAllByRole("combobox");
+  await user.click(triggers[0]);
+  await user.click(await screen.findByRole("option", { name: /Push Day/i }));
+}
+
+describe("BulkAssignForm — the one-time path", () => {
+  it("sends NO recurrence and NO endDate keys at all", async () => {
+    const user = userEvent.setup();
+    renderForm();
+    await pickTemplate(user);
+
+    await confirmWith(["client-1", "client-2"]);
+
+    await waitFor(() => expect(mockBulkAssign).toHaveBeenCalledTimes(1));
+    const payload = mockBulkAssign.mock.calls[0][0];
+    // Documented invariant: the "once" submit is byte-identical to the
+    // pre-recurrence path. Presence of either key — even undefined — changes
+    // what the action does.
+    expect("recurrence" in payload).toBe(false);
+    expect("endDate" in payload).toBe(false);
+    expect(payload.templateId).toBe("tpl-push");
+  });
+
+  it("writes exactly the client list the confirm modal returned", async () => {
+    const user = userEvent.setup();
+    renderForm();
+    await pickTemplate(user);
+
+    // The coach dropped Cami inside the modal.
+    await confirmWith(["client-1", "client-3"]);
+
+    await waitFor(() => expect(mockBulkAssign).toHaveBeenCalledTimes(1));
+    expect(mockBulkAssign.mock.calls[0][0].clientIds).toEqual([
+      "client-1",
+      "client-3",
+    ]);
+  });
+
+  it("reports the DOCUMENT count returned by the server", async () => {
+    const user = userEvent.setup();
+    mockBulkAssign.mockResolvedValueOnce({ ids: ["a1", "a2", "a3"] });
+    renderForm();
+    await pickTemplate(user);
+
+    await confirmWith(["client-1", "client-2", "client-3"]);
+
+    await waitFor(() => expect(mockToastSuccess).toHaveBeenCalledTimes(1));
+    expect(String(mockToastSuccess.mock.calls[0][0])).toContain("3");
+  });
+
+  it("navigates to the first client's schedule so the write is visible", async () => {
+    const user = userEvent.setup();
+    renderForm();
+    await pickTemplate(user);
+
+    await confirmWith(["client-2", "client-1"]);
+
+    await waitFor(() => expect(mockPush).toHaveBeenCalledTimes(1));
+    expect(mockPush).toHaveBeenCalledWith(
+      "/gc-fitness/schedule?clientId=client-2",
+    );
+  });
+});
+
+describe("BulkAssignForm — failure handling", () => {
+  it("surfaces an error and does NOT navigate away", async () => {
+    const user = userEvent.setup();
+    mockBulkAssign.mockRejectedValueOnce(new Error("nope"));
+    renderForm();
+    await pickTemplate(user);
+
+    await confirmWith(["client-1"]);
+
+    await waitFor(() => expect(mockToastError).toHaveBeenCalled());
+    // Navigating after a failed bulk write drops the coach on a schedule that
+    // shows none of what they thought they just assigned.
+    expect(mockPush).not.toHaveBeenCalled();
+    expect(mockToastSuccess).not.toHaveBeenCalled();
+  });
+});

--- a/backoffice/src/components/gc-fitness/__tests__/bulk-assign-habit-dialog.test.tsx
+++ b/backoffice/src/components/gc-fitness/__tests__/bulk-assign-habit-dialog.test.tsx
@@ -1,0 +1,211 @@
+/**
+ * @jest-environment jsdom
+ */
+
+// bulk-assign-habit-dialog.test.tsx
+//
+// Assigning one habit template to MANY clients. Like the workout bulk form,
+// every mistake is multiplied by the roster — but this one has a second hazard
+// the workout path does not: the payload is assembled with CONDITIONAL SPREADS.
+//
+// The FIRST THREE LINES of this file MUST stay as the
+// `/** @jest-environment jsdom */` docblock — the backoffice jest config
+// defaults to `testEnvironment: "node"` so without it React Testing Library
+// crashes with `ReferenceError: document is not defined`.
+//
+// Why the spreads matter: the backoffice Firestore handle does NOT set
+// `ignoreUndefinedProperties`, so writing `scheduleWeekdays: undefined` THROWS
+// rather than being ignored. Every cadence-specific key must therefore be
+// ABSENT — not undefined — when it does not apply. `toEqual` treats
+// `{a: undefined}` and `{}` as equal, so these tests assert key PRESENCE with
+// `in` instead.
+
+import "@testing-library/jest-dom";
+
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import React from "react";
+
+import { BulkAssignHabitDialog } from "@/components/gc-fitness/schedule/bulk-assign-habit-dialog";
+
+const mockAssignHabitTemplate = jest.fn();
+const mockListHabitTemplates = jest.fn();
+jest.mock("@/lib/gc-fitness/habit-actions", () => ({
+  assignHabitTemplate: (...args: unknown[]) => mockAssignHabitTemplate(...args),
+  listHabitTemplates: (...args: unknown[]) => mockListHabitTemplates(...args),
+}));
+
+// The dialog only needs the template array present on first render, not the
+// async query lifecycle.
+jest.mock("@tanstack/react-query", () => ({
+  useQuery: () => ({ data: TEMPLATES, isLoading: false }),
+}));
+
+jest.mock("@/components/gc-fitness/StorageImagePreview", () => ({
+  StorageImagePreview: () => null,
+}));
+
+const mockToastSuccess = jest.fn();
+const mockToastError = jest.fn();
+jest.mock("sonner", () => ({
+  toast: {
+    success: (...args: unknown[]) => mockToastSuccess(...args),
+    error: (...args: unknown[]) => mockToastError(...args),
+  },
+}));
+
+const TEMPLATES = [
+  {
+    id: "tpl-water",
+    name: { en: "Drink water", es: "Tomar agua" },
+    description: { en: "", es: "" },
+    type: "binary",
+  },
+];
+
+const CLIENTS = [
+  { uid: "client-1", displayName: "Ana", email: "ana@example.com" },
+  { uid: "client-2", displayName: "Beto", email: "beto@example.com" },
+];
+
+function renderDialog() {
+  const onAssigned = jest.fn();
+  const onOpenChange = jest.fn();
+  render(
+    <BulkAssignHabitDialog
+      open
+      onOpenChange={onOpenChange}
+      clients={CLIENTS as never}
+      onAssigned={onAssigned}
+    />,
+  );
+  return { onAssigned, onOpenChange };
+}
+
+async function pickTemplate(user: ReturnType<typeof userEvent.setup>) {
+  await user.click(await screen.findByText("Drink water"));
+}
+
+async function selectClient(
+  user: ReturnType<typeof userEvent.setup>,
+  name: string,
+) {
+  const boxes = screen.getAllByRole("checkbox");
+  // The checkbox order follows the roster order passed in.
+  const idx = CLIENTS.findIndex((c) => c.displayName === name);
+  await user.click(boxes[idx]);
+}
+
+function submitButton() {
+  return screen.getByRole("button", { name: /Asignar|Assign/i });
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockAssignHabitTemplate.mockResolvedValue({ created: 2 });
+});
+
+describe("BulkAssignHabitDialog — the guard", () => {
+  it("keeps the submit disabled until at least one client is checked", async () => {
+    const user = userEvent.setup();
+    renderDialog();
+    await pickTemplate(user);
+
+    // MEASURED: the `selectedCount === 0` early-return inside `onSubmit` is
+    // defense-in-depth — deleting it keeps these tests green, because
+    // `canSubmit` already disables the button. The REACHABLE guard is the
+    // disabled state, so that is what is asserted; asserting the early return
+    // would be asserting a branch the UI never reaches.
+    expect(submitButton()).toBeDisabled();
+
+    await user.click(submitButton());
+    expect(mockAssignHabitTemplate).not.toHaveBeenCalled();
+
+    await selectClient(user, "Ana");
+    expect(submitButton()).toBeEnabled();
+  });
+});
+
+describe("BulkAssignHabitDialog — the payload", () => {
+  it("sends the selected clients and the template id", async () => {
+    const user = userEvent.setup();
+    renderDialog();
+    await pickTemplate(user);
+    await selectClient(user, "Ana");
+
+    await user.click(submitButton());
+
+    await waitFor(() =>
+      expect(mockAssignHabitTemplate).toHaveBeenCalledTimes(1),
+    );
+    const payload = mockAssignHabitTemplate.mock.calls[0][0];
+    expect(payload.templateId).toBe("tpl-water");
+    expect(payload.clientIds).toEqual(["client-1"]);
+    expect(typeof payload.startsOn).toBe("string");
+  });
+
+  it("never sends an explicit undefined for a cadence key that does not apply", async () => {
+    const user = userEvent.setup();
+    renderDialog();
+    await pickTemplate(user);
+    await selectClient(user, "Ana");
+
+    await user.click(submitButton());
+
+    await waitFor(() =>
+      expect(mockAssignHabitTemplate).toHaveBeenCalledTimes(1),
+    );
+    const payload = mockAssignHabitTemplate.mock.calls[0][0];
+    const schedule = payload.schedule;
+    if (schedule) {
+      // Presence, not value: the Admin SDK handle throws on an explicit
+      // `undefined`, and `toEqual` would not catch it.
+      if (schedule.scheduleCadence !== "weekly") {
+        expect("scheduleWeekdays" in schedule).toBe(false);
+      }
+      if (schedule.scheduleCadence !== "monthly") {
+        expect("scheduleMonthDays" in schedule).toBe(false);
+      }
+    }
+    // Top level too — a bare `schedule: undefined` would throw the same way.
+    if (!schedule) {
+      expect("schedule" in payload).toBe(false);
+    }
+  });
+});
+
+describe("BulkAssignHabitDialog — after the server answers", () => {
+  it("reports the server's created count and tells the parent to refresh", async () => {
+    const user = userEvent.setup();
+    mockAssignHabitTemplate.mockResolvedValueOnce({ created: 5 });
+    const { onAssigned } = renderDialog();
+    await pickTemplate(user);
+    await selectClient(user, "Ana");
+    await selectClient(user, "Beto");
+
+    await user.click(submitButton());
+
+    await waitFor(() => expect(onAssigned).toHaveBeenCalledTimes(1));
+    expect(mockToastSuccess).toHaveBeenCalled();
+    expect(String(mockToastSuccess.mock.calls[0][0])).toContain("5");
+  });
+
+  it("surfaces a failure and does NOT tell the parent anything changed", async () => {
+    const user = userEvent.setup();
+    mockAssignHabitTemplate.mockRejectedValueOnce(
+      new Error("Uno de los clientes ya no existe."),
+    );
+    const { onAssigned } = renderDialog();
+    await pickTemplate(user);
+    await selectClient(user, "Ana");
+
+    await user.click(submitButton());
+
+    await waitFor(() =>
+      expect(mockToastError).toHaveBeenCalledWith(
+        "Uno de los clientes ya no existe.",
+      ),
+    );
+    expect(onAssigned).not.toHaveBeenCalled();
+  });
+});

--- a/backoffice/src/components/gc-fitness/__tests__/exercise-multi-add-dialog.test.tsx
+++ b/backoffice/src/components/gc-fitness/__tests__/exercise-multi-add-dialog.test.tsx
@@ -1,0 +1,343 @@
+/**
+ * @jest-environment jsdom
+ */
+
+// exercise-multi-add-dialog.test.tsx
+//
+// The batch-add flow used while building a workout template: tick ten
+// exercises, confirm once. `ExercisePickerPopover` (its single-select sibling)
+// has its own two test files; this one covers what only the batch dialog has —
+// selection that must SURVIVE the list changing under it.
+//
+// The FIRST THREE LINES of this file MUST stay as the
+// `/** @jest-environment jsdom */` docblock — the backoffice jest config
+// defaults to `testEnvironment: "node"` so without it React Testing Library
+// crashes with `ReferenceError: document is not defined`.
+//
+// What the batch flow gets wrong when it breaks:
+//
+//   • SELECTION IS NOT THE VISIBLE LIST. A coach ticks three chest exercises,
+//     types "row", ticks two more, and confirms. If the ticked set were derived
+//     from what's on screen, the first three would silently not be added —
+//     the template comes out short and nothing errors.
+//   • QUICK-CREATE MUST NOT END THE FLOW. Creating an exercise from inside the
+//     dialog auto-selects it and KEEPS THE DIALOG OPEN. May 2026 onboarding
+//     feedback was exactly this regression: one quick-create closed the dialog
+//     with only the new exercise selected, dropping every other tick.
+//     It also clears the search — the new row would otherwise be hidden by the
+//     now-stale needle the coach typed to discover it was missing.
+//   • CLOSING RESETS. A dialog that reopens with the previous ticks still set
+//     adds exercises the coach didn't pick this time.
+//   • THE SAME VISIBILITY + DEDUPE PIPELINE AS THE LIBRARY (#552 / #179).
+//     Legacy catalog docs stay unpickable and the double-seeded standard twins
+//     collapse to one row here too — a picker that offers the `std-*` twin adds
+//     a broken-media exercise to the routine.
+
+import "@testing-library/jest-dom";
+
+import { render, screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import React from "react";
+
+import type { ExerciseRow } from "@/lib/gc-fitness/exercises-listener";
+
+const mockUseExercises = jest.fn();
+jest.mock("@/lib/gc-fitness/exercises-listener", () => ({
+  EXERCISES_QUERY_KEY: ["gc-fitness", "exercises"],
+  useExercisesQuery: (...args: unknown[]) => mockUseExercises(...args),
+}));
+
+const mockInvalidate = jest.fn();
+jest.mock("@tanstack/react-query", () => ({
+  useQueryClient: () => ({ invalidateQueries: mockInvalidate }),
+}));
+
+// The dialog reuses ChipRow/FilterChip/displayEs from the single-add picker,
+// which pulls in `use-favorites` → `favorites-actions` → firebase-admin, and
+// firebase-admin's `jose` dependency is ESM-only: importing it fails the whole
+// suite with `SyntaxError: Unexpected token 'export'` before a single test runs.
+jest.mock("@/lib/gc-fitness/use-favorites", () => ({
+  useFavorites: () => ({
+    favorites: { exerciseIds: [], workoutTemplateIds: [], habitTemplateIds: [] },
+    isFavorite: () => false,
+    toggle: jest.fn(),
+  }),
+}));
+
+jest.mock("@/components/gc-fitness/exercise-preview-thumb", () => ({
+  ExercisePreviewThumb: () => null,
+}));
+
+// The quick-create panel has its own surface; here it only needs to be able to
+// report a creation, which is the event the dialog reacts to.
+const mockQuickCreateProps = jest.fn();
+jest.mock("@/components/gc-fitness/exercise-quick-create", () => ({
+  QuickCreateExercise: (props: {
+    searchTerm: string;
+    seed: { name: string } | null;
+    onCreated: (created: { id: string; name: string }) => void;
+  }) => {
+    mockQuickCreateProps(props);
+    return (
+      <div data-testid="quick-create">
+        <span data-testid="quick-create-term">{props.searchTerm}</span>
+        <span data-testid="quick-create-seed">{props.seed?.name ?? ""}</span>
+        <button
+          type="button"
+          onClick={() => props.onCreated({ id: "new-ex", name: "Brand New" })}
+        >
+          quick-create-submit
+        </button>
+      </div>
+    );
+  },
+}));
+
+import { ExerciseMultiAddDialog } from "@/components/gc-fitness/exercise-multi-add-dialog";
+
+function exercise(overrides: Partial<ExerciseRow> = {}): ExerciseRow {
+  return {
+    id: "ex-1",
+    name: { en: "Bench Press", es: "" },
+    description: { en: "", es: "" },
+    muscleGroups: ["chest"],
+    equipment: ["barbell"],
+    source: "trainer",
+    ownerId: "trainer-1",
+    tags: [],
+    metric: "reps",
+    version: 1,
+    updatedAt: "2026-08-01T00:00:00.000Z",
+    createdAt: "2026-08-01T00:00:00.000Z",
+    ...overrides,
+  } as ExerciseRow;
+}
+
+const ROWS = [
+  exercise({ id: "bench", name: { en: "Bench Press", es: "" }, muscleGroups: ["chest"] }),
+  exercise({ id: "fly", name: { en: "Chest Fly", es: "" }, muscleGroups: ["chest"] }),
+  exercise({ id: "row", name: { en: "Barbell Row", es: "" }, muscleGroups: ["back"] }),
+];
+
+async function openDialog(rows: ExerciseRow[] = ROWS) {
+  mockUseExercises.mockReturnValue({
+    data: rows,
+    isLoading: false,
+    error: null,
+    hasSnapshot: true,
+  });
+  const onConfirm = jest.fn();
+  const onQuickCreated = jest.fn();
+  const user = userEvent.setup();
+  render(
+    <ExerciseMultiAddDialog
+      onConfirm={onConfirm}
+      onQuickCreated={onQuickCreated}
+    />,
+  );
+  await user.click(screen.getByRole("button", { name: "Add multiple" }));
+  return { user, onConfirm, onQuickCreated };
+}
+
+/** Tick the row whose visible name is `name`. */
+async function tick(user: ReturnType<typeof userEvent.setup>, name: string) {
+  const row = screen.getByText(name).closest("li") as HTMLElement;
+  await user.click(within(row).getByRole("checkbox"));
+}
+
+function searchBox() {
+  return screen.getByPlaceholderText("Search exercises…");
+}
+
+function confirmButton() {
+  return screen.getByRole("button", { name: /^Add \d+$/ });
+}
+
+function visibleRowNames(): string[] {
+  return screen
+    .getAllByRole("checkbox")
+    .map(
+      (cb) =>
+        (cb.closest("li") as HTMLElement).querySelector("span.font-medium")
+          ?.textContent ?? "",
+    );
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe("ExerciseMultiAddDialog — the batch", () => {
+  it("confirms every ticked id at once", async () => {
+    const { user, onConfirm } = await openDialog();
+
+    await tick(user, "Bench Press");
+    await tick(user, "Barbell Row");
+    await user.click(confirmButton());
+
+    expect(onConfirm).toHaveBeenCalledTimes(1);
+    expect(onConfirm.mock.calls[0][0].sort()).toEqual(["bench", "row"]);
+  });
+
+  it("KEEPS ticks made before a search narrowed the list", async () => {
+    const { user, onConfirm } = await openDialog();
+
+    await tick(user, "Bench Press");
+    await user.type(searchBox(), "row");
+    await waitFor(() => expect(visibleRowNames()).toEqual(["Barbell Row"]));
+    await tick(user, "Barbell Row");
+
+    await user.click(confirmButton());
+
+    // The ticked set is state, not a projection of what's on screen. Losing
+    // the off-screen ticks builds a short template and nothing errors.
+    expect(onConfirm.mock.calls[0][0].sort()).toEqual(["bench", "row"]);
+  });
+
+  it("counts the selection, not the visible rows", async () => {
+    const { user } = await openDialog();
+
+    await tick(user, "Bench Press");
+    await tick(user, "Chest Fly");
+    await user.type(searchBox(), "zzzz");
+
+    await waitFor(() => expect(screen.getByText("No matches.")).toBeInTheDocument());
+    expect(screen.getByText("2 selected")).toBeInTheDocument();
+  });
+
+  it("un-ticking removes the id again", async () => {
+    const { user, onConfirm } = await openDialog();
+
+    await tick(user, "Bench Press");
+    await tick(user, "Chest Fly");
+    await tick(user, "Bench Press");
+    await user.click(confirmButton());
+
+    expect(onConfirm.mock.calls[0][0]).toEqual(["fly"]);
+  });
+
+  // The `if (picked.size === 0) return` at the top of `onSubmit` is a guard the
+  // UI never reaches: the confirm button is `disabled` at zero. Asserting the
+  // disabled state is asserting the guard that actually runs. (Third instance
+  // of this pattern in the coach portal — see #307.)
+  it("disables confirm until something is ticked", async () => {
+    const { user } = await openDialog();
+
+    expect(confirmButton()).toBeDisabled();
+
+    await tick(user, "Bench Press");
+
+    expect(confirmButton()).toBeEnabled();
+  });
+
+  it("forgets the selection after the dialog closes", async () => {
+    const { user, onConfirm } = await openDialog();
+
+    await tick(user, "Bench Press");
+    await user.keyboard("{Escape}");
+    await waitFor(() =>
+      expect(screen.queryByPlaceholderText("Search exercises…")).not.toBeInTheDocument(),
+    );
+
+    await user.click(screen.getByRole("button", { name: "Add multiple" }));
+    await tick(user, "Chest Fly");
+    await user.click(confirmButton());
+
+    // Reopening with stale ticks adds exercises the coach didn't pick.
+    expect(onConfirm.mock.calls[0][0]).toEqual(["fly"]);
+  });
+});
+
+describe("ExerciseMultiAddDialog — quick-create keeps the flow alive", () => {
+  it("auto-selects the new exercise WITHOUT closing or confirming", async () => {
+    const { user, onConfirm, onQuickCreated } = await openDialog();
+
+    await tick(user, "Bench Press");
+    // Quick-create appears once the search matches nothing.
+    await user.type(searchBox(), "zzzz");
+    await user.click(await screen.findByRole("button", { name: "quick-create-submit" }));
+
+    // The regression this pins: the dialog stayed open, the earlier tick
+    // survived, and nothing was confirmed on the coach's behalf.
+    expect(onConfirm).not.toHaveBeenCalled();
+    expect(screen.getByPlaceholderText("Search exercises…")).toBeInTheDocument();
+    expect(onQuickCreated).toHaveBeenCalledWith({ id: "new-ex", name: "Brand New" });
+
+    await user.click(confirmButton());
+    expect(onConfirm.mock.calls[0][0].sort()).toEqual(["bench", "new-ex"]);
+  });
+
+  it("clears the search so the new exercise is actually visible", async () => {
+    const { user } = await openDialog();
+
+    await user.type(searchBox(), "zzzz");
+    await user.click(await screen.findByRole("button", { name: "quick-create-submit" }));
+
+    // The needle the coach typed to discover the exercise was missing would
+    // hide the exercise they just created.
+    await waitFor(() => expect(searchBox()).toHaveValue(""));
+    expect(mockInvalidate).toHaveBeenCalled();
+  });
+
+  it("seeds the panel from the row behind 'Create similar'", async () => {
+    const { user } = await openDialog();
+
+    const row = screen.getByText("Barbell Row").closest("li") as HTMLElement;
+    await user.click(within(row).getByRole("button", { name: /Create similar/ }));
+
+    // One-tweak duplication: seeded from THAT row, not from the search term.
+    expect(await screen.findByTestId("quick-create-seed")).toHaveTextContent(
+      "Barbell Row",
+    );
+  });
+});
+
+describe("ExerciseMultiAddDialog — the shared pipeline", () => {
+  it("never offers a legacy catalog exercise (#552)", async () => {
+    await openDialog([
+      exercise({ id: "own", name: { en: "My Curl", es: "" } }),
+      exercise({
+        id: "fexd-legacy",
+        name: { en: "Legacy Row", es: "" },
+        source: "free-exercise-db",
+        ownerId: null,
+        tags: [],
+      }),
+    ]);
+
+    expect(visibleRowNames()).toEqual(["My Curl"]);
+  });
+
+  it("collapses the double-seeded standard twins (#179)", async () => {
+    await openDialog([
+      exercise({
+        id: "1259",
+        name: { en: "Chest Stretch", es: "" },
+        source: "wger",
+        ownerId: null,
+        tags: ["standard-library"],
+        gifUrl: "https://storage.example/1259.gif",
+      } as Partial<ExerciseRow>),
+      exercise({
+        id: "std-chest-stretch",
+        name: { en: "Chest Stretch", es: "" },
+        source: "wger",
+        ownerId: null,
+        tags: ["standard-library"],
+        gifUrl: "gs://gcfitness/std-chest-stretch.gif",
+      } as Partial<ExerciseRow>),
+    ]);
+
+    // Offering the twin lets a coach add the broken-media copy to a routine,
+    // where it renders as a missing thumbnail on the client's phone.
+    expect(visibleRowNames()).toEqual(["Chest Stretch"]);
+  });
+
+  it("filters by muscle chip", async () => {
+    const { user } = await openDialog();
+
+    await user.click(screen.getByTestId("exercise-multi-add-chip-muscles-back"));
+
+    await waitFor(() => expect(visibleRowNames()).toEqual(["Barbell Row"]));
+  });
+});

--- a/backoffice/src/components/gc-fitness/__tests__/exercise-quick-create.test.tsx
+++ b/backoffice/src/components/gc-fitness/__tests__/exercise-quick-create.test.tsx
@@ -1,0 +1,319 @@
+/**
+ * @jest-environment jsdom
+ */
+
+// exercise-quick-create.test.tsx
+//
+// The inline "exercise not found — create it here" panel shared by the single
+// picker and the multi-add dialog. It is the fastest path from "the exercise I
+// want doesn't exist" to "it's in the routine", which is exactly why what it
+// writes matters: nobody reviews it afterwards.
+//
+// The FIRST THREE LINES of this file MUST stay as the
+// `/** @jest-environment jsdom */` docblock — the backoffice jest config
+// defaults to `testEnvironment: "node"` so without it React Testing Library
+// crashes with `ReferenceError: document is not defined`.
+//
+// The payload:
+//
+//   • BILINGUAL DUPLICATION. One typed name goes out as `{en, es}` with the
+//     same text — the Zod schema requires both and a Spanish client would
+//     otherwise see a nameless exercise. The coach refines the translation
+//     later from the full editor.
+//   • THE PICKED MUSCLE IS THE PRIMARY (#480). It goes into BOTH
+//     `muscleGroups: [m]` and `primaryMuscleGroup: m`, so the exercise weights
+//     a full set (1.0, not 0.5) in the coach's muscle-group progress charts.
+//   • `thumbnailURL` IS null WHEN BLANK, never "". An empty string is a real
+//     value on Firestore and the media resolvers treat a present-but-empty URL
+//     differently from an absent one.
+//   • `ownerId: null` ON THE WIRE IS FINE — but only because `createExercise`
+//     overwrites it with the session uid server-side. Worth knowing: the
+//     visibility predicate is `source === "trainer" && ownerId != null`, so a
+//     server change that ever TRUSTED this field would make every
+//     quick-created exercise invisible in every picker, including the one that
+//     just created it.
+//
+// The seeding rules are the other half. The panel's Name field is prefilled
+// from the search term the coach typed — until they edit it themselves, at
+// which point their text must survive every subsequent keystroke in the search
+// box. "Create similar" replaces the whole form from a source row and marks the
+// name dirty for the same reason.
+
+import "@testing-library/jest-dom";
+
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import React from "react";
+
+const mockCreateExercise = jest.fn();
+jest.mock("@/lib/gc-fitness/exercise-server-actions", () => ({
+  createExercise: (...args: unknown[]) => mockCreateExercise(...args),
+}));
+
+import {
+  QuickCreateExercise,
+  type QuickCreateSeed,
+} from "@/components/gc-fitness/exercise-quick-create";
+
+function seed(overrides: Partial<QuickCreateSeed> = {}): QuickCreateSeed {
+  return {
+    name: "Barbell Row",
+    description: "Pull the bar to your waist.",
+    muscleGroup: "back",
+    equipment: "barbell",
+    gifUrl: "https://storage.example/row.gif",
+    ...overrides,
+  };
+}
+
+function renderPanel(
+  props: Partial<React.ComponentProps<typeof QuickCreateExercise>> = {},
+) {
+  const onCreated = jest.fn();
+  const onSeedCleared = jest.fn();
+  const view = render(
+    <QuickCreateExercise
+      searchTerm=""
+      seed={null}
+      onCreated={onCreated}
+      onSeedCleared={onSeedCleared}
+      {...props}
+    />,
+  );
+  return { onCreated, onSeedCleared, rerender: view.rerender };
+}
+
+function nameField() {
+  return screen.getByPlaceholderText("Name");
+}
+
+function createButton() {
+  return screen.getByRole("button", { name: /^create exercise$/i });
+}
+
+async function createdPayload(): Promise<Record<string, unknown>> {
+  await waitFor(() => expect(mockCreateExercise).toHaveBeenCalledTimes(1));
+  return mockCreateExercise.mock.calls[0][0] as Record<string, unknown>;
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockCreateExercise.mockResolvedValue({ id: "custom-1" });
+});
+
+describe("QuickCreateExercise — the payload", () => {
+  it("duplicates the single typed name into both languages", async () => {
+    const user = userEvent.setup();
+    renderPanel();
+
+    await user.type(nameField(), "  Landmine Press  ");
+    await user.click(createButton());
+
+    const payload = await createdPayload();
+    // Trimmed, and the same text in both — a blank ES is a nameless exercise
+    // on a Spanish client's phone.
+    expect(payload.name).toEqual({ en: "Landmine Press", es: "Landmine Press" });
+  });
+
+  it("makes the picked muscle the PRIMARY, not just a member (#480)", async () => {
+    const user = userEvent.setup();
+    renderPanel();
+
+    await user.type(nameField(), "Landmine Press");
+    await user.click(createButton());
+
+    const payload = await createdPayload();
+    // Without `primaryMuscleGroup` the exercise falls back to the anatomy
+    // heuristic and can weight 0.5 instead of a full set on the coach's
+    // weekly-sets chart.
+    expect(payload.muscleGroups).toEqual([payload.primaryMuscleGroup]);
+    expect(payload.primaryMuscleGroup).toBeTruthy();
+  });
+
+  it("sends null, not '', for a blank thumbnail", async () => {
+    const user = userEvent.setup();
+    renderPanel();
+
+    await user.type(nameField(), "Landmine Press");
+    await user.click(createButton());
+
+    const payload = await createdPayload();
+    expect(payload.thumbnailURL).toBeNull();
+  });
+
+  it("carries the media URL through when one is seeded", async () => {
+    const user = userEvent.setup();
+    renderPanel({ seed: seed() });
+
+    await user.clear(nameField());
+    await user.type(nameField(), "Pendlay Row");
+    await user.click(createButton());
+
+    const payload = await createdPayload();
+    expect(payload.thumbnailURL).toBe("https://storage.example/row.gif");
+    expect(payload.equipment).toEqual(["barbell"]);
+    expect(payload.primaryMuscleGroup).toBe("back");
+  });
+
+  it("always claims source 'trainer'", async () => {
+    const user = userEvent.setup();
+    renderPanel();
+
+    await user.type(nameField(), "Landmine Press");
+    await user.click(createButton());
+
+    const payload = await createdPayload();
+    // The Server Action rejects anything else outright; sending the wrong
+    // value turns a quick-create into an error toast the coach can't act on.
+    expect(payload.source).toBe("trainer");
+  });
+
+  it("reports the new exercise to the parent and clears the form", async () => {
+    const user = userEvent.setup();
+    const { onCreated, onSeedCleared } = renderPanel();
+
+    await user.type(nameField(), "Landmine Press");
+    await user.click(createButton());
+
+    await waitFor(() =>
+      expect(onCreated).toHaveBeenCalledWith({
+        id: "custom-1",
+        name: "Landmine Press",
+      }),
+    );
+    // The panel stays mounted for the next one — a stale name would be
+    // submitted again on the following create.
+    await waitFor(() => expect(nameField()).toHaveValue(""));
+    expect(onSeedCleared).toHaveBeenCalled();
+  });
+
+  it("surfaces a failure instead of reporting a creation", async () => {
+    const user = userEvent.setup();
+    mockCreateExercise.mockRejectedValue(new Error("Name already in use."));
+    const { onCreated } = renderPanel();
+
+    await user.type(nameField(), "Landmine Press");
+    await user.click(createButton());
+
+    expect(await screen.findByText("Name already in use.")).toBeInTheDocument();
+    // Reporting a creation that didn't happen adds a dangling id to the
+    // routine being built.
+    expect(onCreated).not.toHaveBeenCalled();
+  });
+});
+
+describe("QuickCreateExercise — the name prefill", () => {
+  it("prefills from the search term the coach typed", () => {
+    renderPanel({ searchTerm: "  Landmine Press  " });
+
+    // The whole point of the panel: they already typed the name once.
+    expect(nameField()).toHaveValue("Landmine Press");
+  });
+
+  it("stops following the search box once the coach edits the name", async () => {
+    const user = userEvent.setup();
+    const { rerender } = renderPanel({ searchTerm: "Landmine" });
+
+    await user.clear(nameField());
+    await user.type(nameField(), "Landmine Press (Half Kneeling)");
+
+    // The coach keeps typing in the search box behind the panel.
+    rerender(
+      <QuickCreateExercise
+        searchTerm="Landmine P"
+        seed={null}
+        onCreated={jest.fn()}
+        onSeedCleared={jest.fn()}
+      />,
+    );
+
+    // Overwriting their name mid-edit is the kind of input-stealing that makes
+    // a coach retype the same thing three times.
+    expect(nameField()).toHaveValue("Landmine Press (Half Kneeling)");
+  });
+});
+
+describe("QuickCreateExercise — 'Create similar'", () => {
+  it("copies the whole source row into the form", () => {
+    renderPanel({ seed: seed(), searchTerm: "row" });
+
+    expect(nameField()).toHaveValue("Barbell Row");
+    expect(
+      screen.getByPlaceholderText("Description (optional)"),
+    ).toHaveValue("Pull the bar to your waist.");
+  });
+
+  it("does not let the search term overwrite a seeded name", () => {
+    // While the seed is present the prefill effect bails on `seed` alone.
+    renderPanel({ seed: seed(), searchTerm: "bench" });
+
+    expect(nameField()).toHaveValue("Barbell Row");
+  });
+
+  it("keeps the seeded name after the PARENT drops the seed", () => {
+    // This is the case `setNameDirty(true)` in the seed effect actually
+    // covers, and the only one — verified by mutation: with the seed still
+    // set, the prefill already bails on `seed`, so removing the flag changes
+    // nothing. It bites here, where the parent clears `seed` on its own (the
+    // multi-add dialog does exactly that after a create) WITHOUT the coach
+    // pressing Clear: with the flag gone, the search term the coach typed to
+    // find the source row overwrites the name they were about to tweak.
+    const { rerender } = renderPanel({ seed: seed(), searchTerm: "bench" });
+    expect(nameField()).toHaveValue("Barbell Row");
+
+    rerender(
+      <QuickCreateExercise
+        searchTerm="bench"
+        seed={null}
+        onCreated={jest.fn()}
+        onSeedCleared={jest.fn()}
+      />,
+    );
+
+    expect(nameField()).toHaveValue("Barbell Row");
+  });
+
+  it("blocks Create while the form is still an exact copy", async () => {
+    const user = userEvent.setup();
+    renderPanel({ seed: seed() });
+
+    // "Create similar" means TWEAK something. Creating a byte-identical
+    // duplicate is how the library gets two rows with the same name — the
+    // very thing the dedupe layer exists to paper over.
+    expect(createButton()).toBeDisabled();
+
+    await user.type(nameField(), " (Pendlay)");
+
+    expect(createButton()).toBeEnabled();
+  });
+
+  it("clearing the seed empties the form and tells the parent", async () => {
+    const user = userEvent.setup();
+    const { onSeedCleared } = renderPanel({ seed: seed() });
+
+    await user.click(screen.getByRole("button", { name: "Clear" }));
+
+    expect(nameField()).toHaveValue("");
+    expect(onSeedCleared).toHaveBeenCalled();
+  });
+});
+
+describe("QuickCreateExercise — the name is required", () => {
+  it("keeps Create disabled with an empty name", () => {
+    renderPanel();
+
+    // The `if (!trimmedName)` branch inside `onCreate` is unreachable from the
+    // UI — the button is disabled first. This asserts the guard that runs.
+    expect(createButton()).toBeDisabled();
+    expect(mockCreateExercise).not.toHaveBeenCalled();
+  });
+
+  it("enables Create as soon as there is a name", async () => {
+    const user = userEvent.setup();
+    renderPanel();
+
+    await user.type(nameField(), "X");
+
+    expect(createButton()).toBeEnabled();
+  });
+});

--- a/backoffice/src/components/gc-fitness/__tests__/habit-detail-dialog.test.tsx
+++ b/backoffice/src/components/gc-fitness/__tests__/habit-detail-dialog.test.tsx
@@ -1,0 +1,206 @@
+/**
+ * @jest-environment jsdom
+ */
+
+// habit-detail-dialog.test.tsx
+//
+// The dialog behind a habit chip on the calendar. It offers two destructive
+// actions that look almost identical in the UI and are very different in the
+// data:
+//
+//   • "Quitar de este día"       → skipHabitOccurrence — adds ONE date to the
+//     habit's skip list. The habit survives.
+//   • "Eliminar el hábito"       → deleteHabitRecurrenceFromDate — caps the
+//     recurrence so the habit stops from this day ONWARD. Everything after is
+//     gone.
+//
+// The FIRST THREE LINES of this file MUST stay as the
+// `/** @jest-environment jsdom */` docblock — the backoffice jest config
+// defaults to `testEnvironment: "node"` so without it React Testing Library
+// crashes with `ReferenceError: document is not defined`.
+//
+// Both are behind an inline confirm, and both take the TAPPED DAY as their
+// cutoff. Wiring one CTA to the other action, or passing the wrong date, is
+// silent: the dialog closes, a success toast appears, and the client quietly
+// loses a habit they were supposed to keep.
+
+import "@testing-library/jest-dom";
+
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import React from "react";
+
+import { HabitDetailDialog } from "@/components/gc-fitness/schedule/habit-detail-dialog";
+
+const mockGetHabit = jest.fn();
+const mockSkipOccurrence = jest.fn();
+const mockDeleteFromDate = jest.fn();
+jest.mock("@/lib/gc-fitness/habit-actions", () => ({
+  getHabit: (...args: unknown[]) => mockGetHabit(...args),
+  skipHabitOccurrence: (...args: unknown[]) => mockSkipOccurrence(...args),
+  deleteHabitRecurrenceFromDate: (...args: unknown[]) =>
+    mockDeleteFromDate(...args),
+}));
+
+jest.mock("@/components/gc-fitness/StorageImagePreview", () => ({
+  StorageImagePreview: () => null,
+}));
+
+const mockToastSuccess = jest.fn();
+const mockToastError = jest.fn();
+jest.mock("sonner", () => ({
+  toast: {
+    success: (...args: unknown[]) => mockToastSuccess(...args),
+    error: (...args: unknown[]) => mockToastError(...args),
+  },
+}));
+
+const TAPPED_DAY = "2026-09-17";
+
+function habit(overrides: Record<string, unknown> = {}) {
+  return {
+    id: "habit-1",
+    clientId: "client-1",
+    name: { en: "Drink water", es: "Tomar agua" },
+    description: { en: "", es: "" },
+    scheduleType: "recurring",
+    scheduleCadence: "daily",
+    scheduleWeekdays: [],
+    scheduleMonthDays: [],
+    startsOn: "2026-08-01",
+    endsOn: null,
+    skippedDates: [],
+    reminderEnabled: false,
+    reminderTime: null,
+    photoUrl: null,
+    youtubeUrl: null,
+    ...overrides,
+  };
+}
+
+function renderDialog(overrides: Record<string, unknown> = {}) {
+  const onChanged = jest.fn();
+  const onOpenChange = jest.fn();
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  render(
+    <QueryClientProvider client={client}>
+      <HabitDetailDialog
+        open
+        onOpenChange={onOpenChange}
+        habitId="habit-1"
+        civilDate={TAPPED_DAY}
+        clientName="Ana"
+        onChanged={onChanged}
+        {...overrides}
+      />
+    </QueryClientProvider>,
+  );
+  return { onChanged, onOpenChange };
+}
+
+async function waitForLoaded() {
+  await screen.findByRole("button", { name: /Quitar de este día/i });
+}
+
+/** Click a CTA, then its inline confirmation. */
+async function confirmAction(
+  user: ReturnType<typeof userEvent.setup>,
+  ctaPattern: RegExp,
+  confirmPattern: RegExp,
+) {
+  await user.click(screen.getByRole("button", { name: ctaPattern }));
+  const confirmButtons = await screen.findAllByRole("button", {
+    name: confirmPattern,
+  });
+  // The inline confirm renders a second button with the same label; the last
+  // one on screen is the confirmation, not the CTA that opened it.
+  await user.click(confirmButtons[confirmButtons.length - 1]);
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockGetHabit.mockResolvedValue(habit());
+  mockSkipOccurrence.mockResolvedValue(undefined);
+  mockDeleteFromDate.mockResolvedValue(undefined);
+});
+
+describe("HabitDetailDialog — skip one day", () => {
+  it("calls skipHabitOccurrence with the TAPPED day and nothing else", async () => {
+    const user = userEvent.setup();
+    const { onChanged } = renderDialog();
+    await waitForLoaded();
+
+    await confirmAction(user, /^Quitar de este día/, /Quitar de este día/);
+
+    await waitFor(() => expect(mockSkipOccurrence).toHaveBeenCalledTimes(1));
+    expect(mockSkipOccurrence).toHaveBeenCalledWith({
+      habitId: "habit-1",
+      civilDate: TAPPED_DAY,
+    });
+    // The destructive twin must stay untouched — this action keeps the habit.
+    expect(mockDeleteFromDate).not.toHaveBeenCalled();
+    await waitFor(() => expect(onChanged).toHaveBeenCalledTimes(1));
+  });
+
+  it("requires the inline confirm — one click alone writes nothing", async () => {
+    const user = userEvent.setup();
+    renderDialog();
+    await waitForLoaded();
+
+    await user.click(
+      screen.getByRole("button", { name: /^Quitar de este día/ }),
+    );
+
+    expect(mockSkipOccurrence).not.toHaveBeenCalled();
+  });
+});
+
+describe("HabitDetailDialog — delete from this day onward", () => {
+  it("calls deleteHabitRecurrenceFromDate with the tapped day as the cutoff", async () => {
+    const user = userEvent.setup();
+    const { onChanged } = renderDialog();
+    await waitForLoaded();
+
+    await confirmAction(user, /^Eliminar el hábito/, /Eliminar el hábito/);
+
+    await waitFor(() => expect(mockDeleteFromDate).toHaveBeenCalledTimes(1));
+    // Positional args, and the date is the cutoff — passing anything else caps
+    // the habit on the wrong day.
+    expect(mockDeleteFromDate).toHaveBeenCalledWith("habit-1", TAPPED_DAY);
+    expect(mockSkipOccurrence).not.toHaveBeenCalled();
+    await waitFor(() => expect(onChanged).toHaveBeenCalledTimes(1));
+  });
+
+  it("requires the inline confirm for the destructive action too", async () => {
+    const user = userEvent.setup();
+    renderDialog();
+    await waitForLoaded();
+
+    await user.click(
+      screen.getByRole("button", { name: /^Eliminar el hábito/ }),
+    );
+
+    expect(mockDeleteFromDate).not.toHaveBeenCalled();
+  });
+});
+
+describe("HabitDetailDialog — failure handling", () => {
+  it("surfaces the error and does not tell the parent anything changed", async () => {
+    const user = userEvent.setup();
+    mockDeleteFromDate.mockRejectedValueOnce(new Error("No se pudo eliminar"));
+    const { onChanged } = renderDialog();
+    await waitForLoaded();
+
+    await confirmAction(user, /^Eliminar el hábito/, /Eliminar el hábito/);
+
+    await waitFor(() =>
+      expect(mockToastError).toHaveBeenCalledWith("No se pudo eliminar"),
+    );
+    // onChanged invalidates the calendar; firing it after a failed write paints
+    // a calendar that disagrees with Firestore.
+    expect(onChanged).not.toHaveBeenCalled();
+  });
+});

--- a/backoffice/src/components/gc-fitness/__tests__/month-calendar-drag-move.test.tsx
+++ b/backoffice/src/components/gc-fitness/__tests__/month-calendar-drag-move.test.tsx
@@ -1,0 +1,381 @@
+/**
+ * @jest-environment jsdom
+ */
+
+// month-calendar-drag-move.test.tsx
+//
+// SCOPE: the drag-a-chip → move path of the month calendar, and nothing else.
+// `month-calendar.tsx` is 1767 lines and renders eight dialogs, three views and
+// a client filter bar; covering it whole is a different (and much more
+// expensive) job. The drag path is the one that WRITES — every other
+// interaction on this surface either navigates or opens a dialog that already
+// has its own regression file.
+//
+// The FIRST THREE LINES of this file MUST stay as the
+// `/** @jest-environment jsdom */` docblock — the backoffice jest config
+// defaults to `testEnvironment: "node"` so without it React Testing Library
+// crashes with `ReferenceError: document is not defined`.
+//
+// What `onCellDrop` decides, and why each branch matters:
+//
+//   1. THE FORK. A one-off workout moves IMMEDIATELY (`scope: "one"`); a
+//      recurring one must stop and ask, because `moveAssignment` with
+//      `scope: "all"` rewrites every occurrence in the series. Taking the wrong
+//      branch does not throw — it either reschedules a whole series when the
+//      coach nudged one day, or silently drops the prompt that was the only
+//      thing standing between a drag and that rewrite.
+//   2. `recurrenceKind === "single"` COUNTS AS NON-RECURRING even when a
+//      `seriesId` is present. Assignments created one-at-a-time still carry a
+//      series id, so a `seriesId`-only check would prompt on every single drag.
+//   3. THE SAME-DAY NO-OP. Picking a chip up and dropping it back must not
+//      write. Without the guard, every accidental jiggle costs a Firestore
+//      write and a "Workout movido" toast for a move that didn't happen.
+//   4. #449 — a CLIENT-CREATED workout is not draggable at all. The server
+//      action throws on ownership, so the guard here exists to keep the coach
+//      from ever seeing that error: the chip simply doesn't lift.
+//
+// Note on the drag mechanics: `user-event` has no drag-and-drop API (HTML5 DnD
+// isn't implemented in jsdom either), so these tests fire the two React
+// synthetic events the component actually listens to — `dragStart` on the chip
+// and `drop` on the target cell — with a stub `dataTransfer`. That is exactly
+// the pair the browser delivers; nothing about the component is bypassed.
+
+import "@testing-library/jest-dom";
+
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import React from "react";
+
+import { MonthCalendar } from "@/components/gc-fitness/schedule/month-calendar";
+import type {
+  MonthCalendarPayload,
+  MonthWorkoutChip,
+} from "@/lib/gc-fitness/schedule-month-actions";
+
+// The actions module pulls in firebase-admin, which explodes on import under
+// jsdom. The query is seeded with `initialData` for the initial month +
+// selection, so the chips are on screen from the first render; React Query
+// still revalidates in the background, and `listMonthForClients` is wired to
+// return the same payload so that refetch is a no-op instead of console noise.
+const mockListMonthForClients = jest.fn();
+const mockMoveAssignment = jest.fn();
+jest.mock("@/lib/gc-fitness/schedule-month-actions", () => ({
+  listMonthForClients: (...args: unknown[]) => mockListMonthForClients(...args),
+  moveAssignment: (...args: unknown[]) => mockMoveAssignment(...args),
+}));
+
+jest.mock("next/navigation", () => ({
+  useSearchParams: () => new URLSearchParams(""),
+}));
+
+// Every other surface the calendar can open. Stubbed to null so the tree stays
+// small — each one has (or will have) its own regression file.
+jest.mock("@/components/gc-fitness/schedule/assign-template-modal", () => ({
+  AssignTemplateModal: () => null,
+}));
+jest.mock("@/components/gc-fitness/schedule/new-habit-dialog", () => ({
+  NewHabitDialog: () => null,
+}));
+jest.mock("@/components/gc-fitness/schedule/workout-detail-dialog", () => ({
+  WorkoutDetailDialog: () => null,
+}));
+jest.mock("@/components/gc-fitness/schedule/habit-detail-dialog", () => ({
+  HabitDetailDialog: () => null,
+}));
+jest.mock("@/components/gc-fitness/schedule/bulk-assign-habit-dialog", () => ({
+  BulkAssignHabitDialog: () => null,
+}));
+
+// The move dialog is stubbed rather than mounted: what this file is testing is
+// the SHELL's decision — whether the prompt opens at all, with which chip and
+// which target date, and what it does with the scope that comes back. The
+// dialog's own three-scope contract is pinned in move-assignment-dialog.test.tsx.
+const mockMoveDialogProps = jest.fn();
+jest.mock("@/components/gc-fitness/schedule/move-assignment-dialog", () => ({
+  MoveAssignmentDialog: (props: {
+    chip: { id: string };
+    newDate: string;
+    onConfirm: (scope: "one" | "future" | "all") => void;
+    onOpenChange: (open: boolean) => void;
+  }) => {
+    mockMoveDialogProps(props);
+    return (
+      <div data-testid="move-dialog">
+        <span data-testid="move-dialog-chip">{props.chip.id}</span>
+        <span data-testid="move-dialog-date">{props.newDate}</span>
+        <button type="button" onClick={() => props.onConfirm("one")}>
+          scope-one
+        </button>
+        <button type="button" onClick={() => props.onConfirm("future")}>
+          scope-future
+        </button>
+        <button type="button" onClick={() => props.onConfirm("all")}>
+          scope-all
+        </button>
+      </div>
+    );
+  },
+}));
+
+const mockToastSuccess = jest.fn();
+const mockToastError = jest.fn();
+jest.mock("sonner", () => ({
+  toast: {
+    success: (...args: unknown[]) => mockToastSuccess(...args),
+    error: (...args: unknown[]) => mockToastError(...args),
+  },
+}));
+
+// September 2026 as the rendered month. The Mon-first grid runs Aug 31 →
+// Oct 11, so day numbers 12..30 appear EXACTLY ONCE in the DOM. Days 1..11 do
+// not (they're also the October pad), which is why both the source day (15) and
+// the target day (22) are picked from the unique range — `getByText("3")` would
+// silently match the wrong cell.
+const TODAY = "2026-09-10";
+const MONTH_FIRST = "2026-09-01";
+const SOURCE_DAY = "2026-09-15";
+const TARGET_DAY = "2026-09-22";
+
+const CLIENT = {
+  uid: "client-1",
+  displayName: "Ana Gomez",
+  email: "ana@example.com",
+  photoURL: null,
+  birthDate: null,
+};
+
+function chip(overrides: Partial<MonthWorkoutChip> = {}): MonthWorkoutChip {
+  return {
+    id: "assign-1",
+    clientId: CLIENT.uid,
+    scheduledFor: SOURCE_DAY,
+    originallyScheduledFor: null,
+    templateName: "Push Day",
+    templateTag: "push",
+    status: "scheduled",
+    seriesId: null,
+    recurrenceKind: null,
+    selfAssigned: false,
+    ...overrides,
+  };
+}
+
+function payloadWith(chips: MonthWorkoutChip[]): MonthCalendarPayload {
+  const workoutsByDay: Record<string, MonthWorkoutChip[]> = {};
+  for (const c of chips) {
+    (workoutsByDay[c.scheduledFor] ??= []).push(c);
+  }
+  return {
+    monthStart: MONTH_FIRST,
+    monthEnd: "2026-09-30",
+    workoutsByDay,
+    habitsByDay: {},
+  };
+}
+
+function renderCalendar(chips: MonthWorkoutChip[]) {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  const payload = payloadWith(chips);
+  mockListMonthForClients.mockResolvedValue(payload);
+  render(
+    <QueryClientProvider client={client}>
+      <MonthCalendar
+        clients={[CLIENT]}
+        initialMonthFirst={MONTH_FIRST}
+        initialClientIds={[CLIENT.uid]}
+        initialPayload={payload}
+        todayCivil={TODAY}
+        trainerUid="trainer-1"
+      />
+    </QueryClientProvider>,
+  );
+}
+
+/** The chip button, matched on its template name. */
+function chipButton(name: string): HTMLElement {
+  return screen.getByRole("button", { name: new RegExp(name) });
+}
+
+/** The day cell carrying `dayNumber` — its number label, which the drop event
+ *  bubbles up from into the cell's own `onDrop`. */
+function dayCell(dayNumber: number): HTMLElement {
+  return screen.getByText(String(dayNumber));
+}
+
+/** Minimal stand-in for the browser's DataTransfer. `onDragStart` writes
+ *  `effectAllowed` and calls `setData` before handing the chip to the shell. */
+function dataTransfer() {
+  return { effectAllowed: "", setData: jest.fn(), getData: jest.fn() };
+}
+
+function dragChipToDay(chipName: string, dayNumber: number) {
+  fireEvent.dragStart(chipButton(chipName), { dataTransfer: dataTransfer() });
+  fireEvent.drop(dayCell(dayNumber), { dataTransfer: dataTransfer() });
+}
+
+/**
+ * Let React Query's mutation queue drain.
+ *
+ * REQUIRED before any "did NOT write" assertion. `mutate()` does not call the
+ * mutation function synchronously, so asserting `not.toHaveBeenCalled()` right
+ * after the drop passes no matter what the component did — verified by
+ * mutation: deleting the same-day guard left every negative test GREEN until
+ * this flush was added.
+ */
+async function settle() {
+  await act(async () => {
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  });
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockMoveAssignment.mockResolvedValue({ movedCount: 1 });
+});
+
+describe("MonthCalendar — dragging a ONE-OFF workout writes straight away", () => {
+  it("moves it with scope 'one' and the dropped-on date, no prompt", async () => {
+    renderCalendar([chip()]);
+
+    dragChipToDay("Push Day", 22);
+
+    await waitFor(() => expect(mockMoveAssignment).toHaveBeenCalledTimes(1));
+    expect(mockMoveAssignment).toHaveBeenCalledWith({
+      id: "assign-1",
+      newScheduledFor: TARGET_DAY,
+      scope: "one",
+    });
+    // No series to reshape → the coach is never asked.
+    expect(screen.queryByTestId("move-dialog")).not.toBeInTheDocument();
+  });
+
+  it("treats a seriesId with recurrenceKind 'single' as one-off", async () => {
+    // Assignments created one at a time still carry a series id. Prompting on
+    // those would put a scope dialog in front of every ordinary drag.
+    renderCalendar([chip({ seriesId: "series-1", recurrenceKind: "single" })]);
+
+    dragChipToDay("Push Day", 22);
+
+    await waitFor(() => expect(mockMoveAssignment).toHaveBeenCalledTimes(1));
+    expect(mockMoveAssignment).toHaveBeenCalledWith(
+      expect.objectContaining({ scope: "one" }),
+    );
+    expect(screen.queryByTestId("move-dialog")).not.toBeInTheDocument();
+  });
+});
+
+describe("MonthCalendar — dragging a RECURRING workout asks first", () => {
+  const RECURRING = chip({
+    id: "assign-recurring",
+    seriesId: "series-1",
+    recurrenceKind: "weekly",
+  });
+
+  it("opens the scope prompt and writes NOTHING yet", async () => {
+    renderCalendar([RECURRING]);
+
+    dragChipToDay("Push Day", 22);
+
+    expect(screen.getByTestId("move-dialog")).toBeInTheDocument();
+    // The whole point of the prompt: no write has happened.
+    await settle();
+    expect(mockMoveAssignment).not.toHaveBeenCalled();
+  });
+
+  it("hands the prompt the dragged chip and the day it landed on", () => {
+    renderCalendar([RECURRING]);
+
+    dragChipToDay("Push Day", 22);
+
+    // Passing a stale chip or the source date here would move the wrong
+    // occurrence to the wrong day while the dialog copy reads correctly.
+    expect(screen.getByTestId("move-dialog-chip")).toHaveTextContent(
+      "assign-recurring",
+    );
+    expect(screen.getByTestId("move-dialog-date")).toHaveTextContent(TARGET_DAY);
+  });
+
+  it("forwards the chosen scope verbatim to moveAssignment", async () => {
+    renderCalendar([RECURRING]);
+
+    dragChipToDay("Push Day", 22);
+    fireEvent.click(screen.getByRole("button", { name: "scope-all" }));
+
+    await waitFor(() => expect(mockMoveAssignment).toHaveBeenCalledTimes(1));
+    expect(mockMoveAssignment).toHaveBeenCalledWith({
+      id: "assign-recurring",
+      newScheduledFor: TARGET_DAY,
+      scope: "all",
+    });
+    // And the prompt closes — leaving it open invites a second write.
+    expect(screen.queryByTestId("move-dialog")).not.toBeInTheDocument();
+  });
+
+  it("forwards 'future' just as literally", async () => {
+    renderCalendar([RECURRING]);
+
+    dragChipToDay("Push Day", 22);
+    fireEvent.click(screen.getByRole("button", { name: "scope-future" }));
+
+    await waitFor(() => expect(mockMoveAssignment).toHaveBeenCalledTimes(1));
+    expect(mockMoveAssignment).toHaveBeenCalledWith(
+      expect.objectContaining({ scope: "future" }),
+    );
+  });
+});
+
+describe("MonthCalendar — drags that must NOT write", () => {
+  it("ignores a drop back onto the chip's own day", async () => {
+    renderCalendar([chip()]);
+
+    dragChipToDay("Push Day", 15); // 2026-09-15 — where it already is
+
+    await settle();
+    expect(mockMoveAssignment).not.toHaveBeenCalled();
+    expect(screen.queryByTestId("move-dialog")).not.toBeInTheDocument();
+  });
+
+  it("ignores a drop with no chip in hand", async () => {
+    renderCalendar([chip()]);
+
+    // A drop that never started as a drag (e.g. a file dragged in from the
+    // desktop) reaches the same handler.
+    fireEvent.drop(dayCell(22), { dataTransfer: dataTransfer() });
+
+    await settle();
+    expect(mockMoveAssignment).not.toHaveBeenCalled();
+    expect(screen.queryByTestId("move-dialog")).not.toBeInTheDocument();
+  });
+});
+
+describe("MonthCalendar — #449, a client-created workout can't be dragged", () => {
+  it("does not mark the chip draggable", () => {
+    renderCalendar([chip({ templateName: "Mi rutina", selfAssigned: true })]);
+
+    // This attribute IS the guard the coach meets: the chip never lifts, so
+    // `moveAssignment`'s ownership throw is unreachable from the calendar.
+    expect(chipButton("Mi rutina")).toHaveAttribute("draggable", "false");
+  });
+
+  it("stays inert even if a dragStart is delivered anyway", async () => {
+    renderCalendar([chip({ templateName: "Mi rutina", selfAssigned: true })]);
+
+    dragChipToDay("Mi rutina", 22);
+
+    // `onDragStart` early-returns for self-assigned chips, so nothing was ever
+    // put in hand and the drop finds none.
+    await settle();
+    expect(mockMoveAssignment).not.toHaveBeenCalled();
+    expect(screen.queryByTestId("move-dialog")).not.toBeInTheDocument();
+  });
+
+  it("leaves coach-assigned chips draggable", () => {
+    renderCalendar([chip()]);
+
+    // The other direction of the same guard: over-hiding it would make the
+    // whole calendar unmovable and nothing would error.
+    expect(chipButton("Push Day")).toHaveAttribute("draggable", "true");
+  });
+});

--- a/backoffice/src/components/gc-fitness/__tests__/move-assignment-dialog.test.tsx
+++ b/backoffice/src/components/gc-fitness/__tests__/move-assignment-dialog.test.tsx
@@ -1,0 +1,114 @@
+/**
+ * @jest-environment jsdom
+ */
+
+// move-assignment-dialog.test.tsx
+//
+// The dialog shown when a coach drags a RECURRING workout chip onto a new day.
+// It doesn't write anything itself — it emits a scope to the parent, which then
+// decides how much of the series to move.
+//
+// The FIRST THREE LINES of this file MUST stay as the
+// `/** @jest-environment jsdom */` docblock — the backoffice jest config
+// defaults to `testEnvironment: "node"` so without it React Testing Library
+// crashes with `ReferenceError: document is not defined`.
+//
+// Small component, real contract: the three scope strings are switched on by
+// the caller. Mixing up "one" and "all" doesn't throw — it silently reschedules
+// an entire series when the coach meant to nudge a single day, which is exactly
+// the kind of destructive-but-quiet mistake that reaches a client's phone
+// before anyone notices.
+
+import "@testing-library/jest-dom";
+
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import React from "react";
+
+import { MoveAssignmentDialog } from "@/components/gc-fitness/schedule/move-assignment-dialog";
+import type { MonthWorkoutChip } from "@/lib/gc-fitness/schedule-month-actions";
+
+const CHIP: MonthWorkoutChip = {
+  id: "assign-1",
+  clientId: "client-1",
+  scheduledFor: "2026-08-05",
+  originallyScheduledFor: null,
+  templateName: "Push Day",
+  templateTag: "push",
+  status: "scheduled",
+  seriesId: "series-1",
+  recurrenceKind: "weekly",
+  selfAssigned: false,
+};
+
+function renderDialog() {
+  const onConfirm = jest.fn();
+  const onOpenChange = jest.fn();
+  render(
+    <MoveAssignmentDialog
+      open
+      chip={CHIP}
+      newDate="2026-08-07"
+      onOpenChange={onOpenChange}
+      onConfirm={onConfirm}
+    />,
+  );
+  return { onConfirm, onOpenChange };
+}
+
+describe("MoveAssignmentDialog", () => {
+  it("emits 'one' for just this occurrence", async () => {
+    const user = userEvent.setup();
+    const { onConfirm } = renderDialog();
+
+    await user.click(
+      screen.getByRole("button", { name: /Solo esta ocurrencia/i }),
+    );
+
+    expect(onConfirm).toHaveBeenCalledTimes(1);
+    expect(onConfirm).toHaveBeenCalledWith("one");
+  });
+
+  it("emits 'future' for this and every following occurrence", async () => {
+    const user = userEvent.setup();
+    const { onConfirm } = renderDialog();
+
+    await user.click(
+      screen.getByRole("button", { name: /Esta y todas las futuras/i }),
+    );
+
+    expect(onConfirm).toHaveBeenCalledWith("future");
+  });
+
+  it("emits 'all' for the whole series", async () => {
+    const user = userEvent.setup();
+    const { onConfirm } = renderDialog();
+
+    await user.click(screen.getByRole("button", { name: /Toda la serie/i }));
+
+    expect(onConfirm).toHaveBeenCalledWith("all");
+  });
+
+  it("shows the occurrence being moved and the target date", () => {
+    renderDialog();
+
+    // The coach is about to reschedule someone's training. Both dates must be
+    // on screen — a dialog that says "move this?" without saying from-where and
+    // to-where is how the wrong day gets confirmed.
+    expect(screen.getByText(/Push Day/)).toBeInTheDocument();
+    expect(screen.getByText("2026-08-07")).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /Solo esta ocurrencia \(2026-08-05\)/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("cancels without emitting any scope", async () => {
+    const user = userEvent.setup();
+    const { onConfirm, onOpenChange } = renderDialog();
+
+    await user.click(screen.getByRole("button", { name: "Cancelar" }));
+
+    expect(onConfirm).not.toHaveBeenCalled();
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+  });
+});

--- a/backoffice/src/components/gc-fitness/__tests__/new-habit-dialog.test.tsx
+++ b/backoffice/src/components/gc-fitness/__tests__/new-habit-dialog.test.tsx
@@ -1,0 +1,216 @@
+/**
+ * @jest-environment jsdom
+ */
+
+// new-habit-dialog.test.tsx
+//
+// The habit-creation shell used from two very different places: a calendar cell
+// (FIXED mode — one client, one day, both pre-set) and the habits page (ROSTER
+// mode — the coach picks the client inside the form).
+//
+// The FIRST THREE LINES of this file MUST stay as the
+// `/** @jest-environment jsdom */` docblock — the backoffice jest config
+// defaults to `testEnvironment: "node"` so without it React Testing Library
+// crashes with `ReferenceError: document is not defined`.
+//
+// This component barely renders anything itself — it decides WHAT TO HAND the
+// shared `HabitForm` / `HabitTemplateForm`. So that is what the tests assert:
+// the props crossing that boundary. Specifically:
+//
+//   1. FIXED vs ROSTER. In fixed mode the client dropdown must be pinned to the
+//      one client from the calendar cell; in roster mode it must offer the whole
+//      roster with no client pre-selected. Getting this backwards assigns a
+//      habit to the WRONG CLIENT — silently, because both modes render fine.
+//   2. THE SEEDED DATE. The calendar cell's day must reach the form as
+//      `startsOn`. Losing it silently starts the habit today instead of on the
+//      day the coach clicked.
+//   3. THE DRAFT IDS, which are namespaced per trainer. Two coaches drafting at
+//      once must not collide on a document id.
+
+import "@testing-library/jest-dom";
+
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import React from "react";
+
+import { NewHabitDialog } from "@/components/gc-fitness/schedule/new-habit-dialog";
+
+// Capture what the shell hands each child form. Both stubs expose a button that
+// fires `onAfterSubmit`, which is how we exercise the post-save path without
+// pulling the real (large, separately tested) forms into the render.
+const habitFormProps: Array<Record<string, unknown>> = [];
+jest.mock("@/app/gc-fitness/habits/_components/HabitForm", () => ({
+  HabitForm: (props: Record<string, unknown>) => {
+    habitFormProps.push(props);
+    return (
+      <button
+        type="button"
+        onClick={() => (props.onAfterSubmit as () => void)()}
+      >
+        stub-submit-habit
+      </button>
+    );
+  },
+}));
+
+const templateFormProps: Array<Record<string, unknown>> = [];
+jest.mock("@/app/gc-fitness/habits/_components/HabitTemplateForm", () => ({
+  HabitTemplateForm: (props: Record<string, unknown>) => {
+    templateFormProps.push(props);
+    return (
+      <button
+        type="button"
+        onClick={() => (props.onAfterSubmit as () => void)()}
+      >
+        stub-submit-template
+      </button>
+    );
+  },
+}));
+
+// The existing-habit tab lists templates over react-query; an empty list keeps
+// the shell on its empty state, which is where the "create it" shortcut lives.
+jest.mock("@tanstack/react-query", () => ({
+  useQuery: () => ({ data: [], isLoading: false }),
+}));
+
+jest.mock("@/lib/gc-fitness/habit-actions", () => ({
+  createHabit: jest.fn(),
+  createHabitTemplate: jest.fn(),
+  listHabitTemplates: jest.fn(),
+}));
+
+// Deliberately NOT today. `effStartsOn` falls back to `todayCivilDate()`, so a
+// fixture equal to today makes the seeding assertion unfalsifiable — dropping
+// the seed entirely would still produce the expected value.
+const SEEDED_DAY = "2026-09-17";
+
+const ROSTER = [
+  { uid: "client-1", displayName: "Ana" },
+  { uid: "client-2", displayName: "Beto" },
+];
+
+function renderDialog(
+  overrides: Partial<React.ComponentProps<typeof NewHabitDialog>> = {},
+) {
+  const onCreated = jest.fn();
+  const onOpenChange = jest.fn();
+  render(
+    <NewHabitDialog
+      open
+      onOpenChange={onOpenChange}
+      trainerUid="trainer-9"
+      onCreated={onCreated}
+      {...overrides}
+    />,
+  );
+  return { onCreated, onOpenChange };
+}
+
+/** Last props the shell handed `HabitForm`. */
+function lastHabitFormProps() {
+  return habitFormProps[habitFormProps.length - 1];
+}
+
+/** Switch to the "new habit" tab, where the forms render. */
+async function openNewTab(user: ReturnType<typeof userEvent.setup>) {
+  await user.click(screen.getByRole("button", { name: /Nuevo hábito|Crear/i }));
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  habitFormProps.length = 0;
+  templateFormProps.length = 0;
+});
+
+describe("NewHabitDialog — FIXED mode (from a calendar cell)", () => {
+  it("pins the client dropdown to the cell's client and pre-selects it", async () => {
+    const user = userEvent.setup();
+    renderDialog({
+      clientId: "client-1",
+      clientName: "Ana",
+      startsOn: SEEDED_DAY,
+    });
+    await openNewTab(user);
+
+    const props = lastHabitFormProps();
+    // One option only — the coach cannot accidentally retarget the habit at
+    // somebody else from a cell that already named a client.
+    expect(props.clientOptions).toEqual([
+      { uid: "client-1", displayName: "Ana" },
+    ]);
+    expect(
+      (props.defaultValues as Record<string, unknown>).clientId,
+    ).toBe("client-1");
+  });
+
+  it("seeds startsOn from the clicked day, not from today", async () => {
+    const user = userEvent.setup();
+    renderDialog({
+      clientId: "client-1",
+      clientName: "Ana",
+      startsOn: SEEDED_DAY,
+    });
+    await openNewTab(user);
+
+    expect(
+      (lastHabitFormProps().defaultValues as Record<string, unknown>).startsOn,
+    ).toBe(SEEDED_DAY);
+  });
+});
+
+describe("NewHabitDialog — ROSTER mode (from the habits page)", () => {
+  it("renders the TEMPLATE form — a client-less habit, assigned later", async () => {
+    const user = userEvent.setup();
+    renderDialog({ clients: ROSTER });
+    await openNewTab(user);
+
+    // This is the whole fork: from the habits page the coach builds a reusable
+    // TEMPLATE with no client attached, and assigns it afterwards from the
+    // library. Rendering the per-client HabitForm here would demand a client
+    // the coach never intended to pick.
+    expect(templateFormProps).toHaveLength(1);
+    expect(habitFormProps).toHaveLength(0);
+  });
+
+  it("namespaces the roster-mode template id by trainer too", async () => {
+    const user = userEvent.setup();
+    renderDialog({ clients: ROSTER });
+    await openNewTab(user);
+
+    const templateId = templateFormProps[0].templateId as string;
+    expect(templateId.startsWith("habit-template-trainer-9-")).toBe(true);
+  });
+});
+
+describe("NewHabitDialog — draft ids", () => {
+  it("namespaces the draft ids by trainer so two coaches can't collide", async () => {
+    const user = userEvent.setup();
+    renderDialog({ clientId: "client-1", clientName: "Ana" });
+    await openNewTab(user);
+
+    const habitId = lastHabitFormProps().habitId as string;
+    expect(habitId.startsWith("habit-draft-trainer-9-")).toBe(true);
+    // A bare `habit-draft-` id would be a single shared document across the
+    // whole platform.
+    expect(habitId.length).toBeGreaterThan("habit-draft-trainer-9-".length);
+  });
+});
+
+describe("NewHabitDialog — after a successful save", () => {
+  it("tells the parent to refresh AND closes itself", async () => {
+    const user = userEvent.setup();
+    const { onCreated, onOpenChange } = renderDialog({
+      clientId: "client-1",
+      clientName: "Ana",
+    });
+    await openNewTab(user);
+
+    await user.click(screen.getByRole("button", { name: "stub-submit-habit" }));
+
+    // Both halves matter: without onCreated the calendar keeps showing stale
+    // data, and without the close the coach can double-submit the same habit.
+    expect(onCreated).toHaveBeenCalledTimes(1);
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+  });
+});

--- a/backoffice/src/components/gc-fitness/__tests__/template-form-save.test.tsx
+++ b/backoffice/src/components/gc-fitness/__tests__/template-form-save.test.tsx
@@ -1,0 +1,441 @@
+/**
+ * @jest-environment jsdom
+ */
+
+// template-form-save.test.tsx
+//
+// The SAVE half of the template editor. `template-form-cancel.test.tsx` covers
+// the draft/discard flow; this file covers what the form actually hands to the
+// Server Action when the coach presses Save.
+//
+// The FIRST THREE LINES of this file MUST stay as the
+// `/** @jest-environment jsdom */` docblock — the backoffice jest config
+// defaults to `testEnvironment: "node"` so without it React Testing Library
+// crashes with `ReferenceError: document is not defined`.
+//
+// `onSubmit` is a PROP, so every assertion here is on the real payload — the
+// exact object `createWorkoutTemplate` / `updateWorkoutTemplate` receives, and
+// therefore the exact doc shape iOS and Android read back.
+//
+// The normalization block in `handleSubmit` is ~140 lines of alignment rules,
+// every one of which was written after a specific bad doc reached Firestore:
+//
+//   • `order` is RECOMPUTED 1-based contiguous. The Firestore rule layer
+//     (P04-02) asserts `order == arrayIndex + 1`; a stale order from a
+//     reordered draft is rejected at the rules layer, not here.
+//   • SET-COUNT ALIGNMENT. The operator's PULL template shipped with
+//     `sets: 1` and `weightBySetKg: [24, 24, 23]` because `sets` used to be
+//     derived from `repsBySet.length` alone. Every per-set array now lands on
+//     one canonical length.
+//   • THE "SIN PESO" SENTINEL (#159 / reps-sin-weight). An explicit empty
+//     `weightBySetKg: []` is a real prescription — reps with no weight — and
+//     must survive as a length-0 array. Zero-filling it turns a bodyweight
+//     exercise into "0 kg × reps" on the client's phone.
+//   • KEYS ARE DELETED, NEVER SET TO `undefined`. The backoffice's Firestore
+//     handle has no `ignoreUndefinedProperties`, so `setTypesBySet: undefined`
+//     throws "Cannot use 'undefined' as a Firestore value" at write time —
+//     a crash, not a bad doc. Same for `supersetGroup`.
+//   • `endsOn` NO LONGER EXISTS on templates (removed in 703d8b2, "templates
+//     do not need endDates") but is STILL IN THE ZOD SCHEMA, so it survives a
+//     parse. A localStorage draft written before that commit still carries it,
+//     which is why the restore path strips it explicitly.
+//
+// Where a rule is reachable from the UI, the test drives the UI (the sets input
+// on a superset leader, the per-set type picker); where it is pure
+// normalization, the test seeds `defaultValues` and presses Save.
+
+import "@testing-library/jest-dom";
+
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import React from "react";
+
+import type { WorkoutTemplateInput } from "@/lib/gc-fitness/workout-template-schema";
+
+const mockBack = jest.fn();
+jest.mock("next/navigation", () => ({
+  useRouter: () => ({ back: mockBack, push: jest.fn() }),
+}));
+
+jest.mock("@/lib/gc-fitness/exercises-listener", () => ({
+  useExercisesQuery: () => ({
+    data: [],
+    isLoading: false,
+    error: null,
+    hasSnapshot: true,
+  }),
+}));
+jest.mock("@/lib/gc-fitness/workout-templates-listener", () => ({
+  useWorkoutTemplates: () => ({ data: [], isLoading: false, error: null }),
+}));
+
+// Exercise-picking surfaces have their own tests; these fixtures arrive with
+// their exercises already chosen.
+jest.mock("../exercise-picker-popover", () => ({
+  ExercisePickerPopover: () => null,
+}));
+jest.mock("../exercise-multi-add-dialog", () => ({
+  ExerciseMultiAddDialog: () => null,
+}));
+jest.mock("../template-tags-picker", () => ({
+  TemplateTagsPicker: () => null,
+}));
+
+jest.mock("sonner", () => ({
+  toast: { success: jest.fn(), error: jest.fn() },
+}));
+
+import { TemplateForm } from "../template-form";
+
+type Ex = Partial<WorkoutTemplateInput["exercises"][number]> &
+  Record<string, unknown>;
+
+const DRAFT_PREFIX = "gc-fitness:template-draft:";
+
+function exercise(overrides: Ex = {}): Ex {
+  return {
+    exerciseId: "0025",
+    sets: 3,
+    reps: 10,
+    rest_seconds: 90,
+    transition_rest_seconds: 60,
+    order: 1,
+    ...overrides,
+  };
+}
+
+function defaults(exercises: Ex[], extra: Record<string, unknown> = {}) {
+  return {
+    name: { en: "Push Day", es: "Empuje" },
+    description: { en: "", es: "" },
+    tag: "push",
+    tags: ["push"],
+    exercises,
+    ...extra,
+  } as Partial<WorkoutTemplateInput>;
+}
+
+/** Renders in EDIT mode (the Save CTA reads "Save changes"). */
+function renderForm(
+  defaultValues: Partial<WorkoutTemplateInput>,
+  draftKey?: string,
+) {
+  const onSubmit = jest.fn().mockResolvedValue({ ok: true as const });
+  render(
+    <TemplateForm
+      mode="edit"
+      defaultValues={defaultValues}
+      draftKey={draftKey}
+      onSubmit={onSubmit}
+    />,
+  );
+  return { onSubmit };
+}
+
+/** Press Save and return the single payload handed to the Server Action. */
+async function save(onSubmit: jest.Mock): Promise<WorkoutTemplateInput> {
+  const user = userEvent.setup();
+  await user.click(screen.getByRole("button", { name: "Save changes" }));
+  await waitFor(() => expect(onSubmit).toHaveBeenCalledTimes(1));
+  return onSubmit.mock.calls[0][0] as WorkoutTemplateInput;
+}
+
+/** Step 2 ("Details") is where the per-set editors live. */
+async function goToDetails(user: ReturnType<typeof userEvent.setup>) {
+  await user.click(screen.getByRole("button", { name: "2. Details" }));
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  window.localStorage.clear();
+});
+
+describe("TemplateForm save — exercise order", () => {
+  it("renumbers `order` 1-based contiguous, ignoring what came in", async () => {
+    // The Firestore rules assert `order == arrayIndex + 1`. A draft that was
+    // reordered (or a doc written before the rule) carries stale numbers; the
+    // form must not pass them through, or the write is rejected server-side
+    // with an error the coach can do nothing about.
+    const { onSubmit } = renderForm(
+      defaults([
+        exercise({ exerciseId: "a", order: 7 }),
+        exercise({ exerciseId: "b", order: 7 }),
+        exercise({ exerciseId: "c", order: 0 }),
+      ]),
+    );
+
+    const payload = await save(onSubmit);
+
+    expect(payload.exercises.map((e) => e.order)).toEqual([1, 2, 3]);
+    expect(payload.exercises.map((e) => e.exerciseId)).toEqual(["a", "b", "c"]);
+  });
+});
+
+describe("TemplateForm save — per-set arrays land on one length", () => {
+  it("heals the sets=1 / weightBySetKg=[24,24,23] desync", async () => {
+    // The operator's actual PULL template. `sets` used to be derived from
+    // repsBySet.length only, so the longer weight array survived and the
+    // assign modal rendered a workout nobody authored.
+    const { onSubmit } = renderForm(
+      defaults([
+        exercise({
+          sets: 1,
+          reps: 8,
+          repsBySet: [8],
+          weightBySetKg: [24, 24, 23],
+        }),
+      ]),
+    );
+
+    const payload = await save(onSubmit);
+    const ex = payload.exercises[0];
+
+    expect(ex.sets).toBe(3);
+    expect(ex.repsBySet).toHaveLength(3);
+    expect(ex.weightBySetKg).toHaveLength(3);
+    // The declared count follows the longest authored array, and the short
+    // array is padded from the exercise-level fallback rather than truncating
+    // work the coach already entered.
+    expect(ex.repsBySet).toEqual([8, 8, 8]);
+    expect(ex.weightBySetKg).toEqual([24, 24, 23]);
+  });
+
+  it("pads a short weight array with 0 rather than leaving holes", async () => {
+    const { onSubmit } = renderForm(
+      defaults([
+        exercise({ sets: 3, reps: 10, repsBySet: [10, 10, 10], weightBySetKg: [40] }),
+      ]),
+    );
+
+    const payload = await save(onSubmit);
+
+    // A sparse array would serialize with nulls, which iOS's Codable rejects.
+    expect(payload.exercises[0].weightBySetKg).toEqual([40, 0, 0]);
+  });
+});
+
+describe("TemplateForm save — the 'Sin peso' sentinel (#159)", () => {
+  it("keeps an explicit empty weightBySetKg as a length-0 array", async () => {
+    // `weightBySetKg: []` IS the prescription: reps, no weight. Coercing it to
+    // undefined (dropped) or zero-filling it both change what the client sees.
+    const { onSubmit } = renderForm(
+      defaults([
+        exercise({ sets: 3, reps: 12, repsBySet: [12, 12, 12], weightBySetKg: [] }),
+      ]),
+    );
+
+    const payload = await save(onSubmit);
+    const ex = payload.exercises[0];
+
+    expect(ex.weightBySetKg).toEqual([]);
+    // And the sentinel must not shrink the set count with it.
+    expect(ex.sets).toBe(3);
+    expect(ex.repsBySet).toEqual([12, 12, 12]);
+  });
+});
+
+describe("TemplateForm save — setTypesBySet (#403)", () => {
+  it("OMITS the key entirely when every set is normal", async () => {
+    const { onSubmit } = renderForm(
+      defaults([
+        exercise({ sets: 2, repsBySet: [10, 10], setTypesBySet: ["normal", "normal"] }),
+      ]),
+    );
+
+    const payload = await save(onSubmit);
+
+    // `in`, not `toBeUndefined()`: the wire contract is that the key is ABSENT.
+    // Present-with-undefined is what makes the Admin SDK throw
+    // "Cannot use 'undefined' as a Firestore value".
+    expect("setTypesBySet" in payload.exercises[0]).toBe(false);
+  });
+
+  it("keeps and pads the array when any set is non-normal", async () => {
+    const { onSubmit } = renderForm(
+      defaults([
+        exercise({
+          sets: 3,
+          repsBySet: [10, 10, 10],
+          setTypesBySet: ["warmup"], // shorter than the set count
+        }),
+      ]),
+    );
+
+    const payload = await save(onSubmit);
+
+    // Padded POSITIONALLY with "normal" — the first set stays the warmup.
+    expect(payload.exercises[0].setTypesBySet).toEqual([
+      "warmup",
+      "normal",
+      "normal",
+    ]);
+  });
+
+  it("writes the type the coach picks in the per-set menu", async () => {
+    const user = userEvent.setup();
+    const { onSubmit } = renderForm(
+      defaults([exercise({ sets: 3, reps: 10, repsBySet: [10, 10, 10] })]),
+    );
+
+    await goToDetails(user);
+    // The set-number cell IS the type picker trigger. Its aria-label is
+    // hardcoded Spanish in the component, catalog or no catalog.
+    await user.click(
+      screen.getByRole("button", { name: /^Tipo de la serie 2:/ }),
+    );
+    await user.click(await screen.findByRole("menuitem", { name: /fallo/i }));
+
+    const payload = await save(onSubmit);
+
+    // Positional: set 2 and only set 2.
+    expect(payload.exercises[0].setTypesBySet).toEqual([
+      "normal",
+      "failure",
+      "normal",
+    ]);
+  });
+});
+
+describe("TemplateForm save — supersets", () => {
+  // NOTE — this is the ONE per-exercise key that does NOT follow the
+  // "omit when empty" convention, and the test asserts what the form really
+  // emits, not what the code reads like it emits.
+  //
+  // The normalizer spreads `...ex` FIRST and then tries to omit a blank group
+  // with a conditional spread:
+  //     ...(ex.supersetGroup?.trim() ? { supersetGroup: ex.supersetGroup.trim() } : {})
+  // A conditional spread can only ADD a key — `...ex` already put
+  // `supersetGroup` in the object, so the blank case emits `""` rather than
+  // omitting. (`setTypesBySet` a few lines below gets this right by using an
+  // explicit `delete`.) The trim half is dead too: `values` is the ZOD-PARSED
+  // object and `supersetGroupSchema` is `.trim()`ed, so nothing untrimmed ever
+  // reaches here.
+  //
+  // Not a live bug: `""` is a legal Firestore value (only `undefined` throws)
+  // and every reader goes through `normalizeSupersetGroup` + a truthiness
+  // check, so an empty label is "no group" on all three surfaces. Pinned here
+  // so the next person doesn't read the source and assume omission.
+  it("emits '' for a blank group — the conditional spread does not omit", async () => {
+    const { onSubmit } = renderForm(
+      defaults([
+        exercise({ exerciseId: "a", supersetGroup: " B " }),
+        exercise({ exerciseId: "b", supersetGroup: "   " }),
+      ]),
+    );
+
+    const payload = await save(onSubmit);
+
+    // Trimmed — by Zod, on the way in.
+    expect(payload.exercises[0].supersetGroup).toBe("B");
+    expect(payload.exercises[1].supersetGroup).toBe("");
+    // What DOES matter, and is the reason the key can stay: never `undefined`,
+    // which is the value the Admin SDK throws on.
+    expect(payload.exercises[1].supersetGroup).not.toBeUndefined();
+  });
+
+  it("propagates a set-count change from the leader to every member", async () => {
+    const user = userEvent.setup();
+    const { onSubmit } = renderForm(
+      defaults([
+        exercise({ exerciseId: "a", supersetGroup: "A", sets: 3, repsBySet: [10, 10, 10] }),
+        exercise({ exerciseId: "b", supersetGroup: "A", sets: 3, repsBySet: [10, 10, 10] }),
+        exercise({ exerciseId: "solo", sets: 3, repsBySet: [10, 10, 10] }),
+      ]),
+    );
+
+    await goToDetails(user);
+    const leaderSets = document.querySelector<HTMLInputElement>(
+      '[data-field-sets="0"]',
+    )!;
+    await user.clear(leaderSets);
+    await user.type(leaderSets, "4");
+    await user.tab(); // commits on blur
+
+    const payload = await save(onSubmit);
+
+    // A superset is one round: members running a different number of sets is
+    // not a thing the client app can execute.
+    expect(payload.exercises[0].sets).toBe(4);
+    expect(payload.exercises[1].sets).toBe(4);
+    // …and the change is scoped to the group.
+    expect(payload.exercises[2].sets).toBe(3);
+  });
+
+  it("locks a follower's set count in the UI", async () => {
+    const user = userEvent.setup();
+    renderForm(
+      defaults([
+        exercise({ exerciseId: "a", supersetGroup: "A" }),
+        exercise({ exerciseId: "b", supersetGroup: "A" }),
+      ]),
+    );
+
+    await goToDetails(user);
+
+    // The guard the coach actually meets: a follower can't be edited into a
+    // different count in the first place, so the propagation above is the only
+    // way the numbers change.
+    expect(
+      document.querySelector('[data-field-sets="1"]'),
+    ).toBeDisabled();
+    expect(
+      document.querySelector('[data-field-sets="0"]'),
+    ).not.toBeDisabled();
+  });
+});
+
+describe("TemplateForm save — legacy `endsOn` from an old draft", () => {
+  it("never reaches the payload", async () => {
+    // Templates lost their end date in 703d8b2, but `endsOn` is still a key in
+    // `workoutTemplateSchema`, so a draft written before that commit parses
+    // clean and would be persisted onto the template doc. The restore path
+    // strips it; this is the only test that watches it do so.
+    const draftKey = "edit:tpl-legacy";
+    window.localStorage.setItem(
+      `${DRAFT_PREFIX}${draftKey}`,
+      JSON.stringify({
+        ...defaults([exercise()]),
+        endsOn: "2026-12-31",
+      }),
+    );
+
+    const { onSubmit } = renderForm(defaults([exercise()]), draftKey);
+
+    const payload = await save(onSubmit);
+
+    expect("endsOn" in payload).toBe(false);
+  });
+
+  it("keeps restoring the rest of that draft", async () => {
+    // The strip must be surgical — a draft that loses its exercises on restore
+    // is worse than one that carries a dead field.
+    const draftKey = "edit:tpl-legacy-2";
+    window.localStorage.setItem(
+      `${DRAFT_PREFIX}${draftKey}`,
+      JSON.stringify({
+        ...defaults([exercise({ exerciseId: "drafted", sets: 5, repsBySet: [6, 6, 6, 6, 6] })]),
+        endsOn: "2026-12-31",
+      }),
+    );
+
+    const { onSubmit } = renderForm(defaults([exercise()]), draftKey);
+
+    const payload = await save(onSubmit);
+
+    expect(payload.exercises[0].exerciseId).toBe("drafted");
+    expect(payload.exercises[0].sets).toBe(5);
+  });
+});
+
+describe("TemplateForm save — the legacy `tag` mirror", () => {
+  it("mirrors tags[0] onto `tag` so un-migrated clients keep reading", async () => {
+    const { onSubmit } = renderForm(
+      defaults([exercise()], { tag: "stale", tags: ["pull", "upper"] }),
+    );
+
+    const payload = await save(onSubmit);
+
+    expect(payload.tags).toEqual(["pull", "upper"]);
+    expect(payload.tag).toBe("pull");
+  });
+});

--- a/backoffice/src/components/gc-fitness/__tests__/workout-assignment-edit-dialog.test.tsx
+++ b/backoffice/src/components/gc-fitness/__tests__/workout-assignment-edit-dialog.test.tsx
@@ -1,0 +1,260 @@
+/**
+ * @jest-environment jsdom
+ */
+
+// workout-assignment-edit-dialog.test.tsx
+//
+// Editing a workout the coach already assigned. Distinct from the assign modal
+// in one way that matters: this edits the ASSIGNMENT, never the template
+// (`editAssignmentExercises`), and it can fan the edit out across a whole
+// series.
+//
+// The FIRST THREE LINES of this file MUST stay as the
+// `/** @jest-environment jsdom */` docblock — the backoffice jest config
+// defaults to `testEnvironment: "node"` so without it React Testing Library
+// crashes with `ReferenceError: document is not defined`.
+//
+// What these tests protect:
+//
+//   1. THE SCOPE. "Solo este día" must not reach into the series, and "Toda la
+//      serie (futuros)" must. The scope is a plain string in the payload — swap
+//      it and you rewrite every future occurrence of a client's plan with no
+//      error anywhere.
+//   2. THE SECOND ACTION. Changing the series end date fires a SECOND call,
+//      `editAssignmentRecurrence`, and it must carry the series' EXISTING
+//      recurrence rule. Inventing a rule here silently reshapes which days the
+//      client trains.
+//   3. THE GUARDS, which stop a destructive multi-occurrence write on a draft
+//      that isn't complete.
+
+import "@testing-library/jest-dom";
+
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import React from "react";
+
+import { WorkoutAssignmentEditDialog } from "@/components/gc-fitness/schedule/workout-assignment-edit-dialog";
+import type { AssignmentDetail } from "@/lib/gc-fitness/schedule-month-actions";
+
+const mockGetAssignmentDetail = jest.fn();
+jest.mock("@/lib/gc-fitness/schedule-month-actions", () => ({
+  getAssignmentDetail: (...args: unknown[]) => mockGetAssignmentDetail(...args),
+}));
+
+const mockEditExercises = jest.fn();
+const mockEditRecurrence = jest.fn();
+jest.mock("@/lib/gc-fitness/workout-assignment-actions", () => ({
+  editAssignmentExercises: (...args: unknown[]) => mockEditExercises(...args),
+  editAssignmentRecurrence: (...args: unknown[]) => mockEditRecurrence(...args),
+}));
+
+jest.mock("@/lib/gc-fitness/exercises-listener", () => ({
+  useExercisesQuery: () => ({ data: [] }),
+}));
+
+// The picker is its own tested surface; stub it so the rows render statically.
+jest.mock("@/components/gc-fitness/exercise-picker-popover", () => ({
+  ExercisePickerPopover: () => null,
+}));
+
+const mockToastSuccess = jest.fn();
+const mockToastError = jest.fn();
+jest.mock("sonner", () => ({
+  toast: {
+    success: (...args: unknown[]) => mockToastSuccess(...args),
+    error: (...args: unknown[]) => mockToastError(...args),
+  },
+}));
+
+function exercise(overrides: Record<string, unknown> = {}) {
+  return {
+    index: 0,
+    exerciseId: "ex-bench",
+    exerciseName: "Bench Press",
+    previewUrl: null,
+    sets: 3,
+    reps: 10,
+    rest_seconds: 90,
+    transition_rest_seconds: 120,
+    notes: "",
+    repsBySet: [10, 10, 10],
+    weightBySetKg: [60, 60, 60],
+    hasExplicitNoWeightPrescription: false,
+    supersetGroup: null,
+    ...overrides,
+  };
+}
+
+function detail(overrides: Partial<AssignmentDetail> = {}): AssignmentDetail {
+  return {
+    id: "assign-1",
+    clientId: "client-1",
+    clientName: "Ana",
+    coachName: "Manu",
+    scheduledFor: "2026-08-05",
+    scheduledTime: null,
+    status: "scheduled",
+    templateName: "Push Day",
+    templateTag: "push",
+    meetingNotes: null,
+    seriesId: "series-1",
+    recurrence: { kind: "weekly", weekday: 3 },
+    seriesEndDate: "2026-10-05",
+    exercises: [exercise()],
+    selfAssigned: false,
+    ...overrides,
+  } as AssignmentDetail;
+}
+
+function renderDialog() {
+  const onSaved = jest.fn();
+  const onOpenChange = jest.fn();
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  render(
+    <QueryClientProvider client={client}>
+      <WorkoutAssignmentEditDialog
+        open
+        onOpenChange={onOpenChange}
+        assignmentId="assign-1"
+        onSaved={onSaved}
+      />
+    </QueryClientProvider>,
+  );
+  return { onSaved, onOpenChange };
+}
+
+/**
+ * The dialog loads through react-query. Anchor on the scope control, which only
+ * renders once the detail resolved AND the assignment is a series — the exercise
+ * NAME is not a usable anchor here because it is rendered by the picker, which
+ * these tests stub out.
+ */
+async function waitForLoaded() {
+  await screen.findByRole("button", { name: /Solo este día/i });
+}
+
+function saveButton() {
+  return screen.getByRole("button", { name: /^Guardar/i });
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockGetAssignmentDetail.mockResolvedValue(detail());
+  mockEditExercises.mockResolvedValue({ updatedCount: 1 });
+  mockEditRecurrence.mockResolvedValue({ createdCount: 4 });
+});
+
+describe("WorkoutAssignmentEditDialog — scope", () => {
+  it("defaults to 'one' so a plain edit never touches the rest of the series", async () => {
+    const user = userEvent.setup();
+    const { onSaved } = renderDialog();
+    await waitForLoaded();
+
+    await user.click(saveButton());
+
+    await waitFor(() => expect(mockEditExercises).toHaveBeenCalledTimes(1));
+    // The safe default is the whole point: a coach fixing today's weights must
+    // not silently rewrite every future occurrence.
+    expect(mockEditExercises.mock.calls[0][1].scope).toBe("one");
+    expect(mockEditExercises.mock.calls[0][0]).toBe("assign-1");
+    expect(onSaved).toHaveBeenCalledTimes(1);
+  });
+
+  it("sends scope 'series' once the coach picks the series option", async () => {
+    const user = userEvent.setup();
+    renderDialog();
+    await waitForLoaded();
+
+    await user.click(screen.getByRole("button", { name: /Toda la serie/i }));
+    await user.click(saveButton());
+
+    await waitFor(() => expect(mockEditExercises).toHaveBeenCalledTimes(1));
+    expect(mockEditExercises.mock.calls[0][1].scope).toBe("series");
+  });
+
+  it("does not touch the recurrence when only exercises changed", async () => {
+    const user = userEvent.setup();
+    renderDialog();
+    await waitForLoaded();
+
+    await user.click(saveButton());
+
+    await waitFor(() => expect(mockEditExercises).toHaveBeenCalledTimes(1));
+    // A delete-future + re-expand is expensive and destructive. It must fire
+    // ONLY when the end date actually moved.
+    expect(mockEditRecurrence).not.toHaveBeenCalled();
+  });
+});
+
+describe("WorkoutAssignmentEditDialog — the payload it builds", () => {
+  it("sends the exercise rows with a set-type entry per set", async () => {
+    const user = userEvent.setup();
+    renderDialog();
+    await waitForLoaded();
+
+    await user.click(saveButton());
+
+    await waitFor(() => expect(mockEditExercises).toHaveBeenCalledTimes(1));
+    const payload = mockEditExercises.mock.calls[0][1];
+    expect(payload.exercises).toHaveLength(1);
+    const [row] = payload.exercises;
+    expect(row.exerciseId).toBe("ex-bench");
+    // #403 — the FULL aligned array is always sent; the server decides whether
+    // to persist or delete the key. A short array silently mis-labels sets.
+    expect(row.setTypesBySet).toHaveLength(row.repsBySet.length);
+    expect(row.setTypesBySet.every((t: string) => typeof t === "string")).toBe(
+      true,
+    );
+  });
+
+  it("reports the server's updated count rather than assuming one", async () => {
+    const user = userEvent.setup();
+    mockEditExercises.mockResolvedValueOnce({ updatedCount: 6 });
+    renderDialog();
+    await waitForLoaded();
+
+    await user.click(screen.getByRole("button", { name: /Toda la serie/i }));
+    await user.click(saveButton());
+
+    await waitFor(() =>
+      expect(mockToastSuccess).toHaveBeenCalledWith(
+        "6 ocurrencias actualizadas",
+      ),
+    );
+  });
+});
+
+describe("WorkoutAssignmentEditDialog — failure handling", () => {
+  it("surfaces the server message and does NOT report success upstream", async () => {
+    const user = userEvent.setup();
+    mockEditExercises.mockRejectedValueOnce(
+      new Error("La serie ya no existe."),
+    );
+    const { onSaved } = renderDialog();
+    await waitForLoaded();
+
+    await user.click(saveButton());
+
+    await waitFor(() =>
+      expect(mockToastError).toHaveBeenCalledWith("La serie ya no existe."),
+    );
+    // onSaved invalidates the calendar — calling it after a failed write paints
+    // the coach a calendar that disagrees with Firestore.
+    expect(onSaved).not.toHaveBeenCalled();
+  });
+
+  it("re-enables Guardar after a failure so the coach can retry", async () => {
+    const user = userEvent.setup();
+    mockEditExercises.mockRejectedValueOnce(new Error("boom"));
+    renderDialog();
+    await waitForLoaded();
+
+    await user.click(saveButton());
+
+    await waitFor(() => expect(mockToastError).toHaveBeenCalled());
+    expect(saveButton()).toBeEnabled();
+  });
+});

--- a/backoffice/src/components/gc-fitness/__tests__/workout-detail-dialog.test.tsx
+++ b/backoffice/src/components/gc-fitness/__tests__/workout-detail-dialog.test.tsx
@@ -1,0 +1,177 @@
+/**
+ * @jest-environment jsdom
+ */
+
+// workout-detail-dialog.test.tsx
+//
+// The read surface behind a workout chip on the calendar, and the gate for
+// every mutating CTA on it.
+//
+// The FIRST THREE LINES of this file MUST stay as the
+// `/** @jest-environment jsdom */` docblock — the backoffice jest config
+// defaults to `testEnvironment: "node"` so without it React Testing Library
+// crashes with `ReferenceError: document is not defined`.
+//
+// The invariant under test is issue #449: a CLIENT-CREATED workout
+// (`selfAssigned`) is READ-ONLY for the coach. They can look at the
+// prescription, but edit / recurrence / delete and the coach-run live session
+// must all be hidden — it isn't the coach's workout to manage.
+//
+// This is worth pinning because the failure is quiet in both directions:
+//   • Leaking the CTAs lets a coach edit or delete a workout the client made
+//     for themselves, which the client experiences as their own plan changing
+//     under them.
+//   • Over-hiding them makes normal coach-assigned workouts unmanageable, and
+//     nothing errors — the buttons are simply not there.
+//
+// The status gate rides along on the same CTAs: a completed or missed workout
+// has no live session to start and no future occurrences to reshape.
+
+import "@testing-library/jest-dom";
+
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen } from "@testing-library/react";
+import React from "react";
+
+import { WorkoutDetailDialog } from "@/components/gc-fitness/schedule/workout-detail-dialog";
+import type { AssignmentDetail } from "@/lib/gc-fitness/schedule-month-actions";
+
+const mockGetAssignmentDetail = jest.fn();
+jest.mock("@/lib/gc-fitness/schedule-month-actions", () => ({
+  getAssignmentDetail: (...args: unknown[]) => mockGetAssignmentDetail(...args),
+}));
+
+// The log panel loads separately; keep it out of the way.
+jest.mock("@/lib/gc-fitness/recent-logs-actions", () => ({
+  getWorkoutLogDetail: jest.fn().mockResolvedValue(null),
+}));
+
+jest.mock("@/components/gc-fitness/workout-log-detail-view", () => ({
+  WorkoutLogDetailView: () => null,
+}));
+
+jest.mock("@/components/gc-fitness/schedule/workout-assignment-edit-dialog", () => ({
+  WorkoutAssignmentEditDialog: () => null,
+}));
+
+jest.mock("@/components/gc-fitness/schedule/workout-recurrence-edit-dialog", () => ({
+  WorkoutRecurrenceEditDialog: () => null,
+}));
+
+jest.mock("@/components/gc-fitness/workout-assignment-delete-dialog", () => ({
+  WorkoutAssignmentDeleteDialog: () => null,
+}));
+
+jest.mock("sonner", () => ({
+  toast: { success: jest.fn(), error: jest.fn() },
+}));
+
+function detail(overrides: Partial<AssignmentDetail> = {}): AssignmentDetail {
+  return {
+    id: "assign-1",
+    clientId: "client-1",
+    clientName: "Ana",
+    coachName: "Manu",
+    scheduledFor: "2026-09-17",
+    scheduledTime: null,
+    status: "scheduled",
+    templateName: "Push Day",
+    templateTag: "push",
+    meetingNotes: null,
+    seriesId: "series-1",
+    recurrence: { kind: "weekly", weekday: 4 },
+    seriesEndDate: "2026-12-17",
+    exercises: [],
+    selfAssigned: false,
+    ...overrides,
+  } as AssignmentDetail;
+}
+
+async function renderDialog(d: AssignmentDetail) {
+  mockGetAssignmentDetail.mockResolvedValue(d);
+  const onDeleted = jest.fn();
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  render(
+    <QueryClientProvider client={client}>
+      <WorkoutDetailDialog
+        open
+        onOpenChange={jest.fn()}
+        assignmentId="assign-1"
+        onDeleted={onDeleted}
+      />
+    </QueryClientProvider>,
+  );
+  // Anchor on the template name, which only renders once the detail resolved.
+  // It appears more than once (dialog title + body), so match all.
+  await screen.findAllByText(/Push Day/);
+  return { onDeleted };
+}
+
+function queryButton(pattern: RegExp) {
+  return screen.queryByRole("button", { name: pattern });
+}
+
+/** "Iniciar entrenamiento" is a Link rendered `asChild` inside a Button. */
+function queryStartLink() {
+  return screen.queryByRole("link", { name: /entrenamiento|Continuar/i });
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe("WorkoutDetailDialog — a COACH-assigned workout is manageable", () => {
+  it("offers edit, recurrence, delete and the live session", async () => {
+    await renderDialog(detail());
+
+    // Anchored: a bare /Editar/ also matches "Editar recurrencia".
+    expect(queryButton(/^Editar$/)).toBeInTheDocument();
+    expect(queryButton(/Editar recurrencia/)).toBeInTheDocument();
+    expect(queryButton(/Eliminar/)).toBeInTheDocument();
+    expect(queryStartLink()).toBeInTheDocument();
+  });
+});
+
+describe("WorkoutDetailDialog — a CLIENT-created workout is read-only (#449)", () => {
+  it("hides every mutating CTA and the coach-run live session", async () => {
+    await renderDialog(detail({ selfAssigned: true }));
+
+    // The coach may look, not manage: this workout belongs to the client.
+    expect(queryButton(/Editar recurrencia/)).not.toBeInTheDocument();
+    expect(queryButton(/Eliminar/)).not.toBeInTheDocument();
+    expect(queryStartLink()).not.toBeInTheDocument();
+  });
+
+  it("still shows the workout itself, with the client-created badge", async () => {
+    await renderDialog(detail({ selfAssigned: true }));
+
+    // Read-only must not mean invisible — the coach needs to see what their
+    // client is doing.
+    expect(screen.getAllByText(/Push Day/).length).toBeGreaterThan(0);
+  });
+});
+
+describe("WorkoutDetailDialog — finished workouts", () => {
+  it("drops the live-session entry once the workout is completed", async () => {
+    await renderDialog(detail({ status: "completed" }));
+
+    // Nothing left to run; the log is what matters now.
+    expect(queryStartLink()).not.toBeInTheDocument();
+  });
+
+  it("drops 'Editar recurrencia' on a completed occurrence", async () => {
+    await renderDialog(detail({ status: "completed" }));
+
+    // Reshaping a series from an occurrence already in the past would rewrite
+    // history the client already lived.
+    expect(queryButton(/Editar recurrencia/)).not.toBeInTheDocument();
+  });
+
+  it("drops 'Editar recurrencia' on a single (non-series) assignment", async () => {
+    await renderDialog(detail({ seriesId: null, recurrence: null }));
+
+    expect(queryButton(/Editar recurrencia/)).not.toBeInTheDocument();
+  });
+});

--- a/backoffice/src/components/gc-fitness/__tests__/workout-generator-wizard.test.tsx
+++ b/backoffice/src/components/gc-fitness/__tests__/workout-generator-wizard.test.tsx
@@ -1,0 +1,438 @@
+/**
+ * @jest-environment jsdom
+ */
+
+// workout-generator-wizard.test.tsx
+//
+// SCOPE: the wizard as a SHELL. The engine underneath it
+// (`lib/gc-fitness/workout-generator`) is pure and already has its own suite;
+// the editor it hands off to (`TemplateForm`) has `template-form-save.test.tsx`.
+// What has never been covered is the seam between them — the wizard's real job
+// is to build the POOL and translate the engine's output into TemplateForm
+// `defaultValues`, and both of those are silent when they go wrong: the coach
+// gets a workout, it just contains the wrong exercises or the wrong
+// prescription shape.
+//
+// The FIRST THREE LINES of this file MUST stay as the
+// `/** @jest-environment jsdom */` docblock — the backoffice jest config
+// defaults to `testEnvironment: "node"` so without it React Testing Library
+// crashes with `ReferenceError: document is not defined`.
+//
+// So TemplateForm is stubbed and the props crossing that boundary are the
+// assertions (the pattern that worked best on the other shells). What that
+// pins:
+//
+//   • THE POOL IS THE CURATED STANDARD LIBRARY ONLY, deduped. Legacy wger/fexd
+//     docs and coach customs must not leak in (#296), and the double-seeded
+//     `std-*` twins must appear once (#179) — otherwise the generator can emit
+//     the same movement twice, or emit one with broken `gs://` media.
+//   • THE "SIN PESO" SENTINEL. A no-load exercise ships `weightBySetKg: []`
+//     (#159/#206 wire contract); anything loadable must NOT, or the coach
+//     loses the weight column on a barbell movement.
+//   • A TIME-METRIC exercise ships `reps: 0` + `durationSeconds`, never reps.
+//   • REGENERATE REMOUNTS the editor with a different seed — without the `key`
+//     bump React keeps the old form state and the "new" workout is the old one.
+
+import "@testing-library/jest-dom";
+
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import React from "react";
+
+import type { ExerciseRow } from "@/lib/gc-fitness/exercises-listener";
+
+// Every module below reaches Firebase at import time (firebase-admin on the
+// action, the web SDK on the two hooks) and explodes under jsdom.
+const mockUseExercisesQuery = jest.fn();
+jest.mock("@/lib/gc-fitness/exercises-listener", () => ({
+  useExercisesQuery: () => mockUseExercisesQuery(),
+}));
+
+const mockUseFavorites = jest.fn();
+jest.mock("@/lib/gc-fitness/use-favorites", () => ({
+  useFavorites: () => mockUseFavorites(),
+}));
+
+const mockCreateWorkoutTemplate = jest.fn();
+jest.mock("@/lib/gc-fitness/workout-template-actions", () => ({
+  createWorkoutTemplate: (...args: unknown[]) => mockCreateWorkoutTemplate(...args),
+}));
+
+jest.mock("sonner", () => ({
+  toast: { success: jest.fn(), error: jest.fn() },
+}));
+
+// The editor. Its own contract (order renumbering, per-set arrays, the
+// superset propagation) is pinned in template-form-save.test.tsx; here it is a
+// probe that records the props it was handed and exposes the two callbacks the
+// wizard depends on.
+const mockTemplateFormProps = jest.fn();
+const mockTemplateFormMounted = jest.fn();
+jest.mock("@/components/gc-fitness/template-form", () => ({
+  TemplateForm: (props: Record<string, unknown>) => {
+    mockTemplateFormProps(props);
+    // `key` never reaches props — React consumes it — so a REMOUNT is observed
+    // the only way it can be: by counting mounts.
+    // eslint-disable-next-line react-hooks/rules-of-hooks
+    React.useEffect(() => {
+      mockTemplateFormMounted();
+    }, []);
+    return (
+      <div data-testid="template-form">
+        <button
+          type="button"
+          onClick={() => (props.onCreated as (id: string) => void)("tpl-new")}
+        >
+          fake-save
+        </button>
+      </div>
+    );
+  },
+}));
+
+const mockAssignModalProps = jest.fn();
+jest.mock("@/components/gc-fitness/generator/assign-generated-modal", () => ({
+  AssignGeneratedModal: (props: { open: boolean; templateId: string }) => {
+    mockAssignModalProps(props);
+    return props.open ? (
+      <div data-testid="assign-modal">{props.templateId}</div>
+    ) : null;
+  },
+}));
+
+import { WorkoutGeneratorWizard } from "@/components/gc-fitness/generator/workout-generator-wizard";
+
+const STANDARD_TAG = "standard-library";
+
+function exercise(overrides: Partial<ExerciseRow> = {}): ExerciseRow {
+  return {
+    id: "std-1",
+    name: { en: "Barbell Bench Press", es: "Press de banca" },
+    description: { en: "", es: "" },
+    muscleGroups: ["chest"],
+    equipment: ["barbell", "bench"],
+    mediaURL: null,
+    thumbnailURL: null,
+    youtubeURL: null,
+    keywords: [],
+    tags: [STANDARD_TAG],
+    variations: [],
+    source: "wger",
+    ownerId: null,
+    version: 1,
+    updatedAt: null,
+    createdAt: null,
+    deleted: false,
+    ...overrides,
+  } as ExerciseRow;
+}
+
+function renderWizard(library: ExerciseRow[]) {
+  mockUseExercisesQuery.mockReturnValue({ data: library, isLoading: false });
+  render(<WorkoutGeneratorWizard clients={[]} trainerTimezone="UTC" />);
+  return { user: userEvent.setup() };
+}
+
+/**
+ * The chip for an equipment / muscle / preset label.
+ *
+ * Chips are the only buttons carrying `aria-pressed`, which is what tells the
+ * "Back" MUSCLE GROUP apart from the "Back" NAV BUTTON sitting on the same
+ * screen — `getByRole("button", { name: "Back" })` finds both.
+ */
+function chip(label: string): HTMLElement {
+  const node = screen
+    .getAllByRole("button", { name: label })
+    .find((el) => el.hasAttribute("aria-pressed"));
+  if (!node) throw new Error(`no chip labelled ${label}`);
+  return node;
+}
+
+/** A wizard nav button ("Next" / "Back" / "Generate workout") — never a chip. */
+function nav(label: RegExp): HTMLElement {
+  const node = screen
+    .getAllByRole("button", { name: label })
+    .find((el) => !el.hasAttribute("aria-pressed"));
+  if (!node) throw new Error(`no nav button matching ${label}`);
+  return node;
+}
+
+/**
+ * Walk steps 1→4 and generate: pick the equipment and muscles the fixtures
+ * need, accept the volume/type defaults, press Generate.
+ */
+async function generate(
+  user: ReturnType<typeof userEvent.setup>,
+  opts: { equipment: string[]; muscles: string[] },
+) {
+  for (const label of opts.equipment) await user.click(chip(label));
+  await user.click(nav(/Next/));
+  for (const label of opts.muscles) await user.click(chip(label));
+  await user.click(nav(/Next/));
+  await user.click(nav(/Next/)); // volume defaults
+  await user.click(nav(/Generate workout/));
+}
+
+/** The `defaultValues` the wizard handed the editor on its last render. */
+function lastDefaults(): {
+  name: { en: string; es: string };
+  tag: string;
+  tags: string[];
+  exercises: Array<Record<string, unknown>>;
+} {
+  const props = mockTemplateFormProps.mock.calls.at(-1)?.[0];
+  return props.defaultValues;
+}
+
+function generatedIds(): string[] {
+  return lastDefaults().exercises.map((e) => e.exerciseId as string);
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockUseFavorites.mockReturnValue({ favorites: { exerciseIds: [] } });
+  mockCreateWorkoutTemplate.mockResolvedValue("tpl-new");
+});
+
+describe("WorkoutGeneratorWizard — the pool it draws from", () => {
+  it("uses ONLY the curated standard library", async () => {
+    // A coach custom and a legacy catalog doc, both chest+barbell, both
+    // otherwise eligible — they must not appear in a generated workout.
+    const { user } = renderWizard([
+      exercise({ id: "std-bench" }),
+      exercise({ id: "coach-custom", tags: [], ownerId: "trainer-1", source: "trainer" }),
+      exercise({ id: "legacy-wger", tags: ["wger-import"] }),
+    ]);
+
+    await generate(user, { equipment: ["Barbell", "Bench"], muscles: ["Chest"] });
+
+    expect(generatedIds()).toEqual(["std-bench"]);
+  });
+
+  it("drops soft-deleted library docs", async () => {
+    const { user } = renderWizard([
+      exercise({ id: "std-bench" }),
+      // A DISTINCT name on purpose: with the same name as the live doc, the
+      // display-name dedupe collapses the pair and the test passes with the
+      // `deleted` filter deleted (verified by mutation).
+      exercise({
+        id: "std-gone",
+        name: { en: "Incline Bench Press", es: "Press inclinado" },
+        deleted: true,
+      }),
+    ]);
+
+    await generate(user, { equipment: ["Barbell", "Bench"], muscles: ["Chest"] });
+
+    expect(generatedIds()).not.toContain("std-gone");
+  });
+
+  it("collapses the double-seeded twins into one exercise (#179)", async () => {
+    // Prod carries the same movement twice: the canonical numeric-id doc and a
+    // `std-*` twin with broken gs:// media. Without the dedupe the generator
+    // can put the SAME movement in the workout twice.
+    const { user } = renderWizard([
+      exercise({ id: "1234", name: { en: "Barbell Bench Press", es: "Press de banca" } }),
+      exercise({ id: "std-1234", name: { en: "Barbell Bench Press", es: "Press de banca" } }),
+      exercise({
+        id: "5678",
+        name: { en: "Push Up", es: "Flexiones" },
+        equipment: ["bodyweight"],
+      }),
+    ]);
+
+    await generate(user, {
+      equipment: ["Barbell", "Bench", "Bodyweight"],
+      muscles: ["Chest"],
+    });
+
+    const ids = generatedIds();
+    expect(new Set(ids).size).toBe(ids.length);
+    expect(ids).not.toContain("std-1234");
+  });
+
+  it("refuses an exercise whose equipment is not fully available", async () => {
+    // The engine's hard rule: EVERY required piece must be selected. Bench is
+    // required by the barbell press and is not on the list.
+    const { user } = renderWizard([
+      exercise({ id: "std-bench" }),
+      exercise({ id: "std-pushup", name: { en: "Push Up", es: "Flexiones" }, equipment: ["bodyweight"] }),
+    ]);
+
+    await generate(user, { equipment: ["Bodyweight"], muscles: ["Chest"] });
+
+    expect(generatedIds()).toEqual(["std-pushup"]);
+  });
+});
+
+describe("WorkoutGeneratorWizard — the prescription shape it hands the editor", () => {
+  it("seeds the 'Sin peso' sentinel ONLY on no-load exercises", async () => {
+    // `weightBySetKg: []` is the reps-without-weight wire contract (#206). On a
+    // barbell movement it would take the weight column away from the coach.
+    const { user } = renderWizard([
+      exercise({ id: "std-pushup", name: { en: "Push Up", es: "Flexiones" }, equipment: ["bodyweight"] }),
+      exercise({ id: "std-pullup", name: { en: "Pull Up", es: "Dominadas" }, equipment: ["pull_up_bar"], muscleGroups: ["back"] }),
+      exercise({ id: "std-row", name: { en: "Barbell Row", es: "Remo" }, equipment: ["barbell"], muscleGroups: ["back"] }),
+    ]);
+
+    await generate(user, {
+      equipment: ["Bodyweight", "Pull-up bar", "Barbell"],
+      muscles: ["Chest", "Back"],
+    });
+
+    const byId = new Map(
+      lastDefaults().exercises.map((e) => [e.exerciseId as string, e]),
+    );
+    expect(byId.get("std-pushup")).toHaveProperty("weightBySetKg", []);
+    expect(byId.get("std-pullup")).toHaveProperty("weightBySetKg", []);
+    expect(byId.get("std-row")).not.toHaveProperty("weightBySetKg");
+  });
+
+  it("gives a TIME exercise a duration and zero reps", async () => {
+    const { user } = renderWizard([
+      exercise({
+        id: "std-plank",
+        name: { en: "Plank", es: "Plancha" },
+        equipment: ["bodyweight"],
+        muscleGroups: ["abs"],
+        metric: "time",
+      } as Partial<ExerciseRow>),
+    ]);
+
+    await generate(user, { equipment: ["Bodyweight"], muscles: ["Abs"] });
+
+    const [first] = lastDefaults().exercises;
+    // NOTE: `reps: 0` here is the ENGINE's doing (engine.ts sets it for a time
+    // metric); the wizard repeats the same ternary, so mutating the wizard's
+    // copy changes nothing. The assertion is on the shape that reaches the
+    // editor, which is what the mobile apps read — whichever layer produces it.
+    expect(first).toMatchObject({ metric: "time", reps: 0 });
+    expect(first.durationSeconds).toBeGreaterThan(0);
+  });
+
+  it("numbers the exercises from 1, in order", async () => {
+    const { user } = renderWizard([
+      exercise({ id: "a", name: { en: "Push Up", es: "Flexiones" }, equipment: ["bodyweight"] }),
+      exercise({ id: "b", name: { en: "Dip", es: "Fondos" }, equipment: ["bodyweight"] }),
+      exercise({ id: "c", name: { en: "Fly", es: "Aperturas" }, equipment: ["bodyweight"] }),
+    ]);
+
+    await generate(user, { equipment: ["Bodyweight"], muscles: ["Chest"] });
+
+    expect(lastDefaults().exercises.map((e) => e.order)).toEqual([1, 2, 3]);
+  });
+
+  it("tags the workout with the chosen style, on both the tag and tags fields", async () => {
+    // `tag` is the legacy single field the mobile apps still read; `tags` is
+    // the array. They must not drift.
+    const { user } = renderWizard([
+      exercise({ id: "std-pushup", name: { en: "Push Up", es: "Flexiones" }, equipment: ["bodyweight"] }),
+    ]);
+
+    await generate(user, { equipment: ["Bodyweight"], muscles: ["Chest"] });
+
+    const { tag, tags } = lastDefaults();
+    expect(tags).toEqual([tag]);
+    expect(tag).toBeTruthy();
+  });
+
+  it("hands the editor the coach's own filters for the swap picker (#361)", async () => {
+    const { user } = renderWizard([
+      exercise({ id: "std-pushup", name: { en: "Push Up", es: "Flexiones" }, equipment: ["bodyweight"] }),
+    ]);
+
+    await generate(user, { equipment: ["Bodyweight"], muscles: ["Chest"] });
+
+    expect(mockTemplateFormProps.mock.calls.at(-1)?.[0]).toMatchObject({
+      mode: "create",
+      pickerInitialFilters: { muscles: ["chest"], equipment: ["bodyweight"] },
+    });
+  });
+});
+
+describe("WorkoutGeneratorWizard — the steps", () => {
+  it("will not advance past step 1 with no equipment picked", async () => {
+    const { user } = renderWizard([exercise()]);
+
+    expect(nav(/Next/)).toBeDisabled();
+
+    await user.click(chip("Barbell"));
+    expect(nav(/Next/)).toBeEnabled();
+  });
+
+  it("will not advance past step 2 with no muscles picked", async () => {
+    const { user } = renderWizard([exercise()]);
+
+    await user.click(chip("Barbell"));
+    await user.click(nav(/Next/));
+
+    expect(nav(/Next/)).toBeDisabled();
+  });
+
+  it("keeps the picks when stepping back", async () => {
+    const { user } = renderWizard([exercise()]);
+
+    await user.click(chip("Barbell"));
+    await user.click(nav(/Next/));
+    await user.click(nav(/Back/));
+
+    expect(chip("Barbell")).toHaveAttribute("aria-pressed", "true");
+  });
+
+  it("selects a whole bundle in one press, and clears it on a second", async () => {
+    const { user } = renderWizard([exercise()]);
+
+    await user.click(chip("Free weights"));
+    expect(chip("Barbell")).toHaveAttribute("aria-pressed", "true");
+
+    await user.click(chip("Free weights"));
+    expect(chip("Barbell")).toHaveAttribute("aria-pressed", "false");
+  });
+});
+
+describe("WorkoutGeneratorWizard — regenerate and save", () => {
+  it("REMOUNTS the editor on regenerate so the new workout actually applies", async () => {
+    // Same `key` → React reuses the form and its internal state, and the coach
+    // keeps editing the previous workout under a new heading.
+    const { user } = renderWizard([
+      exercise({ id: "a", name: { en: "Push Up", es: "Flexiones" }, equipment: ["bodyweight"] }),
+      exercise({ id: "b", name: { en: "Dip", es: "Fondos" }, equipment: ["bodyweight"] }),
+      exercise({ id: "c", name: { en: "Fly", es: "Aperturas" }, equipment: ["bodyweight"] }),
+    ]);
+
+    await generate(user, { equipment: ["Bodyweight"], muscles: ["Chest"] });
+    expect(mockTemplateFormMounted).toHaveBeenCalledTimes(1);
+
+    await user.click(nav(/Regenerate/));
+
+    expect(mockTemplateFormMounted).toHaveBeenCalledTimes(2);
+  });
+
+  it("lands on the success screen with the SAVED id, and assigns that one", async () => {
+    // The assign modal writes against this template id; handing it a stale one
+    // assigns a different workout than the coach just made.
+    const { user } = renderWizard([
+      exercise({ id: "std-pushup", name: { en: "Push Up", es: "Flexiones" }, equipment: ["bodyweight"] }),
+    ]);
+
+    await generate(user, { equipment: ["Bodyweight"], muscles: ["Chest"] });
+    await user.click(screen.getByRole("button", { name: "fake-save" }));
+
+    expect(screen.queryByTestId("template-form")).not.toBeInTheDocument();
+    await user.click(nav(/Assign/));
+    expect(screen.getByTestId("assign-modal")).toHaveTextContent("tpl-new");
+  });
+
+  it("'Generate another' returns to a blank step 1", async () => {
+    const { user } = renderWizard([
+      exercise({ id: "std-pushup", name: { en: "Push Up", es: "Flexiones" }, equipment: ["bodyweight"] }),
+    ]);
+
+    await generate(user, { equipment: ["Bodyweight"], muscles: ["Chest"] });
+    await user.click(screen.getByRole("button", { name: "fake-save" }));
+    await user.click(nav(/Generate another/));
+
+    expect(chip("Bodyweight")).toHaveAttribute("aria-pressed", "false");
+    expect(nav(/Next/)).toBeDisabled();
+  });
+});

--- a/backoffice/src/components/gc-fitness/__tests__/workout-log-detail-view.test.tsx
+++ b/backoffice/src/components/gc-fitness/__tests__/workout-log-detail-view.test.tsx
@@ -1,0 +1,477 @@
+/**
+ * @jest-environment jsdom
+ */
+
+// workout-log-detail-view.test.tsx
+//
+// The canonical read view of a workout that already happened — rendered both
+// on `/workouts/[logId]` and inside the calendar's WorkoutDetailDialog.
+//
+// The FIRST THREE LINES of this file MUST stay as the
+// `/** @jest-environment jsdom */` docblock — the backoffice jest config
+// defaults to `testEnvironment: "node"` so without it React Testing Library
+// crashes with `ReferenceError: document is not defined`.
+//
+// This is the ONE component in this regression net whose assertions are on the
+// SCREEN rather than on an outgoing payload — the component is presentational
+// and writes nothing. Its output IS the contract: it takes a resolved
+// `WorkoutLogDetail` and is the only place a coach ever sees what their client
+// actually did. Everything below is derived, and every derivation can be
+// wrong in a way that still renders a perfectly convincing table:
+//
+//   • THE CLIENT'S TIMEZONE, not the host's (#747 sibling). The page is server
+//     rendered on Vercel, i.e. in UTC. A workout finished at 23:15 in Buenos
+//     Aires is 02:15 the NEXT DAY in UTC — so a dropped `timeZone`/`locale`
+//     moves someone's Tuesday session to Wednesday.
+//   • THE COMPLETION TIME IS RECONSTRUCTED. iOS writes the authoritative
+//     elapsed time as `duration_seconds`; `completedAt` is unreliable and is
+//     frequently stamped equal to `startedAt`. When it is, the view derives
+//     start + duration instead of showing a workout that took zero minutes.
+//   • REST IS A GAP, NOT A FIELD. Nothing on the log stores rest. It is the
+//     delta between consecutive sets over the FLAT, completion-ordered list —
+//     which is what makes it correct across a superset, where consecutive sets
+//     belong to different exercises.
+//   • GROUPING IS BY EXERCISE, ORDER IS BY FIRST APPEARANCE. A superset logs
+//     A, B, A, B; the view must show two exercise blocks in the order they
+//     started, not four blocks and not alphabetical ones.
+//
+// Fixtures use a fixed timezone + fixed ISO instants on purpose: this is one of
+// the few places where a hardcoded date is REQUIRED rather than a smell, since
+// the zone conversion is the thing under test.
+
+import "@testing-library/jest-dom";
+
+import { render, screen, within } from "@testing-library/react";
+import React from "react";
+
+import { WorkoutLogDetailView } from "@/components/gc-fitness/workout-log-detail-view";
+import type { WorkoutLogDetail } from "@/lib/gc-fitness/recent-logs-actions";
+
+// UTC-3. Every instant below is chosen so the UTC rendering differs visibly.
+const TZ = "America/Argentina/Buenos_Aires";
+
+type LoggedSet = WorkoutLogDetail["sets"][number];
+
+function set(overrides: Partial<LoggedSet> = {}): LoggedSet {
+  return {
+    index: 1,
+    setLogId: "set-1",
+    exerciseId: "ex-bench",
+    exerciseName: "Bench Press",
+    metric: "reps",
+    reps: 10,
+    weight: 60,
+    durationSeconds: null,
+    completedAt: "2026-08-05T01:00:00.000Z",
+    isWarmup: false,
+    setType: "normal",
+    isPR: false,
+    prEstimatedOneRM: null,
+    prPrevious: null,
+    supersetGroup: null,
+    ...overrides,
+  } as LoggedSet;
+}
+
+function detail(overrides: Partial<WorkoutLogDetail> = {}): WorkoutLogDetail {
+  return {
+    id: "log-1",
+    clientId: "client-1",
+    clientName: "Ana Gomez",
+    clientTimezone: TZ,
+    coachName: "Manu",
+    workoutName: "Push Day",
+    startedAt: "2026-08-05T01:00:00.000Z",
+    completedAt: "2026-08-05T02:15:00.000Z",
+    status: "completed",
+    setCount: 4,
+    completedSetCount: 3,
+    exerciseCount: 1,
+    durationSeconds: null,
+    rpe: null,
+    athleteNotes: null,
+    source: "client",
+    sets: [set()],
+    ...overrides,
+  } as WorkoutLogDetail;
+}
+
+function renderDetail(d: WorkoutLogDetail) {
+  render(<WorkoutLogDetailView detail={d} />);
+}
+
+/** The exercise block whose heading is `name`. */
+function exerciseBlock(name: string): HTMLElement {
+  const heading = screen.getByRole("heading", { name });
+  return heading.closest("div.rounded-2xl") as HTMLElement;
+}
+
+/**
+ * The rest cell of a set row — the LAST column.
+ *
+ * Read exactly, not with `toHaveTextContent`: a substring match on "-" is
+ * satisfied by "-300s" as happily as by the dash, which is exactly the bug the
+ * negative-gap test is supposed to catch (verified by mutation — admitting
+ * negative deltas left the loose version green).
+ */
+function restCell(row: HTMLElement): string {
+  const cells = within(row).getAllByRole("cell");
+  return cells[cells.length - 1].textContent ?? "";
+}
+
+/**
+ * Metric tiles are label-over-value pairs; read the value under `label`.
+ *
+ * Scoped to the LABEL paragraph on purpose: "Completed" is both the label of
+ * the completion-time tile and the VALUE of the status tile, so a plain
+ * `getByText("Completed")` matches two nodes and throws.
+ */
+function metricValue(label: string): string {
+  const labelNode = Array.from(
+    document.querySelectorAll("p.uppercase.tracking-wide"),
+  ).find((p) => p.textContent === label);
+  if (!labelNode) throw new Error(`metric tile "${label}" not found`);
+  return labelNode.parentElement?.querySelector("p:last-child")?.textContent ?? "";
+}
+
+describe("WorkoutLogDetailView — grouping", () => {
+  it("collapses an interleaved superset into two blocks, in start order", () => {
+    // A superset logs A, B, A, B. Four blocks (or alphabetical ones) would
+    // misrepresent how the session was actually run.
+    renderDetail(
+      detail({
+        exerciseCount: 2,
+        sets: [
+          set({ index: 1, setLogId: "s1", exerciseId: "ex-row", exerciseName: "Row", supersetGroup: "A" }),
+          set({ index: 1, setLogId: "s2", exerciseId: "ex-bench", exerciseName: "Bench Press", supersetGroup: "A" }),
+          set({ index: 2, setLogId: "s3", exerciseId: "ex-row", exerciseName: "Row", supersetGroup: "A" }),
+          set({ index: 2, setLogId: "s4", exerciseId: "ex-bench", exerciseName: "Bench Press", supersetGroup: "A" }),
+        ],
+      }),
+    );
+
+    const headings = screen
+      .getAllByRole("heading", { level: 3 })
+      .map((h) => h.textContent);
+    expect(headings).toEqual(["Row", "Bench Press"]);
+    // Both of Row's sets are inside Row's block.
+    expect(within(exerciseBlock("Row")).getAllByRole("row")).toHaveLength(3); // header + 2
+  });
+
+  it("labels the superset block", () => {
+    renderDetail(
+      detail({
+        sets: [set({ supersetGroup: "B" })],
+      }),
+    );
+
+    expect(screen.getByText(/Superserie B/)).toBeInTheDocument();
+  });
+
+  it("says so when nothing was logged", () => {
+    renderDetail(detail({ sets: [], completedSetCount: 0 }));
+
+    expect(
+      screen.getByText("No sets logged for this workout."),
+    ).toBeInTheDocument();
+  });
+});
+
+describe("WorkoutLogDetailView — reps vs time exercises", () => {
+  it("drops the weight column for a time-only exercise", () => {
+    renderDetail(
+      detail({
+        sets: [
+          set({
+            exerciseId: "ex-plank",
+            exerciseName: "Plank",
+            metric: "time",
+            reps: null,
+            weight: null,
+            durationSeconds: 45,
+          }),
+        ],
+      }),
+    );
+
+    const block = exerciseBlock("Plank");
+    // A weight column on a plank is a column of dashes pretending to be data.
+    expect(within(block).queryByText("Weight")).not.toBeInTheDocument();
+    expect(within(block).getByText("Sec")).toBeInTheDocument();
+    expect(within(block).getByText("45s")).toBeInTheDocument();
+  });
+
+  it("keeps reps + weight for a reps exercise, dashing a missing weight", () => {
+    renderDetail(
+      detail({
+        sets: [
+          set({ index: 1, setLogId: "s1", reps: 10, weight: 60 }),
+          set({ index: 2, setLogId: "s2", reps: 8, weight: null }),
+        ],
+      }),
+    );
+
+    const block = exerciseBlock("Bench Press");
+    expect(within(block).getByText("Reps")).toBeInTheDocument();
+    expect(within(block).getByText("60 kg")).toBeInTheDocument();
+    // Bodyweight / unrecorded → dash, never "0 kg" (which is a claim).
+    expect(within(block).getAllByText("-").length).toBeGreaterThan(0);
+  });
+
+  it("reports the heaviest set of the block", () => {
+    renderDetail(
+      detail({
+        sets: [
+          set({ index: 1, setLogId: "s1", weight: 60 }),
+          set({ index: 2, setLogId: "s2", weight: 80 }),
+          set({ index: 3, setLogId: "s3", weight: 70 }),
+        ],
+      }),
+    );
+
+    expect(screen.getByText("Top: 80 kg")).toBeInTheDocument();
+  });
+});
+
+describe("WorkoutLogDetailView — rest is derived from the gaps", () => {
+  it("has no rest on the first set and the real gap afterwards", () => {
+    renderDetail(
+      detail({
+        sets: [
+          set({ index: 1, setLogId: "s1", completedAt: "2026-08-05T01:00:00.000Z" }),
+          // +90s
+          set({ index: 2, setLogId: "s2", completedAt: "2026-08-05T01:01:30.000Z" }),
+          // +45s
+          set({ index: 3, setLogId: "s3", completedAt: "2026-08-05T01:02:15.000Z" }),
+        ],
+      }),
+    );
+
+    const rows = within(exerciseBlock("Bench Press")).getAllByRole("row");
+    // rows[0] is the header.
+    expect(restCell(rows[1])).toBe("-"); // nothing preceded set 1
+    expect(restCell(rows[2])).toBe("1m 30s");
+    expect(restCell(rows[3])).toBe("45s");
+  });
+
+  it("carries the gap ACROSS exercises, which is what a superset needs", () => {
+    // The rest before Bench's first set is the gap from Row's set — the two
+    // are consecutive in time even though they're in different blocks. Reset
+    // the computation per block and every superset transition reads as "-".
+    renderDetail(
+      detail({
+        exerciseCount: 2,
+        sets: [
+          set({ index: 1, setLogId: "s1", exerciseId: "ex-row", exerciseName: "Row", completedAt: "2026-08-05T01:00:00.000Z" }),
+          set({ index: 1, setLogId: "s2", completedAt: "2026-08-05T01:02:00.000Z" }),
+        ],
+      }),
+    );
+
+    const benchRows = within(exerciseBlock("Bench Press")).getAllByRole("row");
+    expect(restCell(benchRows[1])).toBe("2m");
+  });
+
+  it("omits a non-positive gap instead of printing a negative rest", () => {
+    renderDetail(
+      detail({
+        sets: [
+          set({ index: 1, setLogId: "s1", completedAt: "2026-08-05T01:05:00.000Z" }),
+          // Logged out of order (offline drain, re-stamped set) — earlier than
+          // the one before it.
+          set({ index: 2, setLogId: "s2", completedAt: "2026-08-05T01:00:00.000Z" }),
+        ],
+      }),
+    );
+
+    const rows = within(exerciseBlock("Bench Press")).getAllByRole("row");
+    expect(restCell(rows[2])).toBe("-");
+  });
+});
+
+describe("WorkoutLogDetailView — the client's clock, not the server's", () => {
+  it("renders set times in the CLIENT timezone", () => {
+    // 02:15Z is 23:15 the PREVIOUS day in Buenos Aires.
+    renderDetail(
+      detail({
+        sets: [set({ completedAt: "2026-08-05T02:15:00.000Z" })],
+      }),
+    );
+
+    const block = exerciseBlock("Bench Press");
+    expect(within(block).getByText("11:15 PM")).toBeInTheDocument();
+  });
+
+  it("dates the session by the client's day, not UTC's", () => {
+    renderDetail(
+      detail({
+        startedAt: "2026-08-05T01:00:00.000Z",
+        completedAt: "2026-08-05T02:15:00.000Z",
+        sets: [set()],
+      }),
+    );
+
+    // In UTC this session is on August 5th. It happened on the 4th.
+    expect(screen.getByText(/Tuesday, August 4, 2026/)).toBeInTheDocument();
+  });
+});
+
+describe("WorkoutLogDetailView — the completion time is reconstructed", () => {
+  it("derives start + duration when completedAt equals startedAt", () => {
+    // The finalize path frequently stamps both the same; taking it literally
+    // shows a 45-minute workout as instantaneous.
+    renderDetail(
+      detail({
+        startedAt: "2026-08-05T01:00:00.000Z",
+        completedAt: "2026-08-05T01:00:00.000Z",
+        durationSeconds: 45 * 60,
+      }),
+    );
+
+    expect(metricValue("Started")).toContain("10:00 PM");
+    expect(metricValue("Completed")).toContain("10:45 PM");
+  });
+
+  it("prefers a real completedAt over the stored duration", () => {
+    renderDetail(
+      detail({
+        startedAt: "2026-08-05T01:00:00.000Z",
+        completedAt: "2026-08-05T02:15:00.000Z",
+        durationSeconds: 45 * 60,
+      }),
+    );
+
+    expect(metricValue("Completed")).toContain("11:15 PM");
+  });
+
+  it("falls back to startedAt when there is neither", () => {
+    renderDetail(
+      detail({
+        startedAt: "2026-08-05T01:00:00.000Z",
+        completedAt: null,
+        durationSeconds: null,
+      }),
+    );
+
+    expect(metricValue("Completed")).toContain("10:00 PM");
+  });
+});
+
+describe("WorkoutLogDetailView — PRs (#405)", () => {
+  it("badges the block and shows the record that was beaten", () => {
+    renderDetail(
+      detail({
+        sets: [
+          set({ index: 1, setLogId: "s1" }),
+          set({
+            index: 2,
+            setLogId: "s2",
+            weight: 100,
+            reps: 5,
+            isPR: true,
+            prEstimatedOneRM: 116.7,
+            prPrevious: {
+              weightKg: 95,
+              reps: 5,
+              estimatedOneRM: 110.8,
+              durationSeconds: null,
+            },
+          }),
+        ],
+      }),
+    );
+
+    // "New PR" means nothing without what it beat.
+    expect(screen.getByText(/prev 95 kg × 5/)).toBeInTheDocument();
+    expect(screen.getAllByText("PR").length).toBeGreaterThan(0);
+  });
+
+  it("shows no PR chrome on a workout without one", () => {
+    renderDetail(detail({ sets: [set()] }));
+
+    expect(screen.queryByText("PR")).not.toBeInTheDocument();
+    expect(screen.queryByText(/prev /)).not.toBeInTheDocument();
+  });
+
+  it("renders a time PR's previous as a duration", () => {
+    renderDetail(
+      detail({
+        sets: [
+          set({
+            exerciseId: "ex-plank",
+            exerciseName: "Plank",
+            metric: "time",
+            reps: null,
+            weight: null,
+            durationSeconds: 90,
+            isPR: true,
+            prEstimatedOneRM: null,
+            prPrevious: {
+              weightKg: 0,
+              reps: 0,
+              estimatedOneRM: 0,
+              durationSeconds: 75,
+            },
+          }),
+        ],
+      }),
+    );
+
+    // "0 kg × 0" would be the reps formatting leaking onto a plank.
+    expect(screen.getByText(/prev 75s/)).toBeInTheDocument();
+  });
+});
+
+describe("WorkoutLogDetailView — set types (#403)", () => {
+  it("marks a non-normal set with its letter and leaves normals bare", () => {
+    renderDetail(
+      detail({
+        sets: [
+          set({ index: 1, setLogId: "s1", setType: "warmup", isWarmup: true }),
+          set({ index: 2, setLogId: "s2", setType: "failure" }),
+          set({ index: 3, setLogId: "s3" }),
+        ],
+      }),
+    );
+
+    expect(screen.getByLabelText("Calentamiento")).toHaveTextContent("W");
+    expect(screen.getByLabelText("Al fallo")).toHaveTextContent("F");
+    // Exactly two badges — a "normal" badge would make every row noisy.
+    expect(screen.queryByLabelText("Normal")).not.toBeInTheDocument();
+  });
+});
+
+describe("WorkoutLogDetailView — the header facts", () => {
+  it("shows logged vs prescribed set counts", () => {
+    renderDetail(detail({ completedSetCount: 3, setCount: 4 }));
+
+    // "3/4" is how a coach sees the client stopped early. A bare "3" hides it.
+    expect(metricValue("Sets logged")).toBe("3/4");
+  });
+
+  it("distinguishes a coach-run session from a client-run one", () => {
+    renderDetail(detail({ source: "coach" }));
+    expect(screen.getByText("Coach-run")).toBeInTheDocument();
+  });
+
+  it("treats a missing source as client-run", () => {
+    renderDetail(detail({ source: undefined }));
+    expect(screen.getByText("Client-run")).toBeInTheDocument();
+  });
+
+  it("reports RPE, or says it wasn't reported", () => {
+    const { unmount } = render(<WorkoutLogDetailView detail={detail({ rpe: null })} />);
+    expect(
+      screen.getByText("Client did not report effort."),
+    ).toBeInTheDocument();
+    unmount();
+
+    renderDetail(detail({ rpe: 7 }));
+    expect(screen.getByText("7 / 10")).toBeInTheDocument();
+  });
+
+  it("shows the client's own notes verbatim", () => {
+    renderDetail(detail({ athleteNotes: "Hombro molesto en la 3a" }));
+    expect(screen.getByText("Hombro molesto en la 3a")).toBeInTheDocument();
+  });
+});

--- a/backoffice/src/components/gc-fitness/__tests__/workout-recurrence-edit-dialog.test.tsx
+++ b/backoffice/src/components/gc-fitness/__tests__/workout-recurrence-edit-dialog.test.tsx
@@ -1,0 +1,247 @@
+/**
+ * @jest-environment jsdom
+ */
+
+// workout-recurrence-edit-dialog.test.tsx
+//
+// Regression net for "Editar recurrencia" — the coach-portal flow with the worst
+// blast radius on the schedule: saving here runs a delete-future + re-expand of
+// the whole series from the viewed occurrence onward.
+//
+// The FIRST THREE LINES of this file MUST stay as the
+// `/** @jest-environment jsdom */` docblock — the backoffice jest config defaults
+// to `testEnvironment: "node"` so without it React Testing Library crashes with
+// `ReferenceError: document is not defined`.
+//
+// What these tests are actually protecting:
+//
+//   1. THE WIRE SHAPE. Mobile (iOS + Android) reads the recurrence rule this
+//      dialog writes. One selected weekday must collapse to `{kind:"weekly",
+//      weekday}` and two or more must widen to `{kind:"weekly_days", weekdays}`
+//      — SORTED. Emitting `weekly_days` for a single day, or an unsorted array,
+//      is a silent cross-surface break that no type checks.
+//   2. THE GUARDS. Every early return in `handleSave` exists to stop a
+//      destructive re-expand from running on nonsense input. A guard that stops
+//      firing doesn't throw — it just quietly reprograms the series wrong.
+//   3. THE SEED. The picker is pre-filled from the occurrence's CURRENT rule. If
+//      seeding regresses, a coach who opens the dialog to change the end date
+//      silently rewrites the coach's weekday pattern too.
+
+import "@testing-library/jest-dom";
+
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import React from "react";
+
+import { WorkoutRecurrenceEditDialog } from "@/components/gc-fitness/schedule/workout-recurrence-edit-dialog";
+
+// Mock the Server Action so we can assert the exact payload and drive
+// success/failure without touching Firestore.
+const mockEditRecurrence = jest.fn();
+jest.mock("@/lib/gc-fitness/workout-assignment-actions", () => ({
+  editAssignmentRecurrence: (...args: unknown[]) => mockEditRecurrence(...args),
+}));
+
+// Mock sonner — the dialog reports every guard through a toast, so these
+// doubles are how we observe "it refused" vs "it saved".
+const mockToastSuccess = jest.fn();
+const mockToastError = jest.fn();
+jest.mock("sonner", () => ({
+  toast: {
+    success: (...args: unknown[]) => mockToastSuccess(...args),
+    error: (...args: unknown[]) => mockToastError(...args),
+  },
+}));
+
+// 2026-08-05 is a Wednesday (getDay() === 3) — the fixture leans on that for
+// the "unknown recurrence seeds on the occurrence's own weekday" case.
+const SCHEDULED_FOR = "2026-08-05";
+
+function renderDialog(
+  overrides: Partial<React.ComponentProps<typeof WorkoutRecurrenceEditDialog>> = {},
+) {
+  const onOpenChange = jest.fn();
+  const onSaved = jest.fn();
+  render(
+    <WorkoutRecurrenceEditDialog
+      open
+      onOpenChange={onOpenChange}
+      assignmentId="assign-1"
+      scheduledFor={SCHEDULED_FOR}
+      recurrence={{ kind: "weekly", weekday: 3 }}
+      seriesEndDate="2026-10-05"
+      onSaved={onSaved}
+      {...overrides}
+    />,
+  );
+  return { onOpenChange, onSaved };
+}
+
+/** The weekday chips are Sunday-first: Dom Lun Mar Mié Jue Vie Sáb. */
+function weekdayChip(label: string) {
+  return screen.getByRole("button", { name: label });
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockEditRecurrence.mockResolvedValue({ createdCount: 4 });
+});
+
+describe("WorkoutRecurrenceEditDialog — the rule it writes", () => {
+  it("collapses a single selected weekday to kind 'weekly'", async () => {
+    const user = userEvent.setup();
+    const { onSaved, onOpenChange } = renderDialog();
+
+    await user.click(screen.getByRole("button", { name: "Guardar" }));
+
+    await waitFor(() => expect(mockEditRecurrence).toHaveBeenCalledTimes(1));
+    expect(mockEditRecurrence).toHaveBeenCalledWith("assign-1", {
+      recurrence: { kind: "weekly", weekday: 3 },
+      endDate: "2026-10-05",
+    });
+    expect(onSaved).toHaveBeenCalledTimes(1);
+    // Saving closes the dialog — leaving it open invites a double re-expand.
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+  });
+
+  it("widens to 'weekly_days' with a SORTED array once a second day is picked", async () => {
+    const user = userEvent.setup();
+    renderDialog();
+
+    // Seeded on Wednesday (3). Add Monday (1) — selection order is Wed-then-Mon,
+    // so an implementation that emitted insertion order would produce [3, 1].
+    await user.click(weekdayChip("Lun"));
+    await user.click(screen.getByRole("button", { name: "Guardar" }));
+
+    await waitFor(() => expect(mockEditRecurrence).toHaveBeenCalledTimes(1));
+    expect(mockEditRecurrence).toHaveBeenCalledWith("assign-1", {
+      recurrence: { kind: "weekly_days", weekdays: [1, 3] },
+      endDate: "2026-10-05",
+    });
+  });
+
+  it("seeds the picker from an existing weekly_days rule instead of resetting it", async () => {
+    const user = userEvent.setup();
+    renderDialog({ recurrence: { kind: "weekly_days", weekdays: [1, 5] } });
+
+    // Mon + Fri must come back pressed. If seeding regressed, a coach opening
+    // this dialog only to push the end date would silently rewrite the pattern.
+    expect(weekdayChip("Lun")).toHaveAttribute("aria-pressed", "true");
+    expect(weekdayChip("Vie")).toHaveAttribute("aria-pressed", "true");
+    expect(weekdayChip("Mié")).toHaveAttribute("aria-pressed", "false");
+
+    await user.click(screen.getByRole("button", { name: "Guardar" }));
+
+    await waitFor(() => expect(mockEditRecurrence).toHaveBeenCalledTimes(1));
+    expect(mockEditRecurrence.mock.calls[0][1].recurrence).toEqual({
+      kind: "weekly_days",
+      weekdays: [1, 5],
+    });
+  });
+
+  it("falls back to the occurrence's own weekday when the rule is unknown", async () => {
+    const user = userEvent.setup();
+    // A single (non-recurring) assignment, or a rule kind this build predates.
+    renderDialog({ recurrence: { kind: "something_new_from_the_future" } });
+
+    // 2026-08-05 is a Wednesday → Mié.
+    expect(weekdayChip("Mié")).toHaveAttribute("aria-pressed", "true");
+
+    await user.click(screen.getByRole("button", { name: "Guardar" }));
+
+    await waitFor(() => expect(mockEditRecurrence).toHaveBeenCalledTimes(1));
+    expect(mockEditRecurrence.mock.calls[0][1].recurrence).toEqual({
+      kind: "weekly",
+      weekday: 3,
+    });
+  });
+});
+
+describe("WorkoutRecurrenceEditDialog — the guards that stop a bad re-expand", () => {
+  it("refuses to save with zero weekdays selected", async () => {
+    const user = userEvent.setup();
+    const { onSaved } = renderDialog();
+
+    // Deselect the only seeded day, leaving an empty selection.
+    await user.click(weekdayChip("Mié"));
+    expect(weekdayChip("Mié")).toHaveAttribute("aria-pressed", "false");
+
+    await user.click(screen.getByRole("button", { name: "Guardar" }));
+
+    // The whole point: the destructive action must NOT run.
+    expect(mockEditRecurrence).not.toHaveBeenCalled();
+    expect(onSaved).not.toHaveBeenCalled();
+    expect(mockToastError).toHaveBeenCalledWith(
+      "Elegí al menos un día de la semana.",
+    );
+  });
+
+  it("refuses an end date earlier than the occurrence being edited", async () => {
+    const user = userEvent.setup();
+    const { onSaved } = renderDialog();
+
+    const endDate = document.getElementById("recur-end-date") as HTMLInputElement;
+    await user.clear(endDate);
+    await user.type(endDate, "2026-07-01"); // before SCHEDULED_FOR
+
+    await user.click(screen.getByRole("button", { name: "Guardar" }));
+
+    expect(mockEditRecurrence).not.toHaveBeenCalled();
+    expect(onSaved).not.toHaveBeenCalled();
+    expect(mockToastError).toHaveBeenCalledWith(
+      "La fecha de fin debe ser igual o posterior a esta fecha.",
+    );
+  });
+
+  it("clamps 'every N days' into the 2..30 range the expander accepts", async () => {
+    const user = userEvent.setup();
+    renderDialog({ recurrence: { kind: "every_n_days", everyN: 3 } });
+
+    const everyN = document.getElementById("recur-every-n") as HTMLInputElement;
+    await user.clear(everyN);
+    await user.type(everyN, "99");
+    await user.tab(); // blur normalizes the draft
+
+    await user.click(screen.getByRole("button", { name: "Guardar" }));
+
+    await waitFor(() => expect(mockEditRecurrence).toHaveBeenCalledTimes(1));
+    expect(mockEditRecurrence.mock.calls[0][1].recurrence).toEqual({
+      kind: "every_n_days",
+      everyN: 30,
+    });
+  });
+});
+
+describe("WorkoutRecurrenceEditDialog — failure handling", () => {
+  it("surfaces the server's message and keeps the dialog open on failure", async () => {
+    const user = userEvent.setup();
+    mockEditRecurrence.mockRejectedValueOnce(
+      new Error("No se pudo reprogramar la serie."),
+    );
+    const { onSaved, onOpenChange } = renderDialog();
+
+    await user.click(screen.getByRole("button", { name: "Guardar" }));
+
+    await waitFor(() =>
+      expect(mockToastError).toHaveBeenCalledWith(
+        "No se pudo reprogramar la serie.",
+      ),
+    );
+    // A failed re-expand must not report success upstream, and must not close —
+    // closing would strand the coach with no idea the series is unchanged.
+    expect(onSaved).not.toHaveBeenCalled();
+    expect(onOpenChange).not.toHaveBeenCalledWith(false);
+  });
+
+  it("re-enables Guardar after a failure so the coach can retry", async () => {
+    const user = userEvent.setup();
+    mockEditRecurrence.mockRejectedValueOnce(new Error("boom"));
+    renderDialog();
+
+    const save = screen.getByRole("button", { name: "Guardar" });
+    await user.click(save);
+
+    await waitFor(() => expect(mockToastError).toHaveBeenCalled());
+    expect(screen.getByRole("button", { name: "Guardar" })).toBeEnabled();
+  });
+});

--- a/backoffice/src/lib/gc-fitness/__tests__/exercises-listener-scope.test.tsx
+++ b/backoffice/src/lib/gc-fitness/__tests__/exercises-listener-scope.test.tsx
@@ -1,0 +1,192 @@
+/**
+ * @jest-environment jsdom
+ */
+
+// exercises-listener-scope.test.tsx
+//
+// The VIEWER SCOPE of #552 — which exercises a given coach may see at all.
+//
+// The FIRST THREE LINES of this file MUST stay as the
+// `/** @jest-environment jsdom */` docblock — the backoffice jest config
+// defaults to `testEnvironment: "node"` so without it `renderHook` crashes
+// with `ReferenceError: document is not defined`.
+//
+// #306 lists this as "extend exercise-picker-popover to the #552 viewer
+// scope". It can't live there: the picker renders whatever `useExercisesQuery`
+// hands it, and every picker test mocks that hook. The scope is enforced ONE
+// LAYER DOWN, in the hook's own `canTrainerAccessExercise` filter, so that is
+// where the test goes. What the picker DOES own — the legacy-retirement
+// predicate and the selected-value fallback — is already covered in
+// `components/gc-fitness/__tests__/exercise-picker-popover.test.tsx`.
+//
+// The rule has three cases and the middle one is the leak:
+//
+//   1. A library exercise (wger / free-exercise-db / standard) is visible to
+//      every coach — it's shared catalog.
+//   2. A `source: "trainer"` exercise is visible ONLY to the coach who owns
+//      it. Another coach's authored exercise must never appear in a picker:
+//      assigning it puts a stranger's prescription into a client's routine,
+//      and it looks exactly like an exercise the coach forgot writing.
+//   3. With no signed-in uid, NO trainer-authored exercise is visible. Failing
+//      open here would show every coach's private library to an anonymous
+//      session.
+//
+// The curation soft-delete (`deletedAt`) is filtered in the same pass and
+// tested alongside, because it is the other reason a row legitimately vanishes
+// and the two are easy to confuse when one breaks.
+
+import "@testing-library/jest-dom";
+
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { renderHook, waitFor } from "@testing-library/react";
+import React from "react";
+
+const mockGetDocs = jest.fn();
+jest.mock("firebase/firestore", () => ({
+  getFirestore: () => ({}),
+  collection: (...args: unknown[]) => ({ __collection: args[1] }),
+  query: (...args: unknown[]) => ({ __query: args }),
+  orderBy: (...args: unknown[]) => ({ __orderBy: args }),
+  getDocs: (...args: unknown[]) => mockGetDocs(...args),
+}));
+
+jest.mock("@/lib/firebase/gc-fitness-client", () => ({
+  getGCFitnessAuth: () => ({ app: {}, currentUser: null }),
+}));
+
+import { useExercisesQuery } from "@/lib/gc-fitness/exercises-listener";
+
+/** A Firestore doc snapshot shaped the way `snapToRow` consumes it. */
+function doc(id: string, data: Record<string, unknown>) {
+  return { id, data: () => data };
+}
+
+function libraryDoc(id: string, name: string) {
+  return doc(id, {
+    name: { en: name, es: "" },
+    description: { en: "", es: "" },
+    muscleGroups: ["chest"],
+    equipment: ["barbell"],
+    source: "wger",
+    ownerId: null,
+    tags: ["standard-library"],
+    updatedAt: "2026-08-01T00:00:00.000Z",
+  });
+}
+
+function trainerDoc(id: string, name: string, ownerId: string | null) {
+  return doc(id, {
+    name: { en: name, es: "" },
+    description: { en: "", es: "" },
+    muscleGroups: ["chest"],
+    equipment: ["barbell"],
+    source: "trainer",
+    ownerId,
+    updatedAt: "2026-08-01T00:00:00.000Z",
+  });
+}
+
+async function loadFor(
+  trainerUid: string | null,
+  docs: ReturnType<typeof doc>[],
+): Promise<string[]> {
+  mockGetDocs.mockResolvedValue({ docs });
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  const wrapper = ({ children }: { children: React.ReactNode }) => (
+    <QueryClientProvider client={client}>{children}</QueryClientProvider>
+  );
+  const { result } = renderHook(() => useExercisesQuery(trainerUid), {
+    wrapper,
+  });
+  await waitFor(() => expect(result.current.isFetched).toBe(true));
+  return (result.current.data ?? []).map((r) => r.id);
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe("useExercisesQuery — the #552 viewer scope", () => {
+  it("shows library exercises to every coach", async () => {
+    const ids = await loadFor("trainer-1", [libraryDoc("1259", "Bench Press")]);
+
+    expect(ids).toEqual(["1259"]);
+  });
+
+  it("shows the coach their OWN authored exercise", async () => {
+    const ids = await loadFor("trainer-1", [
+      trainerDoc("mine", "My Curl", "trainer-1"),
+    ]);
+
+    expect(ids).toEqual(["mine"]);
+  });
+
+  it("HIDES another coach's authored exercise", async () => {
+    const ids = await loadFor("trainer-1", [
+      trainerDoc("mine", "My Curl", "trainer-1"),
+      trainerDoc("theirs", "Their Curl", "trainer-2"),
+      libraryDoc("1259", "Bench Press"),
+    ]);
+
+    // Assigning a stranger's exercise puts their prescription into this
+    // coach's client's routine, and reads as one the coach forgot writing.
+    expect(ids.sort()).toEqual(["1259", "mine"]);
+  });
+
+  it("hides EVERY trainer-authored exercise when there is no uid", async () => {
+    const ids = await loadFor(null, [
+      trainerDoc("mine", "My Curl", "trainer-1"),
+      trainerDoc("theirs", "Their Curl", "trainer-2"),
+      libraryDoc("1259", "Bench Press"),
+    ]);
+
+    // Failing open here shows every coach's private library to a session that
+    // hasn't identified itself.
+    expect(ids).toEqual(["1259"]);
+  });
+
+  it("hides an ownerless doc that snapToRow coerced to 'trainer'", async () => {
+    // `snapToRow` coerces any unknown wire `source` to "trainer" — the 24
+    // `standard_alias` docs land here with `ownerId: null`, so the ownership
+    // comparison is what keeps them out rather than an equality on source.
+    const ids = await loadFor("trainer-1", [
+      doc("alias-1", {
+        name: { en: "Aliased", es: "" },
+        description: { en: "", es: "" },
+        muscleGroups: [],
+        equipment: [],
+        source: "standard_alias",
+        ownerId: null,
+        updatedAt: "2026-08-01T00:00:00.000Z",
+      }),
+      libraryDoc("1259", "Bench Press"),
+    ]);
+
+    expect(ids).toEqual(["1259"]);
+  });
+});
+
+describe("useExercisesQuery — the curation soft-delete", () => {
+  it("drops a doc with a deletedAt stamp", async () => {
+    const ids = await loadFor("trainer-1", [
+      doc("curated-out", {
+        name: { en: "Superseded", es: "" },
+        description: { en: "", es: "" },
+        muscleGroups: [],
+        equipment: [],
+        source: "wger",
+        ownerId: null,
+        tags: ["standard-library"],
+        deletedAt: "2026-06-12T00:00:00.000Z",
+        updatedAt: "2026-08-01T00:00:00.000Z",
+      }),
+      libraryDoc("1259", "Bench Press"),
+    ]);
+
+    // A separate reason from the viewer scope for a row to vanish; when one
+    // of the two breaks it is easy to blame the other.
+    expect(ids).toEqual(["1259"]);
+  });
+});

--- a/backoffice/src/lib/test-utils/next-intl-stub.tsx
+++ b/backoffice/src/lib/test-utils/next-intl-stub.tsx
@@ -105,8 +105,26 @@ function makeTFn(namespace?: string): TFn {
   return t;
 }
 
+// Real `useTranslations` returns a REFERENTIALLY STABLE `t` across renders for
+// a given namespace — and components rely on that: `t` legitimately appears in
+// `useEffect` dependency arrays. A stub that minted a fresh closure per render
+// turns any such effect into an infinite render loop ("Maximum update depth
+// exceeded"), which looks like a component bug and is not one.
+//
+// `AssignTemplateModal` is the case that surfaced this: its template-detail
+// effect lists `t` in its deps and calls `setOverrideDrafts({})` on the
+// no-template branch. A fresh `{}` is never `Object.is`-equal, so each render
+// re-ran the effect, which re-rendered, forever. Caching per namespace matches
+// production behavior and the loop disappears.
+const tFnCache = new Map<string, TFn>();
+
 export function useTranslations(namespace?: string): TFn {
-  return makeTFn(namespace);
+  const key = namespace ?? "";
+  const cached = tFnCache.get(key);
+  if (cached) return cached;
+  const fn = makeTFn(namespace);
+  tFnCache.set(key, fn);
+  return fn;
 }
 
 export function useLocale(): string {


### PR DESCRIPTION
Cierra el catálogo de #306: **P1 a P7, todos**.

La suite pasó de **94 archivos / 1084 tests** a **132 / 1553**, verde. Son **469 tests nuevos sobre ~38 componentes**, y **~350 mutaciones corridas** — porque un test que pasa a la primera no prueba nada hasta que lo viste fallar.

## Por qué

La capa de lógica (`lib/gc-fitness/*`) estaba bien cubierta: sabíamos que los *payloads* estaban bien y que los *cálculos* daban bien. Lo que nadie miraba era si el componente **arma** ese payload y **llama** a la acción cuando el coach hace clic. Ahí vivieron casi todos los bugs que llegaron a producción (#392, #400, #163, #449, #574, #578…).

Importa más que en otros repos porque el backoffice **auto-deploya `main` al pushear** y CI está apagado por costo: `npx jest` local es lo único entre un merge malo y producción.

## Qué toca

**Sólo tests y documentación. Cero cambios de fuente de producción**, a propósito: así se revisa leyendo únicamente los tests. La limpieza que sí toca fuente va aparte (#307 y compañía).

- 38 archivos de test nuevos bajo `src/**/__tests__/`
- `backoffice/README.md` → sección "Tests": comandos, el docblock de jsdom, qué módulos hay que mockear sí o sí, el stub de next-intl, la regla de asertar el payload, cómo verificar por mutación, y ~25 trampas de query/jsdom acumuladas.

## Lo que salió de escribirlos

Cuatro issues, ninguno arreglado acá:

- **#308** — el comparador de fotos queda TRABADO si las dos fotos más recientes del ángulo caen el mismo día. Único bug de usuario real de la tanda. Hay un test que fija el comportamiento roto a propósito para que el fix tenga algo que dar vuelta.
- **#309** — `ClientDailyTimeline.tsx` + sus dos server actions (~1100 líneas) no las monta nadie desde el 2026-05-28. Dos commits POSTERIORES arreglaron bugs de producción adentro.
- **#307** — once guards inalcanzables + un ternario que repite al que ya hizo su llamador.
- **#310** — en la higiene de datos un chat huérfano se dibuja con ícono de tacho, en la única pantalla cuya acción es borrar.

## Gate

`npx jest` → **132 suites / 1553 tests, verde**. Es la única suite que este cambio puede afectar: no toca `firestore.rules` ni ningún gemelo de algoritmo compartido con iOS/Android.