### PR TITLE
Backoffice: gráfico de pulsaciones en el detalle de workout finalizado

### DIFF
--- a/backoffice/messages/en.json
+++ b/backoffice/messages/en.json
@@ -1961,7 +1961,15 @@
       "shareStatDuration": "DURATION",
       "shareStatCalories": "CALORIES",
       "shareError": "Couldn't generate the image. Try again.",
-      "shareLoading": "Preparing…"
+      "shareLoading": "Preparing…",
+      "heartRate": {
+        "title": "Heart rate",
+        "min": "min",
+        "avg": "avg",
+        "max": "max",
+        "tooltipLabel": "Heart rate",
+        "tooltipMinute": "Minute {minute}"
+      }
     }
   },
   "myActivity": {

--- a/backoffice/messages/es.json
+++ b/backoffice/messages/es.json
@@ -1961,7 +1961,15 @@
       "shareStatDuration": "DURACIÓN",
       "shareStatCalories": "CALORÍAS",
       "shareError": "No se pudo generar la imagen. Reintentá.",
-      "shareLoading": "Preparando…"
+      "shareLoading": "Preparando…",
+      "heartRate": {
+        "title": "Pulsaciones",
+        "min": "mín",
+        "avg": "prom",
+        "max": "máx",
+        "tooltipLabel": "Pulsaciones",
+        "tooltipMinute": "Minuto {minute}"
+      }
     }
   },
   "myActivity": {

--- a/backoffice/src/components/gc-fitness/workout-heart-rate-chart.tsx
+++ b/backoffice/src/components/gc-fitness/workout-heart-rate-chart.tsx
@@ -1,0 +1,128 @@
+"use client";
+
+// workout-heart-rate-chart.tsx — the BPM line on a finished workout.
+//
+// Renders inside WorkoutLogDetailView, so it appears everywhere a workout can be
+// inspected: the Recent Logs page, the admin god-mode page, and the calendar's
+// completed-workout dialog.
+//
+// THE NUMBERS BESIDE THE LINE ARE THE STORED AGGREGATES, NOT THE PLOTTED POINTS.
+// The client's app thins the series to ≤300 samples before uploading and the
+// thinning averages within buckets, so a 178 bpm peak can be DRAWN at 126 while
+// still being the real maximum. Reading min/max off the line would under-report
+// exactly the moment a coach opens this screen for. The gap between the line's
+// apex and the "Máx" number is expected, and is the point.
+
+import {
+  CartesianGrid,
+  Line,
+  LineChart,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from "recharts";
+import { HeartPulse } from "lucide-react";
+import { useTranslations } from "next-intl";
+
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import type { WorkoutHeartRateSeries } from "@/lib/gc-fitness/workout-heart-rate";
+
+export function WorkoutHeartRateChart({
+  series,
+}: {
+  series: WorkoutHeartRateSeries | null;
+}) {
+  const t = useTranslations("recentLogs.workoutDetail.heartRate");
+
+  // Most workouts are logged without a watch. An empty chart frame on every one
+  // of them is noise that teaches a coach to scroll past this screen.
+  if (!series || series.samples.length === 0) return null;
+
+  // Padded so the line never rides the frame edges, floored at zero so a very
+  // steady session doesn't render pinned to the top.
+  const low = Math.max(0, series.minBpm - 10);
+  const high = Math.max(low + 10, series.maxBpm + 10);
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2">
+          <HeartPulse className="size-4 text-rose-500" />
+          {t("title")}
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <div className="h-48 w-full">
+          <ResponsiveContainer width="100%" height="100%">
+            <LineChart
+              data={series.samples}
+              margin={{ top: 6, right: 8, left: 0, bottom: 0 }}
+            >
+              <CartesianGrid
+                strokeDasharray="3 3"
+                stroke="var(--muted-foreground)"
+                strokeOpacity={0.16}
+                vertical={false}
+              />
+              <XAxis
+                dataKey="offsetSeconds"
+                type="number"
+                domain={["dataMin", "dataMax"]}
+                tick={{ fontSize: 11 }}
+                tickLine={false}
+                axisLine={false}
+                minTickGap={24}
+                // Whole minutes: an axis in seconds is unreadable past the
+                // first couple of minutes of a workout.
+                tickFormatter={(value: number) => `${Math.round(value / 60)}′`}
+              />
+              <YAxis
+                domain={[low, high]}
+                tick={{ fontSize: 11 }}
+                tickLine={false}
+                axisLine={false}
+                width={32}
+                allowDecimals={false}
+              />
+              <Tooltip
+                contentStyle={{
+                  borderRadius: 10,
+                  border: "1px solid hsl(var(--border))",
+                  background: "hsl(var(--background))",
+                }}
+                labelFormatter={(label) =>
+                  t("tooltipMinute", { minute: Math.round(Number(label) / 60) })
+                }
+                formatter={(value) => [`${value} bpm`, t("tooltipLabel")]}
+              />
+              <Line
+                type="monotone"
+                dataKey="bpm"
+                stroke="var(--color-rose-500, #f43f5e)"
+                strokeWidth={2}
+                dot={false}
+                isAnimationActive={false}
+              />
+            </LineChart>
+          </ResponsiveContainer>
+        </div>
+
+        <div className="grid grid-cols-3 gap-2">
+          <Stat label={t("min")} value={series.minBpm} />
+          <Stat label={t("avg")} value={series.avgBpm} />
+          <Stat label={t("max")} value={series.maxBpm} />
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+function Stat({ label, value }: { label: string; value: number }) {
+  return (
+    <div className="rounded-md border bg-muted/35 p-2.5 text-center">
+      <p className="text-lg font-semibold leading-tight tabular-nums">{value}</p>
+      <p className="mt-0.5 text-xs text-muted-foreground">{label}</p>
+    </div>
+  );
+}

--- a/backoffice/src/components/gc-fitness/workout-log-detail-view.tsx
+++ b/backoffice/src/components/gc-fitness/workout-log-detail-view.tsx
@@ -23,6 +23,7 @@ import { useLocale, useTranslations } from "next-intl";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import type { WorkoutLogDetail } from "@/lib/gc-fitness/recent-logs-actions";
+import { WorkoutHeartRateChart } from "@/components/gc-fitness/workout-heart-rate-chart";
 // quick-260714-m57 (#403) — W/F/D badge on logged sets in "Detalle de series".
 import {
   SET_TYPE_BADGE_CLASS,
@@ -174,6 +175,11 @@ export function WorkoutLogDetailView({ detail }: { detail: WorkoutLogDetail }) {
           </CardContent>
         </Card>
       </div>
+
+      {/* Above the set detail because it describes the SESSION, not a set — and
+          it renders nothing at all when the workout has no series, which is
+          most of them (no watch, no wearable). */}
+      <WorkoutHeartRateChart series={detail.heartRate ?? null} />
 
       <Card>
         <CardHeader>

--- a/backoffice/src/lib/gc-fitness/__tests__/recent-logs-actions.self-workout.test.ts
+++ b/backoffice/src/lib/gc-fitness/__tests__/recent-logs-actions.self-workout.test.ts
@@ -39,14 +39,23 @@ function docSnap(exists: boolean, data: Record<string, unknown>, id = "") {
  * fixture map keyed by `${name}/${id}`.
  */
 function makeDb(fixtures: Record<string, Record<string, unknown> | null>) {
+  // Subcollection support exists for `workout_logs/{id}/metrics/heartRate`: the
+  // detail builder reads the workout's heart-rate series. A fixture key of
+  // "workout_logs/{id}/metrics/heartRate" seeds one; absent, the read resolves
+  // to a missing doc, which is the common case (no watch → no chart).
+  const docRef = (path: string) => ({
+    get: async () => {
+      const data = fixtures[path];
+      const id = path.split("/").pop() ?? "";
+      return data ? docSnap(true, data, id) : docSnap(false, {}, id);
+    },
+    collection: (sub: string) => ({
+      doc: (subId: string) => docRef(`${path}/${sub}/${subId}`),
+    }),
+  });
   return {
     collection: (name: string) => ({
-      doc: (id: string) => ({
-        get: async () => {
-          const data = fixtures[`${name}/${id}`];
-          return data ? docSnap(true, data, id) : docSnap(false, {}, id);
-        },
-      }),
+      doc: (id: string) => docRef(`${name}/${id}`),
     }),
   };
 }

--- a/backoffice/src/lib/gc-fitness/__tests__/workout-heart-rate.test.ts
+++ b/backoffice/src/lib/gc-fitness/__tests__/workout-heart-rate.test.ts
@@ -1,0 +1,154 @@
+// __tests__/workout-heart-rate.test.ts
+//
+// The BPM series behind the chart on a finished workout, as the backoffice
+// reads it.
+//
+// THE LOAD-BEARING RULE: min/max/avg come from the STORED fields, never from
+// the plotted points. The client's app thins the series to ≤300 samples before
+// uploading and the thinning averages within buckets, so a 178 bpm peak can be
+// drawn at 126 while still being the real maximum. A reader that recomputes
+// from `samples` under-reports exactly the moment a coach opens this screen for
+// — and it under-reports plausibly, which is why nobody would notice.
+
+import {
+  projectHeartRateSeries,
+  type WorkoutHeartRateSeries,
+} from "@/lib/gc-fitness/workout-heart-rate";
+
+const doc = (overrides: Record<string, unknown> = {}) => ({
+  clientId: "c1",
+  trainerId: "t1",
+  samples: [
+    { offsetSeconds: 0, bpm: 92 },
+    { offsetSeconds: 30, bpm: 118 },
+    { offsetSeconds: 60, bpm: 141 },
+  ],
+  minBpm: 88,
+  maxBpm: 178,
+  avgBpm: 121,
+  source: "healthkit",
+  ...overrides,
+});
+
+describe("projectHeartRateSeries — the stored aggregates win", () => {
+  it("reports the STORED min/max/avg, not the plotted extremes", () => {
+    // The whole point. The drawn line here tops out at 141; the session's real
+    // peak was 178, smoothed away by the writer's downsampling.
+    const series = projectHeartRateSeries(doc());
+
+    expect(series).toEqual<WorkoutHeartRateSeries>({
+      samples: [
+        { offsetSeconds: 0, bpm: 92 },
+        { offsetSeconds: 30, bpm: 118 },
+        { offsetSeconds: 60, bpm: 141 },
+      ],
+      minBpm: 88,
+      maxBpm: 178,
+      avgBpm: 121,
+    });
+    expect(Math.max(...series!.samples.map((s) => s.bpm))).toBeLessThan(
+      series!.maxBpm,
+    );
+  });
+
+  it("falls back to the points only when an aggregate is absent", () => {
+    // Legacy/partial doc. The fallback under-reports by exactly the amount
+    // thinning smoothed away, which is why it is a fallback and not the rule.
+    const series = projectHeartRateSeries(
+      doc({ minBpm: undefined, maxBpm: undefined, avgBpm: undefined }),
+    );
+
+    expect(series?.minBpm).toBe(92);
+    expect(series?.maxBpm).toBe(141);
+    expect(series?.avgBpm).toBe(117);
+  });
+});
+
+describe("projectHeartRateSeries — absence", () => {
+  it("returns null for a missing doc", () => {
+    // The common case: most sessions are logged without a watch, and the chart
+    // hides itself rather than framing an empty box on every workout.
+    expect(projectHeartRateSeries(null)).toBeNull();
+    expect(projectHeartRateSeries(undefined)).toBeNull();
+  });
+
+  it("returns null when there are no usable samples", () => {
+    expect(projectHeartRateSeries(doc({ samples: [] }))).toBeNull();
+    expect(projectHeartRateSeries(doc({ samples: "92,118" }))).toBeNull();
+    expect(
+      projectHeartRateSeries(doc({ samples: [{ offsetSeconds: 0, bpm: 0 }] })),
+    ).toBeNull();
+  });
+});
+
+describe("projectHeartRateSeries — per-sample guards", () => {
+  it("drops a non-positive bpm rather than charting it", () => {
+    // A dropout charted as 0 drags the line to the floor between two real
+    // values, which reads as a cardiac event rather than a lost signal.
+    const series = projectHeartRateSeries(
+      doc({
+        samples: [
+          { offsetSeconds: 0, bpm: 120 },
+          { offsetSeconds: 30, bpm: 0 },
+          { offsetSeconds: 60, bpm: 130 },
+        ],
+      }),
+    );
+
+    expect(series?.samples.map((s) => s.bpm)).toEqual([120, 130]);
+  });
+
+  it("drops a negative offset — it has no place on the axis", () => {
+    const series = projectHeartRateSeries(
+      doc({
+        samples: [
+          { offsetSeconds: -30, bpm: 70 },
+          { offsetSeconds: 30, bpm: 130 },
+        ],
+      }),
+    );
+
+    expect(series?.samples).toEqual([{ offsetSeconds: 30, bpm: 130 }]);
+  });
+
+  it("drops a malformed entry instead of the whole series", () => {
+    const series = projectHeartRateSeries(
+      doc({
+        samples: [
+          { offsetSeconds: 0, bpm: 120 },
+          "not an object",
+          { offsetSeconds: "x", bpm: 130 },
+          { offsetSeconds: 60, bpm: 135 },
+        ],
+      }),
+    );
+
+    expect(series?.samples).toHaveLength(2);
+  });
+
+  it("rounds fractional values — a bpm is whole", () => {
+    const series = projectHeartRateSeries(
+      doc({ samples: [{ offsetSeconds: 30.4, bpm: 120.6 }] }),
+    );
+
+    expect(series?.samples).toEqual([{ offsetSeconds: 30, bpm: 121 }]);
+  });
+});
+
+describe("projectHeartRateSeries — ordering", () => {
+  it("sorts by offset rather than trusting the stored order", () => {
+    // A chart whose x-axis doubles back on itself draws a scribble, and the
+    // cost of being sure is one sort of at most 300 entries.
+    const series = projectHeartRateSeries(
+      doc({
+        samples: [
+          { offsetSeconds: 60, bpm: 141 },
+          { offsetSeconds: 0, bpm: 92 },
+          { offsetSeconds: 30, bpm: 118 },
+        ],
+      }),
+    );
+
+    expect(series?.samples.map((s) => s.offsetSeconds)).toEqual([0, 30, 60]);
+  });
+});

--- a/backoffice/src/lib/gc-fitness/recent-logs-actions.ts
+++ b/backoffice/src/lib/gc-fitness/recent-logs-actions.ts
@@ -13,6 +13,10 @@ import {
 } from "./coachless-user-model";
 import { FirestoreCollections } from "./collections";
 import {
+  getWorkoutHeartRateSeries,
+  type WorkoutHeartRateSeries,
+} from "./workout-heart-rate";
+import {
   listClients,
   type ClientRosterEntry,
 } from "./client-roster";
@@ -131,6 +135,10 @@ export interface WorkoutLogDetail {
   /** Athlete self-reported RPE (1-10), captured on the iOS post-workout
    *  summary. Optional; null when the user dismissed the slider. */
   rpe: number | null;
+  /** The BPM series written by the client's app at finish, or null when the
+   *  workout has none — the common case, since most sessions are logged without
+   *  a watch. See lib/gc-fitness/workout-heart-rate.ts. */
+  heartRate: WorkoutHeartRateSeries | null;
   /** Athlete self-reported free-form notes from the post-workout summary. */
   athleteNotes: string | null;
   /** Origin of the workout log: coach-run backoffice session or client-run iOS session. */
@@ -2058,6 +2066,12 @@ async function buildWorkoutLogDetail(
     }
   }
 
+  // One extra point read on a single-workout page. Deliberately NOT folded into
+  // the log doc: the coach's client-profile trend widgets fetch up to 500 logs
+  // at once, and a few hundred samples per doc would turn that into megabytes
+  // for a chart no list view draws.
+  const heartRate = await getWorkoutHeartRateSeries(db, logId);
+
   const nextSetIndexByExercise = new Map<string, number>();
   const sets = rawSets.map((set, index) => {
     const exerciseId = typeof set.exerciseId === "string" ? set.exerciseId : "";
@@ -2147,6 +2161,7 @@ async function buildWorkoutLogDetail(
     clientName,
     clientTimezone,
     coachName,
+    heartRate,
     workoutName,
     startedAt,
     completedAt,

--- a/backoffice/src/lib/gc-fitness/workout-heart-rate.ts
+++ b/backoffice/src/lib/gc-fitness/workout-heart-rate.ts
@@ -1,0 +1,112 @@
+// workout-heart-rate.ts — the BPM series for a finished workout.
+//
+// Written by the client's app at finish (iOS `WorkoutHeartRateRepository`) to
+// `workout_logs/{logId}/metrics/heartRate`. Read here so the coach sees the
+// shape of the session, not just the sets.
+//
+// THE NUMBERS ARE STORED, NOT DERIVED FROM THE POINTS. The app thins the series
+// to at most 300 samples before uploading, and thinning averages within buckets
+// — so a 178 bpm spike can be DRAWN at 126 while still being the real peak.
+// Recomputing min/max/avg from `samples` here would quietly under-report exactly
+// the moment a coach is looking for. The chart shows the stored aggregates
+// beside the line for that reason; see the iOS twin
+// `GCFitnessCore.HeartRateSeriesBuffer` for the writer's half.
+//
+// A workout with no series is the COMMON case (most sessions are logged without
+// a watch), so absence resolves to `null` and the section hides itself rather
+// than framing an empty chart on every workout.
+
+import type { Firestore } from "firebase-admin/firestore";
+
+import { FirestoreCollections } from "./collections";
+
+/** Subcollection under `workout_logs/{logId}`. */
+export const WORKOUT_LOG_METRICS_SUBCOLLECTION = "metrics";
+
+/** The one metrics document the apps write today. */
+export const HEART_RATE_METRIC_ID = "heartRate";
+
+export interface HeartRateSample {
+  /** Seconds from the workout's `startedAt` — the chart's x-axis. */
+  offsetSeconds: number;
+  bpm: number;
+}
+
+export interface WorkoutHeartRateSeries {
+  samples: HeartRateSample[];
+  minBpm: number;
+  maxBpm: number;
+  avgBpm: number;
+}
+
+function wholeNumber(value: unknown): number | null {
+  const n = typeof value === "number" ? value : Number(value);
+  return Number.isFinite(n) ? Math.round(n) : null;
+}
+
+/**
+ * Project the raw metrics doc into a chartable series.
+ *
+ * Pure, so every guard is testable without Firestore. Returns `null` for a
+ * missing doc, a malformed one, or one whose samples are all unusable — all of
+ * which mean the same thing to the UI ("this workout has no heart rate"), and
+ * none of which should render a chart.
+ */
+export function projectHeartRateSeries(
+  data: Record<string, unknown> | undefined | null,
+): WorkoutHeartRateSeries | null {
+  if (!data) return null;
+
+  const rawSamples = Array.isArray(data.samples) ? data.samples : [];
+  const samples: HeartRateSample[] = [];
+  for (const raw of rawSamples) {
+    if (!raw || typeof raw !== "object") continue;
+    const entry = raw as Record<string, unknown>;
+    const offsetSeconds = wholeNumber(entry.offsetSeconds);
+    const bpm = wholeNumber(entry.bpm);
+    // A non-positive BPM is a sensor dropout, not a reading; charting it drags
+    // the line to the floor between two real values. A negative offset has no
+    // place on the axis.
+    if (offsetSeconds === null || offsetSeconds < 0) continue;
+    if (bpm === null || bpm <= 0) continue;
+    samples.push({ offsetSeconds, bpm });
+  }
+  if (samples.length === 0) return null;
+
+  // Sorted here rather than trusted: a chart whose x-axis doubles back on
+  // itself draws a scribble, and the cost of being sure is one sort of ≤300.
+  samples.sort((a, b) => a.offsetSeconds - b.offsetSeconds);
+
+  // Stored aggregates win — see the file header. The fallback to the drawn
+  // points is for a legacy/partial doc only, and it under-reports by exactly
+  // the amount thinning smoothed away.
+  const bpms = samples.map((s) => s.bpm);
+  const minBpm = wholeNumber(data.minBpm) ?? Math.min(...bpms);
+  const maxBpm = wholeNumber(data.maxBpm) ?? Math.max(...bpms);
+  const avgBpm =
+    wholeNumber(data.avgBpm) ??
+    Math.round(bpms.reduce((sum, bpm) => sum + bpm, 0) / bpms.length);
+
+  return { samples, minBpm, maxBpm, avgBpm };
+}
+
+/**
+ * Read a finished workout's heart-rate series.
+ *
+ * Fail-soft: one extra point read on a single-workout page, and a chart must
+ * never take the page down. Callers get `null` and hide the section.
+ */
+export async function getWorkoutHeartRateSeries(
+  db: Firestore,
+  workoutLogId: string,
+): Promise<WorkoutHeartRateSeries | null> {
+  const snap = await db
+    .collection(FirestoreCollections.workoutLogs)
+    .doc(workoutLogId)
+    .collection(WORKOUT_LOG_METRICS_SUBCOLLECTION)
+    .doc(HEART_RATE_METRIC_ID)
+    .get()
+    .catch(() => null);
+  if (!snap?.exists) return null;
+  return projectHeartRateSeries(snap.data());
+}


### PR DESCRIPTION
El lado del coach. La app del cliente escribe la serie al terminar (gc-fitness#824) en `workout_logs/{logId}/metrics/heartRate`; esto la lee y la dibuja.

Entra en `WorkoutLogDetailView`, que es el cuerpo compartido, así que aparece en los tres lugares donde se puede inspeccionar un entrenamiento sin tocar ninguno: **Registros recientes**, el **detalle del admin** y el **diálogo de la agenda**.

## Lo que hay que saber para leer el gráfico

**Los números al lado de la línea son los agregados guardados, no los puntos dibujados.** La app diezma la serie a ≤300 muestras antes de subirla y el diezmado promedia por buckets, así que un pico de 178 bpm puede **dibujarse en 126** y seguir siendo el máximo real de la sesión.

Un lector que recalculara min/máx desde `samples` sub-reportaría justo el momento por el que un coach abre esta pantalla — y sub-reportaría de forma plausible, que es exactamente por qué nadie se daría cuenta. La distancia entre el pico de la línea y el número "Máx" es esperada, y es el punto. Está anotado en el módulo, en el componente y en el test.

Un entrenamiento sin serie —la mayoría, porque casi nadie entrena con reloj— no rinde nada, en vez de enmarcar un gráfico vacío en cada sesión.

## Un arreglo colateral

El mock de Firestore de `recent-logs-actions.self-workout.test.ts` no soportaba subcolecciones, así que la lectura nueva lo rompía con un `TypeError` sincrónico que el `.catch()` no atrapa. Lo tentador era envolver en try/catch y seguir; no lo hice — eso taparía un error de programación de verdad. El mock ahora entiende subcolecciones, con la ruta completa como clave de fixture.

## Gate

- `npx jest` → **138 suites / 1624 tests verdes** (9 nuevos)
- `npm run build` → **verde**
- Sin verificación visual: hace falta un workout con serie real, que hoy sólo puede producir gc-fitness#824 corriendo en un dispositivo con reloj.