### PR TITLE
fix(#785): destrabar el deploy de producción — un Server Action no puede exportar una función síncrona

### DIFF
--- a/backoffice/src/lib/gc-fitness/schedule-month-actions.ts
+++ b/backoffice/src/lib/gc-fitness/schedule-month-actions.ts
@@ -173,8 +173,13 @@ function finiteNumber(value: unknown): number | null {
  * Distinct exercises are counted by `exerciseId` alone rather than by
  * `(exerciseId, exercise_order)`: a repeated exercise is still ONE exercise to
  * someone reading "¿qué hizo?" from a calendar.
+ *
+ * NOT exported: this file carries the "use server" directive, and Next only
+ * lets such a module export async functions (Server Actions). Exporting this
+ * synchronous helper broke `next build` — and therefore the production deploy —
+ * while Jest stayed green, because Jest does not enforce the directive.
  */
-export function summarizeLoggedWorkout(
+function summarizeLoggedWorkout(
   data: Record<string, unknown>,
 ): MonthWorkoutLoggedSummary {
   const sets = Array.isArray(data.sets) ? data.sets : [];


### PR DESCRIPTION
## El síntoma

El auto-deploy de `main` a producción está fallando. `next build`:

```
./src/lib/gc-fitness/schedule-month-actions.ts:177:17
Server Actions must be async functions.
> 177 | export function summarizeLoggedWorkout(
```

Lo introdujo `9b479d2` (#785 / PR #313). **Producción está caída desde
ese merge.**

## La causa

`schedule-month-actions.ts` lleva la directiva `"use server"`, así que
Next sólo le admite exports de funciones `async` — cada export es un
Server Action, y un Server Action se invoca por RPC. `summarizeLoggedWorkout`
se agregó como helper puro y **síncrono**, exportado.

## El fix

Sacar el `export`. No cumplía ninguna función:

- la única llamada está en la **línea 842 del mismo archivo**
- **ningún test lo importa** (`grep -rn summarizeLoggedWorkout src/` → 2 hits, ambos en este archivo)

La función queda privada al módulo, que es exactamente como ya se usaba.
Cero cambio de comportamiento. Agregué un comentario explicando por qué
NO va exportada, para que no vuelva.

## Por qué el gate no lo atajó

**Jest no aplica la directiva `"use server"`.** Las 132 suites / 1572 tests
pasaron en verde con producción rota — no era un test faltante, la suite
no podía verlo. Como `main` auto-deploya, se publicó igual.

Misma forma que #755/#759 en Android: la suite corre sobre un artefacto
distinto del que se publica, así que el defecto es invisible por construcción.

El gate se corrige aparte en **gc-fitness#790** (la fila del Backoffice pasa
a `npx jest && npm run build`).

Barrí el resto de los archivos `"use server"`: este es el único caso. Los
demás exports son `type`/`interface` (se borran al compilar) y el
`export const listClients = cache(...)` de `client-roster.ts`, preexistente
y que venía deployando bien.

## Verificación

| Suite | Antes | Después |
|---|---|---|
| `npm run build` | ❌ `Build error occurred` | ✅ exit 0, build completo |
| `npx jest` | ✅ 1572 / 132 suites | ✅ 1572 / 132 suites |