### PR TITLE
fix(#785): los cuatro huecos de monitoreo — movimientos, entrenos libres, actividad del coach-less y versión de app

### DIFF
--- a/backoffice/messages/en.json
+++ b/backoffice/messages/en.json
@@ -1591,6 +1591,12 @@
       "habits": "Habits",
       "birthdayBadge": "Birthday",
       "clientCreatedBadge": "Created by the client",
+      "loggedExercises": "{count, plural, one {# exercise} other {# exercises}}",
+      "loggedSets": "{count, plural, one {# set} other {# sets}}",
+      "loggedMinutes": "{count} min",
+      "loggedVolume": "{count} kg",
+      "loggedNothing": "no sets logged",
+      "freeWorkoutHint": "Free workout: the client built it while training",
       "pickClientsPrompt": "Pick one or more clients above to see their agenda.",
       "pickClientFirstToast": "Pick at least one client first",
       "bulkAssignHabit": "Assign habit"

--- a/backoffice/messages/en.json
+++ b/backoffice/messages/en.json
@@ -1855,6 +1855,7 @@
       "badgeHabit": "Habit",
       "badgeWorkout": "Workout",
       "badgeReschedule": "Moved",
+      "badgeAssignment": "Self-assigned",
       "badgeReminder": "Reminder",
       "badgePhoto": "Photo",
       "badgeWeight": "Weight",

--- a/backoffice/messages/es.json
+++ b/backoffice/messages/es.json
@@ -1855,6 +1855,7 @@
       "badgeHabit": "Hábito",
       "badgeWorkout": "Entrenamiento",
       "badgeReschedule": "Movido",
+      "badgeAssignment": "Se lo asignó",
       "badgeReminder": "Recordatorio",
       "badgePhoto": "Foto",
       "badgeWeight": "Peso",

--- a/backoffice/messages/es.json
+++ b/backoffice/messages/es.json
@@ -1591,6 +1591,12 @@
       "habits": "Hábitos",
       "birthdayBadge": "Cumpleaños",
       "clientCreatedBadge": "Creado por el cliente",
+      "loggedExercises": "{count, plural, one {# ejercicio} other {# ejercicios}}",
+      "loggedSets": "{count, plural, one {# serie} other {# series}}",
+      "loggedMinutes": "{count} min",
+      "loggedVolume": "{count} kg",
+      "loggedNothing": "sin series registradas",
+      "freeWorkoutHint": "Entreno libre: el cliente lo armó mientras entrenaba",
       "pickClientsPrompt": "Elegí uno o más clientes arriba para ver su agenda.",
       "pickClientFirstToast": "Elegí al menos un cliente primero",
       "bulkAssignHabit": "Asignar hábito"

--- a/backoffice/src/app/gc-fitness/admin/coach-less-users/[uid]/page.tsx
+++ b/backoffice/src/app/gc-fitness/admin/coach-less-users/[uid]/page.tsx
@@ -16,6 +16,7 @@
 // action additionally refuses any target that isn't an active coach-less
 // client, so this URL can't be used to read a coached client's data.
 
+import { formatAppDevice } from "@/lib/gc-fitness/client-app-devices";
 import { revalidatePath } from "next/cache";
 import { getTranslations } from "next-intl/server";
 import Link from "next/link";
@@ -388,6 +389,28 @@ export default async function CoachlessUserDetailPage({
                 {profile.auth ? (profile.auth.emailVerified ? "yes" : "no") : "—"}
               </Field>
               <Field label="Timezone">{profile.timezone || "—"}</Field>
+              {/* #785 — "nos falta en cada perfil, qué versión de la app están
+                  usando, y si es iOS o Android". One line per DEVICE: someone
+                  with a phone and a tablet is on two versions at once. */}
+              <Field label="App">
+                {profile.devices.length > 0 ? (
+                  <span className="flex flex-col gap-0.5">
+                    {profile.devices.map((device, index) => (
+                      <span key={`${device.platform}-${device.appVersion ?? "?"}-${index}`}>
+                        {formatAppDevice(device)}
+                        {device.registeredAtISO ? (
+                          <span className="text-muted-foreground">
+                            {" · "}
+                            {formatDateWithAge(device.registeredAtISO, nowMs, timezone)}
+                          </span>
+                        ) : null}
+                      </span>
+                    ))}
+                  </span>
+                ) : (
+                  "—"
+                )}
+              </Field>
               <Field label="Birth date">{profile.birthDate || "—"}</Field>
               {profile.auth?.disabled ? (
                 <Field label="Auth status">

--- a/backoffice/src/app/gc-fitness/clients/[id]/_components/ClientHeader.tsx
+++ b/backoffice/src/app/gc-fitness/clients/[id]/_components/ClientHeader.tsx
@@ -19,6 +19,10 @@
 "use client";
 
 import Link from "next/link";
+import {
+  formatAppDevice,
+  type ClientAppDevice,
+} from "@/lib/gc-fitness/client-app-devices";
 import { ArrowLeft, Calendar, LineChart, MessagesSquare } from "lucide-react";
 import { useTranslations } from "next-intl";
 
@@ -36,6 +40,12 @@ export interface ClientHeaderProps {
   birthDate: string | null;
   heightCm?: number | null;
   bodyWeightKg?: number | null;
+  /**
+   * #785 — which app build(s) the client is on, one badge per device. Read from
+   * the push-token subcollection every signed-in device writes; empty for a
+   * client who has never opened the app.
+   */
+  appDevices?: ClientAppDevice[];
 }
 
 export function ClientHeader({
@@ -48,6 +58,7 @@ export function ClientHeader({
   birthDate,
   heightCm,
   bodyWeightKg,
+  appDevices = [],
 }: ClientHeaderProps) {
   const t = useTranslations("clients.detail");
   const tNav = useTranslations("nav");
@@ -105,6 +116,14 @@ export function ClientHeader({
               <Badge variant="outline">
                 {t("weightLabel", { value: weightValue })}
               </Badge>
+              {appDevices.map((device, index) => (
+                <Badge
+                  key={`${device.platform}-${device.appVersion ?? "?"}-${index}`}
+                  variant="outline"
+                >
+                  {formatAppDevice(device)}
+                </Badge>
+              ))}
             </div>
           </div>
         </div>

--- a/backoffice/src/app/gc-fitness/clients/[id]/_components/ClientRecentLogsFeed.tsx
+++ b/backoffice/src/app/gc-fitness/clients/[id]/_components/ClientRecentLogsFeed.tsx
@@ -5,6 +5,7 @@ import Link from "next/link";
 import { useMemo, useState } from "react";
 import { useLocale, useTranslations } from "next-intl";
 import {
+  CalendarPlus,
   ArrowRightLeft,
   Bell,
   CalendarClock,
@@ -45,6 +46,7 @@ const CATEGORY_ICON: Record<
   habit: ListChecks,
   workout: Dumbbell,
   reschedule: ArrowRightLeft,
+  assignment: CalendarPlus,
   reminder: Bell,
   photo: Camera,
   weight: Scale,
@@ -56,6 +58,7 @@ const CATEGORY_LABEL_KEY: Record<RecentLogRow["category"], string> = {
   habit: "badgeHabit",
   workout: "badgeWorkout",
   reschedule: "badgeReschedule",
+  assignment: "badgeAssignment",
   reminder: "badgeReminder",
   photo: "badgePhoto",
   weight: "badgeWeight",
@@ -70,6 +73,8 @@ const CATEGORY_TONE: Record<RecentLogRow["category"], string> = {
     "border-emerald-200 bg-emerald-50 text-emerald-700 dark:border-emerald-900 dark:bg-emerald-950/40 dark:text-emerald-300",
   reschedule:
     "border-amber-200 bg-amber-50 text-amber-700 dark:border-amber-900 dark:bg-amber-950/40 dark:text-amber-300",
+  assignment:
+    "border-teal-200 bg-teal-50 text-teal-700 dark:border-teal-900 dark:bg-teal-950/40 dark:text-teal-300",
   reminder:
     "border-indigo-200 bg-indigo-50 text-indigo-700 dark:border-indigo-900 dark:bg-indigo-950/40 dark:text-indigo-300",
   photo:

--- a/backoffice/src/app/gc-fitness/clients/[id]/_components/__tests__/client-calendar-peek.test.tsx
+++ b/backoffice/src/app/gc-fitness/clients/[id]/_components/__tests__/client-calendar-peek.test.tsx
@@ -146,6 +146,8 @@ function chip(overrides: Partial<MonthWorkoutChip> = {}): MonthWorkoutChip {
     seriesId: null,
     recurrenceKind: null,
     selfAssigned: false,
+    plannedExercises: 3,
+    logged: null,
     ...overrides,
   };
 }

--- a/backoffice/src/app/gc-fitness/clients/[id]/page.tsx
+++ b/backoffice/src/app/gc-fitness/clients/[id]/page.tsx
@@ -20,6 +20,7 @@
 //   that decision — the roster (11-05) already routes row clicks to
 //   `/gc-fitness/clients/${row.uid}`, not `/(dashboard)/gc-fitness/...`.
 
+import { listClientAppDevices } from "@/lib/gc-fitness/client-app-devices";
 import { Suspense } from "react";
 import { notFound, redirect } from "next/navigation";
 import { getTranslations } from "next-intl/server";
@@ -157,7 +158,8 @@ export default async function ClientDetailPage({
   // Contract: every client activity surface below reads this explicit IANA
   // timezone. Leaf components must not infer UTC or the host timezone.
   const todayCivil = civilDateToday(timezone);
-  const [notes, progressPhotos, goals, bodyWeightFulfilled, calendarPeek] = await Promise.all([
+  const [notes, progressPhotos, goals, bodyWeightFulfilled, calendarPeek, appDevices] =
+    await Promise.all([
     getClientNotes(id).catch(() => ({ notes: "", updatedAt: null, entries: [] })),
     listProgressPhotosForClient(id),
     listClientGoals(id),
@@ -168,6 +170,9 @@ export default async function ClientDetailPage({
       () => ({ fulfilled: false, fulfilledAt: null }),
     ),
     getClientCalendarPeek({ clientId: id, anchorCivil: todayCivil }),
+    // #785 — which app build(s) the client is running, for the header badges.
+    // Fail-soft: a support detail must never 500 the profile.
+    listClientAppDevices(gcFitnessFirestore(), id).catch(() => []),
   ]);
   // Header "Peso" = the client's most recent weigh-in BY MEASUREMENT DATE.
   // On a transient read error fall back to NULL (em dash), never to the
@@ -207,6 +212,7 @@ export default async function ClientDetailPage({
         birthDate={client.birthDate ?? null}
         heightCm={typeof client.heightCm === "number" ? client.heightCm : null}
         bodyWeightKg={latestBodyWeightKg}
+        appDevices={appDevices}
       />
       <ClientIdentityEditor
         clientId={id}

--- a/backoffice/src/app/gc-fitness/recent-logs/_components/RecentLogsFeed.tsx
+++ b/backoffice/src/app/gc-fitness/recent-logs/_components/RecentLogsFeed.tsx
@@ -5,6 +5,7 @@ import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { useMemo, useState } from "react";
 import {
+  CalendarPlus,
   ArrowRightLeft,
   Bell,
   CalendarClock,
@@ -60,6 +61,7 @@ const CATEGORY_ICON: Record<
   habit: ListChecks,
   workout: Dumbbell,
   reschedule: ArrowRightLeft,
+  assignment: CalendarPlus,
   reminder: Bell,
   photo: Camera,
   weight: Scale,
@@ -70,6 +72,7 @@ const CATEGORY_LABEL_KEY: Record<RecentLogRow["category"], string> = {
   habit: "badgeHabit",
   workout: "badgeWorkout",
   reschedule: "badgeReschedule",
+  assignment: "badgeAssignment",
   reminder: "badgeReminder",
   photo: "badgePhoto",
   weight: "badgeWeight",

--- a/backoffice/src/components/gc-fitness/__tests__/month-calendar-drag-move.test.tsx
+++ b/backoffice/src/components/gc-fitness/__tests__/month-calendar-drag-move.test.tsx
@@ -156,6 +156,8 @@ function chip(overrides: Partial<MonthWorkoutChip> = {}): MonthWorkoutChip {
     seriesId: null,
     recurrenceKind: null,
     selfAssigned: false,
+    plannedExercises: 3,
+    logged: null,
     ...overrides,
   };
 }
@@ -377,5 +379,74 @@ describe("MonthCalendar — #449, a client-created workout can't be dragged", ()
     // The other direction of the same guard: over-hiding it would make the
     // whole calendar unmovable and nothing would error.
     expect(chipButton("Push Day")).toHaveAttribute("draggable", "true");
+  });
+});
+
+// #785 — "¿qué son esos libres?"
+//
+// A workout the athlete started EMPTY and built while training (#541) is stored
+// with the placeholder name "Entreno libre", so a coach looking at the calendar
+// sees two identical chips and no way to tell what either of them was. The chip
+// now carries what was actually PERFORMED, which the month query already loads
+// to flip each chip's status.
+describe("MonthCalendar — a free workout says what was performed (#785)", () => {
+  const free = (over: Partial<MonthWorkoutChip> = {}) =>
+    chip({
+      templateName: "Entreno libre",
+      plannedExercises: 0,
+      status: "completed",
+      logged: { exercises: 4, sets: 12, durationMinutes: 38, volumeKg: 2400 },
+      ...over,
+    });
+
+  it("shows the exercise count inline, next to the placeholder name", () => {
+    renderCalendar([free()]);
+
+    expect(chipButton("Entreno libre")).toHaveTextContent("4 exercises");
+  });
+
+  it("puts the whole summary in the tooltip", () => {
+    renderCalendar([free()]);
+
+    expect(chipButton("Entreno libre").getAttribute("title")).toContain(
+      "4 exercises · 12 sets · 38 min · 2400 kg",
+    );
+  });
+
+  it("says so when the workout was started and nothing was logged", () => {
+    renderCalendar([
+      free({ logged: { exercises: 0, sets: 0, durationMinutes: null, volumeKg: null } }),
+    ]);
+
+    const button = chipButton("Entreno libre");
+    expect(button.getAttribute("title")).toContain("no sets logged");
+    // Nothing inline: "· 0 ejercicios" beside the name would be noise on a chip
+    // whose tooltip already says it.
+    expect(button).not.toHaveTextContent("0 exercises");
+  });
+
+  it("leaves a NAMED routine's chip alone", () => {
+    // A routine that says what it is does not need "· 4 ejercicios" glued to it;
+    // the summary is still in the tooltip for anyone who wants the detail.
+    renderCalendar([
+      chip({
+        templateName: "Push Day",
+        plannedExercises: 5,
+        status: "completed",
+        logged: { exercises: 5, sets: 15, durationMinutes: 42, volumeKg: 3100 },
+      }),
+    ]);
+
+    const button = chipButton("Push Day");
+    expect(button).not.toHaveTextContent("5 exercises");
+    expect(button.getAttribute("title")).toContain("5 exercises · 15 sets");
+  });
+
+  it("adds nothing to a chip nobody has trained yet", () => {
+    renderCalendar([free({ status: "scheduled", logged: null })]);
+
+    const button = chipButton("Entreno libre");
+    expect(button).not.toHaveTextContent("exercises");
+    expect(button.getAttribute("title")).not.toContain("sets");
   });
 });

--- a/backoffice/src/components/gc-fitness/__tests__/move-assignment-dialog.test.tsx
+++ b/backoffice/src/components/gc-fitness/__tests__/move-assignment-dialog.test.tsx
@@ -39,6 +39,8 @@ const CHIP: MonthWorkoutChip = {
   seriesId: "series-1",
   recurrenceKind: "weekly",
   selfAssigned: false,
+  plannedExercises: 3,
+  logged: null,
 };
 
 function renderDialog() {

--- a/backoffice/src/components/gc-fitness/schedule/month-calendar.tsx
+++ b/backoffice/src/components/gc-fitness/schedule/month-calendar.tsx
@@ -1328,6 +1328,8 @@ function DayCell({
                       )}
                       title={[
                         w.templateName,
+                        w.plannedExercises === 0 ? t("freeWorkoutHint") : null,
+                        workoutSummaryLabel(w.logged, t),
                         movedFromLabel,
                         w.selfAssigned ? t("clientCreatedBadge") : null,
                       ]
@@ -1337,6 +1339,11 @@ function DayCell({
                       <Dumbbell className="size-3 shrink-0 opacity-80" />
                       <span className="min-w-0 flex-1 truncate font-medium">
                         {w.templateName}
+                        {inlineWorkoutSummary(w, t) ? (
+                          <span className="font-normal opacity-70">
+                            {inlineWorkoutSummary(w, t)}
+                          </span>
+                        ) : null}
                       </span>
                       {w.selfAssigned ? <ClientOwnedBadge /> : null}
                       {movedFromLabel ? (
@@ -1468,6 +1475,8 @@ function ClientDayCell({
               )}
               title={[
                 w.templateName,
+                w.plannedExercises === 0 ? t("freeWorkoutHint") : null,
+                workoutSummaryLabel(w.logged, t),
                 movedFromLabel,
                 w.selfAssigned ? t("clientCreatedBadge") : null,
               ]
@@ -1477,6 +1486,11 @@ function ClientDayCell({
               <Dumbbell className="size-3 shrink-0 opacity-80" />
               <span className="min-w-0 flex-1 truncate font-medium">
                 {w.templateName}
+                {inlineWorkoutSummary(w, t) ? (
+                  <span className="font-normal opacity-70">
+                    {inlineWorkoutSummary(w, t)}
+                  </span>
+                ) : null}
               </span>
               {w.selfAssigned ? <ClientOwnedBadge /> : null}
               {movedFromLabel ? (
@@ -1521,6 +1535,50 @@ function ClientDayCell({
       </div>
     </td>
   );
+}
+
+/**
+ * #785 — "4 ejercicios · 12 series · 38 min", from what was actually performed.
+ *
+ * The reported gap: a coach opens a client's calendar and sees two chips that
+ * say **"Entreno libre"** and nothing else — "¿qué son esos libres?". They are
+ * workouts the athlete started empty and built while training (#541), so their
+ * NAME is a placeholder by construction and no amount of reading it will ever
+ * answer the question. What was done is in the log, which the month query
+ * already loads.
+ *
+ * Returns null when nothing was logged, so a scheduled-but-not-done chip is
+ * unchanged.
+ */
+function workoutSummaryLabel(
+  logged: MonthWorkoutChip["logged"],
+  t: ReturnType<typeof useTranslations>,
+): string | null {
+  if (!logged) return null;
+  if (logged.sets === 0) return t("loggedNothing");
+  return [
+    t("loggedExercises", { count: logged.exercises }),
+    t("loggedSets", { count: logged.sets }),
+    logged.durationMinutes !== null ? t("loggedMinutes", { count: logged.durationMinutes }) : null,
+    logged.volumeKg !== null ? t("loggedVolume", { count: logged.volumeKg }) : null,
+  ]
+    .filter(Boolean)
+    .join(" · ");
+}
+
+/**
+ * The compact suffix a FREE workout's chip carries inline (the month grid has
+ * room for a few characters, not for the whole summary — that lives in the
+ * tooltip). Only free workouts get it: a named routine already says what it is,
+ * and repeating "· 4 ej" on every completed chip is noise.
+ */
+function inlineWorkoutSummary(
+  w: MonthWorkoutChip,
+  t: ReturnType<typeof useTranslations>,
+): string | null {
+  if (w.plannedExercises > 0) return null;
+  if (!w.logged || w.logged.sets === 0) return null;
+  return ` · ${t("loggedExercises", { count: w.logged.exercises })}`;
 }
 
 /**

--- a/backoffice/src/lib/gc-fitness/__tests__/activity-feed-actions.test.ts
+++ b/backoffice/src/lib/gc-fitness/__tests__/activity-feed-actions.test.ts
@@ -303,6 +303,56 @@ describe("assignments, habits and accounts", () => {
   });
 });
 
+// #785 — "se asignó un workout · ver detalle", with no name beside it.
+//
+// The capture elides `templateSnapshot`, so an assignment's name can only come
+// from hydration — and hydration reads the LIVE doc, which is gone for any
+// assignment that was deleted since (a cancelled ad-hoc workout cleans its own
+// up). The row then names nothing, next to sibling rows that do.
+describe("a deleted assignment still gets named (#785)", () => {
+  const selfAssign = (docId: string) =>
+    doc("a-self", {
+      collection: "workout_assignments",
+      docId,
+      op: "create",
+      changedFields: ["scheduledFor", "selfAssigned"],
+      changedFieldCount: 2,
+      after: { scheduledFor: "2026-07-27", selfAssigned: true },
+      trainerId: "solo1",
+      clientId: "solo1",
+      occurredAt: ts("2026-07-27T10:00:00.000Z"),
+    });
+
+  it("falls back to the workout it produced", async () => {
+    const gone = `asg-solo1-20260727-self-${UUID}`;
+    queryGet.audit_log = async () => ({ docs: [selfAssign(gone)] });
+    // The assignment doc is absent from `docsByCollection`, so the point read
+    // misses; the log that references it is what remembers the name.
+    queryGet.workout_logs = async () => ({
+      docs: [
+        doc("log-9", {
+          assignmentId: gone,
+          templateSnapshot: { name: { es: "RESISTANCE D", en: "RESISTANCE D" } },
+        }),
+      ],
+    });
+
+    const [event] = await listActivityFeed();
+    expect(event.title).toBe("Se asignó un workout");
+    expect(event.subject).toBe("RESISTANCE D");
+  });
+
+  it("leaves the row nameless when nothing was ever performed", async () => {
+    queryGet.audit_log = async () => ({
+      docs: [selfAssign(`asg-solo1-20260728-self-${UUID}`)],
+    });
+    queryGet.workout_logs = async () => ({ docs: [] });
+
+    const [event] = await listActivityFeed();
+    expect(event.subject).toBeNull();
+  });
+});
+
 describe("other sources", () => {
   beforeEach(() => {
     queryGet.coach_activity = async () => ({

--- a/backoffice/src/lib/gc-fitness/__tests__/audit-grouping.test.ts
+++ b/backoffice/src/lib/gc-fitness/__tests__/audit-grouping.test.ts
@@ -201,6 +201,72 @@ describe("groupRecurringAuditEntries — #697 different routines, same client", 
   });
 });
 
+describe("groupRecurringAuditEntries — #785 a move is always its own row", () => {
+  /**
+   * The reported bug: a coach moved several workouts and the timeline showed one
+   * movement. A move is an UPDATE of `scheduledFor`, so `templateId` is absent
+   * from the capture and #697's discriminator cannot fire — every move by the
+   * same actor in the same minute merged under the client-wide root, keeping the
+   * head's routine name and the head's dates and dropping the rest.
+   */
+  const move = (id: string, date: string, from: string, to: string) =>
+    raw({
+      id,
+      docId: `asg-uidClient-${date}-${UUID}`,
+      changedFields: ["scheduledFor", "updatedAt"],
+      changedFieldCount: 2,
+      before: { scheduledFor: from },
+      after: { scheduledFor: to },
+    });
+
+  it("keeps two workouts moved in the same minute apart", () => {
+    const groups = groupRecurringAuditEntries([
+      move("1", "20270107", "2027-01-07", "2027-01-08"),
+      move("2", "20270114", "2027-01-14", "2027-01-15"),
+    ]);
+    expect(groups).toHaveLength(2);
+    expect(groups.map((g) => g.count)).toEqual([1, 1]);
+    // Each row keeps its OWN before/after, which is the whole point.
+    expect(groups.map((g) => g.head.after?.scheduledFor)).toEqual([
+      "2027-01-08",
+      "2027-01-15",
+    ]);
+  });
+
+  it("does not change how a non-move update collapses", () => {
+    const groups = groupRecurringAuditEntries([
+      raw({ id: "1", docId: `asg-uidClient-20270107-${UUID}` }),
+      raw({ id: "2", docId: `asg-uidClient-20270114-${UUID}` }),
+    ]);
+    expect(groups).toHaveLength(1);
+    expect(groups[0].count).toBe(2);
+  });
+
+  it("leaves creates and deletes of a series collapsed", () => {
+    // A delete's capture snapshots every key, `scheduledFor` included — so the
+    // move test must key on the OP too, or a recurrence edit's delete batch
+    // would explode into one row per occurrence.
+    const groups = groupRecurringAuditEntries([
+      raw({
+        id: "1",
+        op: "delete",
+        docId: `asg-uidClient-20270107-${UUID}`,
+        changedFields: ["scheduledFor", "templateId", "status"],
+        before: { scheduledFor: "2027-01-07", templateId: "tpl-a" },
+      }),
+      raw({
+        id: "2",
+        op: "delete",
+        docId: `asg-uidClient-20270114-${UUID}`,
+        changedFields: ["scheduledFor", "templateId", "status"],
+        before: { scheduledFor: "2027-01-14", templateId: "tpl-a" },
+      }),
+    ]);
+    expect(groups).toHaveLength(1);
+    expect(groups[0].count).toBe(2);
+  });
+});
+
 describe("findRecurrenceEdits", () => {
   const deleted = (id: string, date: string, templateId: string, atISO: string) =>
     raw({

--- a/backoffice/src/lib/gc-fitness/__tests__/client-app-devices.test.ts
+++ b/backoffice/src/lib/gc-fitness/__tests__/client-app-devices.test.ts
@@ -1,0 +1,128 @@
+// __tests__/client-app-devices.test.ts
+//
+// #785 — the per-device "which app version, and is it iOS or Android" line on a
+// client profile. Both halves are read out of `/users/{uid}/fcm_tokens`, which
+// already carried `platform`; `appVersion` / `appBuild` are the new fields.
+//
+// The projection is where the two traps live: a push token ROTATES (reinstall,
+// restore, Firebase's own schedule) and each rotation writes a NEW doc, so one
+// phone can hold a dozen — and a device registered before this shipped has no
+// version at all, which must read as "unknown", never as "current".
+
+import {
+  formatAppDevice,
+  projectAppDevices,
+  type ClientAppDevice,
+} from "@/lib/gc-fitness/client-app-devices";
+
+const doc = (data: Record<string, unknown>) => ({ data: () => data });
+
+const ts = (iso: string) => ({ toDate: () => new Date(iso) });
+
+describe("projectAppDevices", () => {
+  it("reads platform, version and build, newest registration first", () => {
+    const rows = projectAppDevices([
+      doc({
+        platform: "android",
+        appVersion: "1.2.9",
+        appBuild: "310",
+        registeredAt: ts("2026-08-01T10:00:00Z"),
+      }),
+      doc({
+        platform: "ios",
+        appVersion: "1.3.0",
+        appBuild: "42",
+        registeredAt: ts("2026-08-06T10:00:00Z"),
+      }),
+    ]);
+
+    expect(rows).toEqual<ClientAppDevice[]>([
+      {
+        platform: "ios",
+        appVersion: "1.3.0",
+        appBuild: "42",
+        registeredAtISO: "2026-08-06T10:00:00.000Z",
+      },
+      {
+        platform: "android",
+        appVersion: "1.2.9",
+        appBuild: "310",
+        registeredAtISO: "2026-08-01T10:00:00.000Z",
+      },
+    ]);
+  });
+
+  it("collapses the rotations of ONE device into a single row", () => {
+    // Same phone, same build, three tokens. Without the dedupe the profile
+    // becomes a push-token history instead of an answer.
+    const rows = projectAppDevices([
+      doc({ platform: "ios", appVersion: "1.3.0", appBuild: "42", registeredAt: ts("2026-08-01T10:00:00Z") }),
+      doc({ platform: "ios", appVersion: "1.3.0", appBuild: "42", registeredAt: ts("2026-08-04T10:00:00Z") }),
+      doc({ platform: "ios", appVersion: "1.3.0", appBuild: "42", registeredAt: ts("2026-08-06T10:00:00Z") }),
+    ]);
+
+    expect(rows).toHaveLength(1);
+    // The kept row is the newest — "when did I last see this device".
+    expect(rows[0].registeredAtISO).toBe("2026-08-06T10:00:00.000Z");
+  });
+
+  it("keeps the SAME phone's two versions apart", () => {
+    // An upgrade is exactly what the field is for, so it must not be deduped
+    // away by platform alone.
+    const rows = projectAppDevices([
+      doc({ platform: "ios", appVersion: "1.2.0", appBuild: "30", registeredAt: ts("2026-07-01T10:00:00Z") }),
+      doc({ platform: "ios", appVersion: "1.3.0", appBuild: "42", registeredAt: ts("2026-08-06T10:00:00Z") }),
+    ]);
+
+    expect(rows.map((r) => r.appVersion)).toEqual(["1.3.0", "1.2.0"]);
+  });
+
+  it("reports a pre-#785 device as unknown rather than current", () => {
+    const [row] = projectAppDevices([
+      doc({ platform: "android", registeredAt: ts("2026-05-01T10:00:00Z") }),
+    ]);
+
+    expect(row.appVersion).toBeNull();
+    expect(row.appBuild).toBeNull();
+    expect(formatAppDevice(row)).toBe("Android · versión desconocida");
+  });
+
+  it("survives a doc with no platform and no timestamp", () => {
+    const [row] = projectAppDevices([doc({ token: "abc" })]);
+
+    expect(row.platform).toBe("unknown");
+    expect(row.registeredAtISO).toBeNull();
+  });
+
+  it("accepts an ISO string timestamp as well as a Firestore one", () => {
+    const [row] = projectAppDevices([
+      doc({ platform: "ios", registeredAt: "2026-08-06T10:00:00.000Z" }),
+    ]);
+
+    expect(row.registeredAtISO).toBe("2026-08-06T10:00:00.000Z");
+  });
+});
+
+describe("formatAppDevice", () => {
+  it("names the platform the way a human writes it", () => {
+    expect(
+      formatAppDevice({
+        platform: "ios",
+        appVersion: "1.3.0",
+        appBuild: "42",
+        registeredAtISO: null,
+      }),
+    ).toBe("iOS 1.3.0 (42)");
+  });
+
+  it("omits an absent build instead of printing an empty pair of parens", () => {
+    expect(
+      formatAppDevice({
+        platform: "android",
+        appVersion: "1.2.9",
+        appBuild: null,
+        registeredAtISO: null,
+      }),
+    ).toBe("Android 1.2.9");
+  });
+});

--- a/backoffice/src/lib/gc-fitness/__tests__/recent-logs-actions.self-assignment.test.ts
+++ b/backoffice/src/lib/gc-fitness/__tests__/recent-logs-actions.self-assignment.test.ts
@@ -1,0 +1,209 @@
+// __tests__/recent-logs-actions.self-assignment.test.ts
+//
+// #785 — "en recent activity de un coach-less user no se ve todo lo que hace".
+//
+// The reported profile showed exactly two rows — a body weight and the first
+// sign-in — while the admin timeline showed the same person self-assigning
+// three workouts that same day. The feed only ever spoke about a workout once
+// it was FINISHED, so everything an athlete puts on their own calendar was
+// invisible on the one page that is supposed to say what they do.
+//
+// The row is derived in memory from the assignment docs the reschedule and
+// reminder passes already fetch — no new query, no new index — so these tests
+// pin the two halves that are easy to get wrong: WHICH assignments qualify (a
+// coach's own must not, or the feed becomes the coach re-reading their own
+// work), and WHICH timestamp dates the row (`createdAt`, not the `updatedAt`
+// every later write bumps).
+//
+// Firestore is mocked with the same tiny chainable builder as
+// recent-logs-actions.reminder.test.ts.
+
+const mockState: { db: unknown } = { db: null };
+
+jest.mock("@/lib/firebase/gc-fitness-admin", () => ({
+  gcFitnessFirestore: () => mockState.db,
+}));
+jest.mock("@/lib/gc-fitness/auth-helpers", () => ({
+  getCurrentTrainer: jest.fn(async () => ({ uid: "t1", email: "t@x.com" })),
+}));
+jest.mock("@/lib/gc-fitness/client-roster", () => ({
+  listClients: jest.fn(async () => [
+    {
+      uid: "c1",
+      email: "c1@x.com",
+      displayName: "Client One",
+      createdAt: null,
+      timezone: null,
+      photoURL: null,
+      pendingProvisioning: false,
+    },
+  ]),
+}));
+jest.mock("@/lib/gc-fitness/trainer-timezone", () => ({
+  getTrainerTimezone: jest.fn(async () => "UTC"),
+}));
+
+import { listRecentLogsForTrainer } from "../recent-logs-actions";
+import { FirestoreCollections } from "../collections";
+
+function snap(docs: unknown[]) {
+  return {
+    docs,
+    size: docs.length,
+    empty: docs.length === 0,
+    forEach: (cb: (d: unknown) => void) => docs.forEach(cb),
+  };
+}
+
+function fakeUserDoc() {
+  const data = {
+    email: "c1@x.com",
+    displayName: "Client One",
+    role: "client",
+    coachId: "t1",
+    timezone: null,
+  };
+  return {
+    id: "c1",
+    exists: true,
+    data: () => data,
+    get: (f: string) => (data as Record<string, unknown>)[f],
+  };
+}
+
+function assignmentDoc(id: string, over: Record<string, unknown> = {}) {
+  const data: Record<string, unknown> = {
+    clientId: "c1",
+    // #392's shape: the athlete is their own trainer-of-record on anything they
+    // scheduled themselves.
+    trainerId: "c1",
+    selfAssigned: true,
+    scheduledFor: "2026-06-15",
+    createdAt: "2026-06-11T10:00:00Z",
+    updatedAt: "2026-06-14T22:00:00Z",
+    templateSnapshot: {
+      name: { en: "Push Day", es: "Empuje" },
+      exercises: [{ exerciseId: "e1" }, { exerciseId: "e2" }],
+    },
+    ...over,
+  };
+  return {
+    id,
+    exists: true,
+    data: () => data,
+    get: (f: string) => data[f],
+  };
+}
+
+function makeDb(assignments: ReturnType<typeof assignmentDoc>[]) {
+  function resolve(collName: string) {
+    if (collName === FirestoreCollections.workoutAssignments) {
+      return Promise.resolve(snap(assignments));
+    }
+    if (collName === FirestoreCollections.users) {
+      return Promise.resolve(snap([fakeUserDoc()]));
+    }
+    return Promise.resolve(snap([]));
+  }
+
+  function makeQuery(collName: string): Record<string, unknown> {
+    const q: Record<string, unknown> = {
+      where: () => q,
+      orderBy: () => q,
+      limit: () => q,
+      get: () => resolve(collName),
+      doc: (id: string) => makeDocRef(collName, id),
+    };
+    return q;
+  }
+
+  function makeDocRef(collName: string, id: string) {
+    return {
+      id,
+      get: () =>
+        Promise.resolve({ exists: false, data: () => ({}), get: () => undefined }),
+      collection: (sub: string) => makeQuery(`${collName}/${id}/${sub}`),
+    };
+  }
+
+  return {
+    collection: (name: string) => makeQuery(name),
+    getAll: () => Promise.resolve([]),
+  };
+}
+
+describe("listRecentLogsForTrainer — the athlete scheduled it themselves (#785)", () => {
+  let errSpy: jest.SpyInstance;
+  beforeEach(() => {
+    errSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+  });
+  afterEach(() => {
+    errSpy.mockRestore();
+  });
+
+  const assignmentRows = async () => {
+    const { logs } = await listRecentLogsForTrainer();
+    return logs.filter((r) => r.category === "assignment");
+  };
+
+  it("emits a row naming the routine and the day it is for", async () => {
+    mockState.db = makeDb([assignmentDoc("a1")]);
+
+    const rows = await assignmentRows();
+    expect(rows).toHaveLength(1);
+    expect(rows[0].title).toContain("Client One se asignó");
+    // `localizedText` resolves EN first here, exactly like the reschedule row
+    // beside it — the prose is Spanish, the routine keeps its own name.
+    expect(rows[0].title).toContain("Push Day");
+    expect(rows[0].detail).toContain("2 ejercicios");
+  });
+
+  it("dates the row when it was SCHEDULED, not when it was last touched", async () => {
+    // `updatedAt` is bumped by the move, the finish and the prescription
+    // write-back; using it would walk a two-week-old plan back to the top of
+    // the feed every time the athlete touched it.
+    mockState.db = makeDb([assignmentDoc("a1")]);
+
+    const rows = await assignmentRows();
+    expect(rows[0].eventAt).toBe("2026-06-11T10:00:00.000Z");
+  });
+
+  it("says a free workout is one, instead of pretending to be a plan", async () => {
+    // #541 — started empty and built while training, so the snapshot has no
+    // exercises and the name is the placeholder. "Entreno libre" alone is the
+    // thing the ticket complains about; the row says what it means.
+    mockState.db = makeDb([
+      assignmentDoc("a1", {
+        templateSnapshot: {
+          name: { en: "Free workout", es: "Entreno libre" },
+          exercises: [],
+        },
+      }),
+    ]);
+
+    const rows = await assignmentRows();
+    // The DETAIL is the fixed phrase the row adds — the title still carries
+    // whatever placeholder name the app wrote.
+    expect(rows[0].detail).toContain("Entreno libre (lo arma mientras entrena)");
+    expect(rows[0].detail).not.toContain("ejercicios");
+  });
+
+  it("ignores the COACH's own assignments", async () => {
+    // The feed's reader is the coach. Their own assignments are not news, and
+    // emitting them would bury the rows that are.
+    mockState.db = makeDb([
+      assignmentDoc("a1", { trainerId: "t1", selfAssigned: false }),
+    ]);
+
+    expect(await assignmentRows()).toHaveLength(0);
+  });
+
+  it("qualifies a legacy doc with no `selfAssigned` flag", async () => {
+    // The canonical predicate is `trainerId === clientId` (#392/#449), not the
+    // boolean — docs written before the flag existed still belong to the
+    // athlete.
+    mockState.db = makeDb([assignmentDoc("a1", { selfAssigned: undefined })]);
+
+    expect(await assignmentRows()).toHaveLength(1);
+  });
+});

--- a/backoffice/src/lib/gc-fitness/activity-feed-actions.ts
+++ b/backoffice/src/lib/gc-fitness/activity-feed-actions.ts
@@ -529,6 +529,32 @@ async function resolveUsers(
  * Bounded, deduped, parallel point reads; each one fail-soft. A doc that no
  * longer exists simply resolves to nothing and the row renders without a name.
  */
+/**
+ * #785 — recover a deleted assignment's name from the workout it produced.
+ *
+ * Returns null for any other collection, and for an assignment that never
+ * produced a log (nothing was performed, so there is nothing left to read).
+ */
+async function nameFromWorkoutLogOfAssignment(
+  db: Firestore,
+  ref: FeedSubjectRef,
+): Promise<string | null> {
+  if (ref.collection !== "workout_assignments") return null;
+  const snap = await db
+    .collection(FirestoreCollections.workoutLogs)
+    .where("assignmentId", "==", ref.id)
+    .limit(1)
+    .get()
+    .catch(() => null);
+  const doc = snap?.docs[0];
+  if (!doc) return null;
+  const name = bilingualText(
+    snapshotRecord(doc.data().templateSnapshot)?.name,
+    "",
+  );
+  return name || null;
+}
+
 async function resolveEntityNames(
   db: Firestore,
   refs: FeedSubjectRef[],
@@ -556,7 +582,23 @@ async function resolveEntityNames(
         .doc(ref.id)
         .get()
         .catch(() => null);
-      if (!snap || !snap.exists) return;
+      if (!snap || !snap.exists) {
+        // #785 — "se asignó un workout · ver detalle", with no name at all.
+        //
+        // The capture elides `templateSnapshot` (512-char cap), so an
+        // assignment's name can ONLY come from hydration — and hydration reads
+        // the live doc, which is gone for any assignment that was since deleted
+        // (a cancelled ad-hoc workout cleans its own assignment up). The row
+        // then names nothing, next to sibling rows that do, which reads as the
+        // feed dropping information rather than the doc being gone.
+        //
+        // The workout it produced still knows: every `workout_logs` doc carries
+        // both the `assignmentId` FK and its own frozen `templateSnapshot`. One
+        // query, only on the path that already failed.
+        const recovered = await nameFromWorkoutLogOfAssignment(db, ref);
+        if (recovered) out.set(`${ref.collection}:${ref.id}`, recovered);
+        return;
+      }
       const d = snap.data() as Record<string, unknown>;
       // A log and an assignment both carry the workout's name inside their
       // `templateSnapshot`; a template / habit / exercise carries it top-level.

--- a/backoffice/src/lib/gc-fitness/admin-coachless-actions.ts
+++ b/backoffice/src/lib/gc-fitness/admin-coachless-actions.ts
@@ -18,6 +18,10 @@ import { z } from "zod";
 
 import { deleteClientCascade } from "@/lib/gc-fitness/admin-actions";
 import { getCurrentAdmin } from "@/lib/gc-fitness/auth-helpers";
+import {
+  listClientAppDevices,
+  type ClientAppDevice,
+} from "@/lib/gc-fitness/client-app-devices";
 import { FirestoreCollections } from "@/lib/gc-fitness/collections";
 import {
   bilingualText,
@@ -166,6 +170,8 @@ export interface CoachlessUserProfile {
   auth: CoachlessAuthInfo | null;
   routines: CoachlessRoutineRow[];
   recentWeights: CoachlessWeightRow[];
+  /** #785 — which app build(s) this person is actually running. */
+  devices: ClientAppDevice[];
 }
 
 /**
@@ -217,6 +223,7 @@ export async function getCoachlessUserProfile(
     logsCountAgg,
     photosCountAgg,
     authRecord,
+    devices,
   ] = await Promise.all([
     // Self-authored templates: no orderBy, so no composite index is needed and
     // client-created docs missing `deleted` aren't filtered out (see the
@@ -268,6 +275,9 @@ export async function getCoachlessUserProfile(
     gcFitnessAuth()
       .getUser(uid)
       .catch(() => null),
+    // #785 — which app build(s) this person is on. Reads the push-token
+    // subcollection every signed-in device writes; fail-soft like Auth above.
+    listClientAppDevices(db, uid),
   ]);
 
   const routines: CoachlessRoutineRow[] = templatesSnap.docs
@@ -352,6 +362,7 @@ export async function getCoachlessUserProfile(
       : null,
     routines,
     recentWeights,
+    devices,
   } satisfies CoachlessUserProfile;
 }
 

--- a/backoffice/src/lib/gc-fitness/audit-grouping.ts
+++ b/backoffice/src/lib/gc-fitness/audit-grouping.ts
@@ -85,6 +85,31 @@ export function assignmentTemplateId(entry: RawAuditLogEntry): string | null {
   return null;
 }
 
+/**
+ * #785 — a write that MOVES one workout to another day, which must never
+ * collapse with a sibling.
+ *
+ * The grouping key below discriminates routines by `templateId`, and the doc
+ * comment on `assignmentTemplateId` explains why that field is only reliably
+ * present on a create or a delete: on an update the capture snapshots the
+ * CHANGED keys, and a move changes `scheduledFor`, not `templateId`. So every
+ * move fell back to the client-wide root (`asg-<clientUid>`) and any two moves
+ * by the same actor in the same minute merged into ONE row — which then shows
+ * the head's routine name and the head's date pair, and silently drops the rest.
+ *
+ * That is the literal report in #785: a coach moved several workouts and the
+ * timeline showed one movement. It is also #697's bug, reappearing through the
+ * one branch its `templateId` fix cannot reach.
+ *
+ * A move is therefore always its own row. The collapse exists for a single edit
+ * that re-writes a whole series, and a move is not that: `moveAssignment` writes
+ * each occurrence it moves with its own before/after dates, and those dates are
+ * exactly what the operator is looking at.
+ */
+function isDayMove(entry: RawAuditLogEntry): boolean {
+  return entry.op === "update" && entry.changedFields.includes("scheduledFor");
+}
+
 /** "20270503" → "2027-05-03". */
 export function fmtYmd(yyyymmdd: string): string {
   return `${yyyymmdd.slice(0, 4)}-${yyyymmdd.slice(4, 6)}-${yyyymmdd.slice(6, 8)}`;
@@ -116,7 +141,9 @@ export function groupRecurringAuditEntries<T extends RawAuditLogEntry>(
 
   for (const r of raw) {
     const series =
-      r.collection === "workout_assignments" ? recurringSeries(r.docId) : null;
+      r.collection === "workout_assignments" && !isDayMove(r)
+        ? recurringSeries(r.docId)
+        : null;
     const key = series
       ? `rec|${r.collection}|${r.op}|${r.actorUid ?? ""}|${r.trainerId ?? ""}|${
           r.clientId ?? ""

--- a/backoffice/src/lib/gc-fitness/client-app-devices.ts
+++ b/backoffice/src/lib/gc-fitness/client-app-devices.ts
@@ -1,0 +1,138 @@
+// client-app-devices.ts
+//
+// #785 — "nos falta en cada perfil, qué versión de la app están usando, y si es
+// iOS o Android".
+//
+// WHERE THE ANSWER ALREADY LIVES
+// ------------------------------
+// Every signed-in device registers its push token at
+// `/users/{uid}/fcm_tokens/{tokenId}` with `{ token, platform, registeredAt }` —
+// both apps have written `platform` since P02-07 (`"ios"` / `"android"`). So the
+// platform half of the question needed no new write anywhere; it was simply
+// never read.
+//
+// `appVersion` / `appBuild` are the new half: the apps started stamping them
+// onto the same doc, and the rules whitelist admits them. A device that has not
+// re-registered since that build reports a null version rather than a wrong one
+// — which is itself the answer to "who is on an old build".
+//
+// WHY THE TOKEN SUBCOLLECTION AND NOT THE USER DOC
+// ------------------------------------------------
+// The question is per-DEVICE. Someone with an iPhone and an Android tablet is
+// on two versions at once, and a single `users/{uid}.appVersion` would show
+// whichever wrote last — a value that is right about nothing. One row per
+// device also makes "signed in on the phone in March, never since" visible.
+
+import type { Firestore } from "firebase-admin/firestore";
+
+import { FirestoreCollections } from "@/lib/gc-fitness/collections";
+
+export type ClientAppPlatform = "ios" | "android" | "unknown";
+
+export interface ClientAppDevice {
+  platform: ClientAppPlatform;
+  /** Marketing version ("1.3.0"), or null for a device registered before #785. */
+  appVersion: string | null;
+  /** Build number, when the app reported one. */
+  appBuild: string | null;
+  registeredAtISO: string | null;
+}
+
+/** Firestore subcollection holding one doc per registered device. */
+export const FCM_TOKENS_SUBCOLLECTION = "fcm_tokens";
+
+function asIso(value: unknown): string | null {
+  if (!value) return null;
+  if (typeof value === "string") {
+    const parsed = new Date(value);
+    return Number.isNaN(parsed.getTime()) ? null : parsed.toISOString();
+  }
+  const ts = value as { toDate?: () => Date };
+  if (typeof ts.toDate === "function") {
+    const date = ts.toDate();
+    return Number.isNaN(date.getTime()) ? null : date.toISOString();
+  }
+  return null;
+}
+
+function asPlatform(value: unknown): ClientAppPlatform {
+  return value === "ios" || value === "android" ? value : "unknown";
+}
+
+function asText(value: unknown): string | null {
+  return typeof value === "string" && value.trim().length > 0 ? value.trim() : null;
+}
+
+/**
+ * Project raw token docs into the per-device rows a profile renders.
+ *
+ * Pure — no Firestore — so the shape and the ordering are unit-testable.
+ * Newest registration first, and one row per (platform, version, build): a
+ * token ROTATES (Firebase mints a new one on reinstall, restore, or its own
+ * schedule) and each rotation writes a new doc, so a single phone can hold a
+ * dozen. Collapsing them keeps the profile answering "what is this person
+ * running" instead of listing push-token history.
+ */
+export function projectAppDevices(
+  docs: Array<{ data: () => Record<string, unknown> }>,
+): ClientAppDevice[] {
+  const rows = docs
+    .map((doc) => {
+      const d = doc.data();
+      return {
+        platform: asPlatform(d.platform),
+        appVersion: asText(d.appVersion),
+        appBuild: asText(d.appBuild),
+        registeredAtISO: asIso(d.registeredAt),
+      };
+    })
+    .sort((a, b) => (b.registeredAtISO ?? "").localeCompare(a.registeredAtISO ?? ""));
+
+  const seen = new Set<string>();
+  const out: ClientAppDevice[] = [];
+  for (const row of rows) {
+    const key = `${row.platform}|${row.appVersion ?? ""}|${row.appBuild ?? ""}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    out.push(row);
+  }
+  return out;
+}
+
+/**
+ * "iOS 1.3.0 (42)" — one device, for a profile line.
+ *
+ * A device with no version says so rather than looking current: the whole point
+ * of the field is spotting who is behind.
+ */
+export function formatAppDevice(device: ClientAppDevice): string {
+  const platform =
+    device.platform === "ios"
+      ? "iOS"
+      : device.platform === "android"
+        ? "Android"
+        : "Desconocido";
+  if (!device.appVersion) return `${platform} · versión desconocida`;
+  return device.appBuild
+    ? `${platform} ${device.appVersion} (${device.appBuild})`
+    : `${platform} ${device.appVersion}`;
+}
+
+/**
+ * Read a client's registered devices. Bounded: a heavy token rotator can
+ * accumulate docs, and this feeds one line of a profile.
+ */
+export async function listClientAppDevices(
+  db: Firestore,
+  uid: string,
+  limit = 25,
+): Promise<ClientAppDevice[]> {
+  const snap = await db
+    .collection(FirestoreCollections.users)
+    .doc(uid)
+    .collection(FCM_TOKENS_SUBCOLLECTION)
+    .limit(limit)
+    .get()
+    .catch(() => null);
+  return snap ? projectAppDevices(snap.docs) : [];
+}

--- a/backoffice/src/lib/gc-fitness/recent-logs-actions.ts
+++ b/backoffice/src/lib/gc-fitness/recent-logs-actions.ts
@@ -33,7 +33,23 @@ export type RecentLogCategory =
   | "photo"
   | "weight"
   | "signup"
-  | "profile";
+  | "profile"
+  /**
+   * #785 — the athlete put a workout on their OWN calendar (#392
+   * `selfAssigned`, `trainerId === clientId`).
+   *
+   * Reported against a coach-less user whose profile showed two rows — a body
+   * weight and the first sign-in — while the admin timeline showed him
+   * self-assigning three workouts the same day. Everything they schedule for
+   * themselves was invisible on the one page that is supposed to say what they
+   * do, because the feed only ever spoke about workouts once they were
+   * FINISHED.
+   *
+   * Deliberately self-assignments only: a coach's own assignments are not news
+   * to the coach reading the feed, and adding them would bury the rows that
+   * are.
+   */
+  | "assignment";
 
 export interface RecentLogRow {
   id: string;
@@ -515,7 +531,7 @@ async function buildRecentLogs(params: {
     // 260611-t1y: reminder rows are ALSO derived from these same assignment docs
     // (in-memory, no extra query/index), so fetch them when EITHER category is
     // wanted.
-    const assignSnapsP = want("reschedule") || want("reminder")
+    const assignSnapsP = want("reschedule") || want("reminder") || want("assignment")
       ? Promise.all(
           clients.map((c) => {
             let q: FirebaseFirestore.Query = db
@@ -1138,6 +1154,59 @@ async function buildRecentLogs(params: {
       clientPhotoURL: photoByClientId.get(clientId) ?? null,
       title: `${nameByClientId.get(clientId) ?? clientId} movió ${templateName} de ${fromLabel} a ${toLabel}`,
       detail: `Originalmente ${fromLabel} → ${toLabel}`,
+      workoutLogId: null,
+    });
+  });
+
+  // #785 — the athlete scheduled a workout for themselves.
+  //
+  // Derived from the SAME `trainerAssignmentsSnap` the two passes around it use
+  // — no extra query, no new index. The gate is the #392 shape
+  // (`trainerId === clientId`), not the `selfAssigned` flag, so pre-flag docs
+  // still qualify; a coach's own assignments are excluded on purpose (see the
+  // `"assignment"` category doc).
+  if (wantCategory("assignment")) trainerAssignmentsSnap.docs.forEach((doc) => {
+    const data = doc.data();
+    const clientId = typeof data.clientId === "string" ? data.clientId : "";
+    if (!clientId || !nameByClientId.has(clientId)) return;
+    if (data.trainerId !== clientId) return;
+    // `createdAt` is when they scheduled it — NOT `updatedAt`, which every
+    // later write to the doc (the move, the finish, the prescription
+    // write-back) would bump, walking a two-week-old plan back to the top of
+    // the feed each time it is touched.
+    const eventAt = asIso(data.createdAt) ?? asIso(data.updatedAt);
+    if (!eventAt) return;
+    const scheduledFor =
+      typeof data.scheduledFor === "string" ? data.scheduledFor : "";
+    const templateName = localizedText(
+      (data.templateSnapshot as { name?: unknown } | undefined)?.name,
+      "Entrenamiento",
+    );
+    const plannedExercises = Array.isArray(
+      (data.templateSnapshot as { exercises?: unknown } | undefined)?.exercises,
+    )
+      ? ((data.templateSnapshot as { exercises: unknown[] }).exercises.length)
+      : 0;
+    const name = nameByClientId.get(clientId) ?? clientId;
+    rows.push({
+      id: `assignment:${doc.id}`,
+      category: "assignment",
+      eventAt,
+      clientId,
+      clientName: name,
+      clientPhotoURL: photoByClientId.get(clientId) ?? null,
+      title: `${name} se asignó ${templateName}`,
+      // The date is the point of a scheduled workout, and "Entreno libre" says
+      // nothing on its own — so an empty routine says so rather than pretending
+      // to be a plan (#541, same reason the calendar chip carries a summary).
+      detail: [
+        scheduledFor ? `Para ${formatCivilDateEsAr(scheduledFor)}` : null,
+        plannedExercises > 0
+          ? `${plannedExercises} ejercicio${plannedExercises === 1 ? "" : "s"}`
+          : "Entreno libre (lo arma mientras entrena)",
+      ]
+        .filter(Boolean)
+        .join(" · "),
       workoutLogId: null,
     });
   });

--- a/backoffice/src/lib/gc-fitness/schedule-month-actions.ts
+++ b/backoffice/src/lib/gc-fitness/schedule-month-actions.ts
@@ -65,6 +65,32 @@ export interface MonthWorkoutChip {
    * Drives the calendar's "created by the client" badge and disables the
    * drag/edit affordances (the coach views but does not manage it). */
   selfAssigned: boolean;
+  /**
+   * #785 — how many exercises the assignment PLANNED. Zero means a free
+   * workout ("Entreno libre"): the athlete started with nothing and built it as
+   * they went (#541), so the name carries no information at all and the chip
+   * has to get it from what was actually performed (`logged` below).
+   */
+  plannedExercises: number;
+  /**
+   * #785 — what was actually performed, from the `workout_logs` doc this
+   * assignment produced. Null while nothing has been logged.
+   *
+   * Costs no extra read: the month query already fetches those logs to flip
+   * each chip's status, and it fetches whole documents.
+   */
+  logged: MonthWorkoutLoggedSummary | null;
+}
+
+/** #785 — the performed-workout summary a chip can show. */
+export interface MonthWorkoutLoggedSummary {
+  /** Distinct exercises with at least one logged set. */
+  exercises: number;
+  sets: number;
+  /** Whole minutes, rounded; null when the log carries no duration. */
+  durationMinutes: number | null;
+  /** Total volume in kg, rounded; null when nothing was weighted. */
+  volumeKg: number | null;
 }
 
 export interface MonthHabitChip {
@@ -134,6 +160,40 @@ function statusFromAssignment(
 
 function finiteNumber(value: unknown): number | null {
   return typeof value === "number" && Number.isFinite(value) ? value : null;
+}
+
+/**
+ * #785 — summarize ONE `workout_logs` document for a calendar chip.
+ *
+ * Reads only what the doc already carries — `sets[]` plus the two totals the
+ * app writes at finalize — so it adds no reads and no name hydration. Exercise
+ * NAMES are deliberately out: they live in `exercises/{id}` and would turn a
+ * month view into dozens of point reads for a subtitle.
+ *
+ * Distinct exercises are counted by `exerciseId` alone rather than by
+ * `(exerciseId, exercise_order)`: a repeated exercise is still ONE exercise to
+ * someone reading "¿qué hizo?" from a calendar.
+ */
+export function summarizeLoggedWorkout(
+  data: Record<string, unknown>,
+): MonthWorkoutLoggedSummary {
+  const sets = Array.isArray(data.sets) ? data.sets : [];
+  const exerciseIds = new Set<string>();
+  for (const raw of sets) {
+    const id = (raw as { exerciseId?: unknown } | null)?.exerciseId;
+    if (typeof id === "string" && id.length > 0) exerciseIds.add(id);
+  }
+  const durationSeconds = finiteNumber(data.duration_seconds);
+  const volume = finiteNumber(data.total_volume_kg);
+  return {
+    exercises: exerciseIds.size,
+    sets: sets.length,
+    durationMinutes:
+      durationSeconds !== null && durationSeconds > 0
+        ? Math.max(1, Math.round(durationSeconds / 60))
+        : null,
+    volumeKg: volume !== null && volume > 0 ? Math.round(volume) : null,
+  };
 }
 
 function finiteNumberArray(value: unknown): number[] {
@@ -762,6 +822,11 @@ async function loadMonthForClients(
   // when it was never completed, just because another workout was logged that
   // day — 260528). `assignmentId` is a required, immutable field on every log.
   const logStatusByAssignment = new Map<string, MonthWorkoutChip["status"]>();
+  // #785 — the same pass builds the "what was actually done" summary, because
+  // the docs are already here. A free workout's NAME says nothing ("Entreno
+  // libre"), so this is the only thing that can answer "¿qué fue eso?" without
+  // opening it.
+  const loggedByAssignment = new Map<string, MonthWorkoutLoggedSummary>();
   for (const doc of logSnap.docs) {
     const data = doc.data() as {
       assignmentId?: string;
@@ -774,6 +839,7 @@ async function loadMonthForClients(
     // "completed" wins over "started" if both exist for the same assignment.
     if (logStatusByAssignment.get(assignmentId) === "completed") continue;
     logStatusByAssignment.set(assignmentId, status);
+    loggedByAssignment.set(assignmentId, summarizeLoggedWorkout(doc.data()));
   }
 
   const workoutsByDay: Record<string, MonthWorkoutChip[]> = {};
@@ -783,7 +849,7 @@ async function loadMonthForClients(
       clientId?: string;
       scheduledFor?: string;
       originallyScheduledFor?: string;
-      templateSnapshot?: { name?: unknown; tag?: unknown };
+      templateSnapshot?: { name?: unknown; tag?: unknown; exercises?: unknown };
       seriesId?: string | null;
       recurrence?: { kind?: string };
       status?: string;
@@ -841,6 +907,10 @@ async function loadMonthForClients(
           ? data.recurrence.kind
           : null,
       selfAssigned: isSelfAssigned,
+      plannedExercises: Array.isArray(data.templateSnapshot?.exercises)
+        ? data.templateSnapshot.exercises.length
+        : 0,
+      logged: loggedByAssignment.get(doc.id) ?? null,
     };
     (workoutsByDay[civil] ??= []).push(chip);
   }

--- a/backoffice/src/lib/test-utils/next-intl-stub.tsx
+++ b/backoffice/src/lib/test-utils/next-intl-stub.tsx
@@ -42,12 +42,52 @@ function lookup(path: string): string | undefined {
   return typeof node === "string" ? node : undefined;
 }
 
+/**
+ * Minimal ICU `plural` support: `{count, plural, one {# thing} other {# things}}`.
+ *
+ * The catalog has 30 of these, and without this the stub returned the PATTERN
+ * verbatim — so any test asserting on a pluralized string was really asserting
+ * that the string is broken, and any test written against it had to hard-code
+ * the ICU source. English cardinal rules only (`one` for exactly 1, `other`
+ * otherwise), which is what the EN catalog this stub reads is written in.
+ *
+ * `=0` / `=1` exact matches are honored first, as ICU does. `#` becomes the
+ * count. Nested plurals are out of scope — the catalog has none.
+ */
+function applyPlurals(
+  template: string,
+  vars?: Record<string, string | number>,
+): string {
+  if (!vars) return template;
+  return template.replace(
+    /\{(\w+),\s*plural,\s*([^{}]*(?:\{[^{}]*\}[^{}]*)*)\}/g,
+    (whole, name: string, body: string) => {
+      const raw = vars[name];
+      if (raw === undefined) return whole;
+      const count = Number(raw);
+      if (!Number.isFinite(count)) return whole;
+      const branches = new Map<string, string>();
+      const re = /(=\d+|zero|one|two|few|many|other)\s*\{([^{}]*)\}/g;
+      let match: RegExpExecArray | null;
+      while ((match = re.exec(body)) !== null) {
+        branches.set(match[1], match[2]);
+      }
+      const chosen =
+        branches.get(`=${count}`) ??
+        (count === 1 ? branches.get("one") : undefined) ??
+        branches.get("other") ??
+        "";
+      return chosen.replace(/#/g, String(count));
+    },
+  );
+}
+
 function interpolate(
   template: string,
   vars?: Record<string, string | number>,
 ): string {
   if (!vars) return template;
-  return template.replace(/\{(\w+)\}/g, (_, key) => {
+  return applyPlurals(template, vars).replace(/\{(\w+)\}/g, (_, key) => {
     const value = vars[key];
     return value === undefined ? `{${key}}` : String(value);
   });


### PR DESCRIPTION
Cierra los cuatro puntos de mdb1/gc-fitness#785. El quinto cambio (las apps estampando su
versión) va en el PR gemelo mdb1/gc-fitness#788.

## 1 · Mover varios workouts mostraba UN solo movimiento

Un movimiento de día es un UPDATE de `scheduledFor`, y la captura de `onAuditableWrite`
snapshotea sólo los campos que **cambiaron** — así que `templateId` no está, el discriminador
de rutinas de #697 no puede disparar, y la clave de agrupación cae de vuelta a la raíz
por-cliente (`asg-<clientUid>`). Dos movimientos del mismo actor en el mismo minuto se
fusionaban en una fila que muestra el nombre y las fechas del head y descarta el resto — el
bug de #697 reapareciendo por la única rama que su arreglo no alcanza.

Un movimiento pasa a ser siempre su propia fila. La guarda mira también el `op`: la captura de
un DELETE snapshotea todas las claves, `scheduledFor` incluida, así que sin eso el batch de
borrado de una edición de recurrencia explotaría en una fila por ocurrencia.

## 2 · "¿Qué son esos libres?"

Un entreno que el atleta arranca **vacío** y arma mientras entrena (#541) se guarda con el
nombre placeholder "Entreno libre": dos chips idénticos en el calendario son, por
construcción, todo lo que el coach puede ver. El chip ahora lleva lo que realmente se hizo
—ejercicios, series, minutos, volumen— desde el `workout_logs` que la query del mes ya carga
para decidir el estado de cada chip (**cero lecturas nuevas**). Inline sólo el conteo de
ejercicios y sólo en los libres; el resumen entero, en el tooltip.

Y en el feed de admin, "se asignó un workout · ver detalle" sin nombre: la captura elide
`templateSnapshot`, así que el nombre sólo puede salir de la hidratación, que lee el doc vivo
— ausente para toda asignación borrada después. El workout que produjo sí se acuerda
(`assignmentId` + su propio snapshot congelado): una query, y sólo en el camino que ya falló.

## 3 · La actividad de un usuario sin coach

El perfil reportado mostraba dos filas —un peso y el primer ingreso— mientras el timeline de
admin mostraba a la misma persona auto-asignándose tres workouts ese día. El feed sólo hablaba
de un workout una vez **terminado**. Categoría nueva `assignment`, derivada en memoria de los
docs que las pasadas de reschedule y reminder ya traen (sin query ni índice nuevos), con dos
decisiones que los tests fijan: sólo auto-asignaciones (`trainerId === clientId`, no el
booleano — los docs viejos no lo tienen), y fecha `createdAt`, porque `updatedAt` lo bumpea
cada escritura posterior y un plan de hace dos semanas volvería al tope del feed.

## 4 · Qué versión de la app usa cada cliente

La mitad de la respuesta ya estaba escrita: cada dispositivo logueado registra
`platform` en `/users/{uid}/fcm_tokens/{tokenId}`. Se lee **por dispositivo** (un iPhone y una
tablet corren dos versiones a la vez), colapsando las rotaciones de un mismo dispositivo —un
token rota por reinstalación, restore o decisión de Firebase, y cada rotación escribe un doc—
pero manteniendo separadas dos versiones del mismo teléfono, que es lo que se quiere ver. Se
muestra como badge en el header del cliente y como campo "App" en la ficha god-mode.

Hasta que salga el build de #788, un dispositivo reporta "versión desconocida" en vez de
aparentar estar al día.

## Gate

`npx jest` — **132 suites, 1572 tests, verde**. `tsc --noEmit` limpio.

De paso, el stub de next-intl de los tests aprende `plural`: había 30 mensajes con ICU plural
y el stub devolvía el patrón crudo, así que cualquier test sobre un string pluralizado estaba
asertando que el string está roto.