### PR TITLE
fix(#782): los botones de tienda, desde el navegador in-app de Instagram

### DIFF
--- a/pocket-genes/src/components/GCFitnessDownloadPage.astro
+++ b/pocket-genes/src/components/GCFitnessDownloadPage.astro
@@ -1,6 +1,11 @@
 ---
 import BaseLayout from '../layouts/BaseLayout.astro';
-import { APP_STORE_URL, PLAY_STORE_URL } from '../data/gcFitnessPublic';
+import {
+  APP_STORE_APP_URL,
+  APP_STORE_URL,
+  PLAY_STORE_APP_URL,
+  PLAY_STORE_URL,
+} from '../data/gcFitnessPublic';
 import { defaultLang } from '../i18n/ui';
 import type { Lang } from '../i18n/ui';
 
@@ -104,7 +109,7 @@ const copy = {
               No se pierde nada: un link de store es un destino terminal; en móvil te saca del
               sitio igual para abrir la app nativa.
             -->
-            <a class="gcf-store-card" href={APP_STORE_URL}>
+            <a class="gcf-store-card" href={APP_STORE_URL} data-store="ios">
               <span class="gcf-store-glow" aria-hidden="true"></span>
               <span class="gcf-store-kicker">{copy.kicker}</span>
               <img
@@ -121,7 +126,7 @@ const copy = {
             <!-- Misma navegación que la tarjeta de arriba, para que las dos se comporten
                  igual. En Play el handoff no se rompía (no hay app nativa que abrir desde
                  Safari), pero dejar una con `_blank` y la otra sin él se lee como un olvido. -->
-            <a class="gcf-store-card" href={PLAY_STORE_URL}>
+            <a class="gcf-store-card" href={PLAY_STORE_URL} data-store="android">
               <span class="gcf-store-glow" aria-hidden="true"></span>
               <span class="gcf-store-kicker">{copy.kicker}</span>
               <img
@@ -166,6 +171,62 @@ const copy = {
     </section>
   </main>
 </BaseLayout>
+
+<!--
+  #782 — el hand-off a la tienda desde un NAVEGADOR IN-APP (Instagram, Facebook, TikTok…).
+
+  Reporte: "desde Instagram toco el link de /download, me abre la página dentro de un web view
+  … el botón de Apple no hace nada, a menos que le dé force touch + open link. El de Android
+  me lleva al PlayStore en la web."
+
+  Las dos mitades son el mismo hecho: un web view in-app es un WKWebView / WebView y una
+  navegación a `https://apps.apple.com/…` ahí adentro es una carga de página común — quién la
+  manda a la App Store es la app anfitriona, e Instagram no lo hace. El "force touch → Open
+  Link" del reporte lo confirma: eso SALE del web view hacia Safari, que sí hace el hand-off.
+  Del lado de Android no hay ambigüedad ninguna: la URL `https` de Play renderiza la web de
+  Play adentro del web view, que es exactamente lo que se ve.
+
+  El esquema propio no tiene esa ambigüedad: el web view NO PUEDE cargarlo, así que se lo pasa
+  al sistema operativo, que abre la app de la tienda.
+
+  Por qué se hace acá y no en el HTML: `itms-apps://` / `market://` no significan nada en
+  desktop (y un crawler tampoco sabe qué hacer con ellos), así que el markup se sirve siempre
+  con la URL `https` canónica y esto la reemplaza SÓLO en la plataforma que corresponde. Sigue
+  siendo un `<a href>` común: la navegación que abre la tienda ES el gesto del usuario, no un
+  `window.open` ni un timer — que es justo lo que un navegador descarta.
+-->
+<script is:inline define:vars={{ APP_STORE_APP_URL, PLAY_STORE_APP_URL }}>
+  (() => {
+    const ua = navigator.userAgent || '';
+    // iPadOS 13+ miente y dice "Macintosh"; el touch es lo que lo delata.
+    const isIOS =
+      /iPhone|iPad|iPod/i.test(ua) ||
+      (/Macintosh/i.test(ua) && typeof document.ontouchend !== 'undefined');
+    const isAndroid = /Android/i.test(ua);
+    if (!isIOS && !isAndroid) return;
+
+    const platform = isIOS ? 'ios' : 'android';
+    const appURL = isIOS ? APP_STORE_APP_URL : PLAY_STORE_APP_URL;
+    const card = document.querySelector(`.gcf-store-card[data-store="${platform}"]`);
+    if (!card) return;
+
+    // La URL `https` queda guardada como red de contención: si el sistema no toma el esquema
+    // (un web view que los bloquea del todo), la página sigue visible y la web de la tienda
+    // es un final mucho mejor que un botón muerto. El guard de visibilidad es lo que evita
+    // que esto se dispare cuando la tienda SÍ abrió — misma forma que
+    // `PocketGenesAppLinkRedirect.astro`.
+    const webURL = card.getAttribute('href');
+    card.setAttribute('href', appURL);
+    card.addEventListener('click', () => {
+      if (!webURL) return;
+      window.setTimeout(() => {
+        if (document.visibilityState === 'visible') {
+          window.location.assign(webURL);
+        }
+      }, 1200);
+    });
+  })();
+</script>
 
 <style>
   .gcf-download-page {

--- a/pocket-genes/src/data/gcFitnessPublic.ts
+++ b/pocket-genes/src/data/gcFitnessPublic.ts
@@ -3,10 +3,35 @@
 // Kept in sync with the backoffice wiki (`backoffice/src/app/gc-fitness/wiki/wiki-data.ts`,
 // entries `link-app-store` / `link-play-store`) and `gc-fitness/README.md`.
 //
-// The App Store URL deliberately omits the country segment (`/us/app/gc-fitness/…`)
-// so Apple redirects each visitor to their own storefront.
-export const APP_STORE_URL = 'https://apps.apple.com/app/id6771836254';
+// #782 — the App Store URL is the CANONICAL one, redirect and all included.
+//
+// It used to be the short `apps.apple.com/app/id6771836254`, on purpose: without a country
+// segment Apple sends each visitor to their own storefront. What that costs is a **301**, and
+// the 301 is what kept breaking the button — the hand-off to the App Store app only happens
+// while the user's gesture is still alive, and a redirect outlives it in a new tab (Safari,
+// fixed once by dropping `target="_blank"`) and inside an in-app browser (Instagram, this
+// round). The sibling that always worked is the tell: Pocket Genes points at a canonical
+// `/ar/app/…` URL.
+//
+// The storefront is not really lost. This URL is what a WEB visitor lands on; when the tap
+// reaches the App Store APP, Apple resolves the listing against the signed-in account's
+// country. And the app is free, so nothing here is priced wrong for anyone.
+export const APP_STORE_URL = 'https://apps.apple.com/ar/app/gc-fitness/id6771836254';
 export const PLAY_STORE_URL = 'https://play.google.com/store/apps/details?id=com.goldencrow.fitness';
+
+// #782 — the OS-owned schemes, used ONLY on the matching mobile platform.
+//
+// An in-app browser (Instagram, Facebook, TikTok…) is a WKWebView / Android WebView, and an
+// `https://apps.apple.com/…` navigation inside one is just a page load: the host app decides
+// whether to hand it to the App Store, and Instagram does not. That is the reported symptom
+// exactly — "el botón de Apple no hace nada, a menos que le dé force touch + open link"
+// (force-touch → "Open Link" leaves the WebView and lands in Safari, which does hand off).
+//
+// A custom scheme has no such ambiguity: the WebView cannot load it, so it goes to the OS.
+// Same story on Android, where the `https` Play link renders the Play Store WEB page inside
+// the WebView — also reported — while `market://` opens the app.
+export const APP_STORE_APP_URL = 'itms-apps://apps.apple.com/app/id6771836254';
+export const PLAY_STORE_APP_URL = 'market://details?id=com.goldencrow.fitness';
 
 export const GC_FITNESS_BUNDLE_ID = 'com.goldencrow.fitness';
 export const GC_FITNESS_SUPPORT_EMAIL = 'support@goldencrowvs.com';


### PR DESCRIPTION
Reabre y cierra mdb1/gc-fitness#782.

## Por qué el arreglo anterior no alcanzó

El primero atacó **Safari**: sacar `target="_blank"` para que el gesto del usuario sobreviva
al 301 de la URL corta de la App Store. Eso sigue siendo cierto. Pero el reporte que reabrió
el ticket es otro escenario:

> Desde instagram toco el link de /download, me abre la página dentro de un web view en
> instagram. El botón de apple no hace nada, a menos que le dé force touch + open link. El de
> android me lleva al PlayStore en la web.

Las dos mitades son el mismo hecho: un navegador in-app es un **WKWebView / WebView**, y una
navegación a `https://apps.apple.com/…` adentro de uno es una carga de página común — quién la
manda a la App Store es la app anfitriona, e Instagram no lo hace. El *"force touch → Open
Link"* del propio reporte es la confirmación: eso **sale** del web view hacia Safari, que sí
hace el hand-off. Y del lado de Android no hay ni ambigüedad — la URL `https` de Play
renderiza la web de Play adentro del web view, que es literalmente lo reportado.

## Qué cambia

**1 · Los esquemas del sistema, y sólo en la plataforma que corresponde.** `itms-apps://` y
`market://` **no los puede cargar** un web view, así que se los pasa al SO, que abre la app de
la tienda. El markup se sirve siempre con la URL `https` (desktop y crawlers no saben qué
hacer con un esquema propio) y un script los reemplaza según el user agent — incluido el iPad
que se hace pasar por Macintosh. Sigue siendo un `<a href>`: la navegación que abre la tienda
**es** el gesto del usuario, no un `window.open` ni un timer, que es justo lo que un navegador
descarta.

**2 · La URL de la App Store pasa a ser la canónica** (`/ar/app/gc-fitness/id…`, 200 directo,
verificado con `curl`). La corta evitaba clavar un país a costa de un **301**, y ese 301 es lo
que viene rompiendo el hand-off en los dos escenarios. El storefront no se pierde de verdad:
cuando el tap llega a la **app** de la App Store, Apple resuelve el listado contra el país de
la cuenta — y la app es gratis, así que no hay precio mal mostrado para nadie.

**3 · Red de contención.** Si un web view bloquea los esquemas del todo, a los 1200 ms —con el
guard de `visibilityState`, la misma forma que ya usa `PocketGenesAppLinkRedirect.astro`— se
navega a la URL `https`. La web de la tienda es un final mucho mejor que un botón muerto, y el
guard evita que se dispare cuando la tienda **sí** abrió.

## Gate

- `npm run build` de `pocket-genes`: 80 páginas, OK. El HTML emitido de `/gc-fitness/download`
  lleva el `href` canónico **y** el script con los dos esquemas (verificado sobre `dist/`).
- `npx jest` del backoffice: 1549 en 130 suites, verde (no lo toca, corre como red).

## Verificación que sólo se puede hacer a mano

Abrir `/gc-fitness/download` **desde un link en Instagram** (iOS y Android) y tocar cada
botón. Es el único camino que reproduce el web view in-app; ni Safari ni Chrome de escritorio
lo ejercitan.

## Nota

La página de descarga de **Pocket Genes** tiene el mismo defecto latente (`https` de tienda +
`target="_blank"` dentro de un web view in-app). No la toco acá porque es otro producto y este
ticket es de GC Fitness — se puede replicar el mismo patrón cuando se quiera.