### PR TITLE
fix(#782): el botón de App Store no hacía nada en Safari

### DIFF
--- a/pocket-genes/src/components/GCFitnessDownloadPage.astro
+++ b/pocket-genes/src/components/GCFitnessDownloadPage.astro
@@ -82,7 +82,29 @@ const copy = {
           </ul>
 
           <div class="gcf-store-grid" aria-label={copy.storeGridLabel}>
-            <a class="gcf-store-card" href={APP_STORE_URL} target="_blank" rel="noopener noreferrer">
+            <!--
+              #782 — SIN `target="_blank"`, y no es un descuido.
+
+              En Safari el tap "no hacía nada". La cadena que se rompe es ésta: `_blank` abre
+              una pestaña NUEVA, esa pestaña se come el 301 de
+              `apps.apple.com/app/id…` → `apps.apple.com/us/app/gc-fitness/id…`, y RECIÉN
+              entonces intenta el handoff a la App Store. Para ese momento el salto a la app
+              nativa ya no está dentro del gesto del usuario que lo originó, y Safari lo
+              descarta en silencio: ni pestaña visible ni App Store. El usuario ve un botón
+              muerto.
+
+              El hermano que sí anda lo confirma: Pocket Genes apunta a la URL canónica
+              (`/ar/app/pocket-genes/id…`, sin redirect) con el mismo `_blank`. La diferencia
+              entre los dos links es el 301, no el atributo.
+
+              Navegando en la MISMA pestaña el gesto sobrevive al redirect y el handoff ocurre.
+              Y se puede dejar la URL corta —que Apple redirige al storefront de cada visitante,
+              que es a propósito (ver `gcFitnessPublic.ts`)— en vez de clavar un país.
+
+              No se pierde nada: un link de store es un destino terminal; en móvil te saca del
+              sitio igual para abrir la app nativa.
+            -->
+            <a class="gcf-store-card" href={APP_STORE_URL}>
               <span class="gcf-store-glow" aria-hidden="true"></span>
               <span class="gcf-store-kicker">{copy.kicker}</span>
               <img
@@ -96,7 +118,10 @@ const copy = {
               <span class="gcf-store-note">{copy.appStoreNote}</span>
             </a>
 
-            <a class="gcf-store-card" href={PLAY_STORE_URL} target="_blank" rel="noopener noreferrer">
+            <!-- Misma navegación que la tarjeta de arriba, para que las dos se comporten
+                 igual. En Play el handoff no se rompía (no hay app nativa que abrir desde
+                 Safari), pero dejar una con `_blank` y la otra sin él se lee como un olvido. -->
+            <a class="gcf-store-card" href={PLAY_STORE_URL}>
               <span class="gcf-store-glow" aria-hidden="true"></span>
               <span class="gcf-store-kicker">{copy.kicker}</span>
               <img


### PR DESCRIPTION
Cierra #782 — `/gc-fitness/download`, "lo tapeo y no hace nada".

## Qué pasaba

La cadena que se rompe:

1. `target="_blank"` abre una pestaña **nueva**
2. esa pestaña se come el **301** de `apps.apple.com/app/id…` →
   `apps.apple.com/us/app/gc-fitness/id…`
3. y **recién entonces** intenta el handoff a la App Store

Para ese punto el salto a la app nativa ya no está dentro del gesto del usuario que lo
originó, y Safari lo descarta **en silencio**: ni pestaña visible ni App Store. Botón muerto.

## Cómo se descartó lo otro

- **La URL no está rota**: `curl -L` da `HTTP 200` y redirige a la canónica; el lookup de
  iTunes devuelve `GC Fitness 1.2.0`. El link es correcto.
- **No es el overlay**: `.gcf-store-glow` está en `z-index: -1` dentro de un contenedor con
  `isolation: isolate`, así que no puede interceptar taps — y además es hijo del `<a>`.
- **No es JS**: la página no tiene ni un `addEventListener` ni un `preventDefault`.
- **El hermano que sí anda lo confirma**: Pocket Genes usa la URL **canónica**
  (`/ar/app/pocket-genes/id…`, sin redirect) con el **mismo** `_blank`. La diferencia entre los
  dos links es el 301, no el atributo.

## El arreglo

Sacar `target="_blank"` de las dos tarjetas de store. Navegando en la misma pestaña el gesto
sobrevive al redirect y el handoff ocurre.

**Por qué así y no clavando el país como Pocket Genes**: `gcFitnessPublic.ts` dice
explícitamente que la URL omite el segmento de país *a propósito*, para que Apple mande a cada
visitante a **su** storefront. Hardcodear `/ar/` arreglaba el síntoma rompiendo esa intención.
Así se arreglan los dos.

No se pierde nada al no abrir pestaña: un link de store es un destino terminal — en móvil te
saca del sitio igual para abrir la app nativa. La tarjeta de Play cambia sólo por consistencia
(ahí el handoff no se rompía, no hay app nativa que abrir desde Safari).

## Alcance y verificación

- Toca **las dos** superficies (`/gc-fitness/download` y `/en/gc-fitness/download`) porque
  comparten `GCFitnessDownloadPage.astro`.
- `npm run build` verde, 80 páginas; el HTML generado ya no lleva `target` en ninguna de las
  dos.

⚠️ **La verificación final es humana**: el fallo es específico de Safari y el handoff a la App
Store no se puede reproducir desde un headless. Vale un tap en un iPhone real antes de dar por
cerrado el ticket.