### PR TITLE
fix(#782): desde un navegador in-app de iOS no se puede abrir la App Store — pedir salir a Safari

### DIFF
--- a/pocket-genes/src/components/GCFitnessDownloadPage.astro
+++ b/pocket-genes/src/components/GCFitnessDownloadPage.astro
@@ -32,6 +32,15 @@ const copy = {
     appStoreNote: 'iPhone y Apple Watch',
     playStoreNote: 'Android',
     storeGridLabel: 'Opciones de descarga de GC Fitness',
+    // #782 — el cartel del navegador in-app. Ver el <script> al pie: desde el
+    // navegador de Instagram (o Facebook, TikTok…) iOS NO abre la App Store, y
+    // no hay forma de forzarlo desde la página. Lo único que resuelve es que la
+    // persona salga a Safari, así que se lo pedimos explícitamente.
+    inAppTitle: 'Estás en el navegador de otra app',
+    inAppBody:
+      'Desde acá iOS no puede abrir la App Store. Tocá los ⋯ arriba a la derecha y elegí “Abrir en el navegador”.',
+    inAppCopy: 'Copiar link',
+    inAppCopied: '¡Link copiado!',
     legal: 'Privacidad',
     legalHref: '/gc-fitness/privacy',
     terms: 'Términos de uso',
@@ -57,6 +66,12 @@ const copy = {
     appStoreNote: 'iPhone and Apple Watch',
     playStoreNote: 'Android',
     storeGridLabel: 'GC Fitness download options',
+    // #782 — see the Spanish twin above and the <script> at the bottom.
+    inAppTitle: "You're in another app's browser",
+    inAppBody:
+      'iOS can\'t open the App Store from here. Tap the ⋯ at the top right and choose "Open in browser".',
+    inAppCopy: 'Copy link',
+    inAppCopied: 'Link copied!',
     legal: 'Privacy',
     legalHref: '/en/gc-fitness/privacy',
     terms: 'Terms of Use',
@@ -85,6 +100,29 @@ const copy = {
           <ul class="gcf-chips">
             {copy.chips.map((chip) => <li>{chip}</li>)}
           </ul>
+
+          <!--
+            #782 — se sirve SIEMPRE en el HTML y el script lo revela sólo si detecta
+            un navegador in-app. Al revés (crearlo desde JS) el texto no existiría
+            para nadie más, y esto es contenido, no decoración.
+
+            `hidden` sale con el atributo, no con una clase: si el JS no corre, el
+            cartel queda oculto — que es el estado correcto para la enorme mayoría,
+            que no está en un web view.
+          -->
+          <aside class="gcf-inapp-note" id="gcf-inapp-note" hidden>
+            <p class="gcf-inapp-title">{copy.inAppTitle}</p>
+            <p class="gcf-inapp-body">{copy.inAppBody}</p>
+            <button
+              type="button"
+              class="gcf-inapp-copy"
+              id="gcf-inapp-copy"
+              data-label={copy.inAppCopy}
+              data-copied={copy.inAppCopied}
+            >
+              {copy.inAppCopy}
+            </button>
+          </aside>
 
           <div class="gcf-store-grid" aria-label={copy.storeGridLabel}>
             <!--
@@ -173,58 +211,125 @@ const copy = {
 </BaseLayout>
 
 <!--
-  #782 — el hand-off a la tienda desde un NAVEGADOR IN-APP (Instagram, Facebook, TikTok…).
+  #782 — el hand-off a la tienda, y por qué desde un navegador IN-APP no hay hand-off posible.
 
-  Reporte: "desde Instagram toco el link de /download, me abre la página dentro de un web view
-  … el botón de Apple no hace nada, a menos que le dé force touch + open link. El de Android
-  me lleva al PlayStore en la web."
+  DOS PREMISAS DE LA VUELTA ANTERIOR ERAN FALSAS. Quedan escritas porque las dos son fáciles
+  de volver a deducir mal, y cada una costó un intento de arreglo:
 
-  Las dos mitades son el mismo hecho: un web view in-app es un WKWebView / WebView y una
-  navegación a `https://apps.apple.com/…` ahí adentro es una carga de página común — quién la
-  manda a la App Store es la app anfitriona, e Instagram no lo hace. El "force touch → Open
-  Link" del reporte lo confirma: eso SALE del web view hacia Safari, que sí hace el hand-off.
-  Del lado de Android no hay ambigüedad ninguna: la URL `https` de Play renderiza la web de
-  Play adentro del web view, que es exactamente lo que se ve.
+  1. «La URL `/ar/app/…` es 200 directo; el 301 de la corta es lo que rompe el hand-off.»
+     FALSO. En iOS TODA URL de apps.apple.com contesta 301 hacia un esquema de app. Verificado
+     con user agent de iPhone:
 
-  El esquema propio no tiene esa ambigüedad: el web view NO PUEDE cargarlo, así que se lo pasa
-  al sistema operativo, que abre la app de la tienda.
+         GET https://apps.apple.com/ar/app/gc-fitness/id6771836254
+         → HTTP/2 301
+            location: itms-appss://apps.apple.com/ar/app/gc-fitness/id6771836254
 
-  Por qué se hace acá y no en el HTML: `itms-apps://` / `market://` no significan nada en
-  desktop (y un crawler tampoco sabe qué hacer con ellos), así que el markup se sirve siempre
-  con la URL `https` canónica y esto la reemplaza SÓLO en la plataforma que corresponde. Sigue
-  siendo un `<a href>` común: la navegación que abre la tienda ES el gesto del usuario, no un
-  `window.open` ni un timer — que es justo lo que un navegador descarta.
+     No hay ningún 200 que conseguir en iOS: ese 301 hacia el esquema ES el mecanismo de
+     hand-off de Apple, no el problema. Cambiar de URL no podía arreglar nada.
+
+  2. «El web view NO PUEDE cargar el esquema, así que se lo pasa al sistema operativo.»
+     FALSO, y es la razón de que el botón siga muerto. Un WKWebView NO deriva al SO los
+     esquemas que no entiende: la app anfitriona tiene que implementar `decidePolicyFor` y
+     llamar a `UIApplication.open()`. Si Instagram no lo hace, la navegación se cancela EN
+     SILENCIO. Pasar de `https://` a `itms-apps://` movió el fallo de lugar sin resolverlo.
+
+  Juntas explican el síntoma exacto del reporte, incluido el de antes del primer arreglo: en
+  iOS la URL `https` NUNCA renderiza la web de la tienda — siempre 301 al esquema — así que
+  dentro de un web view no existe NINGUNA URL que muestre la App Store. De ahí el "no hace
+  nada", y de ahí que "force touch + open link" sí funcione: eso sale a Safari.
+
+  CONCLUSIÓN: desde adentro de un navegador in-app de iOS no se puede forzar la App Store. No
+  es un bug a arreglar, es una restricción de la plataforma. Lo único que resuelve es que la
+  persona salga a Safari — así que se lo pedimos, en vez de dejar un botón que no puede
+  cumplir. Esa es toda la diferencia de este arreglo: no depende de que el web view coopere.
+
+  El swap de esquema se conserva, pero SÓLO fuera de un navegador in-app, donde sí sirve
+  (ahorra el 301 en Safari). Adentro se deja la URL `https`, y en Android eso importa: con
+  `market://` un web view que lo descarta deja un botón muerto, mientras que la URL `https`
+  al menos renderiza la web de Play — que es lo que el reporte describía como comportamiento
+  de Android, y es un final mucho mejor que nada.
 -->
 <script is:inline define:vars={{ APP_STORE_APP_URL, PLAY_STORE_APP_URL }}>
   (() => {
     const ua = navigator.userAgent || '';
     // iPadOS 13+ miente y dice "Macintosh"; el touch es lo que lo delata.
+    //
+    // Se mira `maxTouchPoints` y NO `typeof document.ontouchend`, que es lo que había antes:
+    // ese handler existe en entornos sin touch ninguno (jsdom lo define, y un navegador de
+    // escritorio puede exponerlo), así que daba iPad por cualquier Mac. `maxTouchPoints` es 0
+    // en un Mac de escritorio y 5 en un iPad — sin ambigüedad.
     const isIOS =
       /iPhone|iPad|iPod/i.test(ua) ||
-      (/Macintosh/i.test(ua) && typeof document.ontouchend !== 'undefined');
+      (/Macintosh/i.test(ua) && (navigator.maxTouchPoints || 0) > 1);
     const isAndroid = /Android/i.test(ua);
     if (!isIOS && !isAndroid) return;
 
-    const platform = isIOS ? 'ios' : 'android';
-    const appURL = isIOS ? APP_STORE_APP_URL : PLAY_STORE_APP_URL;
-    const card = document.querySelector(`.gcf-store-card[data-store="${platform}"]`);
-    if (!card) return;
+    // Las apps que traen navegador propio se declaran en el user agent. La lista explícita
+    // es la que manda: es la que no tiene falsos positivos.
+    const namedInApp =
+      /Instagram|FBAN|FBAV|FB_IAB|FBIOS|Messenger|Twitter|TikTok|musical_ly|BytedanceWebview|LinkedInApp|Snapchat|Pinterest|WhatsApp|Line\//i.test(
+        ua,
+      );
 
-    // La URL `https` queda guardada como red de contención: si el sistema no toma el esquema
-    // (un web view que los bloquea del todo), la página sigue visible y la web de la tienda
-    // es un final mucho mejor que un botón muerto. El guard de visibilidad es lo que evita
-    // que esto se dispare cuando la tienda SÍ abrió — misma forma que
-    // `PocketGenesAppLinkRedirect.astro`.
-    const webURL = card.getAttribute('href');
-    card.setAttribute('href', appURL);
-    card.addEventListener('click', () => {
-      if (!webURL) return;
-      window.setTimeout(() => {
-        if (document.visibilityState === 'visible') {
-          window.location.assign(webURL);
-        }
-      }, 1200);
-    });
+    // Red de contención para web views que no se nombran. Un WKWebView no pone el token
+    // `Safari/`; los navegadores de verdad en iOS sí (Chrome=CriOS, Firefox=FxiOS,
+    // Edge=EdgiOS, y todos ellos lo incluyen). Sólo aplica a iOS: en Android el token
+    // `Safari` aparece hasta en los WebView, así que ahí no distingue nada.
+    const unnamedIOSWebView = isIOS && !/Safari\//i.test(ua) && !/CriOS|FxiOS|EdgiOS/i.test(ua);
+
+    const isInAppBrowser = namedInApp || unnamedIOSWebView;
+
+    const platform = isIOS ? 'ios' : 'android';
+    const card = document.querySelector(`.gcf-store-card[data-store="${platform}"]`);
+
+    if (isInAppBrowser) {
+      // Nada de esquemas acá: el web view los descarta en silencio y el botón queda muerto.
+      // Se deja la URL `https` (en Android muestra la web de Play; en iOS no puede mostrar
+      // nada, pero tampoco empeora) y se revela la única salida que sí existe.
+      const note = document.getElementById('gcf-inapp-note');
+      if (note) note.hidden = false;
+
+      const copyButton = document.getElementById('gcf-inapp-copy');
+      if (copyButton) {
+        copyButton.addEventListener('click', async () => {
+          const link = window.location.href;
+          try {
+            await navigator.clipboard.writeText(link);
+          } catch {
+            // `navigator.clipboard` no está en todos los web views. El textarea fuera de
+            // pantalla + execCommand es feo, pero es el camino que sí funciona ahí.
+            const scratch = document.createElement('textarea');
+            scratch.value = link;
+            scratch.setAttribute('readonly', '');
+            scratch.style.position = 'absolute';
+            scratch.style.left = '-9999px';
+            document.body.appendChild(scratch);
+            scratch.select();
+            try {
+              document.execCommand('copy');
+            } catch {
+              return; // Sin portapapeles no hay nada que hacer; el texto del cartel alcanza.
+            } finally {
+              document.body.removeChild(scratch);
+            }
+          }
+          copyButton.textContent = copyButton.dataset.copied || copyButton.textContent;
+          window.setTimeout(() => {
+            copyButton.textContent = copyButton.dataset.label || copyButton.textContent;
+          }, 2400);
+        });
+      }
+      return;
+    }
+
+    // Fuera de un web view el esquema sí llega al SO, y ahorra el 301. Sigue siendo un
+    // `<a href>` común: la navegación que abre la tienda ES el gesto del usuario, no un
+    // `window.open` ni un timer — que es justo lo que un navegador descarta.
+    //
+    // Sin red de contención por timer, a propósito: en iOS la URL `https` de respaldo vuelve
+    // a hacer 301 al MISMO esquema que acaba de fallar, así que no rescataba nada.
+    if (!card) return;
+    card.setAttribute('href', isIOS ? APP_STORE_APP_URL : PLAY_STORE_APP_URL);
   })();
 </script>
 
@@ -330,6 +435,47 @@ const copy = {
     line-height: 1.2;
   }
 
+  /* #782 — el cartel del navegador in-app. Se apoya en los mismos tokens que las
+     tarjetas para que no se lea como un error del sitio, pero con el borde ámbar
+     lleno para que se note que es una instrucción y no decoración. */
+  .gcf-inapp-note {
+    margin-top: clamp(1.4rem, 3vw, 1.9rem);
+    border: 1px solid rgba(169, 118, 26, 0.45);
+    border-left-width: 4px;
+    border-radius: 8px;
+    background: rgba(255, 250, 238, 0.94);
+    padding: clamp(0.9rem, 2.6vw, 1.15rem);
+    box-shadow: 0 18px 44px rgba(51, 36, 8, 0.1);
+  }
+  .gcf-inapp-title {
+    margin: 0;
+    color: var(--gcf-ink);
+    font-size: 0.98rem;
+    font-weight: 800;
+    line-height: 1.3;
+  }
+  .gcf-inapp-body {
+    margin: 6px 0 0;
+    color: var(--gcf-muted);
+    font-size: 0.9rem;
+    line-height: 1.45;
+  }
+  .gcf-inapp-copy {
+    margin-top: 12px;
+    border: 1px solid rgba(169, 118, 26, 0.4);
+    border-radius: 999px;
+    background: rgba(255, 255, 255, 0.9);
+    padding: 9px 18px;
+    color: var(--gcf-ink);
+    font: inherit;
+    font-size: 0.88rem;
+    font-weight: 700;
+    line-height: 1.2;
+    /* Cómodo para el pulgar: es el único control de la página que se toca desde
+       un web view, y ahí el layout suele venir apretado. */
+    min-height: 44px;
+    cursor: pointer;
+  }
   .gcf-store-grid {
     display: grid;
     grid-template-columns: repeat(2, minmax(0, 1fr));

--- a/pocket-genes/src/data/gcFitnessPublic.ts
+++ b/pocket-genes/src/data/gcFitnessPublic.ts
@@ -3,33 +3,42 @@
 // Kept in sync with the backoffice wiki (`backoffice/src/app/gc-fitness/wiki/wiki-data.ts`,
 // entries `link-app-store` / `link-play-store`) and `gc-fitness/README.md`.
 //
-// #782 — the App Store URL is the CANONICAL one, redirect and all included.
+// #782 — the App Store URL carries a country segment.
 //
-// It used to be the short `apps.apple.com/app/id6771836254`, on purpose: without a country
-// segment Apple sends each visitor to their own storefront. What that costs is a **301**, and
-// the 301 is what kept breaking the button — the hand-off to the App Store app only happens
-// while the user's gesture is still alive, and a redirect outlives it in a new tab (Safari,
-// fixed once by dropping `target="_blank"`) and inside an in-app browser (Instagram, this
-// round). The sibling that always worked is the tell: Pocket Genes points at a canonical
-// `/ar/app/…` URL.
+// ⚠️ It was switched here from the short `apps.apple.com/app/id6771836254` on a premise that
+// turned out to be FALSE: that `/ar/app/…` answers 200 while the short one's **301** was what
+// broke the hand-off. On iOS there is no 200 to be had — EVERY apps.apple.com URL answers 301
+// to an app scheme, and that redirect IS Apple's hand-off mechanism, not a bug. Verified with
+// an iPhone user agent:
 //
-// The storefront is not really lost. This URL is what a WEB visitor lands on; when the tap
-// reaches the App Store APP, Apple resolves the listing against the signed-in account's
-// country. And the app is free, so nothing here is priced wrong for anyone.
+//     GET https://apps.apple.com/ar/app/gc-fitness/id6771836254
+//     → HTTP/2 301
+//        location: itms-appss://apps.apple.com/ar/app/gc-fitness/id6771836254
+//
+// So the country segment buys nothing for the reported bug. What it does cost is real, if
+// small: a DESKTOP visitor outside Argentina lands on the Argentine storefront page instead of
+// their own, which the short URL avoided. Kept as-is only because the app is free and nothing
+// here is priced wrong for anyone — reverting to the short URL is a safe follow-up, not a fix.
+//
+// When the tap does reach the App Store APP, Apple resolves the listing against the signed-in
+// account's country regardless of what this URL says.
 export const APP_STORE_URL = 'https://apps.apple.com/ar/app/gc-fitness/id6771836254';
 export const PLAY_STORE_URL = 'https://play.google.com/store/apps/details?id=com.goldencrow.fitness';
 
-// #782 — the OS-owned schemes, used ONLY on the matching mobile platform.
+// #782 — the OS-owned schemes, used ONLY on the matching mobile platform AND only OUTSIDE an
+// in-app browser.
 //
-// An in-app browser (Instagram, Facebook, TikTok…) is a WKWebView / Android WebView, and an
-// `https://apps.apple.com/…` navigation inside one is just a page load: the host app decides
-// whether to hand it to the App Store, and Instagram does not. That is the reported symptom
-// exactly — "el botón de Apple no hace nada, a menos que le dé force touch + open link"
-// (force-touch → "Open Link" leaves the WebView and lands in Safari, which does hand off).
+// ⚠️ These do NOT rescue an in-app browser, which is what they were originally added for. A
+// WKWebView does not hand unknown schemes to the OS: the host app has to implement
+// `decidePolicyFor` and call `UIApplication.open()`, and Instagram doesn't — so the navigation
+// is cancelled SILENTLY and the button stays dead. Inside a web view the page now keeps the
+// `https` URL and tells the user to open the page in Safari instead; see the <script> in
+// `GCFitnessDownloadPage.astro`.
 //
-// A custom scheme has no such ambiguity: the WebView cannot load it, so it goes to the OS.
-// Same story on Android, where the `https` Play link renders the Play Store WEB page inside
-// the WebView — also reported — while `market://` opens the app.
+// Where they DO earn their keep is a real browser, where the scheme reaches the OS directly
+// and skips the 301. On Android keeping `https` inside a web view matters even more: a
+// dropped `market://` leaves a dead button, while the `https` link at least renders the Play
+// Store web page.
 export const APP_STORE_APP_URL = 'itms-apps://apps.apple.com/app/id6771836254';
 export const PLAY_STORE_APP_URL = 'market://details?id=com.goldencrow.fitness';
 


### PR DESCRIPTION
Cierra el reporte de que **sigue sin andar en iOS** desde el navegador in-app de Instagram.

## Las dos premisas del arreglo anterior eran falsas

**1. «La URL `/ar/app/…` es 200 directo; el 301 de la corta es lo que rompe el hand-off.»**

En iOS **toda** URL de `apps.apple.com` contesta 301 hacia un esquema de app. Verificado contra los servidores de Apple con user agent de iPhone:

```
GET https://apps.apple.com/ar/app/gc-fitness/id6771836254
→ HTTP/2 301
   location: itms-appss://apps.apple.com/ar/app/gc-fitness/id6771836254
```

La corta y la `/us/` hacen exactamente lo mismo. No hay ningún 200 que conseguir en iOS: ese 301 hacia el esquema **es** el mecanismo de hand-off de Apple, no el problema. Cambiar de URL no podía arreglar nada.

**2. «El web view NO PUEDE cargar el esquema, así que se lo pasa al sistema operativo.»**

Un `WKWebView` **no** deriva al SO los esquemas que no entiende. La app anfitriona tiene que implementar `decidePolicyFor` y llamar a `UIApplication.open()`. Si Instagram no lo hace, la navegación se cancela **en silencio**. Pasar de `https://` a `itms-apps://` movió el fallo de lugar sin resolverlo.

Juntas explican el síntoma exacto, incluido el de antes del primer arreglo: en iOS la URL `https` nunca renderiza la web de la tienda, así que **dentro de un web view no existe ninguna URL que pueda mostrar la App Store**. De ahí el "no hace nada", y de ahí que "force touch → Open Link" sí funcione: eso sale a Safari.

## El arreglo

Desde adentro de un navegador in-app de iOS no se puede forzar la App Store. No es un bug, es una restricción de la plataforma. Así que se deja de pelear con ella:

- Se detecta el navegador in-app (Instagram, Facebook, TikTok, Twitter, LinkedIn, Snapchat, WhatsApp… + red de contención para web views de iOS que no se nombran) y se revela un cartel con la única salida que existe: **"Tocá los ⋯ arriba a la derecha y elegí Abrir en el navegador"**, más un botón de copiar link.
- **No depende de que el web view coopere** — que es toda la diferencia con los dos intentos anteriores.
- El swap a `itms-apps://` / `market://` se conserva **sólo fuera** de un web view, donde sí llega al SO y ahorra el 301.
- **Adentro se deja `https`, y en Android eso importa**: con `market://`, un web view que lo descarta deja un botón muerto — el arreglo anterior podía haber *empeorado* Android, donde antes al menos se veía la web de Play.
- Se elimina la red de contención por timer: en iOS caía a la URL `https`, que vuelve a hacer 301 al mismo esquema que acaba de fallar. No rescataba nada.
- El cartel se sirve siempre en el HTML con `hidden` y el script lo revela. Si el JS no corre, queda oculto — el estado correcto para quien no está en un web view.

Bonus encontrado por los tests: la detección de iPad usaba `typeof document.ontouchend !== 'undefined'`, y ese handler existe en entornos sin touch ninguno → daba iPad por cualquier Mac. Pasa a `navigator.maxTouchPoints > 1` (0 en un Mac de escritorio, 5 en un iPad).

## Verificación

`pocket-genes` no tiene runner de tests, así que armé dos comprobaciones. La segunda ejecuta el **HTML construido con su `<script>` real**, no una copia:

| Escenario | Cartel | href iOS | href Android |
|---|---|---|---|
| Instagram iOS | ✅ visible | `https://apps.apple.com` | `https://play.google.com` |
| Instagram Android | ✅ visible | `https://apps.apple.com` | `https://play.google.com` |
| Safari iOS real | oculto | `itms-apps://` | `https://play.google.com` |
| Chrome Android real | oculto | `https://apps.apple.com` | `market://` |
| iPad Safari | oculto | `itms-apps://` | `https://play.google.com` |
| macOS escritorio | oculto | `https://apps.apple.com` | `https://play.google.com` |

Lo que más me importaba: **cero falsos positivos** — Safari, Chrome y Firefox reales de iOS no ven el cartel.

`npm run build` de Astro verde (80 páginas), copy ES y EN presentes en el HTML generado.

## Lo que NO puedo verificar

**La prueba final es a mano y es tuya**: abrir `/gc-fitness/download` desde un link en Instagram en un iPhone real y confirmar que aparece el cartel. Ningún navegador de escritorio ni jsdom ejercita el WKWebView de Instagram — es exactamente el hueco por el que se colaron los dos intentos anteriores, y quiero dejarlo dicho en vez de que parezca cubierto.

Si querés, puedo dejar el harness de jsdom como chequeo permanente en el repo (necesita agregar `jsdom` como devDependency de `pocket-genes`) — no lo hice para no ampliar el alcance sin que lo pidas.